### PR TITLE
REQ-011 Booking Orchestration domain foundation

### DIFF
--- a/services/booking-orchestration/README.md
+++ b/services/booking-orchestration/README.md
@@ -6,23 +6,42 @@ Language: java
 
 Phase: phase-1-core
 
-Status: skeleton
+Status: REQ-011 domain foundation
 
 ## Owns
 
-- BookingSaga
-- SegmentBooking
-- ProviderReservation mapping
+- `BookingSaga` progress across reservation, payment, confirmation, ticketing, compensation and manual-review steps.
+- `SegmentBooking` lifecycle from reservation requested through confirmed, failed, ticketed and cancelled states.
+- Normalized Provider Integration facts such as `ProviderReservationConfirmed` mapped to internal `SegmentReservationConfirmed` facts.
+
+## Does Not Own
+
+- Journey Order commercial totals or order aggregate state.
+- Capacity inventory conflict algorithms or hold internals.
+- Payment channels, captures, refunds or channel callbacks.
+- Entitlement credentials, ticket display secrets or validation.
+- Raw provider status codes, payload parsing, signatures, retries or supplier API calls.
+
+## Coordination Facts
+
+The domain emits events for consumers instead of writing into other contexts directly:
+
+- Journey Order: `SegmentReservationRequested`, `SegmentReservationConfirmed`, `SegmentReservationFailed`, `BookingSagaFailed`.
+- Capacity: hold, confirm and release intent is represented as saga steps and segment facts.
+- Payment: payment wait/progress is represented by saga status and coordination events only.
+- Entitlement: `SegmentTicketed` records the result of ticketing after Entitlement issues a credential.
+- Provider Integration: late provider confirmation after cancellation emits a cancellation-required hook for reconciliation.
 
 ## DDD Sources
 
 - `docs/02-domains/booking-orchestration.md`
+- `docs/03-ddd-final/phase-1-contract.md`
 
 ## Language Rationale
 
-Java gives the saga layer explicit state transitions and stable integration testing options.
+Java gives the saga layer explicit state transitions, immutable coordination facts and stable integration testing options.
 
