### PR TITLE
Add GitHub CLI to agent env image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -90,11 +90,15 @@ RUN install -m 0755 -d /etc/apt/keyrings \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && chmod a+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         docker-buildx-plugin \
         docker-ce-cli \
         docker-compose-plugin \
+        gh \
         nodejs \
     && npm config set registry https://registry.npmmirror.com \
     && npm install -g "typescript@${TYPESCRIPT_VERSION}" \

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -12,7 +12,8 @@ Included tools:
 - Python 3 and uv, for scripting or Python services.
 - rustup stable, Cargo, rustfmt, and clippy, for Axum invariant-heavy service
   skeletons.
-- Docker CLI, kubectl, Helm, Skaffold, yq, jq, git-lfs, and rsync.
+- Docker CLI, GitHub CLI (`gh`), kubectl, Helm, Skaffold, yq, jq, git-lfs,
+  and rsync.
 
 ## Build
 

--- a/.devcontainer/scripts/check.sh
+++ b/.devcontainer/scripts/check.sh
@@ -11,7 +11,7 @@ require_tool() {
   fi
 }
 
-for tool in git python3 java mvn go node npm tsc pip3 uv rustc cargo; do
+for tool in git gh python3 java mvn go node npm tsc pip3 uv rustc cargo; do
   require_tool "${tool}"
 done
 
@@ -25,7 +25,7 @@ test -f project-index.yaml
 test -x scripts/check-skeleton.py
 
 python3 --version
-for cmd in java mvn go node npm tsc pip3 uv rustc cargo jq yq helm kubectl skaffold docker; do
+for cmd in java mvn go node npm tsc pip3 uv rustc cargo gh jq yq helm kubectl skaffold docker; do
   if command -v "${cmd}" >/dev/null 2>&1; then
     case "${cmd}" in
       java)


### PR DESCRIPTION
## Summary
- install GitHub CLI in the devcontainer base image
- require and report gh in the devcontainer smoke check
- document gh as part of the operational toolchain

## Validation
- make build-agent-env-image
- docker run --rm train-ticket-agent-env:local bash -lc 'gh --version | head -n 1 && .devcontainer/scripts/check.sh'