### PR TITLE
feat(otel): add per-namespace collector sidecar

### DIFF
--- a/manifests/helm/trainticket/Chart.lock
+++ b/manifests/helm/trainticket/Chart.lock
@@ -3,7 +3,7 @@ dependencies:
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 15.4.0
 - name: loadgenerator
-  repository: https://lgu-se-internal.github.io/loadgenerator
+  repository: https://operationspai.github.io/loadgenerator
   version: 0.1.1
-digest: sha256:40938b65ced12423d9d1950dcd0a17f588a33ba759aac13747c522e83b72efff
-generated: "2025-09-30T12:11:38.639341666+08:00"
+digest: sha256:c1dc344d1cf42810034b854697e86de61ae48f8cd83c6c6c0391ebcc56baaee3
+generated: "2026-05-02T06:42:29.308592339+01:00"

--- a/manifests/helm/trainticket/Chart.yaml
+++ b/manifests/helm/trainticket/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/manifests/helm/trainticket/templates/otel-collector-configmap.yaml
+++ b/manifests/helm/trainticket/templates/otel-collector-configmap.yaml
@@ -1,0 +1,119 @@
+{{- if .Values.otelCollector.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.otelCollector.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.otelCollector.name }}
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/part-of: trainticket
+data:
+  collector.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    exporters:
+      clickhouse:
+        database: {{ .Values.otelCollector.clickhouse.database | quote }}
+        endpoint: {{ .Values.otelCollector.clickhouse.endpoint | quote }}
+        logs_table_name: {{ .Values.otelCollector.clickhouse.logsTableName | quote }}
+        metrics_table_name: {{ .Values.otelCollector.clickhouse.metricsTableName | quote }}
+        traces_table_name: {{ .Values.otelCollector.clickhouse.tracesTableName | quote }}
+        ttl: {{ .Values.otelCollector.clickhouse.ttl | quote }}
+        timeout: {{ .Values.otelCollector.clickhouse.timeout | quote }}
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_elapsed_time: 300s
+          max_interval: 30s
+        sending_queue:
+          enabled: {{ .Values.otelCollector.sendingQueue.enabled }}
+          num_consumers: {{ .Values.otelCollector.sendingQueue.numConsumers }}
+          queue_size: {{ .Values.otelCollector.sendingQueue.queueSize }}
+          blocking: {{ .Values.otelCollector.sendingQueue.blocking }}
+    processors:
+      batch:
+        send_batch_max_size: {{ .Values.otelCollector.batch.sendBatchMaxSize }}
+        send_batch_size: {{ .Values.otelCollector.batch.sendBatchSize }}
+        timeout: {{ .Values.otelCollector.batch.timeout | quote }}
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: {{ .Values.otelCollector.memoryLimiter.limitPercentage }}
+        spike_limit_percentage: {{ .Values.otelCollector.memoryLimiter.spikeLimitPercentage }}
+      k8sattributes:
+        auth_type: serviceAccount
+        passthrough: false
+        extract:
+          metadata:
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.deployment.name
+            - k8s.namespace.name
+            - k8s.node.name
+            - k8s.pod.start_time
+            - service.name
+            - service.version
+            - service.instance.id
+          labels:
+            - tag_name: app.label.component
+              key: app.kubernetes.io/component
+              from: pod
+            - tag_name: service.name
+              key: app.kubernetes.io/name
+              from: pod
+            - tag_name: service.name
+              key: app
+              from: pod
+            - tag_name: service.name
+              key: name
+              from: pod
+          otel_annotations: true
+        pod_association:
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.ip
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.uid
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+          - sources:
+              - from: connection
+      transform/service_namespace:
+        trace_statements:
+          - context: resource
+            statements:
+              - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+        metric_statements:
+          - context: resource
+            statements:
+              - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+        log_statements:
+          - context: resource
+            statements:
+              - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+    connectors:
+      spanmetrics: {}
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+          exporters: [spanmetrics, clickhouse]
+        metrics:
+          receivers: [otlp, spanmetrics]
+          processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+          exporters: [clickhouse]
+        logs:
+          receivers: [otlp]
+          processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+          exporters: [clickhouse]
+{{- end }}

--- a/manifests/helm/trainticket/templates/otel-collector-deployment.yaml
+++ b/manifests/helm/trainticket/templates/otel-collector-deployment.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.otelCollector.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.otelCollector.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.otelCollector.name }}
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/part-of: trainticket
+spec:
+  replicas: {{ .Values.otelCollector.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.otelCollector.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.otelCollector.name }}
+        app.kubernetes.io/component: opentelemetry-collector
+        app.kubernetes.io/part-of: trainticket
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/otel-collector-configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ .Values.otelCollector.name }}
+      containers:
+        - name: otel-collector
+          image: "{{ .Values.otelCollector.image.repository }}:{{ .Values.otelCollector.image.tag }}"
+          imagePullPolicy: {{ .Values.otelCollector.image.pullPolicy | default "IfNotPresent" }}
+          args:
+            - --config=/conf/collector.yaml
+          ports:
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+          env:
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OTEL_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OTEL_K8S_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.pod.name=$(OTEL_K8S_POD_NAME),k8s.namespace.name=$(OTEL_K8S_NAMESPACE),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.ip=$(OTEL_K8S_POD_IP)"
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+          resources:
+            {{- toYaml .Values.otelCollector.resources | nindent 12 }}
+          livenessProbe:
+            tcpSocket:
+              port: 4317
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 4317
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: config
+          configMap:
+            name: {{ .Values.otelCollector.name }}
+            items:
+              - key: collector.yaml
+                path: collector.yaml
+{{- end }}

