### PR TITLE
feat(otel): MySQL 9.7 server-side telemetry + trace continuity, RabbitMQ metrics & AMQP tracing

### DIFF
--- a/manifests/helm/trainticket/Chart.yaml
+++ b/manifests/helm/trainticket/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/manifests/helm/trainticket/Chart.yaml
+++ b/manifests/helm/trainticket/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/manifests/helm/trainticket/Chart.yaml
+++ b/manifests/helm/trainticket/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/manifests/helm/trainticket/Chart.yaml
+++ b/manifests/helm/trainticket/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/manifests/helm/trainticket/Chart.yaml
+++ b/manifests/helm/trainticket/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/manifests/helm/trainticket/templates/deployment.yaml
+++ b/manifests/helm/trainticket/templates/deployment.yaml
@@ -137,10 +137,10 @@ spec:
               value: "true"
             {{- if $root.Values.global.otelcollector }}
             - name: JAVA_TOOL_OPTIONS
-              value: "-javaagent:/otel-agent/otel-agent.jar -Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true -Xmx2048m"
+              value: "-javaagent:/otel-agent/otel-agent.jar -Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true -Dotel.instrumentation.jdbc.enabled=false -Xmx2048m"
             {{- else }}
             - name: JAVA_TOOL_OPTIONS
-              value: "-javaagent:/otel-agent/otel-agent.jar -Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true -Xmx2048m -Xms2048m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1ReservePercent=15 -XX:+ParallelRefProcEnabled -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heapdump.hprof -XX:NativeMemoryTracking=summary -XX:+DisableExplicitGC"
+              value: "-javaagent:/otel-agent/otel-agent.jar -Dotel.instrumentation.common.experimental.controller-telemetry.enabled=true -Dotel.instrumentation.jdbc.enabled=false -Xmx2048m -Xms2048m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1ReservePercent=15 -XX:+ParallelRefProcEnabled -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/heapdump.hprof -XX:NativeMemoryTracking=summary -XX:+DisableExplicitGC"
             {{- end }}
             {{- end }}
             {{- end }}

--- a/manifests/helm/trainticket/templates/mysql.yaml
+++ b/manifests/helm/trainticket/templates/mysql.yaml
@@ -11,10 +11,21 @@ data:
     FLUSH PRIVILEGES;
     {{- if .Values.mysql.telemetry.enabled }}
     INSTALL COMPONENT 'file://component_telemetry';
-    SET GLOBAL telemetry.otel_exporter_otlp_traces_endpoint = '{{ .Values.mysql.telemetry.otelEndpoint }}';
-    SET GLOBAL telemetry.otel_exporter_otlp_traces_protocol = '{{ .Values.mysql.telemetry.otelProtocol }}';
-    SET GLOBAL telemetry.trace_enabled = ON;
-    SET GLOBAL telemetry.query_text_enabled = {{ if .Values.mysql.telemetry.queryTextEnabled }}ON{{ else }}OFF{{ end }};
+    -- telemetry.* endpoint vars are non-dynamic. PERSIST_ONLY writes them to
+    -- mysqld-auto.cnf; the docker entrypoint restarts mysqld after the initdb
+    -- scripts, and persisted component vars are re-applied once component_telemetry
+    -- auto-loads on that restart. All three signals default ON and share the
+    -- OTLP/HTTP base from global.otelcollectorHttp.
+    SET PERSIST_ONLY telemetry.otel_exporter_otlp_traces_protocol  = 'http/protobuf';
+    SET PERSIST_ONLY telemetry.otel_exporter_otlp_traces_endpoint  = '{{ .Values.global.otelcollectorHttp }}/v1/traces';
+    SET PERSIST_ONLY telemetry.otel_exporter_otlp_metrics_protocol = 'http/protobuf';
+    SET PERSIST_ONLY telemetry.otel_exporter_otlp_metrics_endpoint = '{{ .Values.global.otelcollectorHttp }}/v1/metrics';
+    SET PERSIST_ONLY telemetry.otel_exporter_otlp_logs_protocol    = 'http/protobuf';
+    SET PERSIST_ONLY telemetry.otel_exporter_otlp_logs_endpoint    = '{{ .Values.global.otelcollectorHttp }}/v1/logs';
+    SET PERSIST_ONLY telemetry.trace_enabled      = ON;
+    SET PERSIST_ONLY telemetry.metrics_enabled    = ON;
+    SET PERSIST_ONLY telemetry.log_enabled        = ON;
+    SET PERSIST_ONLY telemetry.query_text_enabled = {{ if .Values.mysql.telemetry.queryTextEnabled }}ON{{ else }}OFF{{ end }};
     {{- end }}
 ---
 apiVersion: v1

--- a/manifests/helm/trainticket/templates/mysql.yaml
+++ b/manifests/helm/trainticket/templates/mysql.yaml
@@ -9,6 +9,13 @@ data:
     USE mysql;
     GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;
     FLUSH PRIVILEGES;
