### PR TITLE
REQ-009 Offer Management domain foundation

### DIFF
--- a/service-catalog.json
+++ b/service-catalog.json
@@ -157,23 +157,29 @@
       "domain": "Offer Management",
       "language": "typescript",
       "runtime": "node",
-      "phase": "phase-1-core",
-      "status": "skeleton",
+      "phase": "phase-1-offer-domain-foundation",
+      "status": "implemented-foundation",
       "priority": "P0",
       "workPackages": [
-        "WP-07"
+        "REQ-009-Offer-Management-domain-foundation"
       ],
       "docs": [
-        "docs/02-domains/offer-management.md"
+        "docs/02-domains/offer-management.md",
+        "docs/03-ddd-final/phase-1-contract.md"
       ],
       "owns": [
-        "Offer",
-        "OfferItem",
+        "Offer identity and lifecycle",
+        "OfferItem snapshot composition",
+        "ItineraryReference",
+        "AvailabilitySnapshotReference",
         "PriceSnapshot",
+        "FareRuleSnapshotReference",
+        "PassengerMix",
         "RiskDisclosure",
-        "ChangeOffer"
+        "OfferQuoted",
+        "OfferExpired"
       ],
-      "rationale": "TypeScript fits user-facing offer API composition, TTL policy, and disclosure payloads."
+      "rationale": "TypeScript fits user-facing offer API composition, TTL policy, immutable snapshot enforcement, and disclosure payloads."
     },
     {
       "id": "journey-order",

--- a/services/offer-management/README.md
+++ b/services/offer-management/README.md
@@ -2,30 +2,41 @@
 
 Domain: Offer Management
 
-Language: typescript
+Language: TypeScript
 
-Phase: phase-1-core
+Phase: phase-1-offer-domain-foundation
 
-Status: skeleton
+Status: implemented-foundation for `REQ-009-Offer-Management-domain-foundation`
 
-## Owns
+## Owns in this slice
 
-- Offer
-- OfferItem
-- PriceSnapshot
-- RiskDisclosure
-- ChangeOffer
+- `Offer` identity, version, lifecycle, validity window, and expiration behavior.
+- `OfferItem` composition for train segment quote lines.
+- Immutable `ItineraryReference` from Trip Planning.
+- Immutable `AvailabilitySnapshotReference` from Capacity & Availability.
+- Immutable `PriceSnapshot` and `FareRuleSnapshotReference` from Fare & Pricing.
+- `PassengerMix` and traveler-set hash used to prevent stale passenger substitutions.
+- `RiskDisclosure` records that must be accepted before order creation.
+- Domain facts `OfferQuoted` and `OfferExpired` for downstream Journey Order and Notification consumers.
+
+## Explicitly does not own
+
+Offer Management does **not** lock inventory and does **not** create orders, payment intents, holds, reservations, or entitlements. The domain events include a `BoundaryProof` showing no mutation of:
+
+- `CapacityHold`
+- `PaymentIntent`
+- `JourneyOrder`
+- `Entitlement`
 
 ## DDD Sources
 
 - `docs/02-domains/offer-management.md`
+- `docs/03-ddd-final/phase-1-contract.md`
 
-## Language Rationale
-
-TypeScript fits user-facing offer API composition, TTL policy, and disclosure payloads.
-
-## Skeleton Check
+## Validation
 
 ```bash
-npm test
+npm test -- --runInBand || npm test
 ```
+
+The first command form is accepted by the WorkGraph validation contract; this service uses Node's built-in `node:test` runner rather than Jest, so the fallback `npm test` is the expected local runner.

--- a/services/offer-management/package.json
+++ b/services/offer-management/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit",
-    "test": "npm run build"
+    "test": "tsc --noEmit false --outDir dist && node --test dist/**/*.test.js"
   },
   "dependencies": {
     "fastify": "5.9.0"

--- a/services/offer-management/src/domain.test.ts
+++ b/services/offer-management/src/domain.test.ts
@@ -1,0 +1,240 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  DomainError,
+  Offer,
+  nonMutationBoundaryProof,
+  type QuoteOfferCommand,
+} from "./domain.js";
+
+const quotedAt = new Date("2026-07-03T10:00:00.000Z");
+const expiresAt = new Date("2026-07-03T10:10:00.000Z");
+const upstreamExpiresAt = new Date("2026-07-03T10:15:00.000Z");
+
+function money(amount: number) {
+  return { amount, currency: "CNY" } as const;
+}
+
+function quoteCommand(overrides: Partial<QuoteOfferCommand> = {}): QuoteOfferCommand {
+  const base: QuoteOfferCommand = {
+    offerId: "offer-123",
+    quoteRequestId: "quote-request-abc",
+    accountId: "account-1",
+    channelId: "web",
+    quotedAt,
+    validityWindow: {
+      startsAt: new Date("2026-07-03T09:59:00.000Z"),
+      expiresAt,
+    },
+    itinerary: {
+      itineraryId: "itinerary-1",
+      itineraryVersion: "it-v1",
+      sourceContext: "TripPlanning",
+      segmentRefs: ["segment-1"],
+    },
+    passengerMix: {
+      travelerSetHash: "traveler-hash-1",
+      travelers: [{ travelerId: "traveler-1", category: "adult", eligibilitySnapshotRef: "eligibility-1" }],
+    },
+    items: [
+      {
+        offerItemId: "item-1",
+        mode: "train",
+        segmentRef: "segment-1",
+        itemPrice: money(100),
+        availabilitySnapshot: {
+          snapshotId: "availability-snapshot-1",
+          snapshotVersion: "capacity-v4",
+          sourceContext: "CapacityAvailability",
+          capturedAt: new Date("2026-07-03T09:58:00.000Z"),
+          expiresAt: upstreamExpiresAt,
+          sellable: true,
+          confidence: "confirmed-snapshot",
+        },
+        fareSnapshot: {
+          fareQuoteRef: "fare-quote-1",
+          ruleSnapshotRef: "rule-snapshot-1",
+          pricingVersion: "pricing-v7",
+          ruleVersion: "rule-v3",
+          sourceContext: "FarePricing",
+          capturedAt: new Date("2026-07-03T09:58:30.000Z"),
+          expiresAt: upstreamExpiresAt,
+        },
+      },
+    ],
+    priceSnapshot: {
+      snapshotId: "price-snapshot-1",
+      fareQuoteRef: "fare-quote-1",
+      capturedAt: new Date("2026-07-03T09:58:30.000Z"),
+      expiresAt: upstreamExpiresAt,
+      guaranteeLevel: "FixedUntilExpiry",
+      currency: "CNY",
+      subtotal: money(100),
+      taxes: [{ code: "tax", description: "rail tax", amount: money(5) }],
+      fees: [{ code: "service", description: "service fee", amount: money(2) }],
+      discounts: [{ code: "promo", description: "promotion", amount: money(3) }],
+      total: money(104),
+    },
+    riskDisclosures: [
+      {
+        disclosureId: "risk-1",
+        severity: "warning",
+        messageCode: "SELF_TRANSFER_RISK",
+        templateVersion: "risk-template-v1",
+        relatedRef: "segment-1",
+        mustAccept: true,
+        text: "Self transfer is not protected by the platform.",
+      },
+    ],
+  };
+  return { ...base, ...overrides };
+}
+
+function expectDomainError(fn: () => unknown, code: string): void {
+  assert.throws(fn, (error: unknown) => error instanceof DomainError && error.code === code);
+}
+
+describe("Offer Management domain foundation", () => {
+  it("quotes an immutable offer from itinerary, availability, fare/rule, price, passenger, and risk snapshots", () => {
+    const { offer, event } = Offer.quote(quoteCommand());
+
+    assert.equal(offer.id, "offer-123");
+    assert.equal(offer.version, 1);
+    assert.equal(offer.status, "Quoted");
+    assert.equal(event.type, "OfferQuoted");
+    assert.deepEqual(event.availabilitySnapshotRefs, ["availability-snapshot-1"]);
+    assert.deepEqual(event.fareQuoteRefs, ["fare-quote-1"]);
+    assert.deepEqual(event.ruleSnapshotRefs, ["rule-snapshot-1"]);
+    assert.equal(event.downstreamReference.priceSnapshotRef, "price-snapshot-1");
+    assert.deepEqual(event.boundaryProof, nonMutationBoundaryProof());
+
+    const snapshot = offer.toSnapshot();
+    assert.throws(() => {
+      (snapshot.priceSnapshot.total as { amount: number }).amount = 999;
+    }, TypeError);
+    assert.equal(offer.toSnapshot().priceSnapshot.total.amount, 104);
+  });
+
+  it("rejects missing or stale snapshots and offer validity beyond upstream TTLs", () => {
+    expectDomainError(
+      () => Offer.quote(quoteCommand({ items: [] })),
+      "MISSING_OFFER_ITEMS",
+    );
+
+    expectDomainError(
+      () => Offer.quote(quoteCommand({ priceSnapshot: { ...quoteCommand().priceSnapshot, expiresAt: quotedAt } })),
+      "STALE_PRICE_SNAPSHOT",
+    );
+
+    expectDomainError(
+      () => Offer.quote(quoteCommand({
+        items: [{ ...quoteCommand().items[0], availabilitySnapshot: { ...quoteCommand().items[0].availabilitySnapshot, expiresAt: quotedAt } }],
+      })),
+      "STALE_AVAILABILITY_SNAPSHOT",
+    );
+
+    expectDomainError(
+      () => Offer.quote(quoteCommand({
+        items: [{ ...quoteCommand().items[0], fareSnapshot: { ...quoteCommand().items[0].fareSnapshot, expiresAt: quotedAt } }],
+      })),
+      "STALE_FARE_RULE_SNAPSHOT",
+    );
+
+    expectDomainError(
+      () => Offer.quote(quoteCommand({ validityWindow: { startsAt: quotedAt, expiresAt: new Date("2026-07-03T10:20:00.000Z") } })),
+      "PRICE_SNAPSHOT_TTL_TOO_SHORT",
+    );
+  });
+
+  it("rejects unsellable availability and inconsistent price totals", () => {
+    expectDomainError(
+      () => Offer.quote(quoteCommand({
+        items: [{ ...quoteCommand().items[0], availabilitySnapshot: { ...quoteCommand().items[0].availabilitySnapshot, sellable: false } }],
+      })),
+      "UNSELLABLE_AVAILABILITY_SNAPSHOT",
+    );
+
+    expectDomainError(
+      () => Offer.quote(quoteCommand({ priceSnapshot: { ...quoteCommand().priceSnapshot, total: money(999) } })),
+      "PRICE_TOTAL_MISMATCH",
+    );
+  });
+
+  it("enforces expiration and order validation without accepting stale or mismatched snapshots", () => {
+    const { offer } = Offer.quote(quoteCommand());
+
+    const token = offer.validateForOrder({
+      accountId: "account-1",
+      channelId: "web",
+      travelerSetHash: "traveler-hash-1",
+      priceSnapshotRef: "price-snapshot-1",
+      acceptedDisclosureIds: ["risk-1"],
+      at: new Date("2026-07-03T10:05:00.000Z"),
+    });
+    assert.equal(token.offerId, "offer-123");
+    assert.equal(token.offerVersion, 1);
+
+    expectDomainError(
+      () => offer.validateForOrder({
+        accountId: "account-1",
+        channelId: "web",
+        travelerSetHash: "traveler-hash-1",
+        priceSnapshotRef: "price-snapshot-1",
+        acceptedDisclosureIds: [],
+        at: new Date("2026-07-03T10:05:00.000Z"),
+      }),
+      "DISCLOSURE_NOT_ACCEPTED",
+    );
+
+    expectDomainError(
+      () => offer.validateForOrder({
+        accountId: "account-1",
+        channelId: "web",
+        travelerSetHash: "traveler-hash-1",
+        priceSnapshotRef: "other-price-snapshot",
+        acceptedDisclosureIds: ["risk-1"],
+        at: new Date("2026-07-03T10:05:00.000Z"),
+      }),
+      "PRICE_SNAPSHOT_MISMATCH",
+    );
+
+    expectDomainError(
+      () => offer.validateForOrder({
+        accountId: "account-1",
+        channelId: "web",
+        travelerSetHash: "traveler-hash-1",
+        priceSnapshotRef: "price-snapshot-1",
+        acceptedDisclosureIds: ["risk-1"],
+        at: expiresAt,
+      }),
+      "OFFER_EXPIRED",
+    );
+
+    const { offer: expiredOffer, event } = offer.expire(expiresAt, "validity-window-elapsed");
+    assert.equal(expiredOffer.status, "Expired");
+    assert.equal(event.type, "OfferExpired");
+    assert.equal(event.previousStatus, "Quoted");
+    assert.deepEqual(event.boundaryProof, nonMutationBoundaryProof());
+  });
+
+  it("proves quoting does not mutate CapacityHold, PaymentIntent, JourneyOrder, or Entitlement state", () => {
+    const externalState = {
+      capacityHold: { id: "hold-1", status: "Held", version: 2 },
+      paymentIntent: { id: "payment-1", status: "NotCreated" },
+      journeyOrder: { id: "order-1", status: "Draft" },
+      entitlement: { id: "ticket-1", status: "NotIssued" },
+    };
+    const before = structuredClone(externalState);
+
+    const { event } = Offer.quote(quoteCommand());
+
+    assert.deepEqual(externalState, before);
+    assert.equal(event.boundaryProof.inventoryLocked, false);
+    assert.equal(event.boundaryProof.capacityHoldMutated, false);
+    assert.equal(event.boundaryProof.paymentIntentMutated, false);
+    assert.equal(event.boundaryProof.journeyOrderMutated, false);
+    assert.equal(event.boundaryProof.entitlementMutated, false);
+    assert.deepEqual(event.boundaryProof.crossContextWriteTargets, []);
+  });
+});

