### PR TITLE
REQ-012 Payment domain foundation

### DIFF
--- a/services/payment/README.md
+++ b/services/payment/README.md
@@ -4,26 +4,34 @@ Domain: Payment
 
 Language: java
 
-Phase: phase-1-core
+Phase: phase-1-domain-foundation
 
-Status: skeleton
+Status: REQ-012 domain foundation
+
+Work Package: REQ-012-Payment-domain-foundation
 
 ## Owns
 
-- PaymentIntent
-- Refund
-- CallbackRecord
-- IdempotencyKey
+- `PaymentIntent` creation, authorization, capture, failure, cancellation, expiration, captured/refunded balance, and business idempotency keys.
+- `ChannelCallbackRecord` audit and channel callback duplicate detection.
+- `Refund` request, submit, settlement, retryable failure, and final/manual-review failure lifecycle for original-route refunds.
+- `LatePaymentCase` facts for captures that arrive after cancellation or expiration.
+- Domain events including `PaymentIntentCreated`, `PaymentAuthorized`, `PaymentCaptured`, `PaymentFailed`, `PaymentIntentExpired`, `RefundRequested`, `RefundSettled`, `RefundFailed`, `ChannelCallbackReceived`, duplicate callback facts, and `LatePaymentDetected`.
+
+## Boundary Rules
+
+Payment publishes funds facts only. It must not confirm orders, issue entitlements, mutate capacity, send notifications directly, or make post-sales refund eligibility decisions. A late `PaymentCaptured` after order cancellation/intent expiration opens a `LatePaymentCase`; it does not recover an order or ticket.
 
 ## DDD Sources
 
 - `docs/02-domains/payment.md`
+- `docs/03-ddd-final/phase-1-contract.md`
 
 ## Language Rationale
 
 Java is a strong default for money state machines, idempotency, and audit-heavy flows.
 
