### PR TITLE
Add WorkGraph smoke B marker

### DIFF
--- a/docs/workgraph-smoke-b-20260703151610.md
+++ b/docs/workgraph-smoke-b-20260703151610.md
@@ -1,0 +1,3 @@
+# WorkGraph Smoke B 20260703151610
+
+WorkGraph development worker B created this document during the 20260703151610 smoke run.


### PR DESCRIPTION
Adds the WorkGraph smoke marker document for development worker B during the 20260703151610 smoke run.\n\nValidation:\n- test -f docs/workgraph-smoke-b-20260703151610.md