### PR TITLE
fix(otel): drop sending_queue.blocking key

### DIFF
--- a/manifests/helm/trainticket/Chart.yaml
+++ b/manifests/helm/trainticket/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/manifests/helm/trainticket/templates/otel-collector-configmap.yaml
+++ b/manifests/helm/trainticket/templates/otel-collector-configmap.yaml
@@ -35,7 +35,6 @@ data:
           enabled: {{ .Values.otelCollector.sendingQueue.enabled }}
           num_consumers: {{ .Values.otelCollector.sendingQueue.numConsumers }}
           queue_size: {{ .Values.otelCollector.sendingQueue.queueSize }}
-          blocking: {{ .Values.otelCollector.sendingQueue.blocking }}
     processors:
       batch:
         send_batch_max_size: {{ .Values.otelCollector.batch.sendBatchMaxSize }}

--- a/manifests/helm/trainticket/values.yaml
+++ b/manifests/helm/trainticket/values.yaml
@@ -63,7 +63,6 @@ otelCollector:
     enabled: true
     numConsumers: 10
     queueSize: 5000
-    blocking: true
   batch:
     sendBatchSize: 2000
     sendBatchMaxSize: 4000


### PR DESCRIPTION
Hot-fix: collector v0.142.0 rejects `blocking: true` in sending_queue (CrashLoopBackOff). Bumps to 0.3.1.