+    {{- if .Values.mysql.telemetry.enabled }}
+    INSTALL COMPONENT 'file://component_telemetry';
+    SET GLOBAL telemetry.otel_exporter_otlp_traces_endpoint = '{{ .Values.mysql.telemetry.otelEndpoint }}';
+    SET GLOBAL telemetry.otel_exporter_otlp_traces_protocol = '{{ .Values.mysql.telemetry.otelProtocol }}';
+    SET GLOBAL telemetry.trace_enabled = ON;
+    SET GLOBAL telemetry.query_text_enabled = {{ if .Values.mysql.telemetry.queryTextEnabled }}ON{{ else }}OFF{{ end }};
+    {{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/manifests/helm/trainticket/templates/otel-collector-configmap.yaml
+++ b/manifests/helm/trainticket/templates/otel-collector-configmap.yaml
@@ -17,14 +17,11 @@ data:
             endpoint: 0.0.0.0:4317
           http:
             endpoint: 0.0.0.0:4318
-      {{- /* MySQL metrics come from native component_telemetry push (9.7), not a pull receiver. */}}
-      {{- if .Values.rabbitmq.enabled }}
-      rabbitmq:
-        endpoint: http://rabbitmq:15672
-        username: {{ .Values.rabbitmq.auth.username }}
-        password: {{ .Values.rabbitmq.auth.password }}
-        collection_interval: 30s
-      {{- end }}
+      {{- /* No pull receivers: MySQL metrics arrive via native component_telemetry
+             push (9.7); the rabbitmqreceiver was dropped — it emitted a metric with
+             unset type that the clickhouse exporter rejects, poisoning the whole
+             metrics batch (otel-collector-contrib #27671). Revisit via
+             rabbitmq_prometheus + prometheusreceiver if RabbitMQ metrics are needed. */}}
     exporters:
       clickhouse:
         database: {{ .Values.otelCollector.clickhouse.database | quote }}
@@ -116,12 +113,7 @@ data:
           processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
           exporters: [spanmetrics, clickhouse]
         metrics:
-          receivers:
-            - otlp
-            - spanmetrics
-            {{- if .Values.rabbitmq.enabled }}
-            - rabbitmq
-            {{- end }}
+          receivers: [otlp, spanmetrics]
           processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
           exporters: [clickhouse]
         logs:

--- a/manifests/helm/trainticket/templates/otel-collector-configmap.yaml
+++ b/manifests/helm/trainticket/templates/otel-collector-configmap.yaml
@@ -17,11 +17,22 @@ data:
             endpoint: 0.0.0.0:4317
           http:
             endpoint: 0.0.0.0:4318
-      {{- /* No pull receivers: MySQL metrics arrive via native component_telemetry
-             push (9.7); the rabbitmqreceiver was dropped — it emitted a metric with
-             unset type that the clickhouse exporter rejects, poisoning the whole
-             metrics batch (otel-collector-contrib #27671). Revisit via
-             rabbitmq_prometheus + prometheusreceiver if RabbitMQ metrics are needed. */}}
+      {{- /* MySQL metrics arrive via native component_telemetry push (9.7).
+             RabbitMQ metrics are scraped from its built-in rabbitmq_prometheus
+             plugin (Bitnami exposes it on svc port 9419 when metrics.enabled).
+             We deliberately do NOT use the contrib rabbitmqreceiver: in this stack
+             it emitted a metric the clickhouse exporter rejected with "metrics type
+             is unset", poisoning the whole metrics batch into permanent retry. The
+             prometheus path uses standard Prometheus-typed metrics and avoids that. */}}
+      {{- if .Values.rabbitmq.enabled }}
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: rabbitmq
+              scrape_interval: 30s
+              static_configs:
+                - targets: ['rabbitmq:9419']
+      {{- end }}
     exporters:
       clickhouse:
         database: {{ .Values.otelCollector.clickhouse.database | quote }}
@@ -113,7 +124,12 @@ data:
           processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
           exporters: [spanmetrics, clickhouse]
         metrics:
-          receivers: [otlp, spanmetrics]
+          receivers:
+            - otlp
+            - spanmetrics
+            {{- if .Values.rabbitmq.enabled }}
+            - prometheus
+            {{- end }}
           processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
           exporters: [clickhouse]
         logs:

--- a/manifests/helm/trainticket/templates/otel-collector-configmap.yaml
+++ b/manifests/helm/trainticket/templates/otel-collector-configmap.yaml
@@ -17,14 +17,7 @@ data:
             endpoint: 0.0.0.0:4317
           http:
             endpoint: 0.0.0.0:4318
-      {{- if .Values.mysql.enabled }}
-      mysql:
-        endpoint: {{ .Values.mysql.host }}:{{ .Values.mysql.port }}
-        username: {{ .Values.mysql.user }}
-        password: {{ .Values.mysql.password }}
-        database: {{ .Values.mysql.database }}
-        collection_interval: 30s
-      {{- end }}
+      {{- /* MySQL metrics come from native component_telemetry push (9.7), not a pull receiver. */}}
       {{- if .Values.rabbitmq.enabled }}
       rabbitmq:
         endpoint: http://rabbitmq:15672
@@ -126,9 +119,6 @@ data:
           receivers:
             - otlp
             - spanmetrics
-            {{- if .Values.mysql.enabled }}
-            - mysql
-            {{- end }}
             {{- if .Values.rabbitmq.enabled }}
             - rabbitmq
             {{- end }}

--- a/manifests/helm/trainticket/templates/otel-collector-configmap.yaml
+++ b/manifests/helm/trainticket/templates/otel-collector-configmap.yaml
@@ -17,6 +17,21 @@ data:
             endpoint: 0.0.0.0:4317
           http:
             endpoint: 0.0.0.0:4318
+      {{- if .Values.mysql.enabled }}
+      mysql:
+        endpoint: {{ .Values.mysql.host }}:{{ .Values.mysql.port }}
+        username: {{ .Values.mysql.user }}
+        password: {{ .Values.mysql.password }}
+        database: {{ .Values.mysql.database }}
+        collection_interval: 30s
+      {{- end }}
+      {{- if .Values.rabbitmq.enabled }}
+      rabbitmq:
+        endpoint: http://rabbitmq:15672
+        username: {{ .Values.rabbitmq.auth.username }}
+        password: {{ .Values.rabbitmq.auth.password }}
+        collection_interval: 30s
+      {{- end }}
     exporters:
       clickhouse:
         database: {{ .Values.otelCollector.clickhouse.database | quote }}
@@ -108,7 +123,15 @@ data:
           processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
           exporters: [spanmetrics, clickhouse]
         metrics:
-          receivers: [otlp, spanmetrics]
+          receivers:
+            - otlp
+            - spanmetrics
+            {{- if .Values.mysql.enabled }}
+            - mysql
+            {{- end }}
+            {{- if .Values.rabbitmq.enabled }}
+            - rabbitmq
+            {{- end }}
           processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
           exporters: [clickhouse]
         logs:

--- a/manifests/helm/trainticket/values.yaml
+++ b/manifests/helm/trainticket/values.yaml
@@ -31,7 +31,7 @@ autoscaling:
 
 opentelemetry:
   enabled: true
-  image: autoinstrumentation-java:elastic
+  image: autoinstrumentation-java:2.28.1
 
 # Per-namespace OTLP collector sidecar.
 #

--- a/manifests/helm/trainticket/values.yaml
+++ b/manifests/helm/trainticket/values.yaml
@@ -10,6 +10,10 @@ global:
   # (e.g. http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317)
   # — typical when otelCollector.enabled=false.
   otelcollector: "http://otel-collector:4317"
+  # OTLP HTTP/protobuf endpoint (port 4318) for components that push over HTTP instead
+  # of gRPC — currently MySQL 9.7 native telemetry, which appends /v1/{traces,metrics,logs}.
+  # Keep the host in sync with otelcollector when overriding to a shared collector.
+  otelcollectorHttp: "http://otel-collector:4318"
 
 # Autoscaling configuration (HPA)
 autoscaling:
@@ -256,11 +260,12 @@ mysql:
   user: "root"
   password: "yourpassword"
   maxConnections: 1024
-  # component_telemetry (available in Community Edition since 9.7 LTS)
+  # component_telemetry (Community Edition since 9.7 LTS) — one component emits
+  # traces + metrics + logs, all pushed via OTLP/HTTP to global.otelcollectorHttp
+  # (mysql.yaml appends the per-signal /v1/* paths). We rely on native telemetry for
+  # MySQL metrics, so the collector deliberately has NO mysqlreceiver (would double-export).
   telemetry:
     enabled: true
-    otelEndpoint: "http://otel-collector:4318/v1/traces"
-    otelProtocol: "http/protobuf"
     queryTextEnabled: true
   persistence:
     enabled: false

--- a/manifests/helm/trainticket/values.yaml
+++ b/manifests/helm/trainticket/values.yaml
@@ -4,6 +4,10 @@ global:
     tag: latest
   port: 8080
   monitoring: "opentelemetry"
+  # The rabbitmq subchart pins a bitnamilegacy/* image, which Bitnami's image
+  # guard rejects unless this is set. Propagates to the subchart via Helm globals.
+  security:
+    allowInsecureImages: true
   # OTLP gRPC endpoint for ts services. Default targets the per-namespace sidecar
   # collector deployed by this chart (see .Values.otelCollector). Override with
   # --set global.otelcollector=<url> to route at a shared cluster-wide collector
@@ -302,15 +306,12 @@ rabbitmq:
       cpu: 1000m
   metrics:
     enabled: false
-  # RabbitMQ 4.0+ native OpenTelemetry plugin — emits server-side spans
-  extraPlugins: "rabbitmq_opentelemetry"
-  extraEnvVars:
-    - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: "http://otel-collector:4317"
-    - name: OTEL_EXPORTER_OTLP_PROTOCOL
-      value: "grpc"
-    - name: OTEL_SERVICE_NAME
-      value: "rabbitmq"
+  # NOTE: RabbitMQ has no server-side OpenTelemetry plugin (there is no
+  # rabbitmq_opentelemetry tier-1 plugin in any 4.x release — only
+  # rabbitmq_prometheus for metrics). RabbitMQ trace continuity is client-side:
+  # the OTel Java agent instruments Spring AMQP, injecting traceparent into AMQP
+  # headers on publish and extracting it on consume, so producer→consumer spans
+  # link without any broker config. Nothing to enable on the broker for traces.
 
 # Loadgenerator Configuration
 loadgenerator:

--- a/manifests/helm/trainticket/values.yaml
+++ b/manifests/helm/trainticket/values.yaml
@@ -248,7 +248,7 @@ mysql:
   image:
     repository: docker.io/library/mysql
     pullPolicy: IfNotPresent
-    tag: "5.7"
+    tag: "9.7"
   rootPassword: "yourpassword"
   host: "mysql"
   port: "3306"
@@ -256,6 +256,12 @@ mysql:
   user: "root"
   password: "yourpassword"
   maxConnections: 1024
+  # component_telemetry (available in Community Edition since 9.7 LTS)
+  telemetry:
+    enabled: true
+    otelEndpoint: "http://otel-collector:4318/v1/traces"
+    otelProtocol: "http/protobuf"
+    queryTextEnabled: true
   persistence:
     enabled: false
     # existingClaim: mysql-pvc
@@ -291,6 +297,15 @@ rabbitmq:
       cpu: 1000m
   metrics:
     enabled: false
+  # RabbitMQ 4.0+ native OpenTelemetry plugin — emits server-side spans
+  extraPlugins: "rabbitmq_opentelemetry"
+  extraEnvVars:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: "http://otel-collector:4317"
+    - name: OTEL_EXPORTER_OTLP_PROTOCOL
+      value: "grpc"
+    - name: OTEL_SERVICE_NAME
+      value: "rabbitmq"
 
 # Loadgenerator Configuration
 loadgenerator:

--- a/manifests/helm/trainticket/values.yaml
+++ b/manifests/helm/trainticket/values.yaml
@@ -305,7 +305,7 @@ rabbitmq:
       memory: 1Gi
       cpu: 1000m
   metrics:
-    enabled: false
+    enabled: true # enables rabbitmq_prometheus plugin + exposes svc port 9419 (scraped by the collector's prometheus receiver)
   # NOTE: RabbitMQ has no server-side OpenTelemetry plugin (there is no
   # rabbitmq_opentelemetry tier-1 plugin in any 4.x release — only
   # rabbitmq_prometheus for metrics). RabbitMQ trace continuity is client-side:

--- a/otel-java-agent/Dockerfile
+++ b/otel-java-agent/Dockerfile
@@ -3,8 +3,11 @@ FROM alpine:3.18
 # Install wget to download the file
 RUN apk add --no-cache wget
 
-# Download the Java agent JAR file
-RUN wget -O /javaagent.jar https://repo1.maven.org/maven2/co/elastic/otel/elastic-otel-javaagent/1.4.1/elastic-otel-javaagent-1.4.1.jar
+# Upstream OpenTelemetry Java agent 2.x. Replaces the Elastic distro 1.4.1, which
+# was too old to expose opentelemetry-api/context compatibly with Connector/J 9.7,
+# so the driver could not propagate trace context to the MySQL server.
+ARG OTEL_AGENT_VERSION=2.28.1
+RUN wget -O /javaagent.jar https://repo1.maven.org/maven2/io/opentelemetry/javaagent/opentelemetry-javaagent/${OTEL_AGENT_VERSION}/opentelemetry-javaagent-${OTEL_AGENT_VERSION}.jar
 
 # Verify download and set permissions
 RUN chmod 644 /javaagent.jar

--- a/otel-java-agent/build.sh
+++ b/otel-java-agent/build.sh
@@ -1,2 +1,2 @@
-docker build -t docker.io/opspai/autoinstrumentation-java:elastic .
-docker push docker.io/opspai/autoinstrumentation-java:elastic
+docker build -t docker.io/opspai/autoinstrumentation-java:2.28.1 .
+docker push docker.io/opspai/autoinstrumentation-java:2.28.1

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.services</groupId>
     <artifactId>ts-service</artifactId>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
     <packaging>pom</packaging>
     <name>ts-service-cluster</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,20 @@
             <artifactId>fastjson2</artifactId>
             <version>2.0.43</version>
         </dependency>
+
+        <!-- OpenTelemetry API + Context: required at runtime for MySQL Connector/J 9.7
+             to propagate trace context to the MySQL server. Without these on the
+             classpath, Connector/J silently skips propagation (PREFERRED default).
+             Versions managed by opentelemetry-bom; the OTel javaagent supplies the
+             runtime impl and shadows these on the bootstrap classloader. -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+        </dependency>
     </dependencies>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.services</groupId>
     <artifactId>ts-service</artifactId>
-    <version>0.2.0</version>
+    <version>0.1.0</version>
     <packaging>pom</packaging>
     <name>ts-service-cluster</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -153,16 +153,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!--        MySQL Driver (新坐标，兼容旧坐标)-->
-            <dependency>
-                <groupId>mysql</groupId>
-                <artifactId>mysql-connector-java</artifactId>
-                <version>8.0.33</version>
-            </dependency>
+            <!--        MySQL Connector/J 9.7 — native OTel tracing + context propagation to server -->
             <dependency>
                 <groupId>com.mysql</groupId>
                 <artifactId>mysql-connector-j</artifactId>
-                <version>8.0.33</version>
+                <version>9.7.0</version>
             </dependency>
             <!--        Hibernate Core-->
             <dependency>

--- a/ts-admin-basic-info-service/Dockerfile
+++ b/ts-admin-basic-info-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-admin-basic-info-service/src/main/java/adminbasic/AdminBasicInfoApplication.java
+++ b/ts-admin-basic-info-service/src/main/java/adminbasic/AdminBasicInfoApplication.java
@@ -28,10 +28,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
                     + " contacts"))
 public class AdminBasicInfoApplication {
 
-  private AdminBasicInfoApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(AdminBasicInfoApplication.class, args);
   }