-## Skeleton Check
+## Checks
 
 ```bash
 mvn test

--- a/services/booking-orchestration/pom.xml
+++ b/services/booking-orchestration/pom.xml
@@ -11,7 +11,7 @@
   <groupId>com.trainticket</groupId>
   <artifactId>booking-orchestration</artifactId>
   <version>0.1.0-SNAPSHOT</version>
-  <name>Booking Orchestration service skeleton</name>
+  <name>Booking Orchestration domain foundation</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>25</java.version>

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/Application.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/Application.java
@@ -16,8 +16,8 @@ public class Application {
             "Booking Orchestration",
             "java",
             "phase-1-core",
-            "WP-09",
-            "BookingSaga, SegmentBooking, ProviderReservation mapping"
+            "REQ-011",
+            "BookingSaga progress, SegmentBooking lifecycle, normalized ProviderReservation mapping"
         );
     }
 }

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/BookingEvent.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/BookingEvent.java
@@ -1,0 +1,45 @@
+package com.trainticket.bookingorchestration.domain;
+
+import java.time.Instant;
+
+/** Coordination facts emitted by the BookingSaga for Journey Order, Capacity, Payment and Entitlement. */
+public sealed interface BookingEvent extends DomainEvent permits BookingEvent.BookingSagaStarted,
+    BookingEvent.BookingSagaAdvanced,
+    BookingEvent.BookingSagaStepSucceeded,
+    BookingEvent.BookingSagaStepFailed,
+    BookingEvent.BookingSagaRetryScheduled,
+    BookingEvent.BookingSagaCompleted,
+    BookingEvent.BookingSagaFailed,
+    BookingEvent.BookingSagaManualReviewRequired {
+
+    record BookingSagaStarted(String eventId, String aggregateId, Instant occurredAt, String journeyOrderId)
+        implements BookingEvent {
+    }
+
+    record BookingSagaAdvanced(String eventId, String aggregateId, Instant occurredAt, BookingSagaStatus status)
+        implements BookingEvent {
+    }
+
+    record BookingSagaStepSucceeded(String eventId, String aggregateId, Instant occurredAt, String stepName,
+                                    String idempotencyKey) implements BookingEvent {
+    }
+
+    record BookingSagaStepFailed(String eventId, String aggregateId, Instant occurredAt, String stepName,
+                                 String idempotencyKey, String reason) implements BookingEvent {
+    }
+
+    record BookingSagaRetryScheduled(String eventId, String aggregateId, Instant occurredAt, String stepName,
+                                     String idempotencyKey, int attemptNumber) implements BookingEvent {
+    }
+
+    record BookingSagaCompleted(String eventId, String aggregateId, Instant occurredAt) implements BookingEvent {
+    }
+
+    record BookingSagaFailed(String eventId, String aggregateId, Instant occurredAt, String reason)
+        implements BookingEvent {
+    }
+
+    record BookingSagaManualReviewRequired(String eventId, String aggregateId, Instant occurredAt, String reason)
+        implements BookingEvent {
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/BookingSaga.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/BookingSaga.java
@@ -1,0 +1,186 @@
+package com.trainticket.bookingorchestration.domain;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.trainticket.bookingorchestration.domain.BookingEvent.BookingSagaAdvanced;
+import static com.trainticket.bookingorchestration.domain.BookingEvent.BookingSagaCompleted;
+import static com.trainticket.bookingorchestration.domain.BookingEvent.BookingSagaFailed;
+import static com.trainticket.bookingorchestration.domain.BookingEvent.BookingSagaManualReviewRequired;
+import static com.trainticket.bookingorchestration.domain.BookingEvent.BookingSagaRetryScheduled;
+import static com.trainticket.bookingorchestration.domain.BookingEvent.BookingSagaStarted;
+import static com.trainticket.bookingorchestration.domain.BookingEvent.BookingSagaStepFailed;
+import static com.trainticket.bookingorchestration.domain.BookingEvent.BookingSagaStepSucceeded;
+
+public final class BookingSaga {
+    private final String sagaId;
+    private final String journeyOrderId;
+    private final String idempotencyKey;
+    private final EventRecorder eventRecorder;
+    private final Map<String, BookingSagaStep> stepsByIdempotencyKey = new LinkedHashMap<>();
+    private BookingSagaStatus status = BookingSagaStatus.PLANNED;
+    private String terminalReason;
+
+    private BookingSaga(String sagaId, String journeyOrderId, String idempotencyKey, Clock clock) {
+        this.sagaId = requireText(sagaId, "sagaId");
+        this.journeyOrderId = requireText(journeyOrderId, "journeyOrderId");
+        this.idempotencyKey = requireText(idempotencyKey, "idempotencyKey");
+        this.eventRecorder = new EventRecorder(clock);
+    }
+
+    public static BookingSaga start(String sagaId, String journeyOrderId, String orderVersion, String bookingPurpose,
+                                    List<BookingSagaStep> plan, Clock clock) {
+        String idempotencyKey = journeyOrderId + ":" + orderVersion + ":" + bookingPurpose;
+        BookingSaga saga = new BookingSaga(sagaId, journeyOrderId, idempotencyKey, clock);
+        if (plan.isEmpty()) {
+            throw new IllegalArgumentException("saga plan must contain at least one step");
+        }
+        for (BookingSagaStep step : plan) {
+            saga.addStep(step);
+        }
+        saga.status = BookingSagaStatus.RESERVING;
+        saga.record(new BookingSagaStarted(saga.nextEventId(), saga.sagaId, saga.now(), saga.journeyOrderId));
+        saga.record(new BookingSagaAdvanced(saga.nextEventId(), saga.sagaId, saga.now(), saga.status));
+        return saga;
+    }
+
+    public String sagaId() {
+        return sagaId;
+    }
+
+    public String journeyOrderId() {
+        return journeyOrderId;
+    }
+
+    public String idempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public BookingSagaStatus status() {
+        return status;
+    }
+
+    public Optional<String> terminalReason() {
+        return Optional.ofNullable(terminalReason);
+    }
+
+    public Collection<BookingSagaStep> steps() {
+        return List.copyOf(stepsByIdempotencyKey.values());
+    }
+
+    public BookingSagaStep step(String idempotencyKey) {
+        BookingSagaStep step = stepsByIdempotencyKey.get(idempotencyKey);
+        if (step == null) {
+            throw new IllegalArgumentException("unknown saga step idempotency key: " + idempotencyKey);
+        }
+        return step;
+    }
+
+    public void advanceTo(BookingSagaStatus nextStatus) {
+        requireNotTerminal();
+        if (nextStatus == BookingSagaStatus.COMPLETED || nextStatus == BookingSagaStatus.FAILED) {
+            throw new IllegalArgumentException("use complete or fail for terminal saga states");
+        }
+        this.status = nextStatus;
+        record(new BookingSagaAdvanced(nextEventId(), sagaId, now(), nextStatus));
+    }
+
+    public void recordStepSucceeded(String stepIdempotencyKey) {
+        requireNotTerminal();
+        BookingSagaStep step = step(stepIdempotencyKey);
+        if (step.status() == BookingStepStatus.SUCCEEDED) {
+            return;
+        }
+        step.succeed();
+        record(new BookingSagaStepSucceeded(nextEventId(), sagaId, now(), step.name(), step.idempotencyKey()));
+    }
+
+    public void recordStepFailed(String stepIdempotencyKey, String reason) {
+        requireNotTerminal();
+        BookingSagaStep step = step(stepIdempotencyKey);
+        if (step.status() == BookingStepStatus.FAILED && step.failureReason().orElse("").equals(reason)) {
+            return;
+        }
+        step.fail(reason);
+        record(new BookingSagaStepFailed(nextEventId(), sagaId, now(), step.name(), step.idempotencyKey(), reason));
+    }
+
+    public void retryStep(String stepIdempotencyKey) {
+        requireNotTerminal();
+        BookingSagaStep step = step(stepIdempotencyKey);
+        step.scheduleRetry();
+        record(new BookingSagaRetryScheduled(nextEventId(), sagaId, now(), step.name(), step.idempotencyKey(),
+            step.attemptNumber()));
+    }
+
+    public void complete() {
+        requireNotTerminal();
+        this.status = BookingSagaStatus.COMPLETED;
+        this.terminalReason = null;
+        record(new BookingSagaCompleted(nextEventId(), sagaId, now()));
+    }
+
+    public void fail(String reason) {
+        requireNotTerminal();
+        this.status = BookingSagaStatus.FAILED;
+        this.terminalReason = requireText(reason, "reason");
+        record(new BookingSagaFailed(nextEventId(), sagaId, now(), terminalReason));
+    }
+
+    public void moveToManualReview(String reason) {
+        requireNotTerminal();
+        this.status = BookingSagaStatus.MANUAL_REVIEW;
+        this.terminalReason = requireText(reason, "reason");
+        record(new BookingSagaManualReviewRequired(nextEventId(), sagaId, now(), terminalReason));
+    }
+
+    public List<DomainEvent> pullEvents() {
+        return eventRecorder.pullEvents();
+    }
+
+    public List<DomainEvent> peekEvents() {
+        return eventRecorder.peekEvents();
+    }
+
+    public static BookingSagaStep stepPlan(String name, String idempotencyKey, Duration timeout, int retryLimit,
+                                           String compensationAction) {
+        return new BookingSagaStep(name, idempotencyKey, timeout, retryLimit, compensationAction);
+    }
+
+    private void addStep(BookingSagaStep step) {
+        BookingSagaStep previous = stepsByIdempotencyKey.putIfAbsent(step.idempotencyKey(), step);
+        if (previous != null) {
+            throw new IllegalArgumentException("duplicate saga step idempotency key: " + step.idempotencyKey());
+        }
+    }
+
+    private void requireNotTerminal() {
+        if (status == BookingSagaStatus.COMPLETED || status == BookingSagaStatus.FAILED) {
+            throw new IllegalStateException("saga is terminal: " + status);
+        }
+    }
+
+    private void record(DomainEvent event) {
+        eventRecorder.record(event);
+    }
+
+    private String nextEventId() {
+        return eventRecorder.nextEventId();
+    }
+
+    private java.time.Instant now() {
+        return eventRecorder.now();
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " is required");
+        }
+        return value;
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/BookingSagaStatus.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/BookingSagaStatus.java
@@ -1,0 +1,14 @@
+package com.trainticket.bookingorchestration.domain;
+
+public enum BookingSagaStatus {
+    PLANNED,
+    RESERVING,
+    AWAITING_PAYMENT,
+    CONFIRMING,
+    TICKETING,
+    COMPLETED,
+    PARTIALLY_CONFIRMED,
+    COMPENSATING,
+    MANUAL_REVIEW,
+    FAILED
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/BookingSagaStep.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/BookingSagaStep.java
@@ -1,0 +1,109 @@
+package com.trainticket.bookingorchestration.domain;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class BookingSagaStep {
+    private final String name;
+    private final String idempotencyKey;
+    private final Duration timeout;
+    private final int retryLimit;
+    private final String compensationAction;
+    private BookingStepStatus status = BookingStepStatus.PENDING;
+    private int attemptNumber;
+    private String failureReason;
+
+    public BookingSagaStep(String name, String idempotencyKey, Duration timeout, int retryLimit,
+                           String compensationAction) {
+        this.name = requireText(name, "name");
+        this.idempotencyKey = requireText(idempotencyKey, "idempotencyKey");
+        if (timeout.isNegative() || timeout.isZero()) {
+            throw new IllegalArgumentException("timeout must be positive");
+        }
+        if (retryLimit < 0) {
+            throw new IllegalArgumentException("retryLimit must be zero or greater");
+        }
+        this.timeout = timeout;
+        this.retryLimit = retryLimit;
+        this.compensationAction = requireText(compensationAction, "compensationAction");
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String idempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public Duration timeout() {
+        return timeout;
+    }
+
+    public int retryLimit() {
+        return retryLimit;
+    }
+
+    public String compensationAction() {
+        return compensationAction;
+    }
+
+    public BookingStepStatus status() {
+        return status;
+    }
+
+    public int attemptNumber() {
+        return attemptNumber;
+    }
+
+    public Optional<String> failureReason() {
+        return Optional.ofNullable(failureReason);
+    }
+
+    void succeed() {
+        status = BookingStepStatus.SUCCEEDED;
+        failureReason = null;
+    }
+
+    void fail(String reason) {
+        status = BookingStepStatus.FAILED;
+        failureReason = requireText(reason, "reason");
+    }
+
+    boolean canRetry() {
+        return status == BookingStepStatus.FAILED && attemptNumber < retryLimit;
+    }
+
+    void scheduleRetry() {
+        if (!canRetry()) {
+            throw new IllegalStateException("retry limit reached for step " + name);
+        }
+        attemptNumber++;
+        status = BookingStepStatus.PENDING;
+        failureReason = null;
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " is required");
+        }
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BookingSagaStep that)) {
+            return false;
+        }
+        return idempotencyKey.equals(that.idempotencyKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idempotencyKey);
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/BookingStepStatus.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/BookingStepStatus.java
@@ -1,0 +1,7 @@
+package com.trainticket.bookingorchestration.domain;
+
+public enum BookingStepStatus {
+    PENDING,
+    SUCCEEDED,
+    FAILED
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/DomainEvent.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/DomainEvent.java
@@ -1,0 +1,15 @@
+package com.trainticket.bookingorchestration.domain;
+
+import java.time.Instant;
+
+/**
+ * Marker for facts emitted by Booking Orchestration. These facts are integration-safe:
+ * they are intended for other domains to consume instead of mutating Booking state directly.
+ */
+public sealed interface DomainEvent permits BookingEvent, SegmentBookingEvent {
+    String eventId();
+
+    String aggregateId();
+
+    Instant occurredAt();
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/EventRecorder.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/EventRecorder.java
@@ -1,0 +1,38 @@
+package com.trainticket.bookingorchestration.domain;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+final class EventRecorder {
+    private final Clock clock;
+    private final List<DomainEvent> events = new ArrayList<>();
+
+    EventRecorder(Clock clock) {
+        this.clock = clock;
+    }
+
+    Instant now() {
+        return clock.instant();
+    }
+
+    String nextEventId() {
+        return UUID.randomUUID().toString();
+    }
+
+    void record(DomainEvent event) {
+        events.add(event);
+    }
+
+    List<DomainEvent> pullEvents() {
+        List<DomainEvent> copy = List.copyOf(events);
+        events.clear();
+        return copy;
+    }
+
+    List<DomainEvent> peekEvents() {
+        return List.copyOf(events);
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/ProviderReference.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/ProviderReference.java
@@ -1,0 +1,17 @@
+package com.trainticket.bookingorchestration.domain;
+
+/** Normalized provider booking handle. Raw supplier status codes and payloads remain in Provider Integration. */
+public record ProviderReference(String providerId, String reservationId, String displayReference) {
+    public ProviderReference {
+        providerId = requireText(providerId, "providerId");
+        reservationId = requireText(reservationId, "reservationId");
+        displayReference = requireText(displayReference, "displayReference");
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " is required");
+        }
+        return value;
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/ProviderReservationConfirmed.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/ProviderReservationConfirmed.java
@@ -1,0 +1,26 @@
+package com.trainticket.bookingorchestration.domain;
+
+import java.util.Map;
+
+/**
+ * Normalized Provider Integration fact accepted by Booking Orchestration.
+ * Raw supplier codes, signatures and payloads are intentionally not representable here.
+ */
+public record ProviderReservationConfirmed(String segmentBookingId, ProviderReference providerReference,
+                                           String normalizedEvidence, Map<String, String> normalizedAttributes) {
+    public ProviderReservationConfirmed {
+        segmentBookingId = requireText(segmentBookingId, "segmentBookingId");
+        if (providerReference == null) {
+            throw new IllegalArgumentException("providerReference is required");
+        }
+        normalizedEvidence = requireText(normalizedEvidence, "normalizedEvidence");
+        normalizedAttributes = Map.copyOf(normalizedAttributes == null ? Map.of() : normalizedAttributes);
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " is required");
+        }
+        return value;
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/SegmentBooking.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/SegmentBooking.java
@@ -1,0 +1,245 @@
+package com.trainticket.bookingorchestration.domain;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.Optional;
+
+import static com.trainticket.bookingorchestration.domain.SegmentBookingEvent.ProviderCancellationRequired;
+import static com.trainticket.bookingorchestration.domain.SegmentBookingEvent.ProviderConfirmationReceivedAfterCancellation;
+import static com.trainticket.bookingorchestration.domain.SegmentBookingEvent.ProviderReferenceAttached;
+import static com.trainticket.bookingorchestration.domain.SegmentBookingEvent.ProviderReservationTimedOut;
+import static com.trainticket.bookingorchestration.domain.SegmentBookingEvent.SegmentBookingCancelRequested;
+import static com.trainticket.bookingorchestration.domain.SegmentBookingEvent.SegmentBookingCancelled;
+import static com.trainticket.bookingorchestration.domain.SegmentBookingEvent.SegmentCapacityHolding;
+import static com.trainticket.bookingorchestration.domain.SegmentBookingEvent.SegmentReservationConfirmed;
+import static com.trainticket.bookingorchestration.domain.SegmentBookingEvent.SegmentReservationFailed;
+import static com.trainticket.bookingorchestration.domain.SegmentBookingEvent.SegmentReservationRequested;
+import static com.trainticket.bookingorchestration.domain.SegmentBookingEvent.SegmentTicketed;
+
+public final class SegmentBooking {
+    private final String segmentBookingId;
+    private final String journeyOrderId;
+    private final String offerItemRef;
+    private final String segmentRef;
+    private final String travelerRef;
+    private final String bookingPurpose;
+    private final String idempotencyKey;
+    private final EventRecorder eventRecorder;
+    private SegmentBookingStatus status;
+    private String capacityHoldId;
+    private ProviderReference providerReference;
+    private String entitlementId;
+    private String failureReason;
+    private String cancellationReason;
+
+    private SegmentBooking(String segmentBookingId, String journeyOrderId, String offerItemRef, String segmentRef,
+                           String travelerRef, String bookingPurpose, Clock clock) {
+        this.segmentBookingId = requireText(segmentBookingId, "segmentBookingId");
+        this.journeyOrderId = requireText(journeyOrderId, "journeyOrderId");
+        this.offerItemRef = requireText(offerItemRef, "offerItemRef");
+        this.segmentRef = requireText(segmentRef, "segmentRef");
+        this.travelerRef = requireText(travelerRef, "travelerRef");
+        this.bookingPurpose = requireText(bookingPurpose, "bookingPurpose");
+        this.idempotencyKey = journeyOrderId + ":" + segmentRef + ":" + travelerRef + ":" + bookingPurpose;
+        this.eventRecorder = new EventRecorder(clock);
+    }
+
+    public static SegmentBooking requestReservation(String segmentBookingId, String journeyOrderId, String offerItemRef,
+                                                    String segmentRef, String travelerRef, String bookingPurpose,
+                                                    Clock clock) {
+        SegmentBooking booking = new SegmentBooking(segmentBookingId, journeyOrderId, offerItemRef, segmentRef,
+            travelerRef, bookingPurpose, clock);
+        booking.status = SegmentBookingStatus.REQUESTED;
+        booking.record(new SegmentReservationRequested(booking.nextEventId(), booking.segmentBookingId, booking.now(),
+            booking.journeyOrderId, booking.segmentRef, booking.travelerRef, booking.idempotencyKey));
+        return booking;
+    }
+
+    public String segmentBookingId() {
+        return segmentBookingId;
+    }
+
+    public String journeyOrderId() {
+        return journeyOrderId;
+    }
+
+    public String offerItemRef() {
+        return offerItemRef;
+    }
+
+    public String segmentRef() {
+        return segmentRef;
+    }
+
+    public String travelerRef() {
+        return travelerRef;
+    }
+
+    public String bookingPurpose() {
+        return bookingPurpose;
+    }
+
+    public String idempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public SegmentBookingStatus status() {
+        return status;
+    }
+
+    public Optional<String> capacityHoldId() {
+        return Optional.ofNullable(capacityHoldId);
+    }
+
+    public Optional<ProviderReference> providerReference() {
+        return Optional.ofNullable(providerReference);
+    }
+
+    public Optional<String> entitlementId() {
+        return Optional.ofNullable(entitlementId);
+    }
+
+    public Optional<String> failureReason() {
+        return Optional.ofNullable(failureReason);
+    }
+
+    public Optional<String> cancellationReason() {
+        return Optional.ofNullable(cancellationReason);
+    }
+
+    public void markCapacityHolding(String capacityHoldId) {
+        requireStatus(SegmentBookingStatus.REQUESTED, SegmentBookingStatus.HOLDING);
+        this.capacityHoldId = requireText(capacityHoldId, "capacityHoldId");
+        if (status != SegmentBookingStatus.HOLDING) {
+            status = SegmentBookingStatus.HOLDING;
+            record(new SegmentCapacityHolding(nextEventId(), segmentBookingId, now(), capacityHoldId));
+        }
+    }
+
+    public void confirmFromProvider(ProviderReservationConfirmed confirmation) {
+        if (!segmentBookingId.equals(confirmation.segmentBookingId())) {
+            throw new IllegalArgumentException("provider confirmation belongs to a different segment booking");
+        }
+        if (status == SegmentBookingStatus.CANCEL_REQUESTED || status == SegmentBookingStatus.CANCELLED) {
+            attachSameProviderReferenceOrThrow(confirmation.providerReference());
+            record(new ProviderConfirmationReceivedAfterCancellation(nextEventId(), segmentBookingId, now(),
+                confirmation.providerReference(), "provider confirmed after cancellation"));
+            record(new ProviderCancellationRequired(nextEventId(), segmentBookingId, now(),
+                confirmation.providerReference(), "cancel late provider confirmation"));
+            return;
+        }
+        confirmReservation(Optional.of(confirmation.providerReference()), confirmation.normalizedEvidence());
+    }
+
+    public void confirmInternal(String evidence) {
+        confirmReservation(Optional.empty(), evidence);
+    }
+
+    public void markProviderReservationTimeout(String reason) {
+        requireStatus(SegmentBookingStatus.REQUESTED, SegmentBookingStatus.HOLDING);
+        record(new ProviderReservationTimedOut(nextEventId(), segmentBookingId, now(), requireText(reason, "reason")));
+    }
+
+    public void failReservation(String reason) {
+        requireStatus(SegmentBookingStatus.REQUESTED, SegmentBookingStatus.HOLDING, SegmentBookingStatus.CANCEL_REQUESTED);
+        this.status = SegmentBookingStatus.FAILED;
+        this.failureReason = requireText(reason, "reason");
+        record(new SegmentReservationFailed(nextEventId(), segmentBookingId, now(), failureReason));
+    }
+
+    public void markTicketed(String entitlementId) {
+        requireStatus(SegmentBookingStatus.CONFIRMED, SegmentBookingStatus.TICKETED);
+        String requestedEntitlement = requireText(entitlementId, "entitlementId");
+        if (status == SegmentBookingStatus.TICKETED) {
+            if (!requestedEntitlement.equals(this.entitlementId)) {
+                throw new IllegalStateException("segment booking is already ticketed with a different entitlement");
+            }
+            return;
+        }
+        this.entitlementId = requestedEntitlement;
+        this.status = SegmentBookingStatus.TICKETED;
+        record(new SegmentTicketed(nextEventId(), segmentBookingId, now(), requestedEntitlement));
+    }
+
+    public void requestCancellation(String reason) {
+        requireStatus(SegmentBookingStatus.REQUESTED, SegmentBookingStatus.HOLDING, SegmentBookingStatus.CONFIRMED,
+            SegmentBookingStatus.TICKETED, SegmentBookingStatus.CANCEL_REQUESTED);
+        String requestedReason = requireText(reason, "reason");
+        if (status == SegmentBookingStatus.CANCEL_REQUESTED) {
+            return;
+        }
+        this.status = SegmentBookingStatus.CANCEL_REQUESTED;
+        this.cancellationReason = requestedReason;
+        record(new SegmentBookingCancelRequested(nextEventId(), segmentBookingId, now(), requestedReason));
+    }
+
+    public void markCancelled(String reason) {
+        requireStatus(SegmentBookingStatus.CANCEL_REQUESTED, SegmentBookingStatus.REQUESTED, SegmentBookingStatus.HOLDING);
+        String requestedReason = requireText(reason, "reason");
+        if (status == SegmentBookingStatus.CANCELLED) {
+            return;
+        }
+        this.status = SegmentBookingStatus.CANCELLED;
+        this.cancellationReason = requestedReason;
+        record(new SegmentBookingCancelled(nextEventId(), segmentBookingId, now(), requestedReason));
+    }
+
+    public List<DomainEvent> pullEvents() {
+        return eventRecorder.pullEvents();
+    }
+
+    public List<DomainEvent> peekEvents() {
+        return eventRecorder.peekEvents();
+    }
+
+    private void confirmReservation(Optional<ProviderReference> maybeProviderReference, String evidence) {
+        requireStatus(SegmentBookingStatus.REQUESTED, SegmentBookingStatus.HOLDING, SegmentBookingStatus.CONFIRMED);
+        String normalizedEvidence = requireText(evidence, "evidence");
+        maybeProviderReference.ifPresent(this::attachSameProviderReferenceOrThrow);
+        if (status == SegmentBookingStatus.CONFIRMED) {
+            return;
+        }
+        this.status = SegmentBookingStatus.CONFIRMED;
+        this.failureReason = null;
+        record(new SegmentReservationConfirmed(nextEventId(), segmentBookingId, now(), maybeProviderReference,
+            normalizedEvidence));
+    }
+
+    private void attachSameProviderReferenceOrThrow(ProviderReference requestedProviderReference) {
+        if (providerReference != null && !providerReference.equals(requestedProviderReference)) {
+            throw new IllegalStateException("segment booking already has a different provider reference");
+        }
+        if (providerReference == null) {
+            providerReference = requestedProviderReference;
+            record(new ProviderReferenceAttached(nextEventId(), segmentBookingId, now(), requestedProviderReference));
+        }
+    }
+
+    private void requireStatus(SegmentBookingStatus... allowed) {
+        for (SegmentBookingStatus allowedStatus : allowed) {
+            if (status == allowedStatus) {
+                return;
+            }
+        }
+        throw new IllegalStateException("segment booking status " + status + " does not allow this transition");
+    }
+
+    private void record(DomainEvent event) {
+        eventRecorder.record(event);
+    }
+
+    private String nextEventId() {
+        return eventRecorder.nextEventId();
+    }
+
+    private java.time.Instant now() {
+        return eventRecorder.now();
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " is required");
+        }
+        return value;
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/SegmentBookingEvent.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/SegmentBookingEvent.java
@@ -1,0 +1,66 @@
+package com.trainticket.bookingorchestration.domain;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/** Segment-level facts emitted for Journey Order, Capacity, Payment, Entitlement and support read models. */
+public sealed interface SegmentBookingEvent extends DomainEvent permits SegmentBookingEvent.SegmentReservationRequested,
+    SegmentBookingEvent.SegmentCapacityHolding,
+    SegmentBookingEvent.SegmentReservationConfirmed,
+    SegmentBookingEvent.SegmentReservationFailed,
+    SegmentBookingEvent.ProviderReferenceAttached,
+    SegmentBookingEvent.ProviderReservationTimedOut,
+    SegmentBookingEvent.SegmentTicketed,
+    SegmentBookingEvent.SegmentBookingCancelRequested,
+    SegmentBookingEvent.SegmentBookingCancelled,
+    SegmentBookingEvent.ProviderConfirmationReceivedAfterCancellation,
+    SegmentBookingEvent.ProviderCancellationRequired {
+
+    record SegmentReservationRequested(String eventId, String aggregateId, Instant occurredAt, String journeyOrderId,
+                                       String segmentRef, String travelerRef, String idempotencyKey)
+        implements SegmentBookingEvent {
+    }
+
+    record SegmentCapacityHolding(String eventId, String aggregateId, Instant occurredAt, String capacityHoldId)
+        implements SegmentBookingEvent {
+    }
+
+    record SegmentReservationConfirmed(String eventId, String aggregateId, Instant occurredAt,
+                                        Optional<ProviderReference> providerReference, String evidence)
+        implements SegmentBookingEvent {
+    }
+
+    record SegmentReservationFailed(String eventId, String aggregateId, Instant occurredAt, String reason)
+        implements SegmentBookingEvent {
+    }
+
+    record ProviderReferenceAttached(String eventId, String aggregateId, Instant occurredAt,
+                                     ProviderReference providerReference) implements SegmentBookingEvent {
+    }
+
+    record ProviderReservationTimedOut(String eventId, String aggregateId, Instant occurredAt, String reason)
+        implements SegmentBookingEvent {
+    }
+
+    record SegmentTicketed(String eventId, String aggregateId, Instant occurredAt, String entitlementId)
+        implements SegmentBookingEvent {
+    }
+
+    record SegmentBookingCancelRequested(String eventId, String aggregateId, Instant occurredAt, String reason)
+        implements SegmentBookingEvent {
+    }
+
+    record SegmentBookingCancelled(String eventId, String aggregateId, Instant occurredAt, String reason)
+        implements SegmentBookingEvent {
+    }
+
+    record ProviderConfirmationReceivedAfterCancellation(String eventId, String aggregateId, Instant occurredAt,
+                                                         ProviderReference providerReference, String reason)
+        implements SegmentBookingEvent {
+    }
+
+    record ProviderCancellationRequired(String eventId, String aggregateId, Instant occurredAt,
+                                        ProviderReference providerReference, String reason)
+        implements SegmentBookingEvent {
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/SegmentBookingStatus.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/domain/SegmentBookingStatus.java
@@ -1,0 +1,15 @@
+package com.trainticket.bookingorchestration.domain;
+
+public enum SegmentBookingStatus {
+    REQUESTED,
+    HOLDING,
+    CONFIRMED,
+    TICKETED,
+    IN_FULFILLMENT,
+    COMPLETED,
+    CANCEL_REQUESTED,
+    CANCELLED,
+    CHANGE_REQUESTED,
+    CHANGED,
+    FAILED
+}

--- a/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/domain/BookingSagaTest.java
+++ b/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/domain/BookingSagaTest.java
@@ -1,0 +1,81 @@
+package com.trainticket.bookingorchestration.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class BookingSagaTest {
+    private final Clock clock = Clock.fixed(Instant.parse("2026-06-28T12:00:00Z"), ZoneOffset.UTC);
+
+    @Test
+    void startsAndAdvancesSagaWithCoordinationFacts() {
+        BookingSaga saga = BookingSaga.start("saga-1", "order-1", "v1", "initial", List.of(
+            BookingSaga.stepPlan("HoldCapacity", "booking-1:hold", Duration.ofMinutes(5), 2, "ReleaseHold"),
+            BookingSaga.stepPlan("ReserveProvider", "booking-1:reserve", Duration.ofMinutes(2), 1,
+                "CancelProviderReservation")
+        ), clock);
+
+        assertEquals(BookingSagaStatus.RESERVING, saga.status());
+        assertEquals("order-1:v1:initial", saga.idempotencyKey());
+        assertInstanceOf(BookingEvent.BookingSagaStarted.class, saga.peekEvents().getFirst());
+
+        saga.recordStepSucceeded("booking-1:hold");
+        saga.advanceTo(BookingSagaStatus.AWAITING_PAYMENT);
+
+        assertEquals(BookingStepStatus.SUCCEEDED, saga.step("booking-1:hold").status());
+        assertEquals(BookingSagaStatus.AWAITING_PAYMENT, saga.status());
+    }
+
+    @Test
+    void tracksStepsIdempotentlyAndRetriesWithinLimit() {
+        BookingSaga saga = BookingSaga.start("saga-1", "order-1", "v1", "initial", List.of(
+            BookingSaga.stepPlan("ReserveProvider", "booking-1:reserve", Duration.ofMinutes(2), 1,
+                "CancelProviderReservation")
+        ), clock);
+        saga.pullEvents();
+
+        saga.recordStepSucceeded("booking-1:reserve");
+        saga.recordStepSucceeded("booking-1:reserve");
+        assertEquals(1, saga.peekEvents().stream()
+            .filter(BookingEvent.BookingSagaStepSucceeded.class::isInstance)
+            .count());
+
+        BookingSaga retryingSaga = BookingSaga.start("saga-2", "order-2", "v1", "initial", List.of(
+            BookingSaga.stepPlan("ReserveProvider", "booking-2:reserve", Duration.ofMinutes(2), 1,
+                "CancelProviderReservation")
+        ), clock);
+        retryingSaga.pullEvents();
+
+        retryingSaga.recordStepFailed("booking-2:reserve", "provider timeout");
+        retryingSaga.retryStep("booking-2:reserve");
+
+        assertEquals(BookingStepStatus.PENDING, retryingSaga.step("booking-2:reserve").status());
+        assertEquals(1, retryingSaga.step("booking-2:reserve").attemptNumber());
+        assertInstanceOf(BookingEvent.BookingSagaRetryScheduled.class, retryingSaga.peekEvents().getLast());
+
+        retryingSaga.recordStepFailed("booking-2:reserve", "provider timeout again");
+        assertThrows(IllegalStateException.class, () -> retryingSaga.retryStep("booking-2:reserve"));
+    }
+
+    @Test
+    void recordsTerminalFailureAndRejectsFurtherProgress() {
+        BookingSaga saga = BookingSaga.start("saga-1", "order-1", "v1", "initial", List.of(
+            BookingSaga.stepPlan("HoldCapacity", "booking-1:hold", Duration.ofMinutes(5), 0, "ReleaseHold")
+        ), clock);
+        saga.pullEvents();
+
+        saga.fail("capacity and provider unavailable");
+
+        assertEquals(BookingSagaStatus.FAILED, saga.status());
+        assertEquals("capacity and provider unavailable", saga.terminalReason().orElseThrow());
+        assertInstanceOf(BookingEvent.BookingSagaFailed.class, saga.peekEvents().getFirst());
+        assertThrows(IllegalStateException.class, () -> saga.advanceTo(BookingSagaStatus.CONFIRMING));
+    }
+}

--- a/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/domain/SegmentBookingTest.java
+++ b/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/domain/SegmentBookingTest.java
@@ -1,0 +1,112 @@
+package com.trainticket.bookingorchestration.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SegmentBookingTest {
+    private final Clock clock = Clock.fixed(Instant.parse("2026-06-28T12:00:00Z"), ZoneOffset.UTC);
+
+    @Test
+    void movesThroughInternalReservationConfirmationTicketingAndCancellation() {
+        SegmentBooking booking = SegmentBooking.requestReservation("booking-1", "order-1", "offer-item-1",
+            "rail-segment-1", "traveler-1", "initial", clock);
+
+        assertEquals(SegmentBookingStatus.REQUESTED, booking.status());
+        assertEquals("order-1:rail-segment-1:traveler-1:initial", booking.idempotencyKey());
+        assertInstanceOf(SegmentBookingEvent.SegmentReservationRequested.class, booking.peekEvents().getFirst());
+
+        booking.markCapacityHolding("hold-1");
+        booking.confirmInternal("capacity hold confirmed by policy");
+        booking.markTicketed("entitlement-1");
+        booking.requestCancellation("post sales approved");
+        booking.markCancelled("provider and capacity cancellation complete");
+
+        assertEquals(SegmentBookingStatus.CANCELLED, booking.status());
+        assertEquals("hold-1", booking.capacityHoldId().orElseThrow());
+        assertEquals("entitlement-1", booking.entitlementId().orElseThrow());
+    }
+
+    @Test
+    void acceptsOnlyNormalizedProviderConfirmationAndDoesNotExposeRawSupplierCodes() {
+        SegmentBooking booking = SegmentBooking.requestReservation("booking-1", "order-1", "offer-item-1",
+            "rail-segment-1", "traveler-1", "initial", clock);
+        booking.pullEvents();
+
+        ProviderReference providerReference = new ProviderReference("provider-acl", "reservation-42", "PNR-42");
+        ProviderReservationConfirmed confirmation = new ProviderReservationConfirmed("booking-1", providerReference,
+            "confirmed", Map.of("seatClass", "SECOND"));
+
+        booking.confirmFromProvider(confirmation);
+
+        assertEquals(SegmentBookingStatus.CONFIRMED, booking.status());
+        assertEquals(providerReference, booking.providerReference().orElseThrow());
+        assertTrue(booking.peekEvents().stream().anyMatch(SegmentBookingEvent.ProviderReferenceAttached.class::isInstance));
+        assertTrue(booking.peekEvents().stream().anyMatch(SegmentBookingEvent.SegmentReservationConfirmed.class::isInstance));
+        assertFalse(confirmation.normalizedAttributes().containsKey("rawSupplierStatusCode"));
+
+        ProviderReservationConfirmed duplicate = new ProviderReservationConfirmed("booking-1", providerReference,
+            "confirmed", Map.of());
+        booking.confirmFromProvider(duplicate);
+        long confirmedEvents = booking.peekEvents().stream()
+            .filter(SegmentBookingEvent.SegmentReservationConfirmed.class::isInstance)
+            .count();
+        assertEquals(1, confirmedEvents);
+
+        ProviderReservationConfirmed conflicting = new ProviderReservationConfirmed("booking-1",
+            new ProviderReference("provider-acl", "reservation-99", "PNR-99"), "confirmed", Map.of());
+        assertThrows(IllegalStateException.class, () -> booking.confirmFromProvider(conflicting));
+    }
+
+    @Test
+    void providerTimeoutKeepsReservationPendingForStatusQueryRecovery() {
+        SegmentBooking booking = SegmentBooking.requestReservation("booking-1", "order-1", "offer-item-1",
+            "rail-segment-1", "traveler-1", "initial", clock);
+        booking.pullEvents();
+
+        booking.markProviderReservationTimeout("provider reserve timeout");
+
+        assertEquals(SegmentBookingStatus.REQUESTED, booking.status());
+        assertInstanceOf(SegmentBookingEvent.ProviderReservationTimedOut.class, booking.peekEvents().getFirst());
+    }
+
+    @Test
+    void failedReservationDoesNotProgressToTicketed() {
+        SegmentBooking booking = SegmentBooking.requestReservation("booking-1", "order-1", "offer-item-1",
+            "rail-segment-1", "traveler-1", "initial", clock);
+
+        booking.failReservation("capacity hold rejected");
+
+        assertEquals(SegmentBookingStatus.FAILED, booking.status());
+        assertEquals("capacity hold rejected", booking.failureReason().orElseThrow());
+        assertThrows(IllegalStateException.class, () -> booking.markTicketed("entitlement-1"));
+    }
+
+    @Test
+    void lateProviderConfirmationAfterCancellationEmitsCancellationHookWithoutReopeningBooking() {
+        SegmentBooking booking = SegmentBooking.requestReservation("booking-1", "order-1", "offer-item-1",
+            "rail-segment-1", "traveler-1", "initial", clock);
+        booking.requestCancellation("payment expired");
+        booking.markCancelled("capacity released");
+        booking.pullEvents();
+
+        ProviderReference providerReference = new ProviderReference("provider-acl", "reservation-42", "PNR-42");
+        booking.confirmFromProvider(new ProviderReservationConfirmed("booking-1", providerReference, "confirmed",
+            Map.of()));
+
+        assertEquals(SegmentBookingStatus.CANCELLED, booking.status());
+        assertEquals(providerReference, booking.providerReference().orElseThrow());
+        assertTrue(booking.peekEvents().stream()
+            .anyMatch(SegmentBookingEvent.ProviderConfirmationReceivedAfterCancellation.class::isInstance));
+        assertTrue(booking.peekEvents().stream()
+            .anyMatch(SegmentBookingEvent.ProviderCancellationRequired.class::isInstance));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds tested BookingSaga domain behavior for start/progress/failure/retry and idempotent step tracking.
- Adds SegmentBooking lifecycle transitions for reservation requested, holding/confirmed/failed/ticketed/cancelled.
- Accepts normalized ProviderReservationConfirmed facts and emits coordination events including late confirmation after cancellation hooks.
- Updates booking-orchestration README/profile/POM metadata for the REQ-011 domain foundation.

## Validation
- cd services/booking-orchestration && mvn test
- make check-strict