### PR TITLE
REQ-010 Journey Order domain foundation

### DIFF
--- a/services/journey-order/README.md
+++ b/services/journey-order/README.md
@@ -2,28 +2,39 @@
 
 Domain: Journey Order
 
-Language: java
+Language: Java
 
-Phase: phase-1-core
+Phase: phase-1-domain-foundation
 
-Status: skeleton
+Status: REQ-010 domain foundation
+
+Work slice: REQ-010-Journey-Order-domain-foundation
 
 ## Owns
 
-- JourneyOrder
-- OrderItem
-- MonetarySummary
-- OrderTimeline
+- `JourneyOrder` commercial order aggregate
+- `OrderItem` commercial line summaries and traveler/segment bindings
+- `TravelerRef` snapshots and masked document references
+- `MonetarySummary` invariants for order totals, discounts, fees, taxes, and cancelled commercial value
+- `OrderTimeline` / `TimelineFact` audit anchors for downstream visibility
+- Confirmation-condition summary facts required before commercial confirmation
+
+## Explicitly Does Not Own
+
+- Inventory or capacity holds
+- Payment-channel state, payment capture, refunds, or callbacks
+- Entitlement credentials, ticket issuance, or provider PNR/status
+- Fare calculation, refund rules, or supplier calls
 
 ## DDD Sources
 
 - `docs/02-domains/journey-order.md`
 
-## Language Rationale
+## Domain Behavior Covered
 
-Java is conservative for central transactional aggregates and long-lived domain models.
+The current Java model creates a `JourneyOrder` from a valid Offer snapshot and traveler snapshots, enforces order item binding and monetary summary invariants, records timeline facts, publishes domain events (`JourneyOrderCreated`, `JourneyOrderPendingPayment`, `JourneyOrderConfirmed`, cancellation and post-sales adjustment facts), and guards confirmation so `PaymentCaptured` only moves the order into `CONFIRMING` until accepted booking, capacity, payment, entitlement, and risk facts are represented.
 