--- a/ts-admin-order-service/Dockerfile
+++ b/ts-admin-order-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-admin-order-service/src/main/java/adminorder/AdminOrderApplication.java
+++ b/ts-admin-order-service/src/main/java/adminorder/AdminOrderApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Admin Order Service for managing orders"))
 public class AdminOrderApplication {
 
-  private AdminOrderApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(AdminOrderApplication.class, args);
   }

--- a/ts-admin-route-service/Dockerfile
+++ b/ts-admin-route-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-admin-route-service/src/main/java/adminroute/AdminRouteApplication.java
+++ b/ts-admin-route-service/src/main/java/adminroute/AdminRouteApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Admin Route Service for managing routes"))
 public class AdminRouteApplication {
 
-  private AdminRouteApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(AdminRouteApplication.class, args);
   }

--- a/ts-admin-travel-service/Dockerfile
+++ b/ts-admin-travel-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-admin-travel-service/src/main/java/admintravel/AdminTravelApplication.java
+++ b/ts-admin-travel-service/src/main/java/admintravel/AdminTravelApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Admin Travel Service for managing travels"))
 public class AdminTravelApplication {
 
-  private AdminTravelApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(AdminTravelApplication.class, args);
   }

--- a/ts-admin-user-service/Dockerfile
+++ b/ts-admin-user-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-admin-user-service/src/main/java/adminuser/AdminUserApplication.java
+++ b/ts-admin-user-service/src/main/java/adminuser/AdminUserApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Admin User Service API"))
 public class AdminUserApplication {
 
-  private AdminUserApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(AdminUserApplication.class, args);
   }

--- a/ts-assurance-service/Dockerfile
+++ b/ts-assurance-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-assurance-service/pom.xml
+++ b/ts-assurance-service/pom.xml
@@ -29,8 +29,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/ts-assurance-service/src/main/java/assurance/AssuranceApplication.java
+++ b/ts-assurance-service/src/main/java/assurance/AssuranceApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Assurance Service - Manage travel assurance"))
 public class AssuranceApplication {
 
-  private AssuranceApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(AssuranceApplication.class, args);
   }

--- a/ts-assurance-service/src/main/resources/application.yml
+++ b/ts-assurance-service/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
   application:
     name: ts-assurance-service
   datasource:
-    url: jdbc:mysql://${ASSURANCE_MYSQL_HOST:ts-assurance-mysql}:${ASSURANCE_MYSQL_PORT:3306}/${ASSURANCE_MYSQL_DATABASE:ts-assurance-mysql}?useUnicode=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=UTC
+    url: jdbc:mysql://${ASSURANCE_MYSQL_HOST:ts-assurance-mysql}:${ASSURANCE_MYSQL_PORT:3306}/${ASSURANCE_MYSQL_DATABASE:ts-assurance-mysql}?useUnicode=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=UTC&openTelemetry=REQUIRED
     username: ${ASSURANCE_MYSQL_USER:root}
     password: ${ASSURANCE_MYSQL_PASSWORD:root}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-auth-service/Dockerfile
+++ b/ts-auth-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-auth-service/pom.xml
+++ b/ts-auth-service/pom.xml
@@ -22,8 +22,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.services</groupId>