--- a/services/offer-management/src/domain.ts
+++ b/services/offer-management/src/domain.ts
@@ -1,0 +1,575 @@
+export class DomainError extends Error {
+  public readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "DomainError";
+    this.code = code;
+  }
+}
+
+export type OfferId = string;
+export type OfferVersion = number;
+export type OfferItemId = string;
+export type ItineraryId = string;
+export type SegmentId = string;
+export type TravelerId = string;
+export type SnapshotId = string;
+export type CurrencyCode = string;
+
+export type OfferStatus = "Quoted" | "Accepted" | "Expired" | "Unavailable" | "Requoted" | "Withdrawn";
+export type PriceGuaranteeLevel = "FixedUntilExpiry" | "EstimatedOnly" | "ProviderFinalConfirmRequired";
+export type TransportMode = "train" | "transfer" | "ancillary";
+export type PassengerCategory = "adult" | "child" | "senior" | "student";
+export type RiskSeverity = "info" | "warning" | "blocking";
+export type AvailabilityConfidence = "confirmed-snapshot" | "low" | "estimated";
+
+export type Money = Readonly<{
+  amount: number;
+  currency: CurrencyCode;
+}>;
+
+export type ValidityWindow = Readonly<{
+  startsAt: Date;
+  expiresAt: Date;
+}>;
+
+export type ItineraryReference = Readonly<{
+  itineraryId: ItineraryId;
+  itineraryVersion: string;
+  sourceContext: "TripPlanning";
+  segmentRefs: readonly SegmentId[];
+}>;
+
+export type AvailabilitySnapshotReference = Readonly<{
+  snapshotId: SnapshotId;
+  snapshotVersion: string;
+  sourceContext: "CapacityAvailability";
+  capturedAt: Date;
+  expiresAt: Date;
+  sellable: boolean;
+  confidence: AvailabilityConfidence;
+}>;
+
+export type FareRuleSnapshotReference = Readonly<{
+  fareQuoteRef: SnapshotId;
+  ruleSnapshotRef: SnapshotId;
+  pricingVersion: string;
+  ruleVersion: string;
+  sourceContext: "FarePricing";
+  capturedAt: Date;
+  expiresAt: Date;
+}>;
+
+export type PriceLine = Readonly<{
+  code: string;
+  description: string;
+  amount: Money;
+}>;
+
+export type PriceSnapshot = Readonly<{
+  snapshotId: SnapshotId;
+  fareQuoteRef: SnapshotId;
+  capturedAt: Date;
+  expiresAt: Date;
+  guaranteeLevel: PriceGuaranteeLevel;
+  currency: CurrencyCode;
+  subtotal: Money;
+  taxes: readonly PriceLine[];
+  fees: readonly PriceLine[];
+  discounts: readonly PriceLine[];
+  total: Money;
+}>;
+
+export type TravelerRef = Readonly<{
+  travelerId: TravelerId;
+  category: PassengerCategory;
+  eligibilitySnapshotRef?: SnapshotId;
+}>;
+
+export type PassengerMix = Readonly<{
+  travelerSetHash: string;
+  travelers: readonly TravelerRef[];
+}>;
+
+export type RiskDisclosure = Readonly<{
+  disclosureId: string;
+  severity: RiskSeverity;
+  messageCode: string;
+  templateVersion: string;
+  relatedRef?: string;
+  mustAccept: boolean;
+  text: string;
+}>;
+
+export type OfferItem = Readonly<{
+  offerItemId: OfferItemId;
+  mode: TransportMode;
+  segmentRef?: SegmentId;
+  fareSnapshot: FareRuleSnapshotReference;
+  availabilitySnapshot: AvailabilitySnapshotReference;
+  itemPrice: Money;
+}>;
+
+export type QuoteOfferCommand = Readonly<{
+  offerId: OfferId;
+  offerVersion?: OfferVersion;
+  quoteRequestId: string;
+  accountId: string;
+  channelId: string;
+  itinerary: ItineraryReference;
+  passengerMix: PassengerMix;
+  validityWindow: ValidityWindow;
+  items: readonly OfferItem[];
+  priceSnapshot: PriceSnapshot;
+  riskDisclosures?: readonly RiskDisclosure[];
+  quotedAt: Date;
+}>;
+
+export type OfferQuoted = Readonly<{
+  type: "OfferQuoted";
+  occurredAt: Date;
+  offerId: OfferId;
+  offerVersion: OfferVersion;
+  quoteRequestId: string;
+  accountId: string;
+  channelId: string;
+  itineraryId: ItineraryId;
+  itineraryVersion: string;
+  travelerSetHash: string;
+  availabilitySnapshotRefs: readonly SnapshotId[];
+  priceSnapshotRef: SnapshotId;
+  fareQuoteRefs: readonly SnapshotId[];
+  ruleSnapshotRefs: readonly SnapshotId[];
+  total: Money;
+  expiresAt: Date;
+  priceGuaranteeLevel: PriceGuaranteeLevel;
+  downstreamReference: Readonly<{
+    offerId: OfferId;
+    offerVersion: OfferVersion;
+    priceSnapshotRef: SnapshotId;
+  }>;
+  boundaryProof: BoundaryProof;
+}>;
+
+export type OfferExpired = Readonly<{
+  type: "OfferExpired";
+  occurredAt: Date;
+  offerId: OfferId;
+  offerVersion: OfferVersion;
+  expiredAt: Date;
+  previousStatus: OfferStatus;
+  reason: "validity-window-elapsed" | "explicit-expire-command";
+  boundaryProof: BoundaryProof;
+}>;
+
+export type OfferDomainEvent = OfferQuoted | OfferExpired;
+
+export type BoundaryProof = Readonly<{
+  inventoryLocked: false;
+  capacityHoldMutated: false;
+  paymentIntentMutated: false;
+  journeyOrderMutated: false;
+  entitlementMutated: false;
+  crossContextWriteTargets: readonly [];
+}>;
+
+export type OfferAcceptanceToken = Readonly<{
+  offerId: OfferId;
+  offerVersion: OfferVersion;
+  priceSnapshotRef: SnapshotId;
+  travelerSetHash: string;
+  acceptedAt: Date;
+}>;
+
+export type ValidateOfferForOrderRequest = Readonly<{
+  accountId: string;
+  channelId: string;
+  travelerSetHash: string;
+  priceSnapshotRef: SnapshotId;
+  at: Date;
+  acceptedDisclosureIds?: readonly string[];
+}>;
+
+export type OfferSnapshot = Readonly<{
+  offerId: OfferId;
+  offerVersion: OfferVersion;
+  status: OfferStatus;
+  accountId: string;
+  channelId: string;
+  quoteRequestId: string;
+  itinerary: ItineraryReference;
+  passengerMix: PassengerMix;
+  validityWindow: ValidityWindow;
+  items: readonly OfferItem[];
+  priceSnapshot: PriceSnapshot;
+  riskDisclosures: readonly RiskDisclosure[];
+  quotedAt: Date;
+  expiredAt?: Date;
+}>;
+
+const boundaryProof: BoundaryProof = Object.freeze({
+  inventoryLocked: false,
+  capacityHoldMutated: false,
+  paymentIntentMutated: false,
+  journeyOrderMutated: false,
+  entitlementMutated: false,
+  crossContextWriteTargets: Object.freeze([]) as readonly [],
+});
+
+export function nonMutationBoundaryProof(): BoundaryProof {
+  return boundaryProof;
+}
+
+export class Offer {
+  private constructor(private readonly snapshot: OfferSnapshot) {
+    deepFreeze(this.snapshot);
+    Object.freeze(this);
+  }
+
+  static quote(command: QuoteOfferCommand): { offer: Offer; event: OfferQuoted } {
+    validateQuoteCommand(command);
+
+    const offerVersion = command.offerVersion ?? 1;
+    const snapshot: OfferSnapshot = deepFreeze(cloneForSnapshot({
+      offerId: command.offerId,
+      offerVersion,
+      status: "Quoted" as const,
+      accountId: command.accountId,
+      channelId: command.channelId,
+      quoteRequestId: command.quoteRequestId,
+      itinerary: command.itinerary,
+      passengerMix: command.passengerMix,
+      validityWindow: command.validityWindow,
+      items: command.items,
+      priceSnapshot: command.priceSnapshot,
+      riskDisclosures: command.riskDisclosures ?? [],
+      quotedAt: command.quotedAt,
+    }));
+
+    const offer = new Offer(snapshot);
+    const event: OfferQuoted = deepFreeze({
+      type: "OfferQuoted" as const,
+      occurredAt: new Date(command.quotedAt),
+      offerId: snapshot.offerId,
+      offerVersion: snapshot.offerVersion,
+      quoteRequestId: snapshot.quoteRequestId,
+      accountId: snapshot.accountId,
+      channelId: snapshot.channelId,
+      itineraryId: snapshot.itinerary.itineraryId,
+      itineraryVersion: snapshot.itinerary.itineraryVersion,
+      travelerSetHash: snapshot.passengerMix.travelerSetHash,
+      availabilitySnapshotRefs: snapshot.items.map((item) => item.availabilitySnapshot.snapshotId),
+      priceSnapshotRef: snapshot.priceSnapshot.snapshotId,
+      fareQuoteRefs: unique(snapshot.items.map((item) => item.fareSnapshot.fareQuoteRef)),
+      ruleSnapshotRefs: unique(snapshot.items.map((item) => item.fareSnapshot.ruleSnapshotRef)),
+      total: snapshot.priceSnapshot.total,
+      expiresAt: new Date(snapshot.validityWindow.expiresAt),
+      priceGuaranteeLevel: snapshot.priceSnapshot.guaranteeLevel,
+      downstreamReference: {
+        offerId: snapshot.offerId,
+        offerVersion: snapshot.offerVersion,
+        priceSnapshotRef: snapshot.priceSnapshot.snapshotId,
+      },
+      boundaryProof,
+    });
+
+    return { offer, event };
+  }
+
+  get id(): OfferId {
+    return this.snapshot.offerId;
+  }
+
+  get version(): OfferVersion {
+    return this.snapshot.offerVersion;
+  }
+
+  get status(): OfferStatus {
+    return this.snapshot.status;
+  }
+
+  get priceSnapshotRef(): SnapshotId {
+    return this.snapshot.priceSnapshot.snapshotId;
+  }
+
+  isExpiredAt(at: Date): boolean {
+    return at.getTime() >= this.snapshot.validityWindow.expiresAt.getTime();
+  }
+
+  expire(at: Date, reason: OfferExpired["reason"] = "explicit-expire-command"): { offer: Offer; event: OfferExpired } {
+    if (!this.isExpirable()) {
+      throw new DomainError("OFFER_NOT_EXPIRABLE", `Offer ${this.id} in ${this.status} cannot expire`);
+    }
+    if (at.getTime() < this.snapshot.validityWindow.expiresAt.getTime() && reason === "validity-window-elapsed") {
+      throw new DomainError("OFFER_NOT_YET_EXPIRED", "Cannot expire by elapsed validity before expiresAt");
+    }
+
+    const expiredSnapshot = deepFreeze(cloneForSnapshot({
+      ...this.snapshot,
+      status: "Expired" as const,
+      expiredAt: at,
+    }));
+    const event: OfferExpired = deepFreeze({
+      type: "OfferExpired" as const,
+      occurredAt: new Date(at),
+      offerId: this.snapshot.offerId,
+      offerVersion: this.snapshot.offerVersion,
+      expiredAt: new Date(at),
+      previousStatus: this.snapshot.status,
+      reason,
+      boundaryProof,
+    });
+    return { offer: new Offer(expiredSnapshot), event };
+  }
+
+  validateForOrder(request: ValidateOfferForOrderRequest): OfferAcceptanceToken {
+    if (this.snapshot.status !== "Quoted" && this.snapshot.status !== "Accepted") {
+      throw new DomainError("OFFER_NOT_ACCEPTABLE", `Offer ${this.id} in ${this.status} cannot be used for order creation`);
+    }
+    if (this.isExpiredAt(request.at)) {
+      throw new DomainError("OFFER_EXPIRED", `Offer ${this.id} expired at ${this.snapshot.validityWindow.expiresAt.toISOString()}`);
+    }
+    if (request.accountId !== this.snapshot.accountId) {
+      throw new DomainError("ACCOUNT_MISMATCH", "Offer account does not match order request");
+    }
+    if (request.channelId !== this.snapshot.channelId) {
+      throw new DomainError("CHANNEL_MISMATCH", "Offer channel does not match order request");
+    }
+    if (request.travelerSetHash !== this.snapshot.passengerMix.travelerSetHash) {
+      throw new DomainError("TRAVELER_SET_MISMATCH", "Offer passenger mix does not match order request");
+    }
+    if (request.priceSnapshotRef !== this.snapshot.priceSnapshot.snapshotId) {
+      throw new DomainError("PRICE_SNAPSHOT_MISMATCH", "Order must reference the immutable price snapshot on the Offer");
+    }
+
+    const accepted = new Set(request.acceptedDisclosureIds ?? []);
+    const missingDisclosure = this.snapshot.riskDisclosures.find((disclosure) => disclosure.mustAccept && !accepted.has(disclosure.disclosureId));
+    if (missingDisclosure) {
+      throw new DomainError("DISCLOSURE_NOT_ACCEPTED", `Required disclosure ${missingDisclosure.disclosureId} was not accepted`);
+    }
+
+    return deepFreeze({
+      offerId: this.snapshot.offerId,
+      offerVersion: this.snapshot.offerVersion,
+      priceSnapshotRef: this.snapshot.priceSnapshot.snapshotId,
+      travelerSetHash: this.snapshot.passengerMix.travelerSetHash,
+      acceptedAt: new Date(request.at),
+    });
+  }
+
+  toSnapshot(): OfferSnapshot {
+    return deepFreeze(cloneForSnapshot(this.snapshot));
+  }
+
+  private isExpirable(): boolean {
+    return this.snapshot.status === "Quoted" || this.snapshot.status === "Accepted";
+  }
+}
+
+function validateQuoteCommand(command: QuoteOfferCommand): void {
+  requireNonBlank(command.offerId, "offerId");
+  requireNonBlank(command.quoteRequestId, "quoteRequestId");
+  requireNonBlank(command.accountId, "accountId");
+  requireNonBlank(command.channelId, "channelId");
+  validateItinerary(command.itinerary);
+  validatePassengerMix(command.passengerMix);
+  validateValidityWindow(command.validityWindow, command.quotedAt);
+  validatePriceSnapshot(command.priceSnapshot, command.quotedAt, command.validityWindow.expiresAt);
+  validateOfferItems(command.items, command.quotedAt, command.validityWindow.expiresAt, command.priceSnapshot.currency);
+  validatePriceTotals(command.priceSnapshot, command.items);
+  for (const disclosure of command.riskDisclosures ?? []) {
+    validateRiskDisclosure(disclosure);
+  }
+}
+
+function validateItinerary(itinerary: ItineraryReference | undefined): void {
+  if (!itinerary) {
+    throw new DomainError("MISSING_ITINERARY", "Offer must reference a Trip Planning itinerary");
+  }
+  requireNonBlank(itinerary.itineraryId, "itineraryId");
+  requireNonBlank(itinerary.itineraryVersion, "itineraryVersion");
+  if (itinerary.sourceContext !== "TripPlanning") {
+    throw new DomainError("INVALID_ITINERARY_SOURCE", "Itinerary reference must come from Trip Planning");
+  }
+  if (itinerary.segmentRefs.length === 0) {
+    throw new DomainError("MISSING_SEGMENTS", "Itinerary reference must include at least one segment reference");
+  }
+}
+
+function validatePassengerMix(passengerMix: PassengerMix | undefined): void {
+  if (!passengerMix) {
+    throw new DomainError("MISSING_PASSENGER_MIX", "Offer must freeze the passenger mix used for pricing");
+  }
+  requireNonBlank(passengerMix.travelerSetHash, "travelerSetHash");
+  if (passengerMix.travelers.length === 0) {
+    throw new DomainError("MISSING_TRAVELERS", "Passenger mix must contain at least one traveler");
+  }
+  for (const traveler of passengerMix.travelers) {
+    requireNonBlank(traveler.travelerId, "travelerId");
+  }
+}
+
+function validateValidityWindow(window: ValidityWindow | undefined, quotedAt: Date): void {
+  if (!window) {
+    throw new DomainError("MISSING_VALIDITY_WINDOW", "Offer must have a validity window");
+  }
+  if (window.startsAt.getTime() > quotedAt.getTime()) {
+    throw new DomainError("VALIDITY_START_IN_FUTURE", "Offer validity cannot start after quote time");
+  }
+  if (window.expiresAt.getTime() <= quotedAt.getTime()) {
+    throw new DomainError("STALE_VALIDITY_WINDOW", "Offer validity must expire after quote time");
+  }
+}
+
+function validatePriceSnapshot(snapshot: PriceSnapshot | undefined, quotedAt: Date, offerExpiresAt: Date): void {
+  if (!snapshot) {
+    throw new DomainError("MISSING_PRICE_SNAPSHOT", "Offer must freeze a PriceSnapshot");
+  }
+  requireNonBlank(snapshot.snapshotId, "priceSnapshot.snapshotId");
+  requireNonBlank(snapshot.fareQuoteRef, "priceSnapshot.fareQuoteRef");
+  requireNonBlank(snapshot.currency, "priceSnapshot.currency");
+  validateMoney(snapshot.subtotal, snapshot.currency, "priceSnapshot.subtotal");
+  validateMoney(snapshot.total, snapshot.currency, "priceSnapshot.total");
+  if (snapshot.capturedAt.getTime() > quotedAt.getTime()) {
+    throw new DomainError("PRICE_SNAPSHOT_FROM_FUTURE", "PriceSnapshot cannot be captured after quote time");
+  }
+  if (snapshot.expiresAt.getTime() <= quotedAt.getTime()) {
+    throw new DomainError("STALE_PRICE_SNAPSHOT", "Cannot quote from an expired PriceSnapshot");
+  }
+  if (snapshot.expiresAt.getTime() < offerExpiresAt.getTime()) {
+    throw new DomainError("PRICE_SNAPSHOT_TTL_TOO_SHORT", "Offer validity cannot outlive the PriceSnapshot TTL");
+  }
+  for (const line of [...snapshot.taxes, ...snapshot.fees, ...snapshot.discounts]) {
+    requireNonBlank(line.code, "price line code");
+    validateMoney(line.amount, snapshot.currency, `price line ${line.code}`);
+  }
+}
+
+function validateOfferItems(items: readonly OfferItem[] | undefined, quotedAt: Date, offerExpiresAt: Date, currency: CurrencyCode): void {
+  if (!items || items.length === 0) {
+    throw new DomainError("MISSING_OFFER_ITEMS", "Offer must contain at least one OfferItem");
+  }
+  for (const item of items) {
+    requireNonBlank(item.offerItemId, "offerItemId");
+    validateMoney(item.itemPrice, currency, `itemPrice ${item.offerItemId}`);
+    validateFareRuleSnapshot(item.fareSnapshot, quotedAt, offerExpiresAt, item.offerItemId);
+    validateAvailabilitySnapshot(item.availabilitySnapshot, quotedAt, offerExpiresAt, item.offerItemId);
+  }
+}
+
+function validateFareRuleSnapshot(snapshot: FareRuleSnapshotReference | undefined, quotedAt: Date, offerExpiresAt: Date, itemId: string): void {
+  if (!snapshot) {
+    throw new DomainError("MISSING_FARE_RULE_SNAPSHOT", `OfferItem ${itemId} must reference fare/rule snapshots`);
+  }
+  requireNonBlank(snapshot.fareQuoteRef, "fareQuoteRef");
+  requireNonBlank(snapshot.ruleSnapshotRef, "ruleSnapshotRef");
+  requireNonBlank(snapshot.pricingVersion, "pricingVersion");
+  requireNonBlank(snapshot.ruleVersion, "ruleVersion");
+  if (snapshot.sourceContext !== "FarePricing") {
+    throw new DomainError("INVALID_FARE_RULE_SOURCE", "Fare/rule snapshot must come from Fare & Pricing");
+  }
+  if (snapshot.expiresAt.getTime() <= quotedAt.getTime()) {
+    throw new DomainError("STALE_FARE_RULE_SNAPSHOT", `Fare/rule snapshot for ${itemId} is expired`);
+  }
+  if (snapshot.expiresAt.getTime() < offerExpiresAt.getTime()) {
+    throw new DomainError("FARE_RULE_TTL_TOO_SHORT", `Offer validity cannot outlive fare/rule snapshot for ${itemId}`);
+  }
+}
+
+function validateAvailabilitySnapshot(snapshot: AvailabilitySnapshotReference | undefined, quotedAt: Date, offerExpiresAt: Date, itemId: string): void {
+  if (!snapshot) {
+    throw new DomainError("MISSING_AVAILABILITY_SNAPSHOT", `OfferItem ${itemId} must reference an AvailabilitySnapshot`);
+  }
+  requireNonBlank(snapshot.snapshotId, "availabilitySnapshot.snapshotId");
+  requireNonBlank(snapshot.snapshotVersion, "availabilitySnapshot.snapshotVersion");
+  if (snapshot.sourceContext !== "CapacityAvailability") {
+    throw new DomainError("INVALID_AVAILABILITY_SOURCE", "Availability snapshot must come from Capacity & Availability");
+  }
+  if (!snapshot.sellable) {
+    throw new DomainError("UNSELLABLE_AVAILABILITY_SNAPSHOT", `Availability snapshot for ${itemId} is not sellable`);
+  }
+  if (snapshot.expiresAt.getTime() <= quotedAt.getTime()) {
+    throw new DomainError("STALE_AVAILABILITY_SNAPSHOT", `Availability snapshot for ${itemId} is expired`);
+  }
+  if (snapshot.expiresAt.getTime() < offerExpiresAt.getTime()) {
+    throw new DomainError("AVAILABILITY_TTL_TOO_SHORT", `Offer validity cannot outlive availability snapshot for ${itemId}`);
+  }
+}
+
+function validatePriceTotals(priceSnapshot: PriceSnapshot, items: readonly OfferItem[]): void {
+  const itemTotal = sum(items.map((item) => item.itemPrice.amount));
+  const taxes = sum(priceSnapshot.taxes.map((line) => line.amount.amount));
+  const fees = sum(priceSnapshot.fees.map((line) => line.amount.amount));
+  const discounts = sum(priceSnapshot.discounts.map((line) => line.amount.amount));
+  const expected = roundMoney(itemTotal + taxes + fees - discounts);
+  if (expected !== priceSnapshot.total.amount) {
+    throw new DomainError("PRICE_TOTAL_MISMATCH", `PriceSnapshot total ${priceSnapshot.total.amount} does not match item/tax/fee/discount total ${expected}`);
+  }
+}
+
+function validateRiskDisclosure(disclosure: RiskDisclosure): void {
+  requireNonBlank(disclosure.disclosureId, "disclosureId");
+  requireNonBlank(disclosure.messageCode, "messageCode");
+  requireNonBlank(disclosure.templateVersion, "templateVersion");
+  requireNonBlank(disclosure.text, "risk disclosure text");
+}
+
+function validateMoney(money: Money | undefined, expectedCurrency: CurrencyCode, label: string): void {
+  if (!money) {
+    throw new DomainError("MISSING_MONEY", `${label} is required`);
+  }
+  if (money.currency !== expectedCurrency) {
+    throw new DomainError("CURRENCY_MISMATCH", `${label} currency ${money.currency} does not match ${expectedCurrency}`);
+  }
+  if (!Number.isFinite(money.amount) || money.amount < 0) {
+    throw new DomainError("INVALID_MONEY", `${label} must be a finite non-negative amount`);
+  }
+}
+
+function requireNonBlank(value: string | undefined, label: string): void {
+  if (!value || value.trim().length === 0) {
+    throw new DomainError("MISSING_REQUIRED_FIELD", `${label} is required`);
+  }
+}
+
+function sum(values: readonly number[]): number {
+  return roundMoney(values.reduce((total, value) => total + value, 0));
+}
+
+function roundMoney(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function unique<T>(values: readonly T[]): readonly T[] {
+  return Object.freeze([...new Set(values)]);
+}
+
+type DeepFreezable = Record<string, unknown> | unknown[];
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object") {
+    for (const nested of Object.values(value as DeepFreezable)) {
+      deepFreeze(nested);
+    }
+    Object.freeze(value);
+  }
+  return value;
+}
+
+function cloneForSnapshot<T>(value: T): T {
+  if (value instanceof Date) {
+    return new Date(value) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => cloneForSnapshot(entry)) as T;
+  }
+  if (value && typeof value === "object") {
+    const clone: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      clone[key] = cloneForSnapshot(nested);
+    }
+    return clone as T;
+  }
+  return value;
+}