-## Skeleton Check
+## Check
 
 ```bash
 mvn test

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/Application.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/Application.java
@@ -15,9 +15,9 @@ public class Application {
             "journey-order",
             "Journey Order",
             "java",
-            "phase-1-core",
-            "WP-08",
-            "JourneyOrder, OrderItem, MonetarySummary, OrderTimeline"
+            "phase-1-domain-foundation",
+            "REQ-010-Journey-Order-domain-foundation",
+            "JourneyOrder aggregate, OrderItem, TravelerRef, MonetarySummary, OrderTimeline facts, confirmation condition guards"
         );
     }
 }

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/ConfirmationConditions.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/ConfirmationConditions.java
@@ -1,0 +1,37 @@
+package com.trainticket.journeyorder.domain;
+
+public record ConfirmationConditions(
+    boolean bookingSummaryAccepted,
+    boolean capacitySummaryAccepted,
+    boolean paymentConditionSatisfied,
+    boolean entitlementSummaryAccepted,
+    boolean riskClear
+) {
+    public static ConfirmationConditions none() {
+        return new ConfirmationConditions(false, false, false, false, true);
+    }
+
+    public ConfirmationConditions withBookingSummaryAccepted() {
+        return new ConfirmationConditions(true, capacitySummaryAccepted, paymentConditionSatisfied, entitlementSummaryAccepted, riskClear);
+    }
+
+    public ConfirmationConditions withCapacitySummaryAccepted() {
+        return new ConfirmationConditions(bookingSummaryAccepted, true, paymentConditionSatisfied, entitlementSummaryAccepted, riskClear);
+    }
+
+    public ConfirmationConditions withPaymentConditionSatisfied() {
+        return new ConfirmationConditions(bookingSummaryAccepted, capacitySummaryAccepted, true, entitlementSummaryAccepted, riskClear);
+    }
+
+    public ConfirmationConditions withEntitlementSummaryAccepted() {
+        return new ConfirmationConditions(bookingSummaryAccepted, capacitySummaryAccepted, paymentConditionSatisfied, true, riskClear);
+    }
+
+    public ConfirmationConditions withRiskBlocked() {
+        return new ConfirmationConditions(bookingSummaryAccepted, capacitySummaryAccepted, paymentConditionSatisfied, entitlementSummaryAccepted, false);
+    }
+
+    public boolean canConfirm() {
+        return bookingSummaryAccepted && capacitySummaryAccepted && paymentConditionSatisfied && entitlementSummaryAccepted && riskClear;
+    }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/DomainRuleViolation.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/DomainRuleViolation.java
@@ -1,0 +1,7 @@
+package com.trainticket.journeyorder.domain;
+
+public class DomainRuleViolation extends RuntimeException {
+    public DomainRuleViolation(String message) {
+        super(message);
+    }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/EventMetadata.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/EventMetadata.java
@@ -1,0 +1,39 @@
+package com.trainticket.journeyorder.domain;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+public record EventMetadata(
+    String eventId,
+    Instant occurredAt,
+    String sourceCommandId,
+    String causationId,
+    String correlationId,
+    int schemaVersion,
+    Map<String, String> attributes
+) {
+    public EventMetadata {
+        eventId = requireText(eventId, "eventId");
+        Objects.requireNonNull(occurredAt, "occurredAt is required");
+        sourceCommandId = requireText(sourceCommandId, "sourceCommandId");
+        causationId = requireText(causationId, "causationId");
+        correlationId = requireText(correlationId, "correlationId");
+        if (schemaVersion < 1) {
+            throw new DomainRuleViolation("schemaVersion must be positive");
+        }
+        attributes = Map.copyOf(Objects.requireNonNull(attributes, "attributes are required"));
+    }
+
+    static EventMetadata create(Instant occurredAt, String sourceCommandId, String causationId, String correlationId, Map<String, String> attributes) {
+        return new EventMetadata(UUID.randomUUID().toString(), occurredAt, sourceCommandId, causationId, correlationId, 1, attributes);
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrder.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrder.java
@@ -1,0 +1,230 @@
+package com.trainticket.journeyorder.domain;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+public final class JourneyOrder {
+    private final String orderId;
+    private final String accountId;
+    private final String channelRef;
+    private final String idempotencyKey;
+    private final OfferSnapshotRef offerSnapshot;
+    private final List<TravelerRef> travelers;
+    private final List<SegmentOrderSnapshot> segments;
+    private final List<OrderItem> orderItems;
+    private final List<TimelineFact> timeline;
+    private final List<JourneyOrderEvent> domainEvents;
+    private OrderLifecycleState state;
+    private MonetarySummary monetarySummary;
+    private ConfirmationConditions confirmationConditions;
+
+    private JourneyOrder(
+        String orderId,
+        String accountId,
+        String channelRef,
+        String idempotencyKey,
+        OfferSnapshotRef offerSnapshot,
+        List<TravelerRef> travelers,
+        List<SegmentOrderSnapshot> segments,
+        List<OrderItem> orderItems
+    ) {
+        this.orderId = requireText(orderId, "orderId");
+        this.accountId = requireText(accountId, "accountId");
+        this.channelRef = requireText(channelRef, "channelRef");
+        this.idempotencyKey = requireText(idempotencyKey, "idempotencyKey");
+        this.offerSnapshot = Objects.requireNonNull(offerSnapshot, "offerSnapshot is required");
+        this.travelers = List.copyOf(Objects.requireNonNull(travelers, "travelers are required"));
+        this.segments = List.copyOf(Objects.requireNonNull(segments, "segments are required"));
+        this.orderItems = new ArrayList<>(Objects.requireNonNull(orderItems, "orderItems are required"));
+        this.timeline = new ArrayList<>();
+        this.domainEvents = new ArrayList<>();
+        this.state = OrderLifecycleState.PENDING_CONFIRMATION;
+        this.confirmationConditions = ConfirmationConditions.none();
+        requireCreateInvariants();
+        this.monetarySummary = MonetarySummary.fromItems(this.orderItems);
+    }
+
+    public static JourneyOrder createFromOffer(
+        String accountId,
+        String channelRef,
+        String clientRequestId,
+        OfferSnapshotRef offerSnapshot,
+        List<TravelerRef> travelers,
+        List<SegmentOrderSnapshot> segments,
+        List<OrderItem> orderItems,
+        Instant now,
+        String sourceCommandId,
+        String correlationId
+    ) {
+        Objects.requireNonNull(offerSnapshot, "offerSnapshot is required").requireValidAt(now);
+        JourneyOrder order = new JourneyOrder(
+            UUID.randomUUID().toString(),
+            accountId,
+            channelRef,
+            accountId + ":" + offerSnapshot.offerId() + ":" + requireText(clientRequestId, "clientRequestId"),
+            offerSnapshot,
+            travelers,
+            segments,
+            orderItems
+        );
+        order.recordTimeline("JourneyOrderCreated", now, "journey-order", "valid offer accepted", Map.of("offerId", offerSnapshot.offerId()));
+        order.domainEvents.add(new JourneyOrderCreated(
+            order.orderId,
+            order.accountId,
+            offerSnapshot.offerId(),
+            order.monetarySummary,
+            EventMetadata.create(now, sourceCommandId, sourceCommandId, correlationId, Map.of("state", order.state.name()))
+        ));
+        return order;
+    }
+
+    public String orderId() { return orderId; }
+    public String accountId() { return accountId; }
+    public String channelRef() { return channelRef; }
+    public String idempotencyKey() { return idempotencyKey; }
+    public OfferSnapshotRef offerSnapshot() { return offerSnapshot; }
+    public List<TravelerRef> travelers() { return travelers; }
+    public List<SegmentOrderSnapshot> segments() { return segments; }
+    public List<OrderItem> orderItems() { return List.copyOf(orderItems); }
+    public List<TimelineFact> timeline() { return List.copyOf(timeline); }
+    public OrderLifecycleState state() { return state; }
+    public MonetarySummary monetarySummary() { return monetarySummary; }
+    public ConfirmationConditions confirmationConditions() { return confirmationConditions; }
+    public List<JourneyOrderEvent> domainEvents() { return List.copyOf(domainEvents); }
+
+    public void markBookingAndCapacityAccepted(Instant occurredAt, String sourceCommandId, String correlationId) {
+        requireState(OrderLifecycleState.PENDING_CONFIRMATION);
+        confirmationConditions = confirmationConditions.withBookingSummaryAccepted().withCapacitySummaryAccepted();
+        recordTimeline("BookingCapacitySummaryAccepted", occurredAt, "booking-orchestration", "required booking and capacity summaries accepted", Map.of());
+    }
+
+    public void markPendingPayment(String paymentPurpose, Instant occurredAt, String sourceCommandId, String correlationId) {
+        requireState(OrderLifecycleState.PENDING_CONFIRMATION);
+        if (!confirmationConditions.bookingSummaryAccepted() || !confirmationConditions.capacitySummaryAccepted()) {
+            throw new DomainRuleViolation("pending payment requires accepted booking and capacity summary facts");
+        }
+        state = OrderLifecycleState.PENDING_PAYMENT;
+        recordTimeline("JourneyOrderPendingPayment", occurredAt, "journey-order", "waiting for payment", Map.of("paymentPurpose", paymentPurpose));
+        domainEvents.add(new JourneyOrderPendingPayment(orderId, accountId, paymentPurpose, monetarySummary,
+            EventMetadata.create(occurredAt, sourceCommandId, sourceCommandId, correlationId, Map.of("state", state.name()))));
+    }
+
+    public void recordPaymentCaptured(String paymentIntentId, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        requireState(OrderLifecycleState.PENDING_PAYMENT);
+        confirmationConditions = confirmationConditions.withPaymentConditionSatisfied();
+        state = OrderLifecycleState.CONFIRMING;
+        recordTimeline("PaymentCaptured", occurredAt, "payment", "payment condition satisfied; awaiting entitlement summary", Map.of("paymentIntentId", paymentIntentId));
+        domainEvents.add(new JourneyOrderPaymentRecorded(orderId, accountId, paymentIntentId,
+            EventMetadata.create(occurredAt, sourceCommandId, causationId, correlationId, Map.of("state", state.name()))));
+    }
+
+    public void recordEntitlementSummaryAccepted(Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        requireState(OrderLifecycleState.CONFIRMING);
+        confirmationConditions = confirmationConditions.withEntitlementSummaryAccepted();
+        recordTimeline("EntitlementSummaryAccepted", occurredAt, "entitlement-ticketing", "required entitlement summary accepted", Map.of());
+    }
+
+    public void confirm(String confirmationAttempt, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        requireState(OrderLifecycleState.CONFIRMING);
+        if (!confirmationConditions.canConfirm()) {
+            throw new DomainRuleViolation("cannot confirm JourneyOrder without accepted booking, capacity, payment, entitlement and risk facts");
+        }
+        state = OrderLifecycleState.CONFIRMED;
+        recordTimeline("JourneyOrderConfirmed", occurredAt, "journey-order", "all confirmation conditions satisfied", Map.of("confirmationAttempt", confirmationAttempt));
+        domainEvents.add(new JourneyOrderConfirmed(orderId, accountId, monetarySummary,
+            EventMetadata.create(occurredAt, sourceCommandId, causationId, correlationId, Map.of("state", state.name()))));
+    }
+
+    public void cancel(String reason, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        if (state == OrderLifecycleState.COMPLETED) {
+            throw new DomainRuleViolation("completed JourneyOrder cannot be cancelled");
+        }
+        if (state == OrderLifecycleState.CANCELLED) {
+            return;
+        }
+        state = OrderLifecycleState.CANCELLED;
+        recordTimeline("JourneyOrderCancelled", occurredAt, "journey-order", reason, Map.of());
+        domainEvents.add(new JourneyOrderCancelled(orderId, accountId, reason,
+            EventMetadata.create(occurredAt, sourceCommandId, causationId, correlationId, Map.of("state", state.name()))));
+    }
+
+    public void expirePayment(String paymentIntentId, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        requireState(OrderLifecycleState.PENDING_PAYMENT);
+        cancel("payment expired: " + paymentIntentId, occurredAt, sourceCommandId, causationId, correlationId);
+    }
+
+    public void applyPostSalesItemCancellation(String orderItemId, String postSalesCaseId, String reason, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        if (state != OrderLifecycleState.CONFIRMED && state != OrderLifecycleState.POST_SALES_ADJUSTED && state != OrderLifecycleState.IN_TRAVEL) {
+            throw new DomainRuleViolation("post-sales item cancellation requires confirmed, adjusted, or in-travel order");
+        }
+        OrderItem item = orderItems.stream()
+            .filter(candidate -> candidate.orderItemId().equals(orderItemId))
+            .findFirst()
+            .orElseThrow(() -> new DomainRuleViolation("unknown order item " + orderItemId));
+        item.cancel(reason);
+        monetarySummary = MonetarySummary.fromItems(orderItems);
+        state = OrderLifecycleState.POST_SALES_ADJUSTED;
+        recordTimeline("PostSalesAdjustmentApplied", occurredAt, "post-sales", reason, Map.of("postSalesCaseId", postSalesCaseId, "orderItemId", orderItemId));
+        domainEvents.add(new JourneyOrderPostSalesAdjusted(orderId, accountId, postSalesCaseId, monetarySummary,
+            EventMetadata.create(occurredAt, sourceCommandId, causationId, correlationId, Map.of("state", state.name()))));
+    }
+
+    private void requireCreateInvariants() {
+        if (travelers.isEmpty()) {
+            throw new DomainRuleViolation("JourneyOrder requires at least one traveler snapshot");
+        }
+        if (segments.isEmpty()) {
+            throw new DomainRuleViolation("JourneyOrder requires at least one segment snapshot");
+        }
+        if (orderItems.isEmpty()) {
+            throw new DomainRuleViolation("JourneyOrder requires at least one order item");
+        }
+        Set<String> travelerIds = new HashSet<>();
+        for (TravelerRef traveler : travelers) {
+            if (!travelerIds.add(traveler.travelerId())) {
+                throw new DomainRuleViolation("duplicate traveler " + traveler.travelerId());
+            }
+        }
+        Set<String> segmentRefs = new HashSet<>();
+        for (SegmentOrderSnapshot segment : segments) {
+            if (!segmentRefs.add(segment.segmentRef())) {
+                throw new DomainRuleViolation("duplicate segment " + segment.segmentRef());
+            }
+        }
+        Set<String> itemIds = new HashSet<>();
+        for (OrderItem item : orderItems) {
+            if (!itemIds.add(item.orderItemId())) {
+                throw new DomainRuleViolation("duplicate order item " + item.orderItemId());
+            }
+            for (OrderLineBinding binding : item.bindings()) {
+                if (!binding.orderItemId().equals(item.orderItemId())) {
+                    throw new DomainRuleViolation("binding item id must match owner item id");
+                }
+                binding.requireKnownRefs(travelerIds, segmentRefs);
+            }
+        }
+    }
+
+    private void requireState(OrderLifecycleState expected) {
+        if (state != expected) {
+            throw new DomainRuleViolation("expected order state " + expected + " but was " + state);
+        }
+    }
+
+    private void recordTimeline(String type, Instant occurredAt, String actor, String reason, Map<String, String> attributes) {
+        timeline.add(TimelineFact.of(type, occurredAt, actor, reason, attributes));
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrderCancelled.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrderCancelled.java
@@ -1,0 +1,14 @@
+package com.trainticket.journeyorder.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record JourneyOrderCancelled(String orderId, String accountId, String cancellationReason, EventMetadata metadata) implements JourneyOrderEvent {
+    public String eventId() { return metadata.eventId(); }
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    public String causationId() { return metadata.causationId(); }
+    public String correlationId() { return metadata.correlationId(); }
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrderConfirmed.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrderConfirmed.java
@@ -1,0 +1,14 @@
+package com.trainticket.journeyorder.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record JourneyOrderConfirmed(String orderId, String accountId, MonetarySummary monetarySummary, EventMetadata metadata) implements JourneyOrderEvent {
+    public String eventId() { return metadata.eventId(); }
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    public String causationId() { return metadata.causationId(); }
+    public String correlationId() { return metadata.correlationId(); }
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrderCreated.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrderCreated.java
@@ -1,0 +1,14 @@
+package com.trainticket.journeyorder.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record JourneyOrderCreated(String orderId, String accountId, String offerId, MonetarySummary monetarySummary, EventMetadata metadata) implements JourneyOrderEvent {
+    public String eventId() { return metadata.eventId(); }
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    public String causationId() { return metadata.causationId(); }
+    public String correlationId() { return metadata.correlationId(); }
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrderEvent.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrderEvent.java
@@ -1,0 +1,25 @@
+package com.trainticket.journeyorder.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public sealed interface JourneyOrderEvent permits
+    JourneyOrderCreated,
+    JourneyOrderPendingPayment,
+    JourneyOrderConfirmed,
+    JourneyOrderCancelled,
+    JourneyOrderPostSalesAdjusted,
+    JourneyOrderPaymentRecorded {
+    String eventId();
+    Instant occurredAt();
+    String orderId();
+    String accountId();
+    String sourceCommandId();
+    String causationId();
+    String correlationId();
+    int schemaVersion();
+    Map<String, String> attributes();
+    default String eventType() {
+        return getClass().getSimpleName();
+    }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrderPaymentRecorded.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrderPaymentRecorded.java
@@ -1,0 +1,14 @@
+package com.trainticket.journeyorder.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record JourneyOrderPaymentRecorded(String orderId, String accountId, String paymentIntentId, EventMetadata metadata) implements JourneyOrderEvent {
+    public String eventId() { return metadata.eventId(); }
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    public String causationId() { return metadata.causationId(); }
+    public String correlationId() { return metadata.correlationId(); }
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrderPendingPayment.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrderPendingPayment.java
@@ -1,0 +1,14 @@
+package com.trainticket.journeyorder.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record JourneyOrderPendingPayment(String orderId, String accountId, String paymentPurpose, MonetarySummary monetarySummary, EventMetadata metadata) implements JourneyOrderEvent {
+    public String eventId() { return metadata.eventId(); }
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    public String causationId() { return metadata.causationId(); }
+    public String correlationId() { return metadata.correlationId(); }
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrderPostSalesAdjusted.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrderPostSalesAdjusted.java
@@ -1,0 +1,14 @@
+package com.trainticket.journeyorder.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record JourneyOrderPostSalesAdjusted(String orderId, String accountId, String postSalesCaseId, MonetarySummary monetarySummary, EventMetadata metadata) implements JourneyOrderEvent {
+    public String eventId() { return metadata.eventId(); }
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    public String causationId() { return metadata.causationId(); }
+    public String correlationId() { return metadata.correlationId(); }
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/MonetarySummary.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/MonetarySummary.java
@@ -1,0 +1,72 @@
+package com.trainticket.journeyorder.domain;
+
+import java.util.Currency;
+import java.util.List;
+import java.util.Objects;
+
+public record MonetarySummary(
+    Currency currency,
+    Money itemSubtotal,
+    Money taxTotal,
+    Money feeTotal,
+    Money discountTotal,
+    Money cancelledTotal,
+    Money payableTotal
+) {
+    public MonetarySummary {
+        Objects.requireNonNull(currency, "currency is required");
+        itemSubtotal = requireCurrency(itemSubtotal, currency, "itemSubtotal");
+        taxTotal = requireCurrency(taxTotal, currency, "taxTotal");
+        feeTotal = requireCurrency(feeTotal, currency, "feeTotal");
+        discountTotal = requireCurrency(discountTotal, currency, "discountTotal");
+        cancelledTotal = requireCurrency(cancelledTotal, currency, "cancelledTotal");
+        payableTotal = requireCurrency(payableTotal, currency, "payableTotal");
+        if (itemSubtotal.isNegative() || taxTotal.isNegative() || feeTotal.isNegative() || cancelledTotal.isNegative() || payableTotal.isNegative()) {
+            throw new DomainRuleViolation("monetary summary non-discount totals must not be negative");
+        }
+        if (discountTotal.amount().signum() > 0) {
+            throw new DomainRuleViolation("discountTotal must be zero or negative");
+        }
+        Money expected = itemSubtotal.plus(taxTotal).plus(feeTotal).plus(discountTotal).minus(cancelledTotal);
+        if (!expected.equals(payableTotal)) {
+            throw new DomainRuleViolation("payableTotal must equal items + taxes + fees + discounts - cancelledTotal");
+        }
+    }
+
+    public static MonetarySummary fromItems(List<OrderItem> items) {
+        if (items == null || items.isEmpty()) {
+            throw new DomainRuleViolation("JourneyOrder requires at least one order item");
+        }
+        Currency currency = items.getFirst().amount().currency();
+        Money itemSubtotal = Money.zero(currency);
+        Money taxTotal = Money.zero(currency);
+        Money feeTotal = Money.zero(currency);
+        Money discountTotal = Money.zero(currency);
+        Money cancelledTotal = Money.zero(currency);
+        for (OrderItem item : items) {
+            Money amount = requireCurrency(item.amount(), currency, "order item " + item.orderItemId());
+            if (item.cancelled()) {
+                cancelledTotal = cancelledTotal.plus(amount.amount().signum() < 0 ? amount.negate() : amount);
+            }
+            switch (item.type()) {
+                case TAX -> taxTotal = taxTotal.plus(amount);
+                case SERVICE_FEE -> feeTotal = feeTotal.plus(amount);
+                case DISCOUNT -> discountTotal = discountTotal.plus(amount);
+                case SEGMENT_FARE, ANCILLARY_SERVICE -> itemSubtotal = itemSubtotal.plus(amount);
+            }
+        }
+        Money payable = itemSubtotal.plus(taxTotal).plus(feeTotal).plus(discountTotal).minus(cancelledTotal);
+        if (payable.isNegative()) {
+            throw new DomainRuleViolation("payableTotal must not become negative");
+        }
+        return new MonetarySummary(currency, itemSubtotal, taxTotal, feeTotal, discountTotal, cancelledTotal, payable);
+    }
+
+    private static Money requireCurrency(Money money, Currency currency, String name) {
+        Objects.requireNonNull(money, name + " is required");
+        if (!money.currency().equals(currency)) {
+            throw new DomainRuleViolation(name + " currency must be " + currency);
+        }
+        return money;
+    }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/Money.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/Money.java
@@ -1,0 +1,61 @@
+package com.trainticket.journeyorder.domain;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Currency;
+import java.util.Objects;
+
+/**
+ * Minor domain money type for Journey Order commercial summaries.
+ * It deliberately models order commercial value only; it is not a payment-channel balance.
+ */
+public record Money(Currency currency, BigDecimal amount) implements Comparable<Money> {
+    public Money {
+        Objects.requireNonNull(currency, "currency is required");
+        Objects.requireNonNull(amount, "amount is required");
+        amount = amount.setScale(currency.getDefaultFractionDigits(), RoundingMode.UNNECESSARY);
+    }
+
+    public static Money of(String currencyCode, String amount) {
+        return new Money(Currency.getInstance(currencyCode), new BigDecimal(amount));
+    }
+
+    public static Money zero(Currency currency) {
+        return new Money(currency, BigDecimal.ZERO.setScale(currency.getDefaultFractionDigits()));
+    }
+
+    public Money plus(Money other) {
+        requireSameCurrency(other);
+        return new Money(currency, amount.add(other.amount));
+    }
+
+    public Money minus(Money other) {
+        requireSameCurrency(other);
+        return new Money(currency, amount.subtract(other.amount));
+    }
+
+    public Money negate() {
+        return new Money(currency, amount.negate());
+    }
+
+    public boolean isNegative() {
+        return amount.signum() < 0;
+    }
+
+    public boolean isZero() {
+        return amount.signum() == 0;
+    }
+
+    @Override
+    public int compareTo(Money other) {
+        requireSameCurrency(other);
+        return amount.compareTo(other.amount);
+    }
+
+    private void requireSameCurrency(Money other) {
+        Objects.requireNonNull(other, "other money is required");
+        if (!currency.equals(other.currency)) {
+            throw new DomainRuleViolation("money currency mismatch: " + currency + " vs " + other.currency);
+        }
+    }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/OfferSnapshotRef.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/OfferSnapshotRef.java
@@ -1,0 +1,38 @@
+package com.trainticket.journeyorder.domain;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record OfferSnapshotRef(
+    String offerId,
+    int offerVersion,
+    Instant quotedAt,
+    Instant expiresAt,
+    String ruleSnapshotId
+) {
+    public OfferSnapshotRef {
+        requireText(offerId, "offerId");
+        if (offerVersion < 1) {
+            throw new DomainRuleViolation("offerVersion must be positive");
+        }
+        Objects.requireNonNull(quotedAt, "quotedAt is required");
+        Objects.requireNonNull(expiresAt, "expiresAt is required");
+        requireText(ruleSnapshotId, "ruleSnapshotId");
+        if (!expiresAt.isAfter(quotedAt)) {
+            throw new DomainRuleViolation("offer expiresAt must be after quotedAt");
+        }
+    }
+
+    public void requireValidAt(Instant now) {
+        Objects.requireNonNull(now, "now is required");
+        if (!now.isBefore(expiresAt)) {
+            throw new DomainRuleViolation("cannot create JourneyOrder from expired offer " + offerId);
+        }
+    }
+
+    private static void requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+    }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/OrderItem.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/OrderItem.java
@@ -1,0 +1,87 @@
+package com.trainticket.journeyorder.domain;
+
+import java.util.List;
+import java.util.Objects;
+
+public final class OrderItem {
+    private final String orderItemId;
+    private final OrderItemType type;
+    private final String description;
+    private final Money amount;
+    private final String commercialReasonRef;
+    private final List<OrderLineBinding> bindings;
+    private boolean cancelled;
+    private String cancellationReason;
+
+    public OrderItem(
+        String orderItemId,
+        OrderItemType type,
+        String description,
+        Money amount,
+        String commercialReasonRef,
+        List<OrderLineBinding> bindings
+    ) {
+        this.orderItemId = requireText(orderItemId, "orderItemId");
+        this.type = Objects.requireNonNull(type, "type is required");
+        this.description = requireText(description, "description");
+        this.amount = Objects.requireNonNull(amount, "amount is required");
+        this.commercialReasonRef = requireText(commercialReasonRef, "commercialReasonRef");
+        this.bindings = List.copyOf(Objects.requireNonNull(bindings, "bindings are required"));
+        if (this.bindings.isEmpty() && type != OrderItemType.SERVICE_FEE && type != OrderItemType.DISCOUNT && type != OrderItemType.TAX) {
+            throw new DomainRuleViolation("chargeable segment or ancillary order item requires traveler/line binding");
+        }
+        if (type == OrderItemType.DISCOUNT && amount.amount().signum() > 0) {
+            throw new DomainRuleViolation("discount order item amount must be zero or negative");
+        }
+        if (type != OrderItemType.DISCOUNT && amount.isNegative()) {
+            throw new DomainRuleViolation(type + " order item amount must not be negative");
+        }
+    }
+
+    public String orderItemId() {
+        return orderItemId;
+    }
+
+    public OrderItemType type() {
+        return type;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    public Money amount() {
+        return amount;
+    }
+
+    public String commercialReasonRef() {
+        return commercialReasonRef;
+    }
+
+    public List<OrderLineBinding> bindings() {
+        return bindings;
+    }
+
+    public boolean cancelled() {
+        return cancelled;
+    }
+
+    public String cancellationReason() {
+        return cancellationReason;
+    }
+
+    public void cancel(String reason) {
+        if (cancelled) {
+            return;
+        }
+        cancelled = true;
+        cancellationReason = requireText(reason, "reason");
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/OrderItemType.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/OrderItemType.java
@@ -1,0 +1,9 @@
+package com.trainticket.journeyorder.domain;
+
+public enum OrderItemType {
+    SEGMENT_FARE,
+    ANCILLARY_SERVICE,
+    SERVICE_FEE,
+    TAX,
+    DISCOUNT
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/OrderLifecycleState.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/OrderLifecycleState.java
@@ -1,0 +1,16 @@
+package com.trainticket.journeyorder.domain;
+
+public enum OrderLifecycleState {
+    DRAFT,
+    PENDING_CONFIRMATION,
+    PENDING_PAYMENT,
+    CONFIRMING,
+    CONFIRMED,
+    PARTIALLY_CONFIRMED,
+    IN_TRAVEL,
+    COMPLETED,
+    CANCELLED,
+    DISRUPTED,
+    FAILED,
+    POST_SALES_ADJUSTED
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/OrderLineBinding.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/OrderLineBinding.java
@@ -1,0 +1,36 @@
+package com.trainticket.journeyorder.domain;
+
+import java.util.Objects;
+import java.util.Set;
+
+public record OrderLineBinding(
+    String orderItemId,
+    String travelerId,
+    String segmentRef,
+    String ancillaryRef
+) {
+    public OrderLineBinding {
+        requireText(orderItemId, "orderItemId");
+        requireText(travelerId, "travelerId");
+        if ((segmentRef == null || segmentRef.isBlank()) && (ancillaryRef == null || ancillaryRef.isBlank())) {
+            throw new DomainRuleViolation("order line binding must reference a segment or ancillary service");
+        }
+        segmentRef = segmentRef == null ? "" : segmentRef;
+        ancillaryRef = ancillaryRef == null ? "" : ancillaryRef;
+    }
+
+    public void requireKnownRefs(Set<String> knownTravelerIds, Set<String> knownSegmentRefs) {
+        if (!knownTravelerIds.contains(travelerId)) {
+            throw new DomainRuleViolation("binding references unknown traveler " + travelerId);
+        }
+        if (!segmentRef.isBlank() && !knownSegmentRefs.contains(segmentRef)) {
+            throw new DomainRuleViolation("binding references unknown segment " + segmentRef);
+        }
+    }
+
+    private static void requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+    }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/SegmentOrderSnapshot.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/SegmentOrderSnapshot.java
@@ -1,0 +1,33 @@
+package com.trainticket.journeyorder.domain;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record SegmentOrderSnapshot(
+    String segmentRef,
+    String origin,
+    String destination,
+    String transportMode,
+    Instant departureTime,
+    Instant arrivalTime,
+    String connectionContractRef
+) {
+    public SegmentOrderSnapshot {
+        requireText(segmentRef, "segmentRef");
+        requireText(origin, "origin");
+        requireText(destination, "destination");
+        requireText(transportMode, "transportMode");
+        Objects.requireNonNull(departureTime, "departureTime is required");
+        Objects.requireNonNull(arrivalTime, "arrivalTime is required");
+        if (!arrivalTime.isAfter(departureTime)) {
+            throw new DomainRuleViolation("segment arrivalTime must be after departureTime");
+        }
+        connectionContractRef = connectionContractRef == null ? "" : connectionContractRef;
+    }
+
+    private static void requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+    }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/TimelineFact.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/TimelineFact.java
@@ -1,0 +1,35 @@
+package com.trainticket.journeyorder.domain;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+public record TimelineFact(
+    String factId,
+    String factType,
+    Instant occurredAt,
+    String actor,
+    String reason,
+    Map<String, String> attributes
+) {
+    public TimelineFact {
+        factId = requireText(factId, "factId");
+        factType = requireText(factType, "factType");
+        Objects.requireNonNull(occurredAt, "occurredAt is required");
+        actor = requireText(actor, "actor");
+        reason = requireText(reason, "reason");
+        attributes = Map.copyOf(Objects.requireNonNull(attributes, "attributes are required"));
+    }
+
+    public static TimelineFact of(String factType, Instant occurredAt, String actor, String reason, Map<String, String> attributes) {
+        return new TimelineFact(UUID.randomUUID().toString(), factType, occurredAt, actor, reason, attributes);
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/TravelerRef.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/TravelerRef.java
@@ -1,0 +1,23 @@
+package com.trainticket.journeyorder.domain;
+
+import java.util.Objects;
+
+public record TravelerRef(
+    String travelerId,
+    String maskedDocumentRef,
+    String travelerType,
+    String qualificationVersion
+) {
+    public TravelerRef {
+        requireText(travelerId, "travelerId");
+        requireText(maskedDocumentRef, "maskedDocumentRef");
+        requireText(travelerType, "travelerType");
+        requireText(qualificationVersion, "qualificationVersion");
+    }
+
+    private static void requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+    }
+}

--- a/services/journey-order/src/test/java/com/trainticket/journeyorder/domain/JourneyOrderTest.java
+++ b/services/journey-order/src/test/java/com/trainticket/journeyorder/domain/JourneyOrderTest.java
@@ -1,0 +1,170 @@
+package com.trainticket.journeyorder.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class JourneyOrderTest {
+    private static final Instant NOW = Instant.parse("2026-07-03T12:00:00Z");
+
+    @Test
+    void createsJourneyOrderFromValidOfferWithTravelerSnapshotsAndCreatedEvent() {
+        JourneyOrder order = sampleOrder();
+
+        assertEquals(OrderLifecycleState.PENDING_CONFIRMATION, order.state());
+        assertEquals("account-1:offer-1:client-req-1", order.idempotencyKey());
+        assertEquals(Money.of("CNY", "143.00"), order.monetarySummary().payableTotal());
+        assertEquals(1, order.travelers().size());
+        assertEquals(1, order.segments().size());
+        assertEquals(1, order.timeline().size());
+        JourneyOrderEvent event = assertInstanceOf(JourneyOrderCreated.class, order.domainEvents().getFirst());
+        assertEquals("JourneyOrderCreated", event.eventType());
+        assertEquals(1, event.schemaVersion());
+        assertEquals(order.orderId(), event.orderId());
+    }
+
+    @Test
+    void refusesExpiredOfferAndInvalidTravelerBinding() {
+        OfferSnapshotRef expiredOffer = new OfferSnapshotRef("offer-expired", 1, NOW.minusSeconds(600), NOW.minusSeconds(1), "rule-1");
+        assertThrows(DomainRuleViolation.class, () -> createOrder(expiredOffer, sampleItems("missing-traveler")));
+
+        assertThrows(DomainRuleViolation.class, () -> createOrder(sampleOffer(), sampleItems("unknown-traveler")));
+    }
+
+    @Test
+    void monetarySummaryRequiresCurrencyAndPayableInvariants() {
+        assertThrows(DomainRuleViolation.class, () -> new MonetarySummary(
+            java.util.Currency.getInstance("CNY"),
+            Money.of("CNY", "100.00"),
+            Money.of("CNY", "10.00"),
+            Money.of("CNY", "5.00"),
+            Money.of("CNY", "-2.00"),
+            Money.of("CNY", "0.00"),
+            Money.of("CNY", "999.00")
+        ));
+        assertThrows(DomainRuleViolation.class, () -> List.of(
+            new OrderItem("fare", OrderItemType.SEGMENT_FARE, "fare", Money.of("CNY", "100.00"), "segment-1", List.of(binding("fare", "traveler-1"))),
+            new OrderItem("fee", OrderItemType.SERVICE_FEE, "fee", Money.of("USD", "1.00"), "fee-rule", List.of())
+        ).stream().collect(java.util.stream.Collectors.collectingAndThen(java.util.stream.Collectors.toList(), MonetarySummary::fromItems)));
+    }
+
+    @Test
+    void paymentCapturedCannotDirectlyConfirmWithoutAcceptedDomainFacts() {
+        JourneyOrder order = sampleOrder();
+        order.markBookingAndCapacityAccepted(NOW.plusSeconds(1), "cmd-booking", "corr-1");
+        order.markPendingPayment("initial-ticket-purchase", NOW.plusSeconds(2), "cmd-pay-request", "corr-1");
+        order.recordPaymentCaptured("payment-intent-1", NOW.plusSeconds(3), "cmd-payment", "payment-event-1", "corr-1");
+
+        assertEquals(OrderLifecycleState.CONFIRMING, order.state());
+        assertTrue(order.confirmationConditions().paymentConditionSatisfied());
+        assertFalse(order.confirmationConditions().entitlementSummaryAccepted());
+        assertThrows(DomainRuleViolation.class, () -> order.confirm("attempt-1", NOW.plusSeconds(4), "cmd-confirm", "payment-event-1", "corr-1"));
+    }
+
+    @Test
+    void confirmsOnlyAfterBookingCapacityPaymentAndEntitlementSummariesAccepted() {
+        JourneyOrder order = sampleOrder();
+        order.markBookingAndCapacityAccepted(NOW.plusSeconds(1), "cmd-booking", "corr-1");
+        order.markPendingPayment("initial-ticket-purchase", NOW.plusSeconds(2), "cmd-pay-request", "corr-1");
+        order.recordPaymentCaptured("payment-intent-1", NOW.plusSeconds(3), "cmd-payment", "payment-event-1", "corr-1");
+        order.recordEntitlementSummaryAccepted(NOW.plusSeconds(4), "cmd-entitlement", "entitlement-event-1", "corr-1");
+        order.confirm("attempt-1", NOW.plusSeconds(5), "cmd-confirm", "entitlement-event-1", "corr-1");
+
+        assertEquals(OrderLifecycleState.CONFIRMED, order.state());
+        assertInstanceOf(JourneyOrderConfirmed.class, order.domainEvents().getLast());
+        assertEquals(List.of(
+            "JourneyOrderCreated",
+            "BookingCapacitySummaryAccepted",
+            "JourneyOrderPendingPayment",
+            "PaymentCaptured",
+            "EntitlementSummaryAccepted",
+            "JourneyOrderConfirmed"
+        ), order.timeline().stream().map(TimelineFact::factType).toList());
+    }
+
+    @Test
+    void paymentExpiryCancelsPendingPaymentOrder() {
+        JourneyOrder order = sampleOrder();
+        order.markBookingAndCapacityAccepted(NOW.plusSeconds(1), "cmd-booking", "corr-1");
+        order.markPendingPayment("initial-ticket-purchase", NOW.plusSeconds(2), "cmd-pay-request", "corr-1");
+
+        order.expirePayment("payment-intent-1", NOW.plusSeconds(3), "cmd-expire", "payment-expired-1", "corr-1");
+
+        assertEquals(OrderLifecycleState.CANCELLED, order.state());
+        assertInstanceOf(JourneyOrderCancelled.class, order.domainEvents().getLast());
+    }
+
+    @Test
+    void postSalesAdjustmentCancelsItemAndRecomputesCommercialSummaryWithoutOwningRefund() {
+        JourneyOrder order = confirmedOrder();
+
+        order.applyPostSalesItemCancellation("meal", "post-sales-case-1", "ancillary cancelled by post sales", NOW.plusSeconds(10), "cmd-adjust", "post-sales-applied-1", "corr-1");
+
+        assertEquals(OrderLifecycleState.POST_SALES_ADJUSTED, order.state());
+        assertEquals(Money.of("CNY", "128.00"), order.monetarySummary().payableTotal());
+        assertEquals(Money.of("CNY", "15.00"), order.monetarySummary().cancelledTotal());
+        assertInstanceOf(JourneyOrderPostSalesAdjusted.class, order.domainEvents().getLast());
+        assertTrue(order.timeline().stream().anyMatch(fact -> fact.factType().equals("PostSalesAdjustmentApplied")
+            && fact.attributes().get("postSalesCaseId").equals("post-sales-case-1")));
+    }
+
+    private static JourneyOrder confirmedOrder() {
+        JourneyOrder order = sampleOrder();
+        order.markBookingAndCapacityAccepted(NOW.plusSeconds(1), "cmd-booking", "corr-1");
+        order.markPendingPayment("initial-ticket-purchase", NOW.plusSeconds(2), "cmd-pay-request", "corr-1");
+        order.recordPaymentCaptured("payment-intent-1", NOW.plusSeconds(3), "cmd-payment", "payment-event-1", "corr-1");
+        order.recordEntitlementSummaryAccepted(NOW.plusSeconds(4), "cmd-entitlement", "entitlement-event-1", "corr-1");
+        order.confirm("attempt-1", NOW.plusSeconds(5), "cmd-confirm", "entitlement-event-1", "corr-1");
+        return order;
+    }
+
+    private static JourneyOrder sampleOrder() {
+        return createOrder(sampleOffer(), sampleItems("traveler-1"));
+    }
+
+    private static JourneyOrder createOrder(OfferSnapshotRef offer, List<OrderItem> items) {
+        return JourneyOrder.createFromOffer(
+            "account-1",
+            "mobile-app",
+            "client-req-1",
+            offer,
+            List.of(new TravelerRef("traveler-1", "doc-mask-1", "ADULT", "qualification-v1")),
+            List.of(new SegmentOrderSnapshot(
+                "segment-1",
+                "BJP",
+                "SHA",
+                "TRAIN",
+                NOW.plusSeconds(86_400),
+                NOW.plusSeconds(111_600),
+                "connection-contract-1"
+            )),
+            items,
+            NOW,
+            "cmd-create",
+            "corr-1"
+        );
+    }
+
+    private static OfferSnapshotRef sampleOffer() {
+        return new OfferSnapshotRef("offer-1", 3, NOW.minusSeconds(60), NOW.plusSeconds(600), "rule-snapshot-1");
+    }
+
+    private static List<OrderItem> sampleItems(String travelerId) {
+        return List.of(
+            new OrderItem("fare", OrderItemType.SEGMENT_FARE, "train fare", Money.of("CNY", "120.00"), "segment-1", List.of(binding("fare", travelerId))),
+            new OrderItem("meal", OrderItemType.ANCILLARY_SERVICE, "meal ancillary", Money.of("CNY", "15.00"), "ancillary-meal-1", List.of(new OrderLineBinding("meal", travelerId, "segment-1", "ancillary-meal-1"))),
+            new OrderItem("service-fee", OrderItemType.SERVICE_FEE, "service fee", Money.of("CNY", "10.00"), "fee-rule-1", List.of()),
+            new OrderItem("discount", OrderItemType.DISCOUNT, "coupon", Money.of("CNY", "-2.00"), "promotion-ref-1", List.of())
+        );
+    }
+
+    private static OrderLineBinding binding(String itemId, String travelerId) {
+        return new OrderLineBinding(itemId, travelerId, "segment-1", "");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds JourneyOrder aggregate/value objects for offer-based creation, traveler and line bindings, monetary summary invariants, lifecycle states and timeline facts.
- Adds confirmation condition guards so PaymentCaptured moves only to confirming until booking/capacity/payment/entitlement/risk summary facts are accepted.
- Adds domain events and post-sales adjustment/cancellation behavior, plus REQ-010 README/profile metadata.

## Validation
- cd services/journey-order && mvn -q test
- make check-strict