--- a/manifests/helm/trainticket/templates/otel-collector-service.yaml
+++ b/manifests/helm/trainticket/templates/otel-collector-service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.otelCollector.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.otelCollector.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.otelCollector.name }}
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/part-of: trainticket
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ .Values.otelCollector.name }}
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+{{- end }}

--- a/manifests/helm/trainticket/templates/otel-collector-serviceaccount.yaml
+++ b/manifests/helm/trainticket/templates/otel-collector-serviceaccount.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.otelCollector.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.otelCollector.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.otelCollector.name }}
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/part-of: trainticket
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Namespace }}-{{ .Values.otelCollector.name }}
+  labels:
+    app: {{ .Values.otelCollector.name }}
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/part-of: trainticket
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets", "deployments"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Namespace }}-{{ .Values.otelCollector.name }}
+  labels:
+    app: {{ .Values.otelCollector.name }}
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/part-of: trainticket
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Namespace }}-{{ .Values.otelCollector.name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.otelCollector.name }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/manifests/helm/trainticket/values.yaml
+++ b/manifests/helm/trainticket/values.yaml
@@ -4,12 +4,12 @@ global:
     tag: latest
   port: 8080
   monitoring: "opentelemetry"
-  # OTLP gRPC endpoint for the chart-installed deployment-collector. Override with --set
-  # global.otelcollector=<host:port> to point at a different collector. The previous default
-  # of http://$(NODE_IP):4317 only works when a node-local DaemonSet collector listens via
-  # hostPort/hostNetwork, which is not the case in our standard deployments — so service
-  # spans were dropped silently while only loadgen (which uses a separate config) landed.
-  otelcollector: "http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317"
+  # OTLP gRPC endpoint for ts services. Default targets the per-namespace sidecar
+  # collector deployed by this chart (see .Values.otelCollector). Override with
+  # --set global.otelcollector=<url> to route at a shared cluster-wide collector
+  # (e.g. http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317)
+  # — typical when otelCollector.enabled=false.
+  otelcollector: "http://otel-collector:4317"
 
 # Autoscaling configuration (HPA)
 autoscaling:
@@ -24,6 +24,53 @@ autoscaling:
 opentelemetry:
   enabled: true
   image: autoinstrumentation-java:elastic
+
+# Per-namespace OTLP collector sidecar.
+#
+# Deploys a single-replica otel-collector-contrib in the release namespace so each
+# train-ticket install gets its own queue and exporter to ClickHouse, instead of all
+# namespaces fanning into one shared cluster-wide collector (which saturates its
+# ClickHouse exporter sending_queue and silently drops spans). See aegis #367.
+#
+# Disable to fall back to a shared collector — also override .global.otelcollector
+# to point at that collector's URL.
+otelCollector:
+  enabled: true
+  name: otel-collector
+  replicas: 1
+  image:
+    # Public upstream image; byte-cluster pulls via its registry mirror automatically.
+    # Override to a private mirror by setting --set otelCollector.image.repository=...
+    repository: otel/opentelemetry-collector-contrib
+    tag: "0.142.0"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
+    limits:
+      cpu: 2
+      memory: 4Gi
+  clickhouse:
+    endpoint: "tcp://clickstack-clickhouse-clickhouse-headless.monitoring.svc.cluster.local:9000?dial_timeout=10s&compress=lz4&username=default"
+    database: otel
+    tracesTableName: otel_traces
+    metricsTableName: otel_metrics
+    logsTableName: otel_logs
+    ttl: 72h
+    timeout: 30s
+  sendingQueue:
+    enabled: true
+    numConsumers: 10
+    queueSize: 5000
+    blocking: true
+  batch:
+    sendBatchSize: 2000
+    sendBatchMaxSize: 4000
+    timeout: 5s
+  memoryLimiter:
+    limitPercentage: 75
+    spikeLimitPercentage: 15
 
 services:
   tsAdminBasicInfoService:
@@ -256,7 +303,7 @@ loadgenerator:
   fullnameOverride: "loadgenerator"
   baseURL: "http://ts-ui-dashboard:8080"
   opentelemetry:
-    endpoint: "opentelemetry-kube-stack-deployment-collector.monitoring:4317"
+    endpoint: "otel-collector:4317"
   config:
     threads: 2
     sleep: 100


### PR DESCRIPTION
## Why

A single shared cluster-wide OTel collector (e.g. `opentelemetry-kube-stack-deployment-ts-collector` in `monitoring`) currently fans-in traces/metrics/logs from every train-ticket namespace in the aegis byte-cluster (23 ts namespaces today). Its ClickHouse-exporter `sending_queue` saturates and silently drops ~1830 spans/sec. Downstream effect: `BuildDatapack` windows produce empty `abnormal_traces.parquet` and the RCA pipeline gets bad data.

Refs: aegis #367, aegis #366.

## What

Each train-ticket release now ships its own OTLP collector sidecar in the release namespace:

- `templates/otel-collector-deployment.yaml` — single-replica `otel/opentelemetry-collector-contrib:0.142.0` (matches the version of the existing shared ts collector).
- `templates/otel-collector-service.yaml` — ClusterIP `otel-collector` exposing `4317` (gRPC) and `4318` (HTTP).
- `templates/otel-collector-configmap.yaml` — pipeline mirrors the shared ts collector (memory_limiter -> k8sattributes -> transform/service_namespace -> batch -> ClickHouse + spanmetrics) sized for one namespace: `sending_queue { num_consumers: 10, queue_size: 5000, blocking: true }`, batch `2000/4000`, exporter `timeout: 30s`.
- `templates/otel-collector-serviceaccount.yaml` — ServiceAccount + ClusterRole/ClusterRoleBinding for `k8sattributes` (pods/namespaces/nodes/replicasets/deployments get/list/watch). ClusterRole name is namespaced (`{ns}-otel-collector`) so multiple ts releases don't collide.

The pipeline still exports to the cluster-wide ClickHouse: `tcp://clickstack-clickhouse-clickhouse-headless.monitoring.svc.cluster.local:9000`.

## Service env wiring

`global.otelcollector` default flips from the cross-ns FQDN of a shared monitoring-namespace collector to the same-ns short name `http://otel-collector:4317`. All ts services (Java, Python, JavaScript, frontend) and the loadgenerator subchart pick up the same default. To fall back to a shared collector: set `otelCollector.enabled=false` and override `global.otelcollector` to the shared collector URL.

## values.yaml additions

```yaml
otelCollector:
  enabled: true
  name: otel-collector
  replicas: 1
  image:
    repository: otel/opentelemetry-collector-contrib
    tag: "0.142.0"
  resources:
    requests: { cpu: 250m, memory: 1Gi }
    limits:   { cpu: 2,    memory: 4Gi }
  clickhouse:
    endpoint: "tcp://clickstack-clickhouse-clickhouse-headless.monitoring.svc.cluster.local:9000?dial_timeout=10s&compress=lz4&username=default"
    ttl: 72h
    timeout: 30s
  sendingQueue: { enabled: true, numConsumers: 10, queueSize: 5000, blocking: true }
  batch:        { sendBatchSize: 2000, sendBatchMaxSize: 4000, timeout: 5s }
  memoryLimiter: { limitPercentage: 75, spikeLimitPercentage: 15 }
```

## Compatibility

- New installs get the sidecar by default.
- Existing aegis byte-cluster installs pick it up on next reseed + `helm upgrade` (or the loop's nuke-and-reinstall cadence).
- The shared monitoring collector can stay running — no-op for ts traffic once ts services point at the sidecar.

## Notes / follow-ups

- Image default is `docker.io/otel/opentelemetry-collector-contrib:0.142.0`. The byte-cluster currently runs `pair-diag-cn-guangzhou.cr.volces.com/pair/opentelemetry-collector-contrib:0.142.0-amd64`; the `pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-collector-contrib:0.142.0` mirror does NOT exist yet (`docker buildx imagetools inspect` returns `not found`). Either point byte-cluster pulls at the existing `pair-diag-cn-guangzhou.cr.volces.com/pair/...` mirror via `--set otelCollector.image.repository=...,otelCollector.image.tag=0.142.0-amd64`, or create the opspai mirror as a follow-up. Public docker.io path is the most portable default and avoids hardcoding a private registry into the chart.
- `Chart.lock` was refreshed to match the already-corrected `loadgenerator` repo URL in `Chart.yaml`.
- Chart version bumped 0.2.1 -> 0.3.0 (behavior change to default OTLP destination).

## Test plan

- [ ] `helm template` renders 4 new resources per release (verified locally — see ServiceAccount, ClusterRole/Binding, ConfigMap, Deployment, Service).
- [ ] `helm lint` passes (verified — only pre-existing bitnami rabbitmq NOTES warning, unrelated to this change).
- [ ] Deploy to one ts namespace and confirm sidecar pod ready, ts service pods send to `otel-collector:4317`, traces appear in ClickHouse with `service.namespace = <ts-ns>`.
- [ ] Compare `otelcol_exporter_send_failed_log_records` / `otelcol_exporter_queue_size` for the sidecar vs the shared collector under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)