--- a/services/offer-management/src/index.ts
+++ b/services/offer-management/src/index.ts
@@ -1,21 +1,60 @@
 import Fastify, { type FastifyInstance } from "fastify";
 
+export {
+  DomainError,
+  Offer,
+  nonMutationBoundaryProof,
+  type AvailabilitySnapshotReference,
+  type BoundaryProof,
+  type FareRuleSnapshotReference,
+  type ItineraryReference,
+  type Money,
+  type OfferAcceptanceToken,
+  type OfferDomainEvent,
+  type OfferExpired,
+  type OfferItem,
+  type OfferQuoted,
+  type OfferSnapshot,
+  type PassengerMix,
+  type PriceSnapshot,
+  type QuoteOfferCommand,
+  type RiskDisclosure,
+  type ValidityWindow,
+} from "./domain.js";
+
 export type ServiceProfile = {
   serviceId: string;
   domain: string;
   language: "typescript";
   phase: string;
+  requirement: string;
   workPackages: string[];
   owns: string[];
+  doesNotOwn: string[];
+  publishes: string[];
 };
 
 export const serviceProfile: ServiceProfile = {
   serviceId: "offer-management",
   domain: "Offer Management",
   language: "typescript",
-  phase: "phase-1-core",
-  workPackages: ["WP-07"],
-  owns: ["Offer", "OfferItem", "PriceSnapshot", "RiskDisclosure", "ChangeOffer"],
+  phase: "phase-1-offer-domain-foundation",
+  requirement: "REQ-009-Offer-Management-domain-foundation",
+  workPackages: ["REQ-009", "WP-07-offer-snapshots"],
+  owns: [
+    "Offer identity and lifecycle",
+    "OfferItem snapshot composition",
+    "ItineraryReference",
+    "AvailabilitySnapshotReference",
+    "PriceSnapshot",
+    "FareRuleSnapshotReference",
+    "PassengerMix",
+    "RiskDisclosure",
+    "OfferQuoted",
+    "OfferExpired",
+  ],
+  doesNotOwn: ["CapacityHold", "PaymentIntent", "JourneyOrder", "Entitlement"],
+  publishes: ["OfferQuoted", "OfferExpired"],
 };
 
 export function health(): "ok" {

--- a/services/offer-management/tsconfig.json
+++ b/services/offer-management/tsconfig.json
@@ -4,9 +4,11 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "strict": true,
-    "noEmit": true,
+    "noEmit": false,
+    "outDir": "dist",
     "skipLibCheck": true,
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["node"]
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
## Summary
- Adds TypeScript Offer Management domain primitives for Offer lifecycle, immutable snapshots, validity, passenger mix, risk disclosures, and OfferQuoted/OfferExpired facts.
- Enforces rejection of stale/missing fare, rule, price, and availability snapshots and validates order-facing offer acceptance without cross-context writes.
- Updates service README/profile/catalog metadata for REQ-009 away from skeleton/WP-only naming.

## Validation
- cd services/offer-management && npm test -- --runInBand || npm test
- make check-strict