### PR TITLE
chart: fix OTel endpoint default + drop NODE_IP indirection

### DIFF
--- a/manifests/helm/trainticket/Chart.yaml
+++ b/manifests/helm/trainticket/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/manifests/helm/trainticket/templates/deployment.yaml
+++ b/manifests/helm/trainticket/templates/deployment.yaml
@@ -68,12 +68,7 @@ spec:
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: "service.name={{ $svc.name }},service.namespace={{ $root.Release.Namespace }},pod.name=$(POD_NAME)"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: |
-                {{- if $root.Values.global.otelcollector }}
-                {{ $root.Values.global.otelcollector }}
-                {{- else }}
-                http://$(NODE_IP):4317
-                {{- end }}
+              value: {{ $root.Values.global.otelcollector | default "http://$(NODE_IP):4317" | quote }}
             {{- end }}
             {{- if eq $svc.lang "frontend" }}
           env:
@@ -92,12 +87,7 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: |
-                {{- if $root.Values.global.otelcollector }}
-                {{ $root.Values.global.otelcollector }}
-                {{- else }}
-                http://$(NODE_IP):4317
-                {{- end }}
+              value: {{ $root.Values.global.otelcollector | default "http://$(NODE_IP):4317" | quote }}
             {{- end }}
             {{- if eq $svc.lang "javascript" }}
           env:
@@ -108,12 +98,7 @@ spec:
             - name: OTEL_METRICS_EXPORTER
               value: console,otlp
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: |
-                {{- if $root.Values.global.otelcollector }}
-                {{ $root.Values.global.otelcollector }}
-                {{- else }}
-                http://$(NODE_IP):4317
-                {{- end }}
+              value: {{ $root.Values.global.otelcollector | default "http://$(NODE_IP):4317" | quote }}
             - name: OTEL_NODE_RESOURCE_DETECTORS
               value: "env,host,os"
             - name: NODE_OPTIONS
@@ -133,33 +118,13 @@ spec:
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: "service.name={{ $svc.name }},service.namespace={{ $root.Release.Namespace }},pod.name=$(POD_NAME)"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: |
-                {{- if $root.Values.global.otelcollector }}
-                {{ $root.Values.global.otelcollector }}
-                {{- else }}
-                http://$(NODE_IP):4317
-                {{- end }}
+              value: {{ $root.Values.global.otelcollector | default "http://$(NODE_IP):4317" | quote }}
             - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-              value: |
-                {{- if $root.Values.global.otelcollector }}
-                {{ $root.Values.global.otelcollector }}
-                {{- else }}
-                http://$(NODE_IP):4317
-                {{- end }}
+              value: {{ $root.Values.global.otelcollector | default "http://$(NODE_IP):4317" | quote }}
             - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
-              value: |
-                {{- if $root.Values.global.otelcollector }}
-                {{ $root.Values.global.otelcollector }}
-                {{- else }}
-                http://$(NODE_IP):4317
-                {{- end }}
+              value: {{ $root.Values.global.otelcollector | default "http://$(NODE_IP):4317" | quote }}
             - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
-              value: |
-                {{- if $root.Values.global.otelcollector }}
-                {{ $root.Values.global.otelcollector }}
-                {{- else }}
-                http://$(NODE_IP):4317
-                {{- end }}
+              value: {{ $root.Values.global.otelcollector | default "http://$(NODE_IP):4317" | quote }}
             - name: OTEL_EXPORTER_OTLP_PROTOCOL
               value: grpc
             - name: OTEL_METRICS_EXPORTER

--- a/manifests/helm/trainticket/values.yaml
+++ b/manifests/helm/trainticket/values.yaml
@@ -4,7 +4,12 @@ global:
     tag: latest
   port: 8080
   monitoring: "opentelemetry"
-  # otelcollector: "http://opentelemetry-collector-deployment.monitoring:4317"
+  # OTLP gRPC endpoint for the chart-installed deployment-collector. Override with --set
+  # global.otelcollector=<host:port> to point at a different collector. The previous default
+  # of http://$(NODE_IP):4317 only works when a node-local DaemonSet collector listens via
+  # hostPort/hostNetwork, which is not the case in our standard deployments — so service
+  # spans were dropped silently while only loadgen (which uses a separate config) landed.
+  otelcollector: "http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317"
 
 # Autoscaling configuration (HPA)
 autoscaling:


### PR DESCRIPTION
## Symptom

On byte-cluster, only the `loadgen` pod's traces reach ClickHouse for any `ts*` namespace. Actual TT service pods (ts-payment-service, ts-train-service, ts-station-service, etc.) appear to NOT be exporting traces. Past rounds saw partial signal because at least loadgen-traffic-correlated spans landed, but with most service spans missing the detector undercounts.

## Root cause

Two bugs in `manifests/helm/trainticket/templates/deployment.yaml`:

1. **`http://$(NODE_IP):4317` default doesn't reach a listener.** Each pod was pointed at its own node's daemon-collector via the `hostIP` field-ref. This only works when the daemon collector binds via `hostPort` or `hostNetwork: true`. In our standard kube-stack values (`hostNetwork: false`), nothing listens on the node IP, so all service-pod spans drop silently. Loadgen ships with a separate endpoint (`opentelemetry-kube-stack-deployment-collector.monitoring:4317`) and is unaffected — explaining the "only loadgen" symptom.

2. **YAML block-scalar trailing newline.** Each endpoint env was rendered as `value: |` followed by the URL on the next line, which produces `"http://...:4317\n"`. Some OTLP gRPC exporters fail to parse the malformed URL and silently drop spans.

## Fix (Path A)

- Set `global.otelcollector` default to `http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317` — the chart-installed deployment-collector ClusterIP service which always listens on 4317 OTLP gRPC. Matches the convention used by the sn/mm/hs DSB charts.
- Replace the `value: |` block-scalar form with a single-line quoted value rendered via `{{ ... | default "http://$(NODE_IP):4317" | quote }}`. Eliminates the trailing-newline bug; the NODE_IP path remains as an explicit fallback if `global.otelcollector` is set empty.
- Bump chart version `0.1.0` -> `0.2.0`.

## Verification (`helm template`)

Default render now emits for every service Deployment:

```yaml
- name: OTEL_EXPORTER_OTLP_ENDPOINT
  value: "http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317"
```

Diff snippet (before -> after, repeats for ~40 services):

```
<               value: |
<                 http://$(NODE_IP):4317
---
>               value: "http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317"
```

Override path also confirmed:
```bash
helm template t manifests/helm/trainticket --set global.otelcollector=foobar:4318
# -> value: "foobar:4318"
```

No trailing newlines anywhere. Loadgen endpoint untouched (separate config).

## Test plan

- [ ] `helm template t manifests/helm/trainticket` renders without error
- [ ] Default endpoint resolves to `opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317` for every service Deployment
- [ ] `--set global.otelcollector=...` overrides correctly
- [ ] Deploy on byte-cluster and confirm spans from `ts-payment-service` / `ts-train-service` / etc. land in ClickHouse alongside loadgen

Closes nothing in OperationsPAI/train-ticket but unblocks the autonomous fault-injection campaign in OperationsPAI/aegis.