### PR TITLE
Add WorkGraph smoke A marker

### DIFF
--- a/docs/workgraph-smoke-a-20260703151610.md
+++ b/docs/workgraph-smoke-a-20260703151610.md
@@ -1,0 +1,3 @@
+# WorkGraph Smoke A
+
+WorkGraph development worker A created this document during the 20260703151610 smoke run.


### PR DESCRIPTION
Adds the requested WorkGraph smoke marker document for worker A during the 20260703151610 smoke run.