--- a/ts-auth-service/src/main/java/auth/AuthApplication.java
+++ b/ts-auth-service/src/main/java/auth/AuthApplication.java
@@ -16,10 +16,6 @@ import org.springframework.context.annotation.Import;
 @Import(RestTemplateConfig.class)
 public class AuthApplication {
 
-  private AuthApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(AuthApplication.class, args);
   }

--- a/ts-basic-service/Dockerfile
+++ b/ts-basic-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-basic-service/src/main/java/fdse/microservice/BasicApplication.java
+++ b/ts-basic-service/src/main/java/fdse/microservice/BasicApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Basic Service - Query basic travel information"))
 public class BasicApplication {
 
-  private BasicApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(BasicApplication.class, args);
   }

--- a/ts-cancel-service/Dockerfile
+++ b/ts-cancel-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-cancel-service/src/main/java/cancel/CancelApplication.java
+++ b/ts-cancel-service/src/main/java/cancel/CancelApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Cancel Service - Cancel tickets"))
 public class CancelApplication {
 
-  private CancelApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(CancelApplication.class, args);
   }

--- a/ts-config-service/Dockerfile
+++ b/ts-config-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-config-service/pom.xml
+++ b/ts-config-service/pom.xml
@@ -33,8 +33,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.services</groupId>

--- a/ts-config-service/src/main/java/config/ConfigApplication.java
+++ b/ts-config-service/src/main/java/config/ConfigApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Config Service - Manage system configurations"))
 public class ConfigApplication {
 
-  private ConfigApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(ConfigApplication.class, args);
   }

--- a/ts-config-service/src/main/resources/application.yml
+++ b/ts-config-service/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: ts-config-service
   datasource:
-    url: jdbc:mysql://${CONFIG_MYSQL_HOST:ts-config-mysql}:${CONFIG_MYSQL_PORT:3306}/${CONFIG_MYSQL_DATABASE:ts-config-mysql}?useSSL=false
+    url: jdbc:mysql://${CONFIG_MYSQL_HOST:ts-config-mysql}:${CONFIG_MYSQL_PORT:3306}/${CONFIG_MYSQL_DATABASE:ts-config-mysql}?useSSL=false&openTelemetry=REQUIRED
     username: ${CONFIG_MYSQL_USER:root}
     password: ${CONFIG_MYSQL_PASSWORD:root}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-consign-price-service/Dockerfile
+++ b/ts-consign-price-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-consign-price-service/pom.xml
+++ b/ts-consign-price-service/pom.xml
@@ -33,8 +33,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.services</groupId>

--- a/ts-consign-price-service/src/main/java/consignprice/ConsignPriceApplication.java
+++ b/ts-consign-price-service/src/main/java/consignprice/ConsignPriceApplication.java
@@ -31,10 +31,6 @@ public class ConsignPriceApplication {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ConsignPriceApplication.class);
 
-  private ConsignPriceApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     ConsignPriceApplication.LOGGER.info(
         "[ConsignPriceApplication.main][launch date: {}]", new Date());

--- a/ts-consign-price-service/src/main/resources/application.yml
+++ b/ts-consign-price-service/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: ts-consign-price-service
   datasource:
-    url: jdbc:mysql://${CONSIGN_PRICE_MYSQL_HOST:ts-consign-price-mysql}:${CONSIGN_PRICE_MYSQL_PORT:3306}/${CONSIGN_PRICE_MYSQL_DATABASE:ts-consign-price-mysql}?useSSL=false
+    url: jdbc:mysql://${CONSIGN_PRICE_MYSQL_HOST:ts-consign-price-mysql}:${CONSIGN_PRICE_MYSQL_PORT:3306}/${CONSIGN_PRICE_MYSQL_DATABASE:ts-consign-price-mysql}?useSSL=false&openTelemetry=REQUIRED
     username: ${CONSIGN_PRICE_MYSQL_USER:root}
     password: ${CONSIGN_PRICE_MYSQL_PASSWORD:Abcd1234#}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-consign-service/Dockerfile
+++ b/ts-consign-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-consign-service/pom.xml
+++ b/ts-consign-service/pom.xml
@@ -29,8 +29,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/ts-consign-service/src/main/java/consign/ConsignApplication.java
+++ b/ts-consign-service/src/main/java/consign/ConsignApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Consign Service - Manage consignments"))
 public class ConsignApplication {
 
-  private ConsignApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(ConsignApplication.class, args);
   }

--- a/ts-consign-service/src/main/resources/application.yml
+++ b/ts-consign-service/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: ts-consign-service
   datasource:
-    url: jdbc:mysql://${CONSIGN_MYSQL_HOST:ts-consign-mysql}:${CONSIGN_MYSQL_PORT:3306}/${CONSIGN_MYSQL_DATABASE:ts-consign-mysql}?useUnicode=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=UTC
+    url: jdbc:mysql://${CONSIGN_MYSQL_HOST:ts-consign-mysql}:${CONSIGN_MYSQL_PORT:3306}/${CONSIGN_MYSQL_DATABASE:ts-consign-mysql}?useUnicode=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=UTC&openTelemetry=REQUIRED
     username: ${CONSIGN_MYSQL_USER:root}
     password: ${CONSIGN_MYSQL_PASSWORD:root}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-contacts-service/Dockerfile
+++ b/ts-contacts-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-contacts-service/pom.xml
+++ b/ts-contacts-service/pom.xml
@@ -33,8 +33,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.services</groupId>

--- a/ts-contacts-service/src/main/java/contacts/ContactsApplication.java
+++ b/ts-contacts-service/src/main/java/contacts/ContactsApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Contacts Service - Manage passenger contacts"))
 public class ContactsApplication {
 
-  private ContactsApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(ContactsApplication.class, args);
   }

--- a/ts-contacts-service/src/main/resources/application.yml
+++ b/ts-contacts-service/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   application:
     name: ts-contacts-service
   datasource:
-    url: jdbc:mysql://${CONTACTS_MYSQL_HOST:ts-contacts-mysql}:${CONTACTS_MYSQL_PORT:3306}/${CONTACTS_MYSQL_DATABASE:ts-contacts-mysql}?useSSL=false
+    url: jdbc:mysql://${CONTACTS_MYSQL_HOST:ts-contacts-mysql}:${CONTACTS_MYSQL_PORT:3306}/${CONTACTS_MYSQL_DATABASE:ts-contacts-mysql}?useSSL=false&openTelemetry=REQUIRED
     username: ${CONTACTS_MYSQL_USER:root}
     password: ${CONTACTS_MYSQL_PASSWORD:Abcd1234#}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-delivery-service/Dockerfile
+++ b/ts-delivery-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-delivery-service/pom.xml
+++ b/ts-delivery-service/pom.xml
@@ -31,8 +31,8 @@
         </dependency>
 
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/ts-delivery-service/src/main/java/delivery/DeliveryApplication.java
+++ b/ts-delivery-service/src/main/java/delivery/DeliveryApplication.java
@@ -20,10 +20,6 @@ import org.springframework.context.annotation.Import;
             description = "Delivery Service API"))
 public class DeliveryApplication {
 
-  private DeliveryApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(DeliveryApplication.class, args);
   }

--- a/ts-delivery-service/src/main/resources/application.yml
+++ b/ts-delivery-service/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   application:
     name: ts-delivery-service
   datasource:
