### PR TITLE
REQ-008 Trip Planning search foundation

### DIFF
--- a/service-catalog.json
+++ b/service-catalog.json
@@ -133,22 +133,23 @@
       "domain": "Trip Planning",
       "language": "python",
       "runtime": "python",
-      "phase": "phase-1-core",
-      "status": "skeleton",
+      "phase": "phase-1-search-foundation",
+      "status": "implemented-foundation",
       "priority": "P0",
       "workPackages": [
-        "WP-06"
+        "REQ-008-Trip-Planning-search-foundation"
       ],
       "docs": [
-        "docs/02-domains/trip-planning.md"
+        "docs/02-domains/trip-planning.md",
+        "docs/03-ddd-final/phase-1-contract.md"
       ],
       "owns": [
-        "TripIntent",
-        "Itinerary",
-        "SearchResult",
-        "PriceHint"
+        "TripIntent validation",
+        "Itinerary candidates",
+        "SearchResult ranking explanations",
+        "Non-authoritative PriceHint and AvailabilityHint snapshots"
       ],
-      "rationale": "Python is a better fit for search heuristics, ranking, and explanation logic."
+      "rationale": "Python is a better fit for search heuristics, deterministic ranking, and auditable explanation logic."
     },
     {
       "id": "offer-management",

--- a/services/trip-planning/README.md
+++ b/services/trip-planning/README.md
@@ -1,29 +1,30 @@
 # trip-planning
 
-Domain: Trip Planning
+Domain: Trip Planning  
+Language: Python  
+Phase: `phase-1-search-foundation`  
+Status: REQ-008 search foundation
 
-Language: python
+Trip Planning turns a validated `TripIntent` and upstream service-plan-like references into deterministic, explainable itinerary candidates. It is a search-only domain slice: it does not create Offers, CapacityHolds, orders, payments, tickets, or provider calls.
 
-Phase: phase-1-core
+## Owns in this slice
 
-Status: skeleton
+- `TripIntent` validation: origin/destination, departure time window, passenger count, transport modes, connection limits, and budget/preferences.
+- `Itinerary` and `LegCandidate` primitives assembled from upstream `Place & Network` and `Service Plan` references.
+- Deterministic `PlanningScore` components and exclusion explanations for auditable ranking.
+- `PriceHint` and `AvailabilityHint` snapshots clearly marked non-authoritative: not offers, not fare freezes, and not inventory locks.
+- FastAPI-safe `/search` adapter plus `search_itineraries(...)` application function returning candidate DTOs.
 
-## Owns
+## Does not own
 
-- TripIntent
-- Itinerary
-- SearchResult
-- PriceHint
+- Schedule, route topology, stop authority, capacity, final price, fare rules, Offers, holds, orders, payments, ticketing, fulfillment, or provider integration.
 
 ## DDD Sources
 
 - `docs/02-domains/trip-planning.md`
+- `docs/03-ddd-final/phase-1-contract.md`
 
-## Language Rationale
-
-Python is a better fit for search heuristics, ranking, and explanation logic.
-
-## Skeleton Check
+## Local validation
 
 ```bash
 PYTHONPATH=src python3 -m unittest discover -s tests

--- a/services/trip-planning/pyproject.toml
+++ b/services/trip-planning/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "trip-planning"
 version = "0.1.0"
-description = "Trip Planning service skeleton"
+description = "Trip Planning search foundation"
 requires-python = ">=3.11"
 dependencies = [
   "fastapi==0.138.1",

--- a/services/trip-planning/src/trip_planning/__init__.py
+++ b/services/trip-planning/src/trip_planning/__init__.py
@@ -1,6 +1,42 @@
 from typing import List, TypedDict
 
-from fastapi import FastAPI
+try:  # FastAPI is used in runtime images; tests can run without installed deps.
+    from fastapi import FastAPI, HTTPException
+except ModuleNotFoundError:  # pragma: no cover - compatibility shim for stdlib-only validation
+    class HTTPException(Exception):
+        def __init__(self, status_code: int, detail: str) -> None:
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    class _Route:
+        def __init__(self, path: str) -> None:
+            self.path = path
+
+    class FastAPI:  # type: ignore[no-redef]
+        def __init__(self, title: str, version: str) -> None:
+            self.title = title
+            self.version = version
+            self.routes: list[_Route] = []
+
+        def get(self, path: str):
+            self.routes.append(_Route(path))
+            return lambda func: func
+
+        def post(self, path: str):
+            self.routes.append(_Route(path))
+            return lambda func: func
+
+from .application import search_itineraries_from_payload
+from .domain import (
+    AvailabilityHint,
+    Itinerary,
+    LegCandidate,
+    PreferenceConstraints,
+    PriceHint,
+    TripIntent,
+    TripPlanningValidationError,
+)
 
 
 class ServiceProfile(TypedDict):
@@ -10,15 +46,22 @@ class ServiceProfile(TypedDict):
     phase: str
     work_packages: List[str]
     owns: List[str]
+    boundary: str
 
 
 SERVICE_PROFILE: ServiceProfile = {
     "service_id": "trip-planning",
     "domain": "Trip Planning",
     "language": "python",
-    "phase": "phase-1-core",
-    "work_packages": ["WP-06"],
-    "owns": ["TripIntent", "Itinerary", "SearchResult", "PriceHint"],
+    "phase": "phase-1-search-foundation",
+    "work_packages": ["REQ-008-Trip-Planning-search-foundation"],
+    "owns": [
+        "TripIntent validation",
+        "Itinerary candidates",
+        "SearchResult ranking explanations",
+        "Non-authoritative PriceHint and AvailabilityHint snapshots",
+    ],
+    "boundary": "Search candidates only: no Offer, CapacityHold, order, payment, ticket, or provider integration.",
 }
 
 
@@ -37,4 +80,26 @@ def create_app() -> FastAPI:
     def health_endpoint() -> dict[str, object]:
         return {"status": health(), "service": profile()}
 
+    @app.post("/search")
+    def search_endpoint(payload: dict[str, object]) -> dict[str, object]:
+        try:
+            return search_itineraries_from_payload(payload)
+        except TripPlanningValidationError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
     return app
+
+
+__all__ = [
+    "AvailabilityHint",
+    "Itinerary",
+    "LegCandidate",
+    "PreferenceConstraints",
+    "PriceHint",
+    "TripIntent",
+    "TripPlanningValidationError",
+    "create_app",
+    "health",
+    "profile",
+    "search_itineraries_from_payload",
+]

--- a/services/trip-planning/src/trip_planning/application.py
+++ b/services/trip-planning/src/trip_planning/application.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from .domain import (
+    AvailabilityHint,
+    ExclusionReason,
+    Itinerary,
+    PlanningScore,
+    PriceHint,
+    ScoreComponent,
+    TripIntent,
+    TripPlanningValidationError,
+    stable_ref,
+)
+
+RANKING_PROFILE_VERSION = "trip-planning-search-v1"
+
+
+@dataclass(frozen=True)
+class CandidateEvaluation:
+    itinerary: Itinerary | None
+    score: PlanningScore | None
+    exclusions: tuple[ExclusionReason, ...]
+
+
+@dataclass(frozen=True)
+class TripPlanResult:
+    trip_plan_ref: str
+    intent_ref: str
+    generated_at: datetime
+    ranking_profile_version: str
+    candidates: tuple[tuple[Itinerary, PlanningScore], ...]
+    exclusions: tuple[ExclusionReason, ...]
+    boundary_notice: str = (
+        "Trip Planning returns search candidates only. Results are not offers, "
+        "do not lock capacity, and do not create orders, payments, or tickets."
+    )
+
+
+def _exclusion(code: str, message: str, itinerary: Itinerary | None = None, **details: Any) -> ExclusionReason:
+    return ExclusionReason(
+        code=code,
+        message=message,
+        itinerary_ref=itinerary.itinerary_ref if itinerary else None,
+        details=details,
+    )
+
+
+def validate_itinerary_for_intent(intent: TripIntent, itinerary: Itinerary) -> tuple[ExclusionReason, ...]:
+    """Return hard-constraint rejections without mutating or reserving anything."""
+
+    exclusions: list[ExclusionReason] = []
+    if itinerary.origin_ref != intent.origin_ref:
+        exclusions.append(
+            _exclusion("ORIGIN_MISMATCH", "candidate does not start at requested origin", itinerary)
+        )
+    if itinerary.destination_ref != intent.destination_ref:
+        exclusions.append(
+            _exclusion(
+                "DESTINATION_MISMATCH", "candidate does not end at requested destination", itinerary
+            )
+        )
+    if not (intent.departure_window_start <= itinerary.departure_time <= intent.departure_window_end):
+        exclusions.append(
+            _exclusion(
+                "DEPARTURE_OUTSIDE_WINDOW",
+                "candidate departure is outside requested time window",
+                itinerary,
+                departure_time=itinerary.departure_time.isoformat(),
+            )
+        )
+    if intent.preferences.allowed_modes:
+        disallowed = sorted(
+            {leg.mode for leg in itinerary.legs if leg.mode not in intent.preferences.allowed_modes}
+        )
+        if disallowed:
+            exclusions.append(
+                _exclusion(
+                    "MODE_NOT_ALLOWED",
+                    "candidate uses transport modes outside requested constraints",
+                    itinerary,
+                    modes=disallowed,
+                )
+            )
+    if (
+        intent.preferences.max_connections is not None
+        and itinerary.connection_count > intent.preferences.max_connections
+    ):
+        exclusions.append(
+            _exclusion(
+                "TOO_MANY_CONNECTIONS",
+                "candidate exceeds requested maximum connections",
+                itinerary,
+                connection_count=itinerary.connection_count,
+            )
+        )
+    for wait in itinerary.connection_waits_minutes():
+        if wait < intent.preferences.min_connection_minutes:
+            exclusions.append(
+                _exclusion(
+                    "IMPOSSIBLE_CONNECTION_WINDOW",
+                    "candidate connection wait is shorter than the minimum connection window",
+                    itinerary,
+                    wait_minutes=wait,
+                    minimum_minutes=intent.preferences.min_connection_minutes,
+                )
+            )
+        if (
+            intent.preferences.max_connection_wait_minutes is not None
+            and wait > intent.preferences.max_connection_wait_minutes
+        ):
+            exclusions.append(
+                _exclusion(
+                    "CONNECTION_WAIT_TOO_LONG",
+                    "candidate connection wait exceeds requested maximum",
+                    itinerary,
+                    wait_minutes=wait,
+                    maximum_minutes=intent.preferences.max_connection_wait_minutes,
+                )
+            )
+    if (
+        intent.preferences.max_price_minor is not None
+        and itinerary.price_hint is not None
+        and itinerary.price_hint.amount_minor > intent.preferences.max_price_minor
+    ):
+        exclusions.append(
+            _exclusion(
+                "PRICE_HINT_OVER_BUDGET",
+                "non-authoritative price hint exceeds requested budget",
+                itinerary,
+                amount_minor=itinerary.price_hint.amount_minor,
+            )
+        )
+    if itinerary.availability_hint and itinerary.availability_hint.status == "unavailable_hint":
+        exclusions.append(
+            _exclusion(
+                "UNAVAILABLE_SNAPSHOT_HINT",
+                "non-authoritative availability snapshot says the candidate is likely unavailable",
+                itinerary,
+            )
+        )
+    return tuple(exclusions)
+
+
+def rank_itinerary(intent: TripIntent, itinerary: Itinerary) -> PlanningScore:
+    """Produce a deterministic, auditable score. Higher is better."""
+
+    components: list[ScoreComponent] = []
+
+    duration_value = max(0, 1440 - itinerary.duration_minutes)
+    duration_weight = 2 if intent.preferences.prefer_short_duration else 1
+    components.append(
+        ScoreComponent(
+            name="duration",
+            value=duration_value,
+            weight=duration_weight,
+            contribution=duration_value * duration_weight,
+            explanation=f"{itinerary.duration_minutes} minute end-to-end duration",
+        )
+    )
+
+    transfer_value = max(0, 500 - itinerary.connection_count * 120)
+    components.append(
+        ScoreComponent(
+            name="connections",
+            value=transfer_value,
+            weight=1,
+            contribution=transfer_value,
+            explanation=f"{itinerary.connection_count} connection(s)",
+        )
+    )
+
+    if itinerary.price_hint is not None:
+        budget = intent.preferences.max_price_minor or max(itinerary.price_hint.amount_minor, 1)
+        price_value = max(0, 1000 - int((itinerary.price_hint.amount_minor / budget) * 1000))
+        price_weight = 2 if intent.preferences.prefer_low_price else 1
+        components.append(
+            ScoreComponent(
+                name="price_hint",
+                value=price_value,
+                weight=price_weight,
+                contribution=price_value * price_weight,
+                explanation=(
+                    f"non-authoritative {itinerary.price_hint.currency} "
+                    f"{itinerary.price_hint.amount_minor} price hint"
+                ),
+            )
+        )
+    else:
+        components.append(
+            ScoreComponent(
+                name="price_hint",
+                value=50,
+                weight=1,
+                contribution=50,
+                explanation="no price hint; candidate remains searchable but less auditable",
+            )
+        )
+
+    availability_value = {
+        None: 80,
+        "available_hint": 200,
+        "limited_hint": 120,
+        "unknown": 60,
+        "unavailable_hint": 0,
+    }[itinerary.availability_hint.status if itinerary.availability_hint else None]
+    components.append(
+        ScoreComponent(
+            name="availability_hint",
+            value=availability_value,
+            weight=1,
+            contribution=availability_value,
+            explanation="non-authoritative availability snapshot only; no inventory lock",
+        )
+    )
+
+    total = sum(component.contribution for component in components)
+    return PlanningScore(
+        total=total,
+        profile_version=RANKING_PROFILE_VERSION,
+        components=tuple(components),
+        explanation=(
+            f"Deterministic score {total} from duration, connection count, price hint, "
+            "and availability hint. Hints are snapshots, not offers or locks."
+        ),
+    )
+
+
+def evaluate_candidates(intent: TripIntent, candidates: Sequence[Itinerary]) -> tuple[CandidateEvaluation, ...]:
+    evaluations: list[CandidateEvaluation] = []
+    for candidate in candidates:
+        exclusions = validate_itinerary_for_intent(intent, candidate)
+        if exclusions:
+            evaluations.append(CandidateEvaluation(None, None, exclusions))
+        else:
+            evaluations.append(CandidateEvaluation(candidate, rank_itinerary(intent, candidate), ()))
+    return tuple(evaluations)
+
+
+def search_itineraries(
+    intent: TripIntent,
+    candidates: Sequence[Itinerary],
+    *,
+    generated_at: datetime | None = None,
+) -> TripPlanResult:
+    """FastAPI-safe application function for search-only trip planning.
+
+    It accepts already-normalized upstream candidate references, applies Trip
+    Planning invariants and ranking, and returns DTO-ready results without
+    creating offers, capacity holds, orders, payments, tickets, or provider calls.
+    """
+
+    generated_at = generated_at or datetime.now(timezone.utc)
+    evaluations = evaluate_candidates(intent, candidates)
+    accepted: list[tuple[Itinerary, PlanningScore]] = []
+    exclusions: list[ExclusionReason] = []
+    for evaluation in evaluations:
+        if evaluation.itinerary and evaluation.score:
+            accepted.append((evaluation.itinerary, evaluation.score))
+        exclusions.extend(evaluation.exclusions)
+    accepted.sort(
+        key=lambda pair: (
+            -pair[1].total,
+            pair[0].arrival_time.isoformat(),
+            pair[0].itinerary_ref or "",
+        )
+    )
+    intent_ref = stable_ref("intent", intent.fingerprint_parts())
+    trip_plan_ref = stable_ref(
+        "tripplan",
+        (intent_ref, generated_at.isoformat(), RANKING_PROFILE_VERSION)
+        + tuple(itinerary.itinerary_ref or "" for itinerary, _score in accepted),
+    )
+    return TripPlanResult(
+        trip_plan_ref=trip_plan_ref,
+        intent_ref=intent_ref,
+        generated_at=generated_at,
+        ranking_profile_version=RANKING_PROFILE_VERSION,
+        candidates=tuple(accepted),
+        exclusions=tuple(exclusions),
+    )
+
+
+def _datetime_to_iso(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+def _dataclass_to_public_dict(value: Any) -> Any:
+    if isinstance(value, tuple):
+        return [_dataclass_to_public_dict(item) for item in value]
+    if isinstance(value, list):
+        return [_dataclass_to_public_dict(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _dataclass_to_public_dict(item) for key, item in value.items()}
+    if hasattr(value, "__dataclass_fields__"):
+        return {key: _dataclass_to_public_dict(item) for key, item in asdict(value).items()}
+    return _datetime_to_iso(value)
+
+
+def itinerary_to_dto(itinerary: Itinerary, score: PlanningScore) -> dict[str, Any]:
+    return {
+        "itineraryRef": itinerary.itinerary_ref,
+        "originRef": itinerary.origin_ref,
+        "destinationRef": itinerary.destination_ref,
+        "departureTime": itinerary.departure_time.isoformat(),
+        "arrivalTime": itinerary.arrival_time.isoformat(),
+        "durationMinutes": itinerary.duration_minutes,
+        "connectionCount": itinerary.connection_count,
+        "legs": [
+            {
+                "legRef": leg.leg_ref,
+                "mode": leg.mode,
+                "servicePlanRef": leg.service_plan_ref,
+                "serviceSegmentRef": leg.service_segment_ref,
+                "originStopRef": leg.origin_stop_ref,
+                "destinationStopRef": leg.destination_stop_ref,
+                "departureTime": leg.departure_time.isoformat(),
+                "arrivalTime": leg.arrival_time.isoformat(),
+                "stopRefs": list(leg.stop_refs),
+                "segmentRefs": list(leg.segment_refs),
+            }
+            for leg in itinerary.legs
+        ],
+        "priceHint": _hint_to_dto(itinerary.price_hint),
+        "availabilityHint": _hint_to_dto(itinerary.availability_hint),
+        "planningSnapshotRefs": list(itinerary.planning_snapshot_refs),
+        "score": _dataclass_to_public_dict(score),
+        "notices": [
+            "Search result only: not an Offer.",
+            "No inventory is held or locked by Trip Planning.",
+        ],
+    }
+
+
+def _hint_to_dto(hint: PriceHint | AvailabilityHint | None) -> dict[str, Any] | None:
+    if hint is None:
+        return None
+    dto = _dataclass_to_public_dict(hint)
+    # Preserve explicit boundary flags in API DTOs even if field names differ by hint type.
+    dto["isOffer"] = False
+    dto["inventoryLocked"] = False
+    return dto
+
+
+def trip_plan_to_dto(result: TripPlanResult) -> dict[str, Any]:
+    return {
+        "tripPlanRef": result.trip_plan_ref,
+        "intentRef": result.intent_ref,
+        "generatedAt": result.generated_at.isoformat(),
+        "rankingProfileVersion": result.ranking_profile_version,
+        "boundaryNotice": result.boundary_notice,
+        "candidates": [itinerary_to_dto(itinerary, score) for itinerary, score in result.candidates],
+        "exclusions": [_dataclass_to_public_dict(exclusion) for exclusion in result.exclusions],
+    }
+
+
+def search_itineraries_from_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """JSON-dict adapter safe for FastAPI request handlers and tests."""
+
+    try:
+        intent = TripIntent.from_dict(payload["intent"])
+        candidates = tuple(Itinerary.from_dict(item) for item in payload.get("candidates", ()))
+        return trip_plan_to_dto(search_itineraries(intent, candidates))
+    except KeyError as exc:
+        raise TripPlanningValidationError(f"missing required field: {exc.args[0]}") from exc

--- a/services/trip-planning/src/trip_planning/domain.py
+++ b/services/trip-planning/src/trip_planning/domain.py
@@ -1,0 +1,439 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from hashlib import sha256
+from typing import Any, Iterable, Mapping, Sequence
+
+
+class TripPlanningValidationError(ValueError):
+    """Raised when a trip-planning domain invariant is violated."""
+
+
+_ALLOWED_AVAILABILITY_STATUSES = {
+    "available_hint",
+    "limited_hint",
+    "unknown",
+    "unavailable_hint",
+}
+_PRICE_HINT_DISCLAIMER = (
+    "Price hint is a non-authoritative planning snapshot. It is not an offer, "
+    "does not freeze fare rules, and cannot be used as a payment amount."
+)
+_AVAILABILITY_HINT_DISCLAIMER = (
+    "Availability hint is a non-authoritative planning snapshot. It is not an "
+    "inventory lock, hold, or sale commitment."
+)
+
+
+def _require_ref(value: str, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise TripPlanningValidationError(f"{field_name} must be a non-empty upstream reference")
+    return value.strip()
+
+
+def _parse_datetime(value: datetime | str, field_name: str) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise TripPlanningValidationError(f"{field_name} must be an ISO-8601 datetime") from exc
+    raise TripPlanningValidationError(f"{field_name} must be an ISO-8601 datetime")
+
+
+def _normalize_modes(modes: Iterable[str]) -> frozenset[str]:
+    normalized: set[str] = set()
+    for mode in modes:
+        normalized.add(_require_ref(mode, "mode").lower())
+    return frozenset(normalized)
+
+
+def _tuple_of_refs(values: Sequence[str], field_name: str) -> tuple[str, ...]:
+    refs = tuple(_require_ref(value, field_name) for value in values)
+    if not refs:
+        raise TripPlanningValidationError(f"{field_name} must contain at least one reference")
+    if len(set(refs)) != len(refs):
+        raise TripPlanningValidationError(f"{field_name} must be ordered without duplicate references")
+    return refs
+
+
+def stable_ref(prefix: str, parts: Iterable[str]) -> str:
+    digest = sha256("|".join(parts).encode("utf-8")).hexdigest()[:16]
+    return f"{prefix}_{digest}"
+
+
+@dataclass(frozen=True)
+class PreferenceConstraints:
+    """Hard planning constraints and soft ranking preferences carried by a search."""
+
+    allowed_modes: frozenset[str] = field(default_factory=frozenset)
+    max_connections: int | None = None
+    min_connection_minutes: int = 5
+    max_connection_wait_minutes: int | None = None
+    max_price_minor: int | None = None
+    prefer_low_price: bool = False
+    prefer_short_duration: bool = True
+    accessibility_required: bool = False
+    connection_intent: str = "self_transfer_allowed"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "allowed_modes", _normalize_modes(self.allowed_modes))
+        if self.max_connections is not None and self.max_connections < 0:
+            raise TripPlanningValidationError("max_connections cannot be negative")
+        if self.min_connection_minutes < 0:
+            raise TripPlanningValidationError("min_connection_minutes cannot be negative")
+        if self.max_connection_wait_minutes is not None and self.max_connection_wait_minutes < 0:
+            raise TripPlanningValidationError("max_connection_wait_minutes cannot be negative")
+        if self.max_price_minor is not None and self.max_price_minor < 0:
+            raise TripPlanningValidationError("max_price_minor cannot be negative")
+        object.__setattr__(
+            self,
+            "connection_intent",
+            _require_ref(self.connection_intent, "connection_intent"),
+        )
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any] | None) -> "PreferenceConstraints":
+        if data is None:
+            return cls()
+        return cls(
+            allowed_modes=frozenset(data.get("allowed_modes", data.get("allowedModes", ()))),
+            max_connections=data.get("max_connections", data.get("maxConnections")),
+            min_connection_minutes=data.get(
+                "min_connection_minutes", data.get("minConnectionMinutes", 5)
+            ),
+            max_connection_wait_minutes=data.get(
+                "max_connection_wait_minutes", data.get("maxConnectionWaitMinutes")
+            ),
+            max_price_minor=data.get("max_price_minor", data.get("maxPriceMinor")),
+            prefer_low_price=bool(data.get("prefer_low_price", data.get("preferLowPrice", False))),
+            prefer_short_duration=bool(
+                data.get("prefer_short_duration", data.get("preferShortDuration", True))
+            ),
+            accessibility_required=bool(
+                data.get("accessibility_required", data.get("accessibilityRequired", False))
+            ),
+            connection_intent=data.get(
+                "connection_intent", data.get("connectionIntent", "self_transfer_allowed")
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class TripIntent:
+    """Search-only trip intent owned by Trip Planning."""
+
+    origin_ref: str
+    destination_ref: str
+    departure_window_start: datetime
+    departure_window_end: datetime
+    passenger_count: int
+    preferences: PreferenceConstraints = field(default_factory=PreferenceConstraints)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "origin_ref", _require_ref(self.origin_ref, "origin_ref"))
+        object.__setattr__(
+            self, "destination_ref", _require_ref(self.destination_ref, "destination_ref")
+        )
+        if self.origin_ref == self.destination_ref:
+            raise TripPlanningValidationError("origin and destination must be different")
+        object.__setattr__(
+            self,
+            "departure_window_start",
+            _parse_datetime(self.departure_window_start, "departure_window_start"),
+        )
+        object.__setattr__(
+            self,
+            "departure_window_end",
+            _parse_datetime(self.departure_window_end, "departure_window_end"),
+        )
+        if self.departure_window_start >= self.departure_window_end:
+            raise TripPlanningValidationError("departure window start must be before end")
+        if self.passenger_count <= 0:
+            raise TripPlanningValidationError("passenger_count must be positive")
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "TripIntent":
+        return cls(
+            origin_ref=data.get("origin_ref", data.get("originRef")),
+            destination_ref=data.get("destination_ref", data.get("destinationRef")),
+            departure_window_start=data.get(
+                "departure_window_start", data.get("departureWindowStart")
+            ),
+            departure_window_end=data.get("departure_window_end", data.get("departureWindowEnd")),
+            passenger_count=int(data.get("passenger_count", data.get("passengerCount", 0))),
+            preferences=PreferenceConstraints.from_dict(data.get("preferences")),
+        )
+
+    def fingerprint_parts(self) -> tuple[str, ...]:
+        return (
+            self.origin_ref,
+            self.destination_ref,
+            self.departure_window_start.isoformat(),
+            self.departure_window_end.isoformat(),
+            str(self.passenger_count),
+            ",".join(sorted(self.preferences.allowed_modes)),
+            str(self.preferences.max_connections),
+            str(self.preferences.min_connection_minutes),
+            str(self.preferences.max_connection_wait_minutes),
+            str(self.preferences.max_price_minor),
+            self.preferences.connection_intent,
+        )
+
+
+@dataclass(frozen=True)
+class PriceHint:
+    """Non-authoritative price snapshot used only for search ranking/explanation."""
+
+    amount_minor: int
+    currency: str
+    snapshot_ref: str
+    captured_at: datetime
+    source: str = "fare-pricing"
+    confidence: int = 50
+    is_offer: bool = False
+    inventory_locked: bool = False
+    disclaimer: str = _PRICE_HINT_DISCLAIMER
+
+    def __post_init__(self) -> None:
+        if self.amount_minor < 0:
+            raise TripPlanningValidationError("amount_minor cannot be negative")
+        currency = _require_ref(self.currency, "currency").upper()
+        if len(currency) != 3:
+            raise TripPlanningValidationError("currency must be a 3-letter ISO code")
+        object.__setattr__(self, "currency", currency)
+        object.__setattr__(self, "snapshot_ref", _require_ref(self.snapshot_ref, "snapshot_ref"))
+        object.__setattr__(self, "captured_at", _parse_datetime(self.captured_at, "captured_at"))
+        object.__setattr__(self, "source", _require_ref(self.source, "source"))
+        if not 0 <= self.confidence <= 100:
+            raise TripPlanningValidationError("confidence must be between 0 and 100")
+        if self.is_offer or self.inventory_locked:
+            raise TripPlanningValidationError("price hints cannot be offers or inventory locks")
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any] | None) -> "PriceHint | None":
+        if not data:
+            return None
+        return cls(
+            amount_minor=int(data.get("amount_minor", data.get("amountMinor"))),
+            currency=data["currency"],
+            snapshot_ref=data.get("snapshot_ref", data.get("snapshotRef")),
+            captured_at=data.get("captured_at", data.get("capturedAt")),
+            source=data.get("source", "fare-pricing"),
+            confidence=int(data.get("confidence", 50)),
+        )
+
+
+@dataclass(frozen=True)
+class AvailabilityHint:
+    """Non-authoritative availability snapshot used only for planning."""
+
+    status: str
+    snapshot_ref: str
+    captured_at: datetime
+    source: str = "capacity-availability"
+    confidence: int = 50
+    not_authoritative: bool = True
+    inventory_locked: bool = False
+    disclaimer: str = _AVAILABILITY_HINT_DISCLAIMER
+
+    def __post_init__(self) -> None:
+        status = _require_ref(self.status, "status").lower()
+        if status not in _ALLOWED_AVAILABILITY_STATUSES:
+            raise TripPlanningValidationError(f"unsupported availability hint status: {status}")
+        object.__setattr__(self, "status", status)
+        object.__setattr__(self, "snapshot_ref", _require_ref(self.snapshot_ref, "snapshot_ref"))
+        object.__setattr__(self, "captured_at", _parse_datetime(self.captured_at, "captured_at"))
+        object.__setattr__(self, "source", _require_ref(self.source, "source"))
+        if not 0 <= self.confidence <= 100:
+            raise TripPlanningValidationError("confidence must be between 0 and 100")
+        if not self.not_authoritative or self.inventory_locked:
+            raise TripPlanningValidationError("availability hints cannot be authoritative locks")
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any] | None) -> "AvailabilityHint | None":
+        if not data:
+            return None
+        return cls(
+            status=data.get("status", "unknown"),
+            snapshot_ref=data.get("snapshot_ref", data.get("snapshotRef")),
+            captured_at=data.get("captured_at", data.get("capturedAt")),
+            source=data.get("source", "capacity-availability"),
+            confidence=int(data.get("confidence", 50)),
+        )
+
+
+@dataclass(frozen=True)
+class LegCandidate:
+    """A service-plan-like leg reference with ordered stop and segment references."""
+
+    service_plan_ref: str
+    service_segment_ref: str
+    origin_stop_ref: str
+    destination_stop_ref: str
+    departure_time: datetime
+    arrival_time: datetime
+    mode: str = "train"
+    stop_refs: tuple[str, ...] = field(default_factory=tuple)
+    segment_refs: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "service_plan_ref",
+            "service_segment_ref",
+            "origin_stop_ref",
+            "destination_stop_ref",
+        ):
+            object.__setattr__(self, field_name, _require_ref(getattr(self, field_name), field_name))
+        object.__setattr__(self, "mode", _require_ref(self.mode, "mode").lower())
+        object.__setattr__(
+            self, "departure_time", _parse_datetime(self.departure_time, "departure_time")
+        )
+        object.__setattr__(self, "arrival_time", _parse_datetime(self.arrival_time, "arrival_time"))
+        if self.departure_time >= self.arrival_time:
+            raise TripPlanningValidationError("leg departure_time must be before arrival_time")
+        stop_refs = self.stop_refs or (self.origin_stop_ref, self.destination_stop_ref)
+        stop_refs = _tuple_of_refs(stop_refs, "stop_refs")
+        if stop_refs[0] != self.origin_stop_ref or stop_refs[-1] != self.destination_stop_ref:
+            raise TripPlanningValidationError(
+                "ordered stop_refs must start at origin_stop_ref and end at destination_stop_ref"
+            )
+        object.__setattr__(self, "stop_refs", stop_refs)
+        segment_refs = self.segment_refs or (self.service_segment_ref,)
+        object.__setattr__(self, "segment_refs", _tuple_of_refs(segment_refs, "segment_refs"))
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "LegCandidate":
+        return cls(
+            service_plan_ref=data.get("service_plan_ref", data.get("servicePlanRef")),
+            service_segment_ref=data.get("service_segment_ref", data.get("serviceSegmentRef")),
+            origin_stop_ref=data.get("origin_stop_ref", data.get("originStopRef")),
+            destination_stop_ref=data.get("destination_stop_ref", data.get("destinationStopRef")),
+            departure_time=data.get("departure_time", data.get("departureTime")),
+            arrival_time=data.get("arrival_time", data.get("arrivalTime")),
+            mode=data.get("mode", "train"),
+            stop_refs=tuple(data.get("stop_refs", data.get("stopRefs", ()))),
+            segment_refs=tuple(data.get("segment_refs", data.get("segmentRefs", ()))),
+        )
+
+    @property
+    def leg_ref(self) -> str:
+        return stable_ref(
+            "leg",
+            (
+                self.service_plan_ref,
+                self.service_segment_ref,
+                self.origin_stop_ref,
+                self.destination_stop_ref,
+                self.departure_time.isoformat(),
+                self.arrival_time.isoformat(),
+            ),
+        )
+
+    @property
+    def duration_minutes(self) -> int:
+        return int((self.arrival_time - self.departure_time).total_seconds() // 60)
+
+
+@dataclass(frozen=True)
+class Itinerary:
+    """Search candidate assembled from upstream references. It never locks inventory."""
+
+    legs: tuple[LegCandidate, ...]
+    itinerary_ref: str | None = None
+    price_hint: PriceHint | None = None
+    availability_hint: AvailabilityHint | None = None
+    planning_snapshot_refs: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        legs = tuple(self.legs)
+        if not legs:
+            raise TripPlanningValidationError("itinerary must contain at least one leg")
+        for previous, current in zip(legs, legs[1:]):
+            if previous.arrival_time > current.departure_time:
+                raise TripPlanningValidationError("itinerary legs must be ordered and non-overlapping")
+            if previous.destination_stop_ref != current.origin_stop_ref:
+                raise TripPlanningValidationError("adjacent legs must connect at the same stop reference")
+        object.__setattr__(self, "legs", legs)
+        snapshot_refs = tuple(_require_ref(ref, "planning_snapshot_refs") for ref in self.planning_snapshot_refs)
+        object.__setattr__(self, "planning_snapshot_refs", snapshot_refs)
+        if self.itinerary_ref is None:
+            object.__setattr__(self, "itinerary_ref", stable_ref("itin", self.fingerprint_parts()))
+        else:
+            object.__setattr__(self, "itinerary_ref", _require_ref(self.itinerary_ref, "itinerary_ref"))
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "Itinerary":
+        return cls(
+            itinerary_ref=data.get("itinerary_ref", data.get("itineraryRef")),
+            legs=tuple(LegCandidate.from_dict(item) for item in data.get("legs", ())),
+            price_hint=PriceHint.from_dict(data.get("price_hint", data.get("priceHint"))),
+            availability_hint=AvailabilityHint.from_dict(
+                data.get("availability_hint", data.get("availabilityHint"))
+            ),
+            planning_snapshot_refs=tuple(
+                data.get("planning_snapshot_refs", data.get("planningSnapshotRefs", ()))
+            ),
+        )
+
+    @property
+    def origin_ref(self) -> str:
+        return self.legs[0].origin_stop_ref
+
+    @property
+    def destination_ref(self) -> str:
+        return self.legs[-1].destination_stop_ref
+
+    @property
+    def departure_time(self) -> datetime:
+        return self.legs[0].departure_time
+
+    @property
+    def arrival_time(self) -> datetime:
+        return self.legs[-1].arrival_time
+
+    @property
+    def duration_minutes(self) -> int:
+        return int((self.arrival_time - self.departure_time).total_seconds() // 60)
+
+    @property
+    def connection_count(self) -> int:
+        return len(self.legs) - 1
+
+    def connection_waits_minutes(self) -> tuple[int, ...]:
+        return tuple(
+            int((current.departure_time - previous.arrival_time).total_seconds() // 60)
+            for previous, current in zip(self.legs, self.legs[1:])
+        )
+
+    def fingerprint_parts(self) -> tuple[str, ...]:
+        return tuple(part for leg in self.legs for part in leg.segment_refs) + tuple(
+            leg.departure_time.isoformat() for leg in self.legs
+        )
+
+
+@dataclass(frozen=True)
+class ExclusionReason:
+    code: str
+    message: str
+    itinerary_ref: str | None = None
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ScoreComponent:
+    name: str
+    value: int
+    weight: int
+    contribution: int
+    explanation: str
+
+
+@dataclass(frozen=True)
+class PlanningScore:
+    total: int
+    profile_version: str
+    components: tuple[ScoreComponent, ...]
+    explanation: str

--- a/services/trip-planning/tests/test_search_foundation.py
+++ b/services/trip-planning/tests/test_search_foundation.py
@@ -1,0 +1,244 @@
+import unittest
+from datetime import datetime, timezone
+
+from trip_planning import create_app
+from trip_planning.application import search_itineraries, search_itineraries_from_payload, trip_plan_to_dto
+from trip_planning.domain import (
+    AvailabilityHint,
+    Itinerary,
+    LegCandidate,
+    PreferenceConstraints,
+    PriceHint,
+    TripIntent,
+    TripPlanningValidationError,
+)
+
+
+CAPTURED = datetime(2026, 7, 3, 12, 0, tzinfo=timezone.utc)
+
+
+def leg(
+    segment_ref: str,
+    origin: str,
+    destination: str,
+    depart: str,
+    arrive: str,
+    mode: str = "train",
+) -> LegCandidate:
+    return LegCandidate(
+        service_plan_ref="sp:2026:summer",
+        service_segment_ref=segment_ref,
+        origin_stop_ref=origin,
+        destination_stop_ref=destination,
+        departure_time=depart,
+        arrival_time=arrive,
+        mode=mode,
+        stop_refs=(origin, destination),
+        segment_refs=(segment_ref,),
+    )
+
+
+def price(amount: int) -> PriceHint:
+    return PriceHint(
+        amount_minor=amount,
+        currency="USD",
+        snapshot_ref=f"fare-snapshot:{amount}",
+        captured_at=CAPTURED,
+        confidence=80,
+    )
+
+
+def availability(status: str = "available_hint") -> AvailabilityHint:
+    return AvailabilityHint(
+        status=status,
+        snapshot_ref=f"availability-snapshot:{status}",
+        captured_at=CAPTURED,
+        confidence=70,
+    )
+
+
+class TripIntentValidationTest(unittest.TestCase):
+    def test_rejects_same_origin_destination(self) -> None:
+        with self.assertRaisesRegex(TripPlanningValidationError, "origin and destination"):
+            TripIntent(
+                origin_ref="station:A",
+                destination_ref="station:A",
+                departure_window_start="2026-08-01T08:00:00+00:00",
+                departure_window_end="2026-08-01T10:00:00+00:00",
+                passenger_count=1,
+            )
+
+    def test_rejects_non_positive_passenger_count(self) -> None:
+        with self.assertRaisesRegex(TripPlanningValidationError, "passenger_count"):
+            TripIntent(
+                origin_ref="station:A",
+                destination_ref="station:B",
+                departure_window_start="2026-08-01T08:00:00+00:00",
+                departure_window_end="2026-08-01T10:00:00+00:00",
+                passenger_count=0,
+            )
+
+    def test_rejects_invalid_time_window(self) -> None:
+        with self.assertRaisesRegex(TripPlanningValidationError, "departure window"):
+            TripIntent(
+                origin_ref="station:A",
+                destination_ref="station:B",
+                departure_window_start="2026-08-01T10:00:00+00:00",
+                departure_window_end="2026-08-01T08:00:00+00:00",
+                passenger_count=1,
+            )
+
+
+class ItineraryValidationTest(unittest.TestCase):
+    def test_builds_candidate_from_upstream_references(self) -> None:
+        itinerary = Itinerary(
+            legs=(leg("seg:1", "station:A", "station:B", "2026-08-01T08:10:00+00:00", "2026-08-01T09:00:00+00:00"),),
+            price_hint=price(2500),
+            availability_hint=availability(),
+            planning_snapshot_refs=("place-graph:v1", "service-plan:v1"),
+        )
+        self.assertEqual(itinerary.origin_ref, "station:A")
+        self.assertEqual(itinerary.destination_ref, "station:B")
+        self.assertFalse(itinerary.price_hint.is_offer)
+        self.assertFalse(itinerary.availability_hint.inventory_locked)
+        self.assertIn("not an offer", itinerary.price_hint.disclaimer)
+        self.assertIn("not an inventory lock", itinerary.availability_hint.disclaimer)
+
+    def test_rejects_unordered_overlapping_legs(self) -> None:
+        with self.assertRaisesRegex(TripPlanningValidationError, "ordered and non-overlapping"):
+            Itinerary(
+                legs=(
+                    leg("seg:1", "station:A", "station:B", "2026-08-01T08:00:00+00:00", "2026-08-01T09:00:00+00:00"),
+                    leg("seg:2", "station:B", "station:C", "2026-08-01T08:55:00+00:00", "2026-08-01T10:00:00+00:00"),
+                )
+            )
+
+    def test_rejects_disconnected_legs(self) -> None:
+        with self.assertRaisesRegex(TripPlanningValidationError, "connect at the same stop"):
+            Itinerary(
+                legs=(
+                    leg("seg:1", "station:A", "station:B", "2026-08-01T08:00:00+00:00", "2026-08-01T09:00:00+00:00"),
+                    leg("seg:2", "station:X", "station:C", "2026-08-01T09:15:00+00:00", "2026-08-01T10:00:00+00:00"),
+                )
+            )
+
+    def test_rejects_unordered_stop_pattern(self) -> None:
+        with self.assertRaisesRegex(TripPlanningValidationError, "ordered stop_refs"):
+            leg(
+                "seg:1",
+                "station:A",
+                "station:B",
+                "2026-08-01T08:00:00+00:00",
+                "2026-08-01T09:00:00+00:00",
+            ).__class__(
+                service_plan_ref="sp:2026:summer",
+                service_segment_ref="seg:1",
+                origin_stop_ref="station:A",
+                destination_stop_ref="station:B",
+                departure_time="2026-08-01T08:00:00+00:00",
+                arrival_time="2026-08-01T09:00:00+00:00",
+                stop_refs=("station:B", "station:A"),
+                segment_refs=("seg:1",),
+            )
+
+
+class SearchFoundationTest(unittest.TestCase):
+    def intent(self) -> TripIntent:
+        return TripIntent(
+            origin_ref="station:A",
+            destination_ref="station:C",
+            departure_window_start="2026-08-01T08:00:00+00:00",
+            departure_window_end="2026-08-01T12:00:00+00:00",
+            passenger_count=2,
+            preferences=PreferenceConstraints(
+                allowed_modes=frozenset({"train"}),
+                max_connections=1,
+                min_connection_minutes=10,
+                max_price_minor=5000,
+                prefer_low_price=True,
+            ),
+        )
+
+    def test_search_returns_ranked_dto_without_locking_inventory(self) -> None:
+        direct = Itinerary(
+            legs=(leg("seg:direct", "station:A", "station:C", "2026-08-01T09:00:00+00:00", "2026-08-01T10:00:00+00:00"),),
+            price_hint=price(2000),
+            availability_hint=availability("limited_hint"),
+        )
+        slower = Itinerary(
+            legs=(leg("seg:slow", "station:A", "station:C", "2026-08-01T09:10:00+00:00", "2026-08-01T11:00:00+00:00"),),
+            price_hint=price(4500),
+            availability_hint=availability("available_hint"),
+        )
+        result = search_itineraries(self.intent(), (slower, direct), generated_at=CAPTURED)
+        dto = trip_plan_to_dto(result)
+        self.assertEqual([c[0].itinerary_ref for c in result.candidates][0], direct.itinerary_ref)
+        self.assertEqual(dto["candidates"][0]["priceHint"]["isOffer"], False)
+        self.assertEqual(dto["candidates"][0]["availabilityHint"]["inventoryLocked"], False)
+        self.assertIn("not offers", dto["boundaryNotice"])
+        self.assertIn("price hint", dto["candidates"][0]["score"]["explanation"])
+
+    def test_impossible_connection_window_is_excluded(self) -> None:
+        candidate = Itinerary(
+            legs=(
+                leg("seg:1", "station:A", "station:B", "2026-08-01T08:00:00+00:00", "2026-08-01T09:00:00+00:00"),
+                leg("seg:2", "station:B", "station:C", "2026-08-01T09:05:00+00:00", "2026-08-01T10:00:00+00:00"),
+            ),
+            price_hint=price(3000),
+            availability_hint=availability(),
+        )
+        result = search_itineraries(self.intent(), (candidate,), generated_at=CAPTURED)
+        self.assertEqual(result.candidates, ())
+        self.assertEqual(result.exclusions[0].code, "IMPOSSIBLE_CONNECTION_WINDOW")
+
+    def test_payload_adapter_accepts_fastapi_safe_dicts(self) -> None:
+        payload = {
+            "intent": {
+                "originRef": "station:A",
+                "destinationRef": "station:C",
+                "departureWindowStart": "2026-08-01T08:00:00+00:00",
+                "departureWindowEnd": "2026-08-01T12:00:00+00:00",
+                "passengerCount": 1,
+                "preferences": {"allowedModes": ["train"], "minConnectionMinutes": 5},
+            },
+            "candidates": [
+                {
+                    "legs": [
+                        {
+                            "servicePlanRef": "sp:2026:summer",
+                            "serviceSegmentRef": "seg:direct",
+                            "originStopRef": "station:A",
+                            "destinationStopRef": "station:C",
+                            "departureTime": "2026-08-01T09:00:00+00:00",
+                            "arrivalTime": "2026-08-01T10:00:00+00:00",
+                            "mode": "train",
+                            "stopRefs": ["station:A", "station:C"],
+                            "segmentRefs": ["seg:direct"],
+                        }
+                    ],
+                    "priceHint": {
+                        "amountMinor": 1800,
+                        "currency": "USD",
+                        "snapshotRef": "fare-snapshot:1800",
+                        "capturedAt": "2026-07-03T12:00:00+00:00",
+                    },
+                    "availabilityHint": {
+                        "status": "available_hint",
+                        "snapshotRef": "availability-snapshot:1",
+                        "capturedAt": "2026-07-03T12:00:00+00:00",
+                    },
+                }
+            ],
+        }
+        dto = search_itineraries_from_payload(payload)
+        self.assertEqual(len(dto["candidates"]), 1)
+        self.assertFalse(dto["candidates"][0]["priceHint"]["isOffer"])
+
+    def test_fastapi_search_route_is_registered(self) -> None:
+        app = create_app()
+        routes = {route.path for route in app.routes}
+        self.assertIn("/search", routes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add TripIntent, Itinerary/LegCandidate, PriceHint, AvailabilityHint, scoring, and exclusion domain primitives for search-only planning.
- Add FastAPI-safe /search adapter and DTO mapping with explicit no-offer/no-inventory-lock notices.
- Update trip-planning README/package/profile and service catalog metadata for REQ-008.

## Validation
- cd services/trip-planning && PYTHONPATH=src python3 -m unittest discover -s tests
- make check-strict