-## Skeleton Check
+## Validation
 
 ```bash
 mvn test

--- a/services/payment/src/main/java/com/trainticket/payment/Application.java
+++ b/services/payment/src/main/java/com/trainticket/payment/Application.java
@@ -15,9 +15,9 @@ public class Application {
             "payment",
             "Payment",
             "java",
-            "phase-1-core",
-            "WP-10",
-            "PaymentIntent, Refund, CallbackRecord, IdempotencyKey"
+            "phase-1-domain-foundation",
+            "REQ-012-Payment-domain-foundation",
+            "PaymentIntent aggregate, Refund aggregate, ChannelCallbackRecord idempotency, LatePaymentCase facts, original-route refund lifecycle"
         );
     }
 }

--- a/services/payment/src/main/java/com/trainticket/payment/domain/CallbackProcessingStatus.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/CallbackProcessingStatus.java
@@ -1,0 +1,8 @@
+package com.trainticket.payment.domain;
+
+public enum CallbackProcessingStatus {
+    RECEIVED,
+    APPLIED,
+    DUPLICATE,
+    REJECTED
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/ChannelCallbackReceived.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/ChannelCallbackReceived.java
@@ -1,0 +1,14 @@
+package com.trainticket.payment.domain;
+
+public record ChannelCallbackReceived(
+    String callbackRecordId,
+    String channel,
+    String callbackId,
+    String payloadDigest,
+    EventMetadata metadata
+) implements PaymentEvent {
+    @Override
+    public String eventType() {
+        return "ChannelCallbackReceived";
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/ChannelCallbackRecord.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/ChannelCallbackRecord.java
@@ -1,0 +1,98 @@
+package com.trainticket.payment.domain;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class ChannelCallbackRecord {
+    private final String callbackRecordId;
+    private final String channel;
+    private final String callbackId;
+    private final String payloadDigest;
+    private final String callbackType;
+    private final Instant receivedAt;
+    private final PaymentEvent auditEvent;
+    private CallbackProcessingStatus status;
+    private String firstCallbackRecordId;
+
+    private ChannelCallbackRecord(
+        String callbackRecordId,
+        String channel,
+        String callbackId,
+        String payloadDigest,
+        String callbackType,
+        Instant receivedAt,
+        CallbackProcessingStatus status,
+        String firstCallbackRecordId,
+        PaymentEvent auditEvent
+    ) {
+        this.callbackRecordId = requireText(callbackRecordId, "callbackRecordId");
+        this.channel = requireText(channel, "channel");
+        this.callbackId = requireText(callbackId, "callbackId");
+        this.payloadDigest = requireText(payloadDigest, "payloadDigest");
+        this.callbackType = requireText(callbackType, "callbackType");
+        this.receivedAt = Objects.requireNonNull(receivedAt, "receivedAt is required");
+        this.status = Objects.requireNonNull(status, "status is required");
+        this.firstCallbackRecordId = firstCallbackRecordId;
+        this.auditEvent = Objects.requireNonNull(auditEvent, "auditEvent is required");
+    }
+
+    public static ChannelCallbackRecord receive(
+        String channel,
+        String callbackId,
+        String payloadDigest,
+        String callbackType,
+        List<ChannelCallbackRecord> existingRecords,
+        Instant receivedAt,
+        String sourceCommandId,
+        String correlationId
+    ) {
+        Objects.requireNonNull(existingRecords, "existingRecords are required");
+        String id = UUID.randomUUID().toString();
+        return existingRecords.stream()
+            .filter(record -> record.hasSameIdempotencyKey(channel, callbackId, payloadDigest))
+            .findFirst()
+            .map(first -> new ChannelCallbackRecord(id, channel, callbackId, payloadDigest, callbackType, receivedAt, CallbackProcessingStatus.DUPLICATE, first.callbackRecordId,
+                new DuplicateChannelCallbackDetected(id, channel, callbackId, first.callbackRecordId,
+                    EventMetadata.create(receivedAt, sourceCommandId, sourceCommandId, correlationId, Map.of("status", CallbackProcessingStatus.DUPLICATE.name())))))
+            .orElseGet(() -> new ChannelCallbackRecord(id, channel, callbackId, payloadDigest, callbackType, receivedAt, CallbackProcessingStatus.RECEIVED, null,
+                new ChannelCallbackReceived(id, channel, callbackId, payloadDigest,
+                    EventMetadata.create(receivedAt, sourceCommandId, sourceCommandId, correlationId, Map.of("status", CallbackProcessingStatus.RECEIVED.name())))));
+    }
+
+    public String callbackRecordId() { return callbackRecordId; }
+    public String channel() { return channel; }
+    public String callbackId() { return callbackId; }
+    public String payloadDigest() { return payloadDigest; }
+    public String callbackType() { return callbackType; }
+    public Instant receivedAt() { return receivedAt; }
+    public CallbackProcessingStatus status() { return status; }
+    public String firstCallbackRecordId() { return firstCallbackRecordId; }
+    public PaymentEvent auditEvent() { return auditEvent; }
+
+    public boolean isDuplicate() {
+        return status == CallbackProcessingStatus.DUPLICATE;
+    }
+
+    public void markApplied() {
+        if (status == CallbackProcessingStatus.DUPLICATE || status == CallbackProcessingStatus.REJECTED) {
+            throw new DomainRuleViolation("duplicate or rejected callbacks cannot be applied");
+        }
+        status = CallbackProcessingStatus.APPLIED;
+    }
+
+    public boolean hasSameIdempotencyKey(String channel, String callbackId, String payloadDigest) {
+        return this.channel.equals(requireText(channel, "channel"))
+            && this.callbackId.equals(requireText(callbackId, "callbackId"))
+            && this.payloadDigest.equals(requireText(payloadDigest, "payloadDigest"));
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/DomainRuleViolation.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/DomainRuleViolation.java
@@ -1,0 +1,7 @@
+package com.trainticket.payment.domain;
+
+public class DomainRuleViolation extends RuntimeException {
+    public DomainRuleViolation(String message) {
+        super(message);
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/DuplicateChannelCallbackDetected.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/DuplicateChannelCallbackDetected.java
@@ -1,0 +1,14 @@
+package com.trainticket.payment.domain;
+
+public record DuplicateChannelCallbackDetected(
+    String callbackRecordId,
+    String channel,
+    String callbackId,
+    String firstCallbackRecordId,
+    EventMetadata metadata
+) implements PaymentEvent {
+    @Override
+    public String eventType() {
+        return "DuplicateChannelCallbackDetected";
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/EventMetadata.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/EventMetadata.java
@@ -1,0 +1,45 @@
+package com.trainticket.payment.domain;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+public record EventMetadata(
+    String eventId,
+    Instant occurredAt,
+    String sourceCommandId,
+    String causationId,
+    String correlationId,
+    int schemaVersion,
+    Map<String, String> attributes
+) {
+    public EventMetadata {
+        eventId = requireText(eventId, "eventId");
+        Objects.requireNonNull(occurredAt, "occurredAt is required");
+        sourceCommandId = requireText(sourceCommandId, "sourceCommandId");
+        causationId = requireText(causationId, "causationId");
+        correlationId = requireText(correlationId, "correlationId");
+        if (schemaVersion < 1) {
+            throw new DomainRuleViolation("schemaVersion must be positive");
+        }
+        attributes = Map.copyOf(Objects.requireNonNull(attributes, "attributes are required"));
+    }
+
+    public static EventMetadata create(
+        Instant occurredAt,
+        String sourceCommandId,
+        String causationId,
+        String correlationId,
+        Map<String, String> attributes
+    ) {
+        return new EventMetadata(UUID.randomUUID().toString(), occurredAt, sourceCommandId, causationId, correlationId, 1, attributes);
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/IdempotencyLedger.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/IdempotencyLedger.java
@@ -1,0 +1,36 @@
+package com.trainticket.payment.domain;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public final class IdempotencyLedger<T> {
+    private final Map<String, Entry<T>> entries = new HashMap<>();
+
+    public T recordOrReturn(String scope, String idempotencyKey, Instant now, Supplier<T> creator) {
+        String ledgerKey = requireText(scope, "scope") + ":" + requireText(idempotencyKey, "idempotencyKey");
+        Entry<T> existing = entries.get(ledgerKey);
+        if (existing != null) {
+            return existing.value();
+        }
+        T value = Objects.requireNonNull(creator, "creator is required").get();
+        entries.put(ledgerKey, new Entry<>(value, Objects.requireNonNull(now, "now is required")));
+        return value;
+    }
+
+    public int size() {
+        return entries.size();
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+
+    private record Entry<T>(T value, Instant recordedAt) {
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/LatePaymentCase.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/LatePaymentCase.java
@@ -1,0 +1,84 @@
+package com.trainticket.payment.domain;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class LatePaymentCase {
+    private final String latePaymentCaseId;
+    private final String paymentIntentId;
+    private final Money capturedAmount;
+    private final String channel;
+    private final String channelTransactionId;
+    private final String reason;
+    private final Instant detectedAt;
+    private final PaymentEvent domainEvent;
+    private LatePaymentCaseStatus status;
+    private String resolutionNote;
+
+    private LatePaymentCase(
+        String latePaymentCaseId,
+        String paymentIntentId,
+        Money capturedAmount,
+        String channel,
+        String channelTransactionId,
+        String reason,
+        Instant detectedAt,
+        PaymentEvent domainEvent
+    ) {
+        this.latePaymentCaseId = requireText(latePaymentCaseId, "latePaymentCaseId");
+        this.paymentIntentId = requireText(paymentIntentId, "paymentIntentId");
+        this.capturedAmount = Objects.requireNonNull(capturedAmount, "capturedAmount is required");
+        this.channel = requireText(channel, "channel");
+        this.channelTransactionId = requireText(channelTransactionId, "channelTransactionId");
+        this.reason = requireText(reason, "reason");
+        this.detectedAt = Objects.requireNonNull(detectedAt, "detectedAt is required");
+        this.domainEvent = Objects.requireNonNull(domainEvent, "domainEvent is required");
+        this.status = LatePaymentCaseStatus.OPEN;
+    }
+
+    static LatePaymentCase open(
+        String paymentIntentId,
+        Money capturedAmount,
+        String channel,
+        String channelTransactionId,
+        String reason,
+        Instant detectedAt,
+        String sourceCommandId,
+        String causationId,
+        String correlationId
+    ) {
+        String id = UUID.randomUUID().toString();
+        LatePaymentDetected event = new LatePaymentDetected(id, paymentIntentId, capturedAmount, channelTransactionId, reason,
+            EventMetadata.create(detectedAt, sourceCommandId, causationId, correlationId, Map.of("status", LatePaymentCaseStatus.OPEN.name(), "channel", channel)));
+        return new LatePaymentCase(id, paymentIntentId, capturedAmount, channel, channelTransactionId, reason, detectedAt, event);
+    }
+
+    public String latePaymentCaseId() { return latePaymentCaseId; }
+    public String paymentIntentId() { return paymentIntentId; }
+    public Money capturedAmount() { return capturedAmount; }
+    public String channel() { return channel; }
+    public String channelTransactionId() { return channelTransactionId; }
+    public String reason() { return reason; }
+    public Instant detectedAt() { return detectedAt; }
+    public LatePaymentCaseStatus status() { return status; }
+    public String resolutionNote() { return resolutionNote; }
+    public List<PaymentEvent> domainEvents() { return List.of(domainEvent); }
+
+    public void resolve(String resolutionNote) {
+        if (status == LatePaymentCaseStatus.RESOLVED) {
+            return;
+        }
+        this.resolutionNote = requireText(resolutionNote, "resolutionNote");
+        this.status = LatePaymentCaseStatus.RESOLVED;
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/LatePaymentCaseStatus.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/LatePaymentCaseStatus.java
@@ -1,0 +1,6 @@
+package com.trainticket.payment.domain;
+
+public enum LatePaymentCaseStatus {
+    OPEN,
+    RESOLVED
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/LatePaymentDetected.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/LatePaymentDetected.java
@@ -1,0 +1,15 @@
+package com.trainticket.payment.domain;
+
+public record LatePaymentDetected(
+    String latePaymentCaseId,
+    String paymentIntentId,
+    Money capturedAmount,
+    String channelTransactionId,
+    String reason,
+    EventMetadata metadata
+) implements PaymentEvent {
+    @Override
+    public String eventType() {
+        return "LatePaymentDetected";
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/Money.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/Money.java
@@ -1,0 +1,68 @@
+package com.trainticket.payment.domain;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Currency;
+import java.util.Objects;
+
+public record Money(BigDecimal amount, Currency currency) implements Comparable<Money> {
+    public Money {
+        Objects.requireNonNull(amount, "amount is required");
+        Objects.requireNonNull(currency, "currency is required");
+        amount = amount.setScale(currency.getDefaultFractionDigits(), RoundingMode.UNNECESSARY);
+        if (amount.signum() < 0) {
+            throw new DomainRuleViolation("money amount must not be negative");
+        }
+    }
+
+    public static Money of(String amount, String currencyCode) {
+        return new Money(new BigDecimal(amount), Currency.getInstance(requireText(currencyCode, "currencyCode")));
+    }
+
+    public static Money zero(Currency currency) {
+        return new Money(BigDecimal.ZERO, currency);
+    }
+
+    public boolean isZero() {
+        return amount.signum() == 0;
+    }
+
+    public Money add(Money other) {
+        requireSameCurrency(other);
+        return new Money(amount.add(other.amount), currency);
+    }
+
+    public Money subtract(Money other) {
+        requireSameCurrency(other);
+        BigDecimal result = amount.subtract(other.amount);
+        if (result.signum() < 0) {
+            throw new DomainRuleViolation("money subtraction would become negative");
+        }
+        return new Money(result, currency);
+    }
+
+    public boolean isGreaterThan(Money other) {
+        requireSameCurrency(other);
+        return amount.compareTo(other.amount) > 0;
+    }
+
+    @Override
+    public int compareTo(Money other) {
+        requireSameCurrency(other);
+        return amount.compareTo(other.amount);
+    }
+
+    private void requireSameCurrency(Money other) {
+        Objects.requireNonNull(other, "other money is required");
+        if (!currency.equals(other.currency)) {
+            throw new DomainRuleViolation("currency mismatch: " + currency + " vs " + other.currency);
+        }
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/PaymentAuthorized.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/PaymentAuthorized.java
@@ -1,0 +1,14 @@
+package com.trainticket.payment.domain;
+
+public record PaymentAuthorized(
+    String paymentIntentId,
+    Money authorizedAmount,
+    String channel,
+    String channelTransactionId,
+    EventMetadata metadata
+) implements PaymentEvent {
+    @Override
+    public String eventType() {
+        return "PaymentAuthorized";
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/PaymentCaptured.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/PaymentCaptured.java
@@ -1,0 +1,14 @@
+package com.trainticket.payment.domain;
+
+public record PaymentCaptured(
+    String paymentIntentId,
+    Money capturedAmount,
+    String channel,
+    String channelTransactionId,
+    EventMetadata metadata
+) implements PaymentEvent {
+    @Override
+    public String eventType() {
+        return "PaymentCaptured";
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/PaymentEvent.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/PaymentEvent.java
@@ -1,0 +1,18 @@
+package com.trainticket.payment.domain;
+
+public sealed interface PaymentEvent permits
+    PaymentIntentCreated,
+    PaymentAuthorized,
+    PaymentCaptured,
+    PaymentFailed,
+    PaymentIntentCancelled,
+    PaymentIntentExpired,
+    RefundRequested,
+    RefundSettled,
+    RefundFailed,
+    ChannelCallbackReceived,
+    DuplicateChannelCallbackDetected,
+    LatePaymentDetected {
+    String eventType();
+    EventMetadata metadata();
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/PaymentFailed.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/PaymentFailed.java
@@ -1,0 +1,13 @@
+package com.trainticket.payment.domain;
+
+public record PaymentFailed(
+    String paymentIntentId,
+    String reasonCode,
+    boolean retryable,
+    EventMetadata metadata
+) implements PaymentEvent {
+    @Override
+    public String eventType() {
+        return "PaymentFailed";
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/PaymentIntent.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/PaymentIntent.java
@@ -1,0 +1,223 @@
+package com.trainticket.payment.domain;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+public final class PaymentIntent {
+    private final String paymentIntentId;
+    private final String businessRef;
+    private final String purpose;
+    private final Money amount;
+    private final String payerRef;
+    private final Instant expiresAt;
+    private final String idempotencyKey;
+    private final Set<String> channelTransactionRefs;
+    private final List<PaymentEvent> domainEvents;
+    private PaymentIntentStatus status;
+    private Money authorizedAmount;
+    private Money capturedAmount;
+    private Money refundedAmount;
+
+    private PaymentIntent(
+        String paymentIntentId,
+        String businessRef,
+        String purpose,
+        Money amount,
+        String payerRef,
+        Instant expiresAt,
+        String idempotencyKey
+    ) {
+        this.paymentIntentId = requireText(paymentIntentId, "paymentIntentId");
+        this.businessRef = requireText(businessRef, "businessRef");
+        this.purpose = requireText(purpose, "purpose");
+        this.amount = Objects.requireNonNull(amount, "amount is required");
+        if (amount.isZero()) {
+            throw new DomainRuleViolation("payment intent amount must be positive");
+        }
+        this.payerRef = requireText(payerRef, "payerRef");
+        this.expiresAt = Objects.requireNonNull(expiresAt, "expiresAt is required");
+        this.idempotencyKey = requireText(idempotencyKey, "idempotencyKey");
+        this.channelTransactionRefs = new HashSet<>();
+        this.domainEvents = new ArrayList<>();
+        this.status = PaymentIntentStatus.CREATED;
+        this.authorizedAmount = Money.zero(amount.currency());
+        this.capturedAmount = Money.zero(amount.currency());
+        this.refundedAmount = Money.zero(amount.currency());
+    }
+
+    public static PaymentIntent create(
+        String businessRef,
+        String purpose,
+        Money amount,
+        String payerRef,
+        Instant expiresAt,
+        String idempotencyKey,
+        Instant occurredAt,
+        String sourceCommandId,
+        String correlationId
+    ) {
+        if (!Objects.requireNonNull(expiresAt, "expiresAt is required").isAfter(Objects.requireNonNull(occurredAt, "occurredAt is required"))) {
+            throw new DomainRuleViolation("payment intent expiry must be in the future");
+        }
+        PaymentIntent intent = new PaymentIntent(UUID.randomUUID().toString(), businessRef, purpose, amount, payerRef, expiresAt, idempotencyKey);
+        intent.domainEvents.add(new PaymentIntentCreated(intent.paymentIntentId, intent.businessRef, intent.purpose, intent.amount, intent.payerRef, intent.idempotencyKey,
+            EventMetadata.create(occurredAt, sourceCommandId, sourceCommandId, correlationId, Map.of("status", intent.status.name()))));
+        return intent;
+    }
+
+    public String paymentIntentId() { return paymentIntentId; }
+    public String businessRef() { return businessRef; }
+    public String purpose() { return purpose; }
+    public Money amount() { return amount; }
+    public String payerRef() { return payerRef; }
+    public Instant expiresAt() { return expiresAt; }
+    public String idempotencyKey() { return idempotencyKey; }
+    public PaymentIntentStatus status() { return status; }
+    public Money authorizedAmount() { return authorizedAmount; }
+    public Money capturedAmount() { return capturedAmount; }
+    public Money refundedAmount() { return refundedAmount; }
+    public List<PaymentEvent> domainEvents() { return List.copyOf(domainEvents); }
+    public Set<String> channelTransactionRefs() { return Set.copyOf(channelTransactionRefs); }
+
+    public boolean semanticallyMatches(String businessRef, String purpose, Money amount, String payerRef, Instant expiresAt, String idempotencyKey) {
+        return this.businessRef.equals(businessRef)
+            && this.purpose.equals(purpose)
+            && this.amount.equals(amount)
+            && this.payerRef.equals(payerRef)
+            && this.expiresAt.equals(expiresAt)
+            && this.idempotencyKey.equals(idempotencyKey);
+    }
+
+    public void authorize(Money authorizedAmount, String channel, String channelTransactionId, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        requireNonTerminalForPayment("authorize payment");
+        requireNotExpiredAt(occurredAt);
+        requirePositiveWithinIntent(authorizedAmount, "authorizedAmount");
+        this.authorizedAmount = authorizedAmount;
+        this.status = PaymentIntentStatus.AUTHORIZED;
+        this.channelTransactionRefs.add(channelTransactionKey(channel, channelTransactionId));
+        domainEvents.add(new PaymentAuthorized(paymentIntentId, authorizedAmount, requireText(channel, "channel"), requireText(channelTransactionId, "channelTransactionId"),
+            EventMetadata.create(occurredAt, sourceCommandId, causationId, correlationId, Map.of("status", status.name()))));
+    }
+
+    public void capture(Money captureAmount, String channel, String channelTransactionId, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        requireNonTerminalForPayment("capture payment");
+        requireNotExpiredAt(occurredAt);
+        applyCapture(captureAmount, channel, channelTransactionId, occurredAt, sourceCommandId, causationId, correlationId);
+    }
+
+    public LatePaymentCase recordLateCapture(Money captureAmount, String channel, String channelTransactionId, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        if (status != PaymentIntentStatus.CANCELLED && status != PaymentIntentStatus.EXPIRED) {
+            throw new DomainRuleViolation("late capture is only valid for cancelled or expired payment intents");
+        }
+        return LatePaymentCase.open(paymentIntentId, captureAmount, channel, channelTransactionId,
+            "capture arrived after " + status.name().toLowerCase(), occurredAt, sourceCommandId, causationId, correlationId);
+    }
+
+    public void fail(String reasonCode, boolean retryable, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        if (status == PaymentIntentStatus.CAPTURED) {
+            throw new DomainRuleViolation("captured payment intent cannot fail");
+        }
+        if (isTerminal()) {
+            return;
+        }
+        status = PaymentIntentStatus.FAILED;
+        domainEvents.add(new PaymentFailed(paymentIntentId, requireText(reasonCode, "reasonCode"), retryable,
+            EventMetadata.create(occurredAt, sourceCommandId, causationId, correlationId, Map.of("status", status.name()))));
+    }
+
+    public void cancel(String reason, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        if (status == PaymentIntentStatus.CAPTURED) {
+            throw new DomainRuleViolation("captured payment intent cannot be cancelled; request refund from upstream decision instead");
+        }
+        if (isTerminal()) {
+            return;
+        }
+        status = PaymentIntentStatus.CANCELLED;
+        domainEvents.add(new PaymentIntentCancelled(paymentIntentId, requireText(reason, "reason"),
+            EventMetadata.create(occurredAt, sourceCommandId, causationId, correlationId, Map.of("status", status.name()))));
+    }
+
+    public void expire(Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        if (status == PaymentIntentStatus.CAPTURED) {
+            throw new DomainRuleViolation("captured payment intent cannot expire");
+        }
+        if (isTerminal()) {
+            return;
+        }
+        if (occurredAt.isBefore(expiresAt)) {
+            throw new DomainRuleViolation("cannot expire payment intent before expiresAt");
+        }
+        status = PaymentIntentStatus.EXPIRED;
+        domainEvents.add(new PaymentIntentExpired(paymentIntentId,
+            EventMetadata.create(occurredAt, sourceCommandId, causationId, correlationId, Map.of("status", status.name()))));
+    }
+
+    void markRefunded(Money amount) {
+        refundedAmount = refundedAmount.add(amount);
+        if (refundedAmount.isGreaterThan(capturedAmount)) {
+            throw new DomainRuleViolation("refunded amount cannot exceed captured amount");
+        }
+    }
+
+    public Money refundableBalance() {
+        return capturedAmount.subtract(refundedAmount);
+    }
+
+    private void applyCapture(Money captureAmount, String channel, String channelTransactionId, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        requirePositiveWithinIntent(captureAmount, "captureAmount");
+        if (capturedAmount.add(captureAmount).isGreaterThan(amount)) {
+            throw new DomainRuleViolation("capture amount cannot exceed payment intent amount");
+        }
+        if (!authorizedAmount.isZero() && capturedAmount.add(captureAmount).isGreaterThan(authorizedAmount)) {
+            throw new DomainRuleViolation("capture amount cannot exceed authorized amount");
+        }
+        this.capturedAmount = capturedAmount.add(captureAmount);
+        this.status = capturedAmount.equals(amount) ? PaymentIntentStatus.CAPTURED : status;
+        this.channelTransactionRefs.add(channelTransactionKey(channel, channelTransactionId));
+        domainEvents.add(new PaymentCaptured(paymentIntentId, captureAmount, requireText(channel, "channel"), requireText(channelTransactionId, "channelTransactionId"),
+            EventMetadata.create(occurredAt, sourceCommandId, causationId, correlationId, Map.of("status", status.name()))));
+    }
+
+    private void requireNonTerminalForPayment(String action) {
+        if (isTerminal()) {
+            throw new DomainRuleViolation("cannot " + action + " when payment intent is " + status);
+        }
+    }
+
+    private boolean isTerminal() {
+        return status == PaymentIntentStatus.CAPTURED || status == PaymentIntentStatus.CANCELLED || status == PaymentIntentStatus.EXPIRED || status == PaymentIntentStatus.FAILED;
+    }
+
+    private void requireNotExpiredAt(Instant occurredAt) {
+        if (!Objects.requireNonNull(occurredAt, "occurredAt is required").isBefore(expiresAt)) {
+            throw new DomainRuleViolation("payment intent is expired for new payment activity");
+        }
+    }
+
+    private void requirePositiveWithinIntent(Money value, String name) {
+        Objects.requireNonNull(value, name + " is required");
+        if (value.isZero()) {
+            throw new DomainRuleViolation(name + " must be positive");
+        }
+        if (value.isGreaterThan(amount)) {
+            throw new DomainRuleViolation(name + " cannot exceed payment intent amount");
+        }
+    }
+
+    private static String channelTransactionKey(String channel, String channelTransactionId) {
+        return requireText(channel, "channel") + ":" + requireText(channelTransactionId, "channelTransactionId");
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/PaymentIntentCancelled.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/PaymentIntentCancelled.java
@@ -1,0 +1,12 @@
+package com.trainticket.payment.domain;
+
+public record PaymentIntentCancelled(
+    String paymentIntentId,
+    String reason,
+    EventMetadata metadata
+) implements PaymentEvent {
+    @Override
+    public String eventType() {
+        return "PaymentIntentCancelled";
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/PaymentIntentCreated.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/PaymentIntentCreated.java
@@ -1,0 +1,16 @@
+package com.trainticket.payment.domain;
+
+public record PaymentIntentCreated(
+    String paymentIntentId,
+    String businessRef,
+    String purpose,
+    Money amount,
+    String payerRef,
+    String idempotencyKey,
+    EventMetadata metadata
+) implements PaymentEvent {
+    @Override
+    public String eventType() {
+        return "PaymentIntentCreated";
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/PaymentIntentExpired.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/PaymentIntentExpired.java
@@ -1,0 +1,11 @@
+package com.trainticket.payment.domain;
+
+public record PaymentIntentExpired(
+    String paymentIntentId,
+    EventMetadata metadata
+) implements PaymentEvent {
+    @Override
+    public String eventType() {
+        return "PaymentIntentExpired";
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/PaymentIntentStatus.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/PaymentIntentStatus.java
@@ -1,0 +1,10 @@
+package com.trainticket.payment.domain;
+
+public enum PaymentIntentStatus {
+    CREATED,
+    AUTHORIZED,
+    CAPTURED,
+    FAILED,
+    CANCELLED,
+    EXPIRED
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/Refund.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/Refund.java
@@ -1,0 +1,123 @@
+package com.trainticket.payment.domain;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class Refund {
+    private final String refundId;
+    private final String paymentIntentId;
+    private final Money amount;
+    private final String sourceCaseRef;
+    private final String reasonCode;
+    private final String idempotencyKey;
+    private final List<PaymentEvent> domainEvents;
+    private RefundStatus status;
+    private String channelRefundTransactionId;
+    private int attemptCount;
+
+    private Refund(String refundId, String paymentIntentId, Money amount, String sourceCaseRef, String reasonCode, String idempotencyKey) {
+        this.refundId = requireText(refundId, "refundId");
+        this.paymentIntentId = requireText(paymentIntentId, "paymentIntentId");
+        this.amount = Objects.requireNonNull(amount, "amount is required");
+        if (amount.isZero()) {
+            throw new DomainRuleViolation("refund amount must be positive");
+        }
+        this.sourceCaseRef = requireText(sourceCaseRef, "sourceCaseRef");
+        this.reasonCode = requireText(reasonCode, "reasonCode");
+        this.idempotencyKey = requireText(idempotencyKey, "idempotencyKey");
+        this.domainEvents = new ArrayList<>();
+        this.status = RefundStatus.REQUESTED;
+    }
+
+    public static Refund request(
+        PaymentIntent capturedIntent,
+        Money amount,
+        String sourceCaseRef,
+        String reasonCode,
+        String idempotencyKey,
+        Instant occurredAt,
+        String sourceCommandId,
+        String correlationId
+    ) {
+        Objects.requireNonNull(capturedIntent, "capturedIntent is required");
+        if (capturedIntent.status() != PaymentIntentStatus.CAPTURED) {
+            throw new DomainRuleViolation("refund requires a captured payment intent");
+        }
+        if (amount.isGreaterThan(capturedIntent.refundableBalance())) {
+            throw new DomainRuleViolation("refund amount cannot exceed captured-and-not-refunded balance");
+        }
+        Refund refund = new Refund(UUID.randomUUID().toString(), capturedIntent.paymentIntentId(), amount, sourceCaseRef, reasonCode, idempotencyKey);
+        refund.domainEvents.add(new RefundRequested(refund.refundId, refund.paymentIntentId, refund.amount, refund.sourceCaseRef, refund.reasonCode, refund.idempotencyKey,
+            EventMetadata.create(occurredAt, sourceCommandId, sourceCommandId, correlationId, Map.of("status", refund.status.name()))));
+        return refund;
+    }
+
+    public String refundId() { return refundId; }
+    public String paymentIntentId() { return paymentIntentId; }
+    public Money amount() { return amount; }
+    public String sourceCaseRef() { return sourceCaseRef; }
+    public String reasonCode() { return reasonCode; }
+    public String idempotencyKey() { return idempotencyKey; }
+    public RefundStatus status() { return status; }
+    public String channelRefundTransactionId() { return channelRefundTransactionId; }
+    public int attemptCount() { return attemptCount; }
+    public List<PaymentEvent> domainEvents() { return List.copyOf(domainEvents); }
+
+    public boolean semanticallyMatches(String paymentIntentId, Money amount, String sourceCaseRef, String reasonCode, String idempotencyKey) {
+        return this.paymentIntentId.equals(paymentIntentId)
+            && this.amount.equals(amount)
+            && this.sourceCaseRef.equals(sourceCaseRef)
+            && this.reasonCode.equals(reasonCode)
+            && this.idempotencyKey.equals(idempotencyKey);
+    }
+
+    public void submitToChannel(String channelRefundTransactionId) {
+        if (status != RefundStatus.REQUESTED && status != RefundStatus.FAILED) {
+            throw new DomainRuleViolation("refund can only be submitted when requested or failed retryable");
+        }
+        this.channelRefundTransactionId = requireText(channelRefundTransactionId, "channelRefundTransactionId");
+        this.attemptCount++;
+        this.status = RefundStatus.SUBMITTED;
+    }
+
+    public void settle(PaymentIntent capturedIntent, String channelRefundTransactionId, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        Objects.requireNonNull(capturedIntent, "capturedIntent is required");
+        if (status == RefundStatus.SETTLED) {
+            return;
+        }
+        if (status != RefundStatus.SUBMITTED && status != RefundStatus.REQUESTED) {
+            throw new DomainRuleViolation("refund can only settle from requested or submitted state");
+        }
+        if (!capturedIntent.paymentIntentId().equals(paymentIntentId)) {
+            throw new DomainRuleViolation("refund settlement payment intent mismatch");
+        }
+        this.channelRefundTransactionId = requireText(channelRefundTransactionId, "channelRefundTransactionId");
+        capturedIntent.markRefunded(amount);
+        this.status = RefundStatus.SETTLED;
+        domainEvents.add(new RefundSettled(refundId, paymentIntentId, amount, this.channelRefundTransactionId,
+            EventMetadata.create(occurredAt, sourceCommandId, causationId, correlationId, Map.of("status", status.name()))));
+    }
+
+    public void fail(String reasonCode, boolean retryable, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        if (status == RefundStatus.SETTLED) {
+            throw new DomainRuleViolation("settled refund cannot fail");
+        }
+        if (status == RefundStatus.MANUAL_REVIEW_REQUIRED) {
+            return;
+        }
+        status = retryable ? RefundStatus.FAILED : RefundStatus.MANUAL_REVIEW_REQUIRED;
+        domainEvents.add(new RefundFailed(refundId, paymentIntentId, requireText(reasonCode, "reasonCode"), retryable,
+            EventMetadata.create(occurredAt, sourceCommandId, causationId, correlationId, Map.of("status", status.name()))));
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/RefundFailed.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/RefundFailed.java
@@ -1,0 +1,14 @@
+package com.trainticket.payment.domain;
+
+public record RefundFailed(
+    String refundId,
+    String paymentIntentId,
+    String reasonCode,
+    boolean retryable,
+    EventMetadata metadata
+) implements PaymentEvent {
+    @Override
+    public String eventType() {
+        return "RefundFailed";
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/RefundRequested.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/RefundRequested.java
@@ -1,0 +1,16 @@
+package com.trainticket.payment.domain;
+
+public record RefundRequested(
+    String refundId,
+    String paymentIntentId,
+    Money amount,
+    String sourceCaseRef,
+    String reasonCode,
+    String idempotencyKey,
+    EventMetadata metadata
+) implements PaymentEvent {
+    @Override
+    public String eventType() {
+        return "RefundRequested";
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/RefundSettled.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/RefundSettled.java
@@ -1,0 +1,14 @@
+package com.trainticket.payment.domain;
+
+public record RefundSettled(
+    String refundId,
+    String paymentIntentId,
+    Money amount,
+    String channelRefundTransactionId,
+    EventMetadata metadata
+) implements PaymentEvent {
+    @Override
+    public String eventType() {
+        return "RefundSettled";
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/RefundStatus.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/RefundStatus.java
@@ -1,0 +1,9 @@
+package com.trainticket.payment.domain;
+
+public enum RefundStatus {
+    REQUESTED,
+    SUBMITTED,
+    SETTLED,
+    FAILED,
+    MANUAL_REVIEW_REQUIRED
+}

--- a/services/payment/src/test/java/com/trainticket/payment/domain/PaymentIntentDomainTest.java
+++ b/services/payment/src/test/java/com/trainticket/payment/domain/PaymentIntentDomainTest.java
@@ -1,0 +1,102 @@
+package com.trainticket.payment.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PaymentIntentDomainTest {
+    private static final Instant NOW = Instant.parse("2026-07-03T10:00:00Z");
+
+    @Test
+    void createsPaymentIntentAndReusesBusinessIdempotencyKey() {
+        IdempotencyLedger<PaymentIntent> ledger = new IdempotencyLedger<>();
+
+        PaymentIntent first = ledger.recordOrReturn("order-123:initial-booking", "idem-1", NOW,
+            () -> newIntent("idem-1"));
+        PaymentIntent second = ledger.recordOrReturn("order-123:initial-booking", "idem-1", NOW.plusSeconds(1),
+            () -> newIntent("idem-1"));
+
+        assertSame(first, second);
+        assertEquals(1, ledger.size());
+        assertEquals(PaymentIntentStatus.CREATED, first.status());
+        assertEquals("idem-1", first.idempotencyKey());
+        assertInstanceOf(PaymentIntentCreated.class, first.domainEvents().getFirst());
+        assertTrue(first.semanticallyMatches("order-123", "initial-booking", Money.of("120.00", "USD"), "payer-9", NOW.plusSeconds(900), "idem-1"));
+    }
+
+    @Test
+    void authorizesAndCapturesWithoutWritingOtherDomains() {
+        PaymentIntent intent = newIntent("idem-capture");
+
+        intent.authorize(Money.of("120.00", "USD"), "stripe", "auth-1", NOW.plusSeconds(10), "AuthorizePayment", "callback-1", "corr-1");
+        intent.capture(Money.of("120.00", "USD"), "stripe", "capture-1", NOW.plusSeconds(20), "CapturePayment", "callback-2", "corr-1");
+
+        assertEquals(PaymentIntentStatus.CAPTURED, intent.status());
+        assertEquals(Money.of("120.00", "USD"), intent.capturedAmount());
+        assertEquals(3, intent.domainEvents().size());
+        assertInstanceOf(PaymentAuthorized.class, intent.domainEvents().get(1));
+        PaymentCaptured captured = assertInstanceOf(PaymentCaptured.class, intent.domainEvents().get(2));
+        assertEquals("PaymentCaptured", captured.eventType());
+        assertEquals("capture-1", captured.channelTransactionId());
+        assertFalse(captured.metadata().attributes().containsKey("orderState"), "payment facts must not carry direct order mutations");
+    }
+
+    @Test
+    void preventsExpiredOrTerminalPaymentActivity() {
+        PaymentIntent intent = newIntent("idem-expire");
+        intent.expire(NOW.plusSeconds(901), "ExpirePaymentIntent", "timer", "corr-2");
+
+        assertEquals(PaymentIntentStatus.EXPIRED, intent.status());
+        assertInstanceOf(PaymentIntentExpired.class, intent.domainEvents().get(1));
+        assertThrows(DomainRuleViolation.class,
+            () -> intent.capture(Money.of("120.00", "USD"), "stripe", "capture-late", NOW.plusSeconds(902), "CapturePayment", "callback", "corr-2"));
+    }
+
+    @Test
+    void lateCaptureAfterCancellationOpensLatePaymentCaseOnly() {
+        PaymentIntent intent = newIntent("idem-cancel");
+        intent.cancel("order cancelled upstream", NOW.plusSeconds(20), "CancelPaymentIntent", "order-cancelled", "corr-3");
+
+        LatePaymentCase lateCase = intent.recordLateCapture(Money.of("120.00", "USD"), "stripe", "late-capture-1", NOW.plusSeconds(30), "DetectLatePaymentSuccess", "callback-3", "corr-3");
+
+        assertEquals(PaymentIntentStatus.CANCELLED, intent.status(), "late capture must not recover or capture the original intent");
+        assertEquals(LatePaymentCaseStatus.OPEN, lateCase.status());
+        LatePaymentDetected event = assertInstanceOf(LatePaymentDetected.class, lateCase.domainEvents().getFirst());
+        assertEquals(intent.paymentIntentId(), event.paymentIntentId());
+        assertTrue(event.reason().contains("cancelled"));
+    }
+
+    @Test
+    void callbackRecordsDetectDuplicateCallbacks() {
+        ChannelCallbackRecord first = ChannelCallbackRecord.receive("stripe", "cb-1", "sha256:abc", "PAYMENT_CAPTURED", List.of(), NOW, "RecordChannelCallback", "corr-4");
+        ChannelCallbackRecord duplicate = ChannelCallbackRecord.receive("stripe", "cb-1", "sha256:abc", "PAYMENT_CAPTURED", List.of(first), NOW.plusSeconds(1), "RecordChannelCallback", "corr-4");
+
+        assertEquals(CallbackProcessingStatus.RECEIVED, first.status());
+        assertInstanceOf(ChannelCallbackReceived.class, first.auditEvent());
+        assertTrue(duplicate.isDuplicate());
+        assertEquals(first.callbackRecordId(), duplicate.firstCallbackRecordId());
+        assertInstanceOf(DuplicateChannelCallbackDetected.class, duplicate.auditEvent());
+        assertThrows(DomainRuleViolation.class, duplicate::markApplied);
+    }
+
+    private static PaymentIntent newIntent(String idempotencyKey) {
+        return PaymentIntent.create(
+            "order-123",
+            "initial-booking",
+            Money.of("120.00", "USD"),
+            "payer-9",
+            NOW.plusSeconds(900),
+            idempotencyKey,
+            NOW,
+            "CreatePaymentIntent",
+            "corr-1"
+        );
+    }
+}

--- a/services/payment/src/test/java/com/trainticket/payment/domain/RefundDomainTest.java
+++ b/services/payment/src/test/java/com/trainticket/payment/domain/RefundDomainTest.java
@@ -1,0 +1,74 @@
+package com.trainticket.payment.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class RefundDomainTest {
+    private static final Instant NOW = Instant.parse("2026-07-03T10:00:00Z");
+
+    @Test
+    void requestsAndSettlesOriginalRouteRefundAgainstCapturedBalance() {
+        PaymentIntent intent = capturedIntent();
+
+        Refund refund = Refund.request(intent, Money.of("45.00", "USD"), "post-sales-case-1", "TICKET_REFUND", "refund-idem-1", NOW.plusSeconds(30), "RequestRefund", "corr-refund");
+        refund.submitToChannel("refund-txn-1");
+        refund.settle(intent, "refund-txn-1", NOW.plusSeconds(40), "SettleRefund", "channel-refund-callback", "corr-refund");
+
+        assertEquals(RefundStatus.SETTLED, refund.status());
+        assertEquals(Money.of("45.00", "USD"), intent.refundedAmount());
+        assertEquals(Money.of("75.00", "USD"), intent.refundableBalance());
+        assertInstanceOf(RefundRequested.class, refund.domainEvents().getFirst());
+        RefundSettled settled = assertInstanceOf(RefundSettled.class, refund.domainEvents().get(1));
+        assertEquals("RefundSettled", settled.eventType());
+        assertEquals(intent.paymentIntentId(), settled.paymentIntentId());
+    }
+
+    @Test
+    void rejectsRefundsAboveCapturedAndNotRefundedBalance() {
+        PaymentIntent intent = capturedIntent();
+        Refund first = Refund.request(intent, Money.of("100.00", "USD"), "post-sales-case-1", "TICKET_REFUND", "refund-idem-1", NOW.plusSeconds(30), "RequestRefund", "corr-refund");
+        first.settle(intent, "refund-txn-1", NOW.plusSeconds(40), "SettleRefund", "channel-refund-callback", "corr-refund");
+
+        DomainRuleViolation violation = assertThrows(DomainRuleViolation.class,
+            () -> Refund.request(intent, Money.of("25.00", "USD"), "post-sales-case-2", "TICKET_REFUND", "refund-idem-2", NOW.plusSeconds(50), "RequestRefund", "corr-refund"));
+        assertTrue(violation.getMessage().contains("captured-and-not-refunded"));
+    }
+
+    @Test
+    void recordsRetryableAndFinalRefundFailureFacts() {
+        PaymentIntent intent = capturedIntent();
+        Refund refund = Refund.request(intent, Money.of("20.00", "USD"), "disruption-case-1", "DISRUPTION_REFUND", "refund-idem-3", NOW.plusSeconds(30), "RequestRefund", "corr-refund");
+        refund.submitToChannel("refund-txn-2");
+
+        refund.fail("CHANNEL_TIMEOUT", true, NOW.plusSeconds(35), "FailRefund", "channel-refund-callback", "corr-refund");
+        assertEquals(RefundStatus.FAILED, refund.status());
+        assertInstanceOf(RefundFailed.class, refund.domainEvents().get(1));
+
+        refund.submitToChannel("refund-txn-3");
+        refund.fail("ACCOUNT_CLOSED", false, NOW.plusSeconds(45), "FailRefund", "channel-refund-callback", "corr-refund");
+        assertEquals(RefundStatus.MANUAL_REVIEW_REQUIRED, refund.status());
+        RefundFailed finalFailure = assertInstanceOf(RefundFailed.class, refund.domainEvents().get(2));
+        assertEquals("ACCOUNT_CLOSED", finalFailure.reasonCode());
+    }
+
+    private static PaymentIntent capturedIntent() {
+        PaymentIntent intent = PaymentIntent.create(
+            "order-456",
+            "initial-booking",
+            Money.of("120.00", "USD"),
+            "payer-10",
+            NOW.plusSeconds(900),
+            "pay-idem-1",
+            NOW,
+            "CreatePaymentIntent",
+            "corr-refund"
+        );
+        intent.capture(Money.of("120.00", "USD"), "stripe", "capture-refund-base", NOW.plusSeconds(20), "CapturePayment", "channel-callback", "corr-refund");
+        return intent;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds PaymentIntent domain model with creation, auth/capture, cancellation, expiration/failure, idempotency support, and late-payment case handling.
- Adds ChannelCallbackRecord duplicate detection and Refund original-route lifecycle with request/settlement/failure behavior.
- Updates payment README/profile metadata from skeleton/WP naming to REQ-012 domain foundation.

## Validation
- cd services/payment && mvn test
- make check-strict