### PR TITLE
fix(chart): skip nodePort when type is ClusterIP

### DIFF
--- a/manifests/helm/trainticket/Chart.yaml
+++ b/manifests/helm/trainticket/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/manifests/helm/trainticket/templates/service.yaml
+++ b/manifests/helm/trainticket/templates/service.yaml
@@ -15,7 +15,7 @@ spec:
       {{- with $svc.targetPort }}
       targetPort: {{ $svc.targetPort }}
       {{- end}}
-      {{- if $svc.nodePort }}
+      {{- if and $svc.nodePort (ne ($svc.type | default "") "ClusterIP") }}
       nodePort: {{ $svc.nodePort }}
       {{- end }}
       protocol: TCP


### PR DESCRIPTION
## Symptom

Overriding `services.<svc>.type=ClusterIP` on the trainticket chart is rejected by k8s:

```
spec.ports[0].nodePort: Invalid value: 30080:
may not be specified when 'type' is 'ClusterIP'
```

## Root cause

`manifests/helm/trainticket/templates/service.yaml:18-20` only checked `$svc.nodePort`, not `$svc.type`. Since every entry under `services:` in `values.yaml` has both `type: NodePort` and a `nodePort:` set as defaults, any user attempting to opt a single service out of NodePort by overriding only `type` still gets a `nodePort:` field rendered, which the apiserver rejects.

## Fix

Tighten the guard so `nodePort:` is only emitted when the service type is not ClusterIP:

```yaml
{{- if and $svc.nodePort (ne ($svc.type | default "") "ClusterIP") }}
nodePort: {{ $svc.nodePort }}
{{- end }}
```

Default behavior is unchanged. Chart version bumped 0.2.0 -> 0.2.1. `appVersion` is not touched (no application code change).

## Verification (helm template)

Before this PR, both renderings emitted `nodePort: 30080`. After:

`helm template trainticket --set services.tsUiDashboard.type=ClusterIP`:

```yaml
metadata:
  name: ts-ui-dashboard
spec:
  type: ClusterIP
  ports:
    - port: 8080
      protocol: TCP
```

`helm template trainticket` (defaults):

```yaml
metadata:
  name: ts-ui-dashboard
spec:
  type: NodePort
  ports:
    - port: 8080
      nodePort: 30080
      protocol: TCP
```

## Why this is needed

Downstream, the aegis byte-cluster runs train-ticket alongside several other benchmarks on a shared kind/VKE host. Multiple charts compete for the same NodePort range and only one can win; the workaround is to demote individual services to ClusterIP per environment. Without this fix the chart cannot be rendered with that override at all. Context: OperationsPAI/aegis#332, OperationsPAI/aegis#331.