-    url: jdbc:mysql://${DELIVERY_MYSQL_HOST:ts-delivery-mysql}:${DELIVERY_MYSQL_PORT:3306}/${DELIVERY_MYSQL_DATABASE:ts-delivery-mysql}?useSSL=false
+    url: jdbc:mysql://${DELIVERY_MYSQL_HOST:ts-delivery-mysql}:${DELIVERY_MYSQL_PORT:3306}/${DELIVERY_MYSQL_DATABASE:ts-delivery-mysql}?useSSL=false&openTelemetry=REQUIRED
     username: ${DELIVERY_MYSQL_USER:root}
     password: ${DELIVERY_MYSQL_PASSWORD:Abcd1234#}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-execute-service/Dockerfile
+++ b/ts-execute-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-execute-service/src/main/java/execute/ExecuteApplication.java
+++ b/ts-execute-service/src/main/java/execute/ExecuteApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Execute Service - Execute orders"))
 public class ExecuteApplication {
 
-  private ExecuteApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(ExecuteApplication.class, args);
   }

--- a/ts-food-delivery-service/Dockerfile
+++ b/ts-food-delivery-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-food-delivery-service/pom.xml
+++ b/ts-food-delivery-service/pom.xml
@@ -29,8 +29,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.services</groupId>

--- a/ts-food-delivery-service/src/main/java/food_delivery/FoodDeliveryApplication.java
+++ b/ts-food-delivery-service/src/main/java/food_delivery/FoodDeliveryApplication.java
@@ -23,10 +23,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Food Delivery Service API"))
 public class FoodDeliveryApplication {
 
-  private FoodDeliveryApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(FoodDeliveryApplication.class, args);
   }

--- a/ts-food-delivery-service/src/main/resources/application.yml
+++ b/ts-food-delivery-service/src/main/resources/application.yml
@@ -4,8 +4,8 @@ spring:
   application:
     name: ts-food-delivery-service
   datasource:
-#    url: jdbc:mysql://localhost:30001/ts-food-delivery-mysql?useSSL=false
-    url: jdbc:mysql://${FOOD_DELIVERY_MYSQL_HOST:ts-food-delivery-mysql}:${FOOD_DELIVERY_MYSQL_PORT:3306}/${FOOD_DELIVERY_MYSQL_DATABASE:ts-food-delivery-mysql}?useSSL=false
+#    url: jdbc:mysql://localhost:30001/ts-food-delivery-mysql?useSSL=false&openTelemetry=REQUIRED
+    url: jdbc:mysql://${FOOD_DELIVERY_MYSQL_HOST:ts-food-delivery-mysql}:${FOOD_DELIVERY_MYSQL_PORT:3306}/${FOOD_DELIVERY_MYSQL_DATABASE:ts-food-delivery-mysql}?useSSL=false&openTelemetry=REQUIRED
     username: ${FOOD_DELIVERY_MYSQL_USER:root}
     password: ${FOOD_DELIVERY_MYSQL_PASSWORD:root}
     driver-class-name: com.mysql.jdbc.Driver

--- a/ts-food-service/Dockerfile
+++ b/ts-food-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-food-service/pom.xml
+++ b/ts-food-service/pom.xml
@@ -29,8 +29,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/ts-food-service/src/main/java/foodsearch/FoodApplication.java
+++ b/ts-food-service/src/main/java/foodsearch/FoodApplication.java
@@ -19,10 +19,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @IntegrationComponentScan
 public class FoodApplication {
 
-  private FoodApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(FoodApplication.class, args);
   }

--- a/ts-food-service/src/main/resources/application.yml
+++ b/ts-food-service/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   application:
     name: ts-food-service
   datasource:
-    url: jdbc:mysql://${FOOD_MYSQL_HOST:ts-food-mysql}:${FOOD_MYSQL_PORT:3306}/${FOOD_MYSQL_DATABASE:ts-food-mysql}?useSSL=false
+    url: jdbc:mysql://${FOOD_MYSQL_HOST:ts-food-mysql}:${FOOD_MYSQL_PORT:3306}/${FOOD_MYSQL_DATABASE:ts-food-mysql}?useSSL=false&openTelemetry=REQUIRED
     username: ${FOOD_MYSQL_USER:root}
     password: ${FOOD_MYSQL_PASSWORD:root}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-inside-payment-service/Dockerfile
+++ b/ts-inside-payment-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-inside-payment-service/pom.xml
+++ b/ts-inside-payment-service/pom.xml
@@ -31,8 +31,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/ts-inside-payment-service/src/main/java/inside_payment/InsidePaymentApplication.java
+++ b/ts-inside-payment-service/src/main/java/inside_payment/InsidePaymentApplication.java
@@ -22,10 +22,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @IntegrationComponentScan
 public class InsidePaymentApplication {
 
-  private InsidePaymentApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(InsidePaymentApplication.class, args);
   }

--- a/ts-inside-payment-service/src/main/resources/application.yml
+++ b/ts-inside-payment-service/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     name: ts-inside-payment-service
 
   datasource:
-    url: jdbc:mysql://${INSIDE_PAYMENT_MYSQL_HOST:ts-inside-payment-mysql}:${INSIDE_PAYMENT_MYSQL_PORT:3306}/${INSIDE_PAYMENT_MYSQL_DATABASE:ts-inside-payment-mysql}?useSSL=false
+    url: jdbc:mysql://${INSIDE_PAYMENT_MYSQL_HOST:ts-inside-payment-mysql}:${INSIDE_PAYMENT_MYSQL_PORT:3306}/${INSIDE_PAYMENT_MYSQL_DATABASE:ts-inside-payment-mysql}?useSSL=false&openTelemetry=REQUIRED
     username: ${INSIDE_PAYMENT_MYSQL_USER:root}
     password: ${INSIDE_PAYMENT_MYSQL_PASSWORD:Abcd1234#}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-notification-service/Dockerfile
+++ b/ts-notification-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-notification-service/pom.xml
+++ b/ts-notification-service/pom.xml
@@ -47,8 +47,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
 		</dependency>
     </dependencies>

--- a/ts-notification-service/src/main/java/notification/NotificationApplication.java
+++ b/ts-notification-service/src/main/java/notification/NotificationApplication.java
@@ -16,10 +16,6 @@ import org.springframework.context.annotation.Import;
 @Import(RestTemplateConfig.class)
 public class NotificationApplication {
 
-  private NotificationApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(NotificationApplication.class, args);
   }

--- a/ts-notification-service/src/main/resources/application.yml
+++ b/ts-notification-service/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
             enable: true
             required: true
   datasource:
-    url: jdbc:mysql://${NOTIFICATION_MYSQL_HOST:ts-notification-mysql}:${NOTIFICATION_MYSQL_PORT:3306}/${NOTIFICATION_MYSQL_DATABASE:ts-notification-mysql}?useSSL=false
+    url: jdbc:mysql://${NOTIFICATION_MYSQL_HOST:ts-notification-mysql}:${NOTIFICATION_MYSQL_PORT:3306}/${NOTIFICATION_MYSQL_DATABASE:ts-notification-mysql}?useSSL=false&openTelemetry=REQUIRED
     username: ${NOTIFICATION_MYSQL_USER:root}
     password: ${NOTIFICATION_MYSQL_PASSWORD:root}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-order-other-service/Dockerfile
+++ b/ts-order-other-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-order-other-service/pom.xml
+++ b/ts-order-other-service/pom.xml
@@ -29,8 +29,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.services</groupId>

--- a/ts-order-other-service/src/main/java/other/OrderOtherApplication.java
+++ b/ts-order-other-service/src/main/java/other/OrderOtherApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Order Other Service - Manage other ticket orders"))
 public class OrderOtherApplication {
 
-  private OrderOtherApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
 
     SpringApplication.run(OrderOtherApplication.class, args);

--- a/ts-order-other-service/src/main/resources/application.yml
+++ b/ts-order-other-service/src/main/resources/application.yml
@@ -6,8 +6,8 @@ spring:
   application:
     name: ts-order-other-service
   datasource:
-#    url: jdbc:mysql://localhost:3306/ts-order-other-mysql?useSSL=false
-    url: jdbc:mysql://${ORDER_OTHER_MYSQL_HOST:ts-order-other-mysql}:${ORDER_OTHER_MYSQL_PORT:3306}/${ORDER_OTHER_MYSQL_DATABASE:ts-order-other-mysql}?useSSL=false
+#    url: jdbc:mysql://localhost:3306/ts-order-other-mysql?useSSL=false&openTelemetry=REQUIRED
+    url: jdbc:mysql://${ORDER_OTHER_MYSQL_HOST:ts-order-other-mysql}:${ORDER_OTHER_MYSQL_PORT:3306}/${ORDER_OTHER_MYSQL_DATABASE:ts-order-other-mysql}?useSSL=false&openTelemetry=REQUIRED
     username: ${ORDER_OTHER_MYSQL_USER:root}
     password: ${ORDER_OTHER_MYSQL_PASSWORD:root}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-order-service/Dockerfile
+++ b/ts-order-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-order-service/pom.xml
+++ b/ts-order-service/pom.xml
@@ -33,8 +33,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.services</groupId>

--- a/ts-order-service/src/main/java/order/OrderApplication.java
+++ b/ts-order-service/src/main/java/order/OrderApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Order Service - Manage ticket orders"))
 public class OrderApplication {
 
-  private OrderApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(OrderApplication.class, args);
   }

--- a/ts-order-service/src/main/resources/application.yml
+++ b/ts-order-service/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
   application:
     name: ts-order-service
   datasource:
-    url: jdbc:mysql://${ORDER_MYSQL_HOST:10.176.122.1}:${ORDER_MYSQL_PORT:3306}/${ORDER_MYSQL_DATABASE:ts}?useSSL=false
+    url: jdbc:mysql://${ORDER_MYSQL_HOST:10.176.122.1}:${ORDER_MYSQL_PORT:3306}/${ORDER_MYSQL_DATABASE:ts}?useSSL=false&openTelemetry=REQUIRED
     username: ${ORDER_MYSQL_USER:root}
     password: ${ORDER_MYSQL_PASSWORD:Abcd1234#}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-payment-service/Dockerfile
+++ b/ts-payment-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-payment-service/pom.xml
+++ b/ts-payment-service/pom.xml
@@ -29,8 +29,8 @@
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>

--- a/ts-payment-service/src/main/java/com/trainticket/PaymentApplication.java
+++ b/ts-payment-service/src/main/java/com/trainticket/PaymentApplication.java
@@ -22,10 +22,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @IntegrationComponentScan
 public class PaymentApplication {
 
-  private PaymentApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(PaymentApplication.class, args);
   }

--- a/ts-payment-service/src/main/resources/application.yml
+++ b/ts-payment-service/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
   application:
     name: ts-payment-service
   datasource:
-    url: jdbc:mysql://${PAYMENT_MYSQL_HOST:ts-payment-mysql}:${PAYMENT_MYSQL_PORT:3306}/${PAYMENT_MYSQL_DATABASE:ts-payment-mysql}?useUnicode=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=UTC
+    url: jdbc:mysql://${PAYMENT_MYSQL_HOST:ts-payment-mysql}:${PAYMENT_MYSQL_PORT:3306}/${PAYMENT_MYSQL_DATABASE:ts-payment-mysql}?useUnicode=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=UTC&openTelemetry=REQUIRED
     username: ${PAYMENT_MYSQL_USER:root}
     password: ${PAYMENT_MYSQL_PASSWORD:Abcd1234#}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-preserve-other-service/Dockerfile
+++ b/ts-preserve-other-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-preserve-other-service/src/main/java/preserveOther/PreserveOtherApplication.java
+++ b/ts-preserve-other-service/src/main/java/preserveOther/PreserveOtherApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Preserve Other Service - Preserve tickets (type 2)"))
 public class PreserveOtherApplication {
 
-  private PreserveOtherApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
 
     SpringApplication.run(PreserveOtherApplication.class, args);

--- a/ts-preserve-service/Dockerfile
+++ b/ts-preserve-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-preserve-service/src/main/java/preserve/PreserveApplication.java
+++ b/ts-preserve-service/src/main/java/preserve/PreserveApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Preserve Service - Preserve tickets"))
 public class PreserveApplication {
 
-  private PreserveApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(PreserveApplication.class, args);
   }

--- a/ts-price-service/Dockerfile
+++ b/ts-price-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-price-service/pom.xml
+++ b/ts-price-service/pom.xml
@@ -34,13 +34,8 @@
             <artifactId>hibernate-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/ts-price-service/src/main/java/price/PriceApplication.java
+++ b/ts-price-service/src/main/java/price/PriceApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Price Service - Manage ticket prices"))
 public class PriceApplication {
 
-  private PriceApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(PriceApplication.class, args);
   }

--- a/ts-price-service/src/main/resources/application.yml
+++ b/ts-price-service/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: ts-price-service
   datasource:
-    url: jdbc:mysql://${PRICE_MYSQL_HOST:10.176.122.1}:${PRICE_MYSQL_PORT:3306}/${PRICE_MYSQL_DATABASE:ts}?useSSL=false
+    url: jdbc:mysql://${PRICE_MYSQL_HOST:10.176.122.1}:${PRICE_MYSQL_PORT:3306}/${PRICE_MYSQL_DATABASE:ts}?useSSL=false&openTelemetry=REQUIRED
     username: ${PRICE_MYSQL_USER:root}
     password: ${PRICE_MYSQL_PASSWORD:Abcd1234#}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-rebook-service/Dockerfile
+++ b/ts-rebook-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-rebook-service/src/main/java/rebook/RebookApplication.java
+++ b/ts-rebook-service/src/main/java/rebook/RebookApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Rebook Service - Rebook tickets"))
 public class RebookApplication {
 
-  private RebookApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(RebookApplication.class, args);
   }

--- a/ts-route-plan-service/Dockerfile
+++ b/ts-route-plan-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-route-plan-service/src/main/java/plan/RoutePlanApplication.java
+++ b/ts-route-plan-service/src/main/java/plan/RoutePlanApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Route Plan Service - Plan travel routes"))
 public class RoutePlanApplication {
 
-  private RoutePlanApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(RoutePlanApplication.class, args);
   }

--- a/ts-route-service/Dockerfile
+++ b/ts-route-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-route-service/pom.xml
+++ b/ts-route-service/pom.xml
@@ -29,8 +29,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.services</groupId>

--- a/ts-route-service/src/main/java/route/RouteApplication.java
+++ b/ts-route-service/src/main/java/route/RouteApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Route Service - Manage route information"))
 public class RouteApplication {
 
-  private RouteApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(RouteApplication.class, args);
   }

--- a/ts-route-service/src/main/resources/application.yml
+++ b/ts-route-service/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: ts-route-service
   datasource:
-    url: jdbc:mysql://${ROUTE_MYSQL_HOST:10.176.122.1}:${ROUTE_MYSQL_PORT:3306}/${ROUTE_MYSQL_DATABASE:ts}?useSSL=false
+    url: jdbc:mysql://${ROUTE_MYSQL_HOST:10.176.122.1}:${ROUTE_MYSQL_PORT:3306}/${ROUTE_MYSQL_DATABASE:ts}?useSSL=false&openTelemetry=REQUIRED
     username: ${ROUTE_MYSQL_USER:root}
     password: ${ROUTE_MYSQL_PASSWORD:Abcd1234#}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-seat-service/Dockerfile
+++ b/ts-seat-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-seat-service/src/main/java/seat/SeatApplication.java
+++ b/ts-seat-service/src/main/java/seat/SeatApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Seat Service - Manage seat availability"))
 public class SeatApplication {
 
-  private SeatApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(SeatApplication.class, args);
   }

--- a/ts-security-service/Dockerfile
+++ b/ts-security-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-security-service/pom.xml
+++ b/ts-security-service/pom.xml
@@ -29,8 +29,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.services</groupId>

--- a/ts-security-service/src/main/java/security/SecurityApplication.java
+++ b/ts-security-service/src/main/java/security/SecurityApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Security Service - Security checks"))
 public class SecurityApplication {
 
-  private SecurityApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(SecurityApplication.class, args);
   }

--- a/ts-security-service/src/main/resources/application.yml
+++ b/ts-security-service/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: ts-security-service
 
   datasource:
-    url: jdbc:mysql://${SECURITY_MYSQL_HOST:ts-security-mysql}:${SECURITY_MYSQL_PORT:3306}/${SECURITY_MYSQL_DATABASE:ts-security-mysql}?useSSL=false
+    url: jdbc:mysql://${SECURITY_MYSQL_HOST:ts-security-mysql}:${SECURITY_MYSQL_PORT:3306}/${SECURITY_MYSQL_DATABASE:ts-security-mysql}?useSSL=false&openTelemetry=REQUIRED
     username: ${SECURITY_MYSQL_USER:root}
     password: ${SECURITY_MYSQL_PASSWORD:root}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-station-food-service/Dockerfile
+++ b/ts-station-food-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-station-food-service/pom.xml
+++ b/ts-station-food-service/pom.xml
@@ -29,8 +29,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.services</groupId>

--- a/ts-station-food-service/src/main/java/food/StationFoodApplication.java
+++ b/ts-station-food-service/src/main/java/food/StationFoodApplication.java
@@ -23,10 +23,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Station Food Service API"))
 public class StationFoodApplication {
 
-  private StationFoodApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(StationFoodApplication.class, args);
   }

--- a/ts-station-food-service/src/main/resources/application.yml
+++ b/ts-station-food-service/src/main/resources/application.yml
@@ -5,8 +5,8 @@ spring:
   application:
     name: ts-station-food-service
   datasource:
-#    url: jdbc:mysql://localhost:3306/ts-station-food-mysql?useSSL=false
-    url: jdbc:mysql://${STATION_FOOD_MYSQL_HOST:10.176.122.1}:${STATION_FOOD_MYSQL_PORT:3306}/${STATION_FOOD_MYSQL_DATABASE:ts}?useSSL=false
+#    url: jdbc:mysql://localhost:3306/ts-station-food-mysql?useSSL=false&openTelemetry=REQUIRED
+    url: jdbc:mysql://${STATION_FOOD_MYSQL_HOST:10.176.122.1}:${STATION_FOOD_MYSQL_PORT:3306}/${STATION_FOOD_MYSQL_DATABASE:ts}?useSSL=false&openTelemetry=REQUIRED
     username: ${STATION_FOOD_MYSQL_USER:root}
     password: ${STATION_FOOD_MYSQL_PASSWORD:Abcd1234#}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-station-service/Dockerfile
+++ b/ts-station-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-station-service/pom.xml
+++ b/ts-station-service/pom.xml
@@ -34,8 +34,8 @@
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.services</groupId>

--- a/ts-station-service/src/main/java/fdse/microservice/StationApplication.java
+++ b/ts-station-service/src/main/java/fdse/microservice/StationApplication.java
@@ -23,10 +23,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Station Service - Manage station information"))
 public class StationApplication {
 
-  private StationApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(StationApplication.class, args);
   }

--- a/ts-station-service/src/main/resources/application.yml
+++ b/ts-station-service/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: ts-station-service
   datasource:
-    url: jdbc:mysql://${STATION_MYSQL_HOST:ts-station-mysql}:${STATION_MYSQL_PORT:3306}/${STATION_MYSQL_DATABASE:ts-station-mysql}?useSSL=false
+    url: jdbc:mysql://${STATION_MYSQL_HOST:ts-station-mysql}:${STATION_MYSQL_PORT:3306}/${STATION_MYSQL_DATABASE:ts-station-mysql}?useSSL=false&openTelemetry=REQUIRED
     username: ${STATION_MYSQL_USER:root}
     password: ${STATION_MYSQL_PASSWORD:Abcd1234#}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-train-food-service/Dockerfile
+++ b/ts-train-food-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-train-food-service/pom.xml
+++ b/ts-train-food-service/pom.xml
@@ -18,8 +18,8 @@
             <version>0.1.0</version>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/ts-train-food-service/src/main/java/trainFood/TrainFoodApplication.java
+++ b/ts-train-food-service/src/main/java/trainFood/TrainFoodApplication.java
@@ -23,10 +23,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Food Service API"))
 public class TrainFoodApplication {
 
-  private TrainFoodApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(TrainFoodApplication.class, args);
   }

--- a/ts-train-food-service/src/main/resources/application.yml
+++ b/ts-train-food-service/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   application:
     name: ts-train-food-service
   datasource:
-    url: jdbc:mysql://${TRAIN_FOOD_MYSQL_HOST:ts-train-food-mysql}:${TRAIN_FOOD_MYSQL_PORT:3306}/${TRAIN_FOOD_MYSQL_DATABASE:ts-train-food-mysql}?useSSL=false
+    url: jdbc:mysql://${TRAIN_FOOD_MYSQL_HOST:ts-train-food-mysql}:${TRAIN_FOOD_MYSQL_PORT:3306}/${TRAIN_FOOD_MYSQL_DATABASE:ts-train-food-mysql}?useSSL=false&openTelemetry=REQUIRED
     username: ${TRAIN_FOOD_MYSQL_USER:root}
     password: ${TRAIN_FOOD_MYSQL_PASSWORD:root}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-train-service/Dockerfile
+++ b/ts-train-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-train-service/pom.xml
+++ b/ts-train-service/pom.xml
@@ -33,8 +33,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.services</groupId>

--- a/ts-train-service/src/main/java/train/TrainApplication.java
+++ b/ts-train-service/src/main/java/train/TrainApplication.java
@@ -23,10 +23,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Train Service - Manage train type information"))
 public class TrainApplication {
 
-  private TrainApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(TrainApplication.class, args);
   }

--- a/ts-train-service/src/main/resources/application.yml
+++ b/ts-train-service/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: ts-train-service
   datasource:
-    url: jdbc:mysql://${TRAIN_MYSQL_HOST:ts-train-mysql}:${TRAIN_MYSQL_PORT:3306}/${TRAIN_MYSQL_DATABASE:s-train-mysql}?useSSL=false
+    url: jdbc:mysql://${TRAIN_MYSQL_HOST:ts-train-mysql}:${TRAIN_MYSQL_PORT:3306}/${TRAIN_MYSQL_DATABASE:s-train-mysql}?useSSL=false&openTelemetry=REQUIRED
     username: ${TRAIN_MYSQL_USER:root}
     password: ${TRAIN_MYSQL_PASSWORD:Abcd1234#}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-travel-plan-service/Dockerfile
+++ b/ts-travel-plan-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-travel-plan-service/src/main/java/travelplan/TravelPlanApplication.java
+++ b/ts-travel-plan-service/src/main/java/travelplan/TravelPlanApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Travel Plan Service - Plan travels"))
 public class TravelPlanApplication {
 
-  private TravelPlanApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(TravelPlanApplication.class, args);
   }

--- a/ts-travel-service/Dockerfile
+++ b/ts-travel-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-travel-service/pom.xml
+++ b/ts-travel-service/pom.xml
@@ -30,8 +30,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/ts-travel-service/src/main/java/travel/TravelApplication.java
+++ b/ts-travel-service/src/main/java/travel/TravelApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Travel Service - Manage travel trips"))
 public class TravelApplication {
 
-  private TravelApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(TravelApplication.class, args);
   }

--- a/ts-travel-service/src/main/resources/application.yml
+++ b/ts-travel-service/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
   application:
     name: ts-travel-service
   datasource:
-    url: jdbc:mysql://${TRAVEL_MYSQL_HOST:ts-travel-mysql}:${TRAVEL_MYSQL_PORT:3306}/${TRAVEL_MYSQL_DATABASE:ts-travel-mysql}?useSSL=false
+    url: jdbc:mysql://${TRAVEL_MYSQL_HOST:ts-travel-mysql}:${TRAVEL_MYSQL_PORT:3306}/${TRAVEL_MYSQL_DATABASE:ts-travel-mysql}?useSSL=false&openTelemetry=REQUIRED
     username: ${TRAVEL_MYSQL_USER:root}
     password: ${TRAVEL_MYSQL_PASSWORD:root}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-travel2-service/Dockerfile
+++ b/ts-travel2-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-travel2-service/pom.xml
+++ b/ts-travel2-service/pom.xml
@@ -31,8 +31,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/ts-travel2-service/src/main/java/travel2/Travel2Application.java
+++ b/ts-travel2-service/src/main/java/travel2/Travel2Application.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Travel2 Service - Manage travel trips (type 2)"))
 public class Travel2Application {
 
-  private Travel2Application() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(Travel2Application.class, args);
   }

--- a/ts-travel2-service/src/main/resources/application.yml
+++ b/ts-travel2-service/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
   application:
     name: ts-travel2-service
   datasource:
-    url: jdbc:mysql://${TRAVEL2_MYSQL_HOST:ts-travel2-mysql}:${TRAVEL2_MYSQL_PORT:3306}/${TRAVEL2_MYSQL_DATABASE:ts-travel2-mysql}?useSSL=false
+    url: jdbc:mysql://${TRAVEL2_MYSQL_HOST:ts-travel2-mysql}:${TRAVEL2_MYSQL_PORT:3306}/${TRAVEL2_MYSQL_DATABASE:ts-travel2-mysql}?useSSL=false&openTelemetry=REQUIRED
     username: ${TRAVEL2_MYSQL_USER:root}
     password: ${TRAVEL2_MYSQL_PASSWORD:Abcd1234#}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/ts-user-service/Dockerfile
+++ b/ts-user-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-user-service/pom.xml
+++ b/ts-user-service/pom.xml
@@ -26,8 +26,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.services</groupId>

--- a/ts-user-service/src/main/java/user/UserApplication.java
+++ b/ts-user-service/src/main/java/user/UserApplication.java
@@ -26,10 +26,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket User Service - Manage users"))
 public class UserApplication {
 
-  private UserApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(UserApplication.class, args);
   }

--- a/ts-verification-code-service/Dockerfile
+++ b/ts-verification-code-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-verification-code-service/src/main/java/verifycode/VerifyCodeApplication.java
+++ b/ts-verification-code-service/src/main/java/verifycode/VerifyCodeApplication.java
@@ -16,10 +16,6 @@ import org.springframework.context.annotation.Import;
 @Import(RestTemplateConfig.class)
 public class VerifyCodeApplication {
 
-  private VerifyCodeApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(VerifyCodeApplication.class, args);
   }

--- a/ts-wait-order-service/Dockerfile
+++ b/ts-wait-order-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/opspai/autoinstrumentation-java:elastic as agent
+FROM docker.io/opspai/autoinstrumentation-java:2.28.1 as agent
 FROM  eclipse-temurin:17-jre
 WORKDIR /app
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/ts-wait-order-service/pom.xml
+++ b/ts-wait-order-service/pom.xml
@@ -29,8 +29,8 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.services</groupId>

--- a/ts-wait-order-service/src/main/java/waitorder/WaitOrderApplication.java
+++ b/ts-wait-order-service/src/main/java/waitorder/WaitOrderApplication.java
@@ -23,10 +23,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
             description = "Train Ticket Wait Order Service - Manage waitlist orders"))
 public class WaitOrderApplication {
 
-  private WaitOrderApplication() {
-    // Private constructor to prevent instantiation
-  }
-
   public static void main(String[] args) {
     SpringApplication.run(WaitOrderApplication.class, args);
   }

--- a/ts-wait-order-service/src/main/resources/application.yml
+++ b/ts-wait-order-service/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
   application:
     name: ts-wait-order-service
   datasource:
-    url: jdbc:mysql://${WAIT_ORDER_MYSQL_HOST:10.176.122.1}:${WAIT_ORDER_MYSQL_PORT:3306}/${WAIT_ORDER_MYSQL_DATABASE:ts}?useSSL=false
+    url: jdbc:mysql://${WAIT_ORDER_MYSQL_HOST:10.176.122.1}:${WAIT_ORDER_MYSQL_PORT:3306}/${WAIT_ORDER_MYSQL_DATABASE:ts}?useSSL=false&openTelemetry=REQUIRED
     username: ${WAIT_ORDER_MYSQL_USER:root}
     password: ${WAIT_ORDER_MYSQL_PASSWORD:Abcd1234#}
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## Summary

End-to-end OpenTelemetry observability for the data tier: **MySQL server-side telemetry** (traces + metrics + logs) with **distributed trace continuity** into the application trace via Connector/J, plus **RabbitMQ** metrics and client-side AMQP tracing. Chart `0.3.x → 0.4.4`, Maven `0.1.0 → 0.2.0`.

## MySQL (`component_telemetry`, server 9.7)

- Server 5.7 → **9.7**; `INSTALL COMPONENT 'file://component_telemetry'` in initdb, with telemetry endpoint vars written via `SET PERSIST_ONLY` (they are non-dynamic, so they re-apply when the component auto-loads on the entrypoint's post-initdb restart).
- All three signals (`traces` / `metrics` / `logs`) pushed natively over OTLP/HTTP to the per-namespace collector (`:4318`). The collector deliberately has **no** `mysqlreceiver` — native push already covers metrics; a pull receiver would double-export.
- **Trace continuity**: Connector/J migrated `mysql:mysql-connector-java:8.0.33` → `com.mysql:mysql-connector-j:9.7.0`, which propagates the W3C `traceparent` as a MySQL query attribute. The server's `component_telemetry` then parents its `stmt` spans under the application span, so `app → JDBC → mysqld` lands in a single trace.
- The OTel Java agent's JDBC auto-instrumentation is disabled (`-Dotel.instrumentation.jdbc.enabled=false`): the agent's auto-JDBC layer cannot propagate context to the DB, so Connector/J's native instrumentation owns it instead.

## RabbitMQ

- **No server-side OTel plugin.** There is no `rabbitmq_opentelemetry` tier-1 plugin in any 4.x release; enabling it left RabbitMQ logging `plugins currently enabled but missing`. Dropped.
- **Metrics** via the built-in `rabbitmq_prometheus` plugin (svc `:9419`), scraped by the collector's `prometheus` receiver. This replaces the contrib `rabbitmqreceiver`, which emitted a metric the ClickHouse exporter rejected with `metrics type is unset`, poisoning the entire metrics batch into permanent retry.
- **Tracing** is client-side: the OTel Java agent instruments Spring AMQP, injecting `traceparent` into AMQP headers on publish and extracting on consume — producer→consumer spans link with zero broker config.

## OTel Java agent — bumped to `2.28.1`

`autoinstrumentation-java:elastic` → **`2.28.1`**. This is **required** for MySQL trace continuity: Connector/J's OpenTelemetry mode defaults to `PREFERRED`-but-silent, so it only propagates when a usable `opentelemetry-api` is on the runtime classpath. The old `elastic` (1.4.1) build did not expose a compatible API, so Connector/J silently skipped propagation and every `mysqld` span was an orphan root. 2.28.1 fixes it.

## Fix history (0.4.0 → 0.4.4)

- **0.4.0** — initial MySQL server-side traces + (bogus) RabbitMQ OTel plugin
- **0.4.1** — MySQL native metrics + logs; OTLP endpoints derived from `global.otelcollectorHttp`
- **0.4.3** — drop the bogus RabbitMQ plugin + poison-batch receiver → `rabbitmq_prometheus`; **remove private constructors from `@SpringBootApplication` main classes** (Spring Boot 3.2 + cglib was failing with `IllegalArgumentException: No visible constructors`, crash-looping every service on startup)
- **0.4.4** — enable Connector/J trace-context propagation (agent `2.28.1`)

## Verification (throwaway namespace, full 40-service stack)

chart `0.4.4` + service images `0.4.4` + agent `2.28.1`:

| Check | Result |
|---|---|
| Services healthy | 45/45 (the `No visible constructors` startup crash is fixed) |
| MySQL spans / metrics / logs | ✅ |
| **MySQL ↔ app trace continuity** | ✅ 712 linked traces; ~83% of `mysqld` spans parented (orphans are non-query ops like `PING`, expected) |
| RabbitMQ metrics (`rabbitmq_prometheus`) | ✅ |
| RabbitMQ AMQP trace | ✅ `ts-food-service` publish → `ts-delivery-service` process |

Example linked trace: `ts-inside-payment-service` (Connector/J `Create connection` / `Set variable` **client** spans) → `mysqld stmt` **server** spans, all under one trace id.

## Deployment notes

- `mysql:9.7` must be reachable from the cluster (mirror it where docker.io is not directly pullable).
- The Bitnami rabbitmq image guard requires `global.security.allowInsecureImages=true` (set in chart values).