### PR TITLE
REQ-015 Provider Integration ACL foundation

### DIFF
--- a/services/provider-integration/README.md
+++ b/services/provider-integration/README.md
@@ -4,26 +4,50 @@ Domain: Provider Integration
 
 Language: golang
 
-Phase: phase-1-support
+Phase: phase-1-acl-foundation
 
-Status: skeleton
+Status: REQ-015 tested domain foundation
 
 ## Owns
 
-- adapter protocol
-- signature verification
-- raw archive
-- external status mapping
+- provider request and callback identity
+- idempotency scope for external provider intents
+- raw archive references for request, response, webhook, status, and error payloads
+- normalized provider error classification
+- mapping confidence metadata
+- external status mapping into internal facts
+- explicit quarantine for unmapped raw provider statuses
+- retry and manual-review directives for ambiguous external outcomes
+
+## Does Not Own
+
+- SegmentBooking, JourneyOrder, PaymentIntent, Entitlement, Capacity, or PostSales aggregate state
+- user-facing provider error copy
+- real provider network calls in this foundation slice
+
+## REQ-015 ACL Facts
+
+The first ACL delivery maps reviewed provider/channel statuses into stable internal facts:
+
+- `PROVIDER_RESERVATION_CONFIRMED`
+- `PROVIDER_RESERVATION_FAILED`
+- `CHANNEL_PAYMENT_CAPTURED`
+- `CHANNEL_REFUND_SETTLED`
+- `SUPPLIER_TICKET_ISSUED`
+- `PROVIDER_BOARDING_ACCEPTED`
+
+Unmapped raw provider status codes are rejected into quarantine with raw archive pointers and manual-review action instead of leaking into core domains. Ambiguous states produce query-status or manual-review directives rather than blind replay of side-effecting operations.
 
 ## DDD Sources
 
 - `docs/02-domains/provider-integration.md`
+- `docs/01-ddd-high-level/acl-provider-contracts.md`
 
 ## Language Rationale
 
 Go fits protocol adapters, webhooks, retry loops, and small deployable edge services.
 
-## Skeleton Check
+## Checks
 
 ```bash
 go test ./...

--- a/services/provider-integration/internal/domain/acl.go
+++ b/services/provider-integration/internal/domain/acl.go
@@ -1,0 +1,655 @@
+package domain
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type ProviderID string
+type ProviderRequestID string
+type ProviderCallbackID string
+type Operation string
+type IdempotencyKey string
+type CorrelationID string
+type BusinessRef string
+type RawArchiveID string
+type RawArchiveURI string
+type ProviderReference string
+type MappingVersion string
+
+const (
+	OperationReserveReservation Operation = "RESERVE_PROVIDER_RESERVATION"
+	OperationConfirmReservation Operation = "CONFIRM_PROVIDER_RESERVATION"
+	OperationIssueTicket        Operation = "ISSUE_SUPPLIER_TICKET"
+	OperationCapturePayment     Operation = "CAPTURE_CHANNEL_PAYMENT"
+	OperationSettleRefund       Operation = "SETTLE_CHANNEL_REFUND"
+	OperationAcceptBoarding     Operation = "ACCEPT_PROVIDER_BOARDING"
+	OperationQueryStatus        Operation = "QUERY_PROVIDER_STATUS"
+)
+
+// ProviderRequestIdentity is the stable identity of one external provider
+// intent. It contains cross-context references only; Provider Integration uses
+// them for idempotency and traceability but does not own the referenced Booking,
+// Payment, Entitlement, Order, or Capacity aggregate.
+type ProviderRequestIdentity struct {
+	ProviderID     ProviderID        `json:"providerId"`
+	RequestID      ProviderRequestID `json:"requestId"`
+	Operation      Operation         `json:"operation"`
+	IdempotencyKey IdempotencyKey    `json:"idempotencyKey"`
+	CorrelationID  CorrelationID     `json:"correlationId"`
+	BusinessRef    BusinessRef       `json:"businessRef"`
+}
+
+func NewProviderRequestIdentity(providerID ProviderID, requestID ProviderRequestID, operation Operation, idempotencyKey IdempotencyKey, correlationID CorrelationID, businessRef BusinessRef) (ProviderRequestIdentity, error) {
+	identity := ProviderRequestIdentity{
+		ProviderID:     ProviderID(trim(providerID)),
+		RequestID:      ProviderRequestID(trim(requestID)),
+		Operation:      operation,
+		IdempotencyKey: IdempotencyKey(trim(idempotencyKey)),
+		CorrelationID:  CorrelationID(trim(correlationID)),
+		BusinessRef:    BusinessRef(trim(businessRef)),
+	}
+	if err := identity.Validate(); err != nil {
+		return ProviderRequestIdentity{}, err
+	}
+	return identity, nil
+}
+
+func (i ProviderRequestIdentity) Validate() error {
+	if trim(i.ProviderID) == "" {
+		return fmt.Errorf("provider id is required")
+	}
+	if trim(i.RequestID) == "" {
+		return fmt.Errorf("provider request id is required")
+	}
+	if !validOperation(i.Operation) {
+		return fmt.Errorf("unsupported provider operation: %q", i.Operation)
+	}
+	if trim(i.IdempotencyKey) == "" {
+		return fmt.Errorf("idempotency key is required")
+	}
+	if trim(i.CorrelationID) == "" {
+		return fmt.Errorf("correlation id is required")
+	}
+	if trim(i.BusinessRef) == "" {
+		return fmt.Errorf("business reference is required")
+	}
+	return nil
+}
+
+// IdempotencyScope is the anti-corruption key that prevents multiple external
+// intents for the same provider operation. The business reference remains only a
+// reference; this service must not mutate the referenced aggregate.
+func (i ProviderRequestIdentity) IdempotencyScope() string {
+	return strings.Join([]string{string(i.ProviderID), string(i.Operation), string(i.IdempotencyKey)}, ":")
+}
+
+// ProviderCallbackIdentity records a webhook/callback before any downstream
+// event can be emitted. SignatureScope is part of the idempotency boundary so
+// provider retries through different credential scopes cannot collide silently.
+type ProviderCallbackIdentity struct {
+	ProviderID     ProviderID         `json:"providerId"`
+	CallbackID     ProviderCallbackID `json:"callbackId"`
+	SignatureScope string             `json:"signatureScope"`
+	IdempotencyKey IdempotencyKey     `json:"idempotencyKey"`
+	CorrelationID  CorrelationID      `json:"correlationId"`
+}
+
+func NewProviderCallbackIdentity(providerID ProviderID, callbackID ProviderCallbackID, signatureScope string, idempotencyKey IdempotencyKey, correlationID CorrelationID) (ProviderCallbackIdentity, error) {
+	identity := ProviderCallbackIdentity{
+		ProviderID:     ProviderID(trim(providerID)),
+		CallbackID:     ProviderCallbackID(trim(callbackID)),
+		SignatureScope: strings.TrimSpace(signatureScope),
+		IdempotencyKey: IdempotencyKey(trim(idempotencyKey)),
+		CorrelationID:  CorrelationID(trim(correlationID)),
+	}
+	if err := identity.Validate(); err != nil {
+		return ProviderCallbackIdentity{}, err
+	}
+	return identity, nil
+}
+
+func (i ProviderCallbackIdentity) Validate() error {
+	if trim(i.ProviderID) == "" {
+		return fmt.Errorf("provider id is required")
+	}
+	if trim(i.CallbackID) == "" {
+		return fmt.Errorf("callback id is required")
+	}
+	if i.SignatureScope == "" {
+		return fmt.Errorf("callback signature scope is required")
+	}
+	if trim(i.IdempotencyKey) == "" {
+		return fmt.Errorf("callback idempotency key is required")
+	}
+	if trim(i.CorrelationID) == "" {
+		return fmt.Errorf("correlation id is required")
+	}
+	return nil
+}
+
+func (i ProviderCallbackIdentity) InboxKey() string {
+	return strings.Join([]string{string(i.ProviderID), string(i.SignatureScope), string(i.CallbackID)}, ":")
+}
+
+type RawArchiveKind string
+
+const (
+	RawArchiveRequest  RawArchiveKind = "RAW_REQUEST"
+	RawArchiveResponse RawArchiveKind = "RAW_RESPONSE"
+	RawArchiveWebhook  RawArchiveKind = "RAW_WEBHOOK"
+	RawArchiveStatus   RawArchiveKind = "RAW_STATUS"
+	RawArchiveError    RawArchiveKind = "RAW_ERROR"
+)
+
+// RawArchiveReference points to immutable raw provider material stored for
+// audit, replay, and supplier disputes. It deliberately carries references and
+// digests rather than raw payloads so raw provider language does not leak into
+// core domain events.
+type RawArchiveReference struct {
+	ArchiveID     RawArchiveID   `json:"archiveId"`
+	Kind          RawArchiveKind `json:"kind"`
+	URI           RawArchiveURI  `json:"uri"`
+	SHA256        string         `json:"sha256"`
+	SchemaVersion string         `json:"schemaVersion"`
+}
+
+func NewRawArchiveReference(archiveID RawArchiveID, kind RawArchiveKind, uri RawArchiveURI, sha256, schemaVersion string) (RawArchiveReference, error) {
+	ref := RawArchiveReference{
+		ArchiveID:     RawArchiveID(trim(archiveID)),
+		Kind:          kind,
+		URI:           RawArchiveURI(trim(uri)),
+		SHA256:        strings.TrimSpace(sha256),
+		SchemaVersion: strings.TrimSpace(schemaVersion),
+	}
+	if err := ref.Validate(); err != nil {
+		return RawArchiveReference{}, err
+	}
+	return ref, nil
+}
+
+func (r RawArchiveReference) Validate() error {
+	if trim(r.ArchiveID) == "" {
+		return fmt.Errorf("raw archive id is required")
+	}
+	if !validRawArchiveKind(r.Kind) {
+		return fmt.Errorf("unsupported raw archive kind: %q", r.Kind)
+	}
+	if trim(r.URI) == "" {
+		return fmt.Errorf("raw archive uri is required")
+	}
+	if r.SHA256 == "" {
+		return fmt.Errorf("raw archive sha256 digest is required")
+	}
+	if r.SchemaVersion == "" {
+		return fmt.Errorf("raw archive schema version is required")
+	}
+	return nil
+}
+
+type ErrorClassification string
+
+const (
+	ErrorBusinessRejected       ErrorClassification = "BUSINESS_REJECTED"
+	ErrorRetryableTechnical     ErrorClassification = "RETRYABLE_TECHNICAL_ERROR"
+	ErrorNonRetryableTechnical  ErrorClassification = "NON_RETRYABLE_TECHNICAL_ERROR"
+	ErrorAmbiguousResult        ErrorClassification = "AMBIGUOUS_RESULT"
+	ErrorProviderRuleChanged    ErrorClassification = "PROVIDER_RULE_CHANGED"
+	ErrorProviderStateConflict  ErrorClassification = "PROVIDER_STATE_CONFLICT"
+	ErrorUnmappedProviderStatus ErrorClassification = "UNMAPPED_PROVIDER_STATUS"
+)
+
+type MappingConfidenceLevel string
+
+const (
+	MappingConfidenceExact       MappingConfidenceLevel = "EXACT"
+	MappingConfidenceHigh        MappingConfidenceLevel = "HIGH"
+	MappingConfidenceMedium      MappingConfidenceLevel = "MEDIUM"
+	MappingConfidenceLow         MappingConfidenceLevel = "LOW"
+	MappingConfidenceQuarantined MappingConfidenceLevel = "QUARANTINED"
+)
+
+type MappingConfidence struct {
+	Level  MappingConfidenceLevel `json:"level"`
+	Score  float64                `json:"score"`
+	Reason string                 `json:"reason,omitempty"`
+}
+
+func NewMappingConfidence(level MappingConfidenceLevel, score float64, reason string) (MappingConfidence, error) {
+	confidence := MappingConfidence{Level: level, Score: score, Reason: strings.TrimSpace(reason)}
+	if err := confidence.Validate(); err != nil {
+		return MappingConfidence{}, err
+	}
+	return confidence, nil
+}
+
+func (c MappingConfidence) Validate() error {
+	if !validMappingConfidenceLevel(c.Level) {
+		return fmt.Errorf("unsupported mapping confidence level: %q", c.Level)
+	}
+	if c.Score < 0 || c.Score > 1 {
+		return fmt.Errorf("mapping confidence score must be between 0 and 1")
+	}
+	if (c.Level == MappingConfidenceLow || c.Level == MappingConfidenceQuarantined) && strings.TrimSpace(c.Reason) == "" {
+		return fmt.Errorf("low confidence and quarantined mappings require a reason")
+	}
+	if c.Level == MappingConfidenceQuarantined && c.Score != 0 {
+		return fmt.Errorf("quarantined mappings must have zero confidence score")
+	}
+	return nil
+}
+
+type ExternalProviderStatus struct {
+	Identity          ProviderRequestIdentity `json:"identity"`
+	RawStatusCode     string                  `json:"rawStatusCode"`
+	RawStatusText     string                  `json:"rawStatusText,omitempty"`
+	ProviderReference ProviderReference       `json:"providerReference,omitempty"`
+	ObservedAt        time.Time               `json:"observedAt"`
+	Archive           RawArchiveReference     `json:"archive"`
+}
+
+func NewExternalProviderStatus(identity ProviderRequestIdentity, rawStatusCode, rawStatusText string, providerReference ProviderReference, observedAt time.Time, archive RawArchiveReference) (ExternalProviderStatus, error) {
+	status := ExternalProviderStatus{
+		Identity:          identity,
+		RawStatusCode:     strings.TrimSpace(rawStatusCode),
+		RawStatusText:     strings.TrimSpace(rawStatusText),
+		ProviderReference: ProviderReference(trim(providerReference)),
+		ObservedAt:        observedAt,
+		Archive:           archive,
+	}
+	if err := status.Validate(); err != nil {
+		return ExternalProviderStatus{}, err
+	}
+	return status, nil
+}
+
+func (s ExternalProviderStatus) Validate() error {
+	if err := s.Identity.Validate(); err != nil {
+		return fmt.Errorf("invalid provider status identity: %w", err)
+	}
+	if s.RawStatusCode == "" {
+		return fmt.Errorf("raw provider status code is required")
+	}
+	if s.ObservedAt.IsZero() {
+		return fmt.Errorf("observed at is required")
+	}
+	if err := s.Archive.Validate(); err != nil {
+		return fmt.Errorf("invalid raw archive reference: %w", err)
+	}
+	return nil
+}
+
+type InternalFactKind string
+
+const (
+	FactProviderReservationConfirmed InternalFactKind = "PROVIDER_RESERVATION_CONFIRMED"
+	FactProviderReservationFailed    InternalFactKind = "PROVIDER_RESERVATION_FAILED"
+	FactChannelPaymentCaptured       InternalFactKind = "CHANNEL_PAYMENT_CAPTURED"
+	FactChannelRefundSettled         InternalFactKind = "CHANNEL_REFUND_SETTLED"
+	FactSupplierTicketIssued         InternalFactKind = "SUPPLIER_TICKET_ISSUED"
+	FactProviderBoardingAccepted     InternalFactKind = "PROVIDER_BOARDING_ACCEPTED"
+)
+
+// MappedInternalFact is the only object emitted to core domains. It contains a
+// normalized fact kind, provider references, and audit pointers, never raw
+// provider status codes as business state.
+type MappedInternalFact struct {
+	Kind              InternalFactKind    `json:"kind"`
+	ProviderID        ProviderID          `json:"providerId"`
+	Operation         Operation           `json:"operation"`
+	BusinessRef       BusinessRef         `json:"businessRef"`
+	ProviderReference ProviderReference   `json:"providerReference,omitempty"`
+	OccurredAt        time.Time           `json:"occurredAt"`
+	CorrelationID     CorrelationID       `json:"correlationId"`
+	SourceRequestID   ProviderRequestID   `json:"sourceRequestId"`
+	Archive           RawArchiveReference `json:"archive"`
+}
+
+func NewMappedInternalFact(kind InternalFactKind, status ExternalProviderStatus) (MappedInternalFact, error) {
+	fact := MappedInternalFact{
+		Kind:              kind,
+		ProviderID:        status.Identity.ProviderID,
+		Operation:         status.Identity.Operation,
+		BusinessRef:       status.Identity.BusinessRef,
+		ProviderReference: status.ProviderReference,
+		OccurredAt:        status.ObservedAt,
+		CorrelationID:     status.Identity.CorrelationID,
+		SourceRequestID:   status.Identity.RequestID,
+		Archive:           status.Archive,
+	}
+	if err := fact.Validate(); err != nil {
+		return MappedInternalFact{}, err
+	}
+	return fact, nil
+}
+
+func (f MappedInternalFact) Validate() error {
+	if !validInternalFactKind(f.Kind) {
+		return fmt.Errorf("unsupported internal fact kind: %q", f.Kind)
+	}
+	if trim(f.ProviderID) == "" {
+		return fmt.Errorf("mapped fact provider id is required")
+	}
+	if !validOperation(f.Operation) {
+		return fmt.Errorf("mapped fact operation is invalid")
+	}
+	if trim(f.BusinessRef) == "" {
+		return fmt.Errorf("mapped fact business reference is required")
+	}
+	if f.Kind != FactProviderReservationFailed && trim(f.ProviderReference) == "" {
+		return fmt.Errorf("mapped fact provider reference is required for %s", f.Kind)
+	}
+	if f.OccurredAt.IsZero() {
+		return fmt.Errorf("mapped fact occurred at is required")
+	}
+	if trim(f.CorrelationID) == "" {
+		return fmt.Errorf("mapped fact correlation id is required")
+	}
+	if trim(f.SourceRequestID) == "" {
+		return fmt.Errorf("mapped fact source request id is required")
+	}
+	if err := f.Archive.Validate(); err != nil {
+		return fmt.Errorf("mapped fact archive is invalid: %w", err)
+	}
+	return nil
+}
+
+type NextAction string
+
+const (
+	NextActionRetry        NextAction = "RETRY"
+	NextActionQueryStatus  NextAction = "QUERY_STATUS"
+	NextActionManualReview NextAction = "MANUAL_REVIEW"
+	NextActionStop         NextAction = "STOP"
+)
+
+type MappingDecisionKind string
+
+const (
+	DecisionMapped     MappingDecisionKind = "MAPPED"
+	DecisionQuarantine MappingDecisionKind = "QUARANTINE"
+	DecisionAmbiguous  MappingDecisionKind = "AMBIGUOUS"
+)
+
+type StatusMappingRule struct {
+	ProviderID     ProviderID          `json:"providerId"`
+	Operation      Operation           `json:"operation"`
+	RawStatusCode  string              `json:"rawStatusCode"`
+	FactKind       InternalFactKind    `json:"factKind,omitempty"`
+	Error          ErrorClassification `json:"error,omitempty"`
+	Confidence     MappingConfidence   `json:"confidence"`
+	NextAction     NextAction          `json:"nextAction"`
+	MappingVersion MappingVersion      `json:"mappingVersion"`
+}
+
+func NewStatusMappingRule(providerID ProviderID, operation Operation, rawStatusCode string, factKind InternalFactKind, errorClass ErrorClassification, confidence MappingConfidence, nextAction NextAction, mappingVersion MappingVersion) (StatusMappingRule, error) {
+	rule := StatusMappingRule{
+		ProviderID:     ProviderID(trim(providerID)),
+		Operation:      operation,
+		RawStatusCode:  strings.TrimSpace(rawStatusCode),
+		FactKind:       factKind,
+		Error:          errorClass,
+		Confidence:     confidence,
+		NextAction:     nextAction,
+		MappingVersion: MappingVersion(trim(mappingVersion)),
+	}
+	if err := rule.Validate(); err != nil {
+		return StatusMappingRule{}, err
+	}
+	return rule, nil
+}
+
+func (r StatusMappingRule) Validate() error {
+	if trim(r.ProviderID) == "" {
+		return fmt.Errorf("mapping rule provider id is required")
+	}
+	if !validOperation(r.Operation) {
+		return fmt.Errorf("mapping rule operation is invalid")
+	}
+	if r.RawStatusCode == "" {
+		return fmt.Errorf("mapping rule raw status code is required")
+	}
+	if err := r.Confidence.Validate(); err != nil {
+		return fmt.Errorf("mapping rule confidence invalid: %w", err)
+	}
+	if !validNextAction(r.NextAction) {
+		return fmt.Errorf("unsupported mapping next action: %q", r.NextAction)
+	}
+	if trim(r.MappingVersion) == "" {
+		return fmt.Errorf("mapping version is required")
+	}
+	if r.NextAction == NextActionQueryStatus || r.NextAction == NextActionManualReview {
+		if r.Error != ErrorAmbiguousResult && r.Error != ErrorProviderStateConflict {
+			return fmt.Errorf("query status or manual review rules must classify ambiguous result or provider state conflict")
+		}
+		return nil
+	}
+	if !validInternalFactKind(r.FactKind) {
+		return fmt.Errorf("mapped rules require an internal fact kind")
+	}
+	if r.Error != "" && !validErrorClassification(r.Error) {
+		return fmt.Errorf("unsupported error classification: %q", r.Error)
+	}
+	return nil
+}
+
+type StatusMappingCatalog struct {
+	rules map[string]StatusMappingRule
+}
+
+func NewStatusMappingCatalog(rules []StatusMappingRule) (StatusMappingCatalog, error) {
+	catalog := StatusMappingCatalog{rules: make(map[string]StatusMappingRule, len(rules))}
+	for _, rule := range rules {
+		if err := rule.Validate(); err != nil {
+			return StatusMappingCatalog{}, err
+		}
+		key := mappingRuleKey(rule.ProviderID, rule.Operation, rule.RawStatusCode)
+		if _, exists := catalog.rules[key]; exists {
+			return StatusMappingCatalog{}, fmt.Errorf("duplicate provider status mapping rule: %s", key)
+		}
+		catalog.rules[key] = rule
+	}
+	return catalog, nil
+}
+
+func (c StatusMappingCatalog) Map(status ExternalProviderStatus) (ProviderMappingDecision, error) {
+	if err := status.Validate(); err != nil {
+		return ProviderMappingDecision{}, err
+	}
+	rule, exists := c.rules[mappingRuleKey(status.Identity.ProviderID, status.Identity.Operation, status.RawStatusCode)]
+	if !exists {
+		confidence, _ := NewMappingConfidence(MappingConfidenceQuarantined, 0, "no provider status mapping rule")
+		return ProviderMappingDecision{
+			Kind:       DecisionQuarantine,
+			Error:      ErrorUnmappedProviderStatus,
+			Confidence: confidence,
+			NextAction: NextActionManualReview,
+			Quarantine: &UnmappedStatusQuarantine{
+				ProviderID:    status.Identity.ProviderID,
+				Operation:     status.Identity.Operation,
+				RawStatusCode: status.RawStatusCode,
+				RawStatusText: status.RawStatusText,
+				BusinessRef:   status.Identity.BusinessRef,
+				CorrelationID: status.Identity.CorrelationID,
+				Archive:       status.Archive,
+				Reason:        "unmapped provider status code",
+				QuarantinedAt: status.ObservedAt,
+			},
+		}, nil
+	}
+	if rule.NextAction == NextActionQueryStatus || rule.NextAction == NextActionManualReview {
+		return ProviderMappingDecision{
+			Kind:           DecisionAmbiguous,
+			Error:          rule.Error,
+			Confidence:     rule.Confidence,
+			NextAction:     rule.NextAction,
+			MappingVersion: rule.MappingVersion,
+			Review: &ReviewDirective{
+				ProviderID:    status.Identity.ProviderID,
+				Operation:     status.Identity.Operation,
+				BusinessRef:   status.Identity.BusinessRef,
+				CorrelationID: status.Identity.CorrelationID,
+				Archive:       status.Archive,
+				Reason:        rule.Confidence.Reason,
+			},
+		}, nil
+	}
+	fact, err := NewMappedInternalFact(rule.FactKind, status)
+	if err != nil {
+		return ProviderMappingDecision{}, err
+	}
+	return ProviderMappingDecision{
+		Kind:           DecisionMapped,
+		Fact:           &fact,
+		Error:          rule.Error,
+		Confidence:     rule.Confidence,
+		NextAction:     rule.NextAction,
+		MappingVersion: rule.MappingVersion,
+	}, nil
+}
+
+type ProviderMappingDecision struct {
+	Kind           MappingDecisionKind       `json:"kind"`
+	Fact           *MappedInternalFact       `json:"fact,omitempty"`
+	Quarantine     *UnmappedStatusQuarantine `json:"quarantine,omitempty"`
+	Review         *ReviewDirective          `json:"review,omitempty"`
+	Error          ErrorClassification       `json:"error,omitempty"`
+	Confidence     MappingConfidence         `json:"confidence"`
+	NextAction     NextAction                `json:"nextAction"`
+	MappingVersion MappingVersion            `json:"mappingVersion,omitempty"`
+}
+
+// UnmappedStatusQuarantine is the explicit rejection path for external status
+// codes without a reviewed mapping. Downstream core domains should receive this
+// as an operations/review input, not as a business fact.
+type UnmappedStatusQuarantine struct {
+	ProviderID    ProviderID          `json:"providerId"`
+	Operation     Operation           `json:"operation"`
+	RawStatusCode string              `json:"rawStatusCode"`
+	RawStatusText string              `json:"rawStatusText,omitempty"`
+	BusinessRef   BusinessRef         `json:"businessRef"`
+	CorrelationID CorrelationID       `json:"correlationId"`
+	Archive       RawArchiveReference `json:"archive"`
+	Reason        string              `json:"reason"`
+	QuarantinedAt time.Time           `json:"quarantinedAt"`
+}
+
+// ReviewDirective represents retry/query/manual-review follow-up for ambiguous
+// external outcomes. Side-effecting operations should query status or escalate;
+// they should not be blindly replayed.
+type ReviewDirective struct {
+	ProviderID    ProviderID          `json:"providerId"`
+	Operation     Operation           `json:"operation"`
+	BusinessRef   BusinessRef         `json:"businessRef"`
+	CorrelationID CorrelationID       `json:"correlationId"`
+	Archive       RawArchiveReference `json:"archive"`
+	Reason        string              `json:"reason"`
+}
+
+type RetryDirective struct {
+	ProviderID     ProviderID          `json:"providerId"`
+	Operation      Operation           `json:"operation"`
+	BusinessRef    BusinessRef         `json:"businessRef"`
+	CorrelationID  CorrelationID       `json:"correlationId"`
+	Attempt        int                 `json:"attempt"`
+	MaxAttempts    int                 `json:"maxAttempts"`
+	NextAttemptAt  time.Time           `json:"nextAttemptAt"`
+	Classification ErrorClassification `json:"classification"`
+	Reason         string              `json:"reason"`
+}
+
+func NewRetryDirective(identity ProviderRequestIdentity, attempt, maxAttempts int, nextAttemptAt time.Time, classification ErrorClassification, reason string) (RetryDirective, error) {
+	directive := RetryDirective{
+		ProviderID:     identity.ProviderID,
+		Operation:      identity.Operation,
+		BusinessRef:    identity.BusinessRef,
+		CorrelationID:  identity.CorrelationID,
+		Attempt:        attempt,
+		MaxAttempts:    maxAttempts,
+		NextAttemptAt:  nextAttemptAt,
+		Classification: classification,
+		Reason:         strings.TrimSpace(reason),
+	}
+	if err := identity.Validate(); err != nil {
+		return RetryDirective{}, err
+	}
+	if directive.Attempt <= 0 {
+		return RetryDirective{}, fmt.Errorf("retry attempt must be positive")
+	}
+	if directive.MaxAttempts < directive.Attempt {
+		return RetryDirective{}, fmt.Errorf("max attempts must be greater than or equal to attempt")
+	}
+	if directive.NextAttemptAt.IsZero() {
+		return RetryDirective{}, fmt.Errorf("next retry attempt time is required")
+	}
+	if directive.Classification != ErrorRetryableTechnical && directive.Classification != ErrorAmbiguousResult {
+		return RetryDirective{}, fmt.Errorf("retry directive requires retryable or ambiguous classification")
+	}
+	if directive.Reason == "" {
+		return RetryDirective{}, fmt.Errorf("retry directive reason is required")
+	}
+	return directive, nil
+}
+
+func mappingRuleKey(providerID ProviderID, operation Operation, rawStatusCode string) string {
+	return strings.Join([]string{string(providerID), string(operation), strings.ToUpper(strings.TrimSpace(rawStatusCode))}, ":")
+}
+
+func validOperation(operation Operation) bool {
+	switch operation {
+	case OperationReserveReservation, OperationConfirmReservation, OperationIssueTicket, OperationCapturePayment, OperationSettleRefund, OperationAcceptBoarding, OperationQueryStatus:
+		return true
+	default:
+		return false
+	}
+}
+
+func validRawArchiveKind(kind RawArchiveKind) bool {
+	switch kind {
+	case RawArchiveRequest, RawArchiveResponse, RawArchiveWebhook, RawArchiveStatus, RawArchiveError:
+		return true
+	default:
+		return false
+	}
+}
+
+func validErrorClassification(classification ErrorClassification) bool {
+	switch classification {
+	case ErrorBusinessRejected, ErrorRetryableTechnical, ErrorNonRetryableTechnical, ErrorAmbiguousResult, ErrorProviderRuleChanged, ErrorProviderStateConflict, ErrorUnmappedProviderStatus:
+		return true
+	default:
+		return false
+	}
+}
+
+func validMappingConfidenceLevel(level MappingConfidenceLevel) bool {
+	switch level {
+	case MappingConfidenceExact, MappingConfidenceHigh, MappingConfidenceMedium, MappingConfidenceLow, MappingConfidenceQuarantined:
+		return true
+	default:
+		return false
+	}
+}
+
+func validInternalFactKind(kind InternalFactKind) bool {
+	switch kind {
+	case FactProviderReservationConfirmed, FactProviderReservationFailed, FactChannelPaymentCaptured, FactChannelRefundSettled, FactSupplierTicketIssued, FactProviderBoardingAccepted:
+		return true
+	default:
+		return false
+	}
+}
+
+func validNextAction(action NextAction) bool {
+	switch action {
+	case NextActionRetry, NextActionQueryStatus, NextActionManualReview, NextActionStop:
+		return true
+	default:
+		return false
+	}
+}
+
+func trim[T ~string](value T) string {
+	return strings.TrimSpace(string(value))
+}

--- a/services/provider-integration/internal/domain/acl_test.go
+++ b/services/provider-integration/internal/domain/acl_test.go
@@ -1,0 +1,282 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestProviderIdentityAndRawArchiveValidation(t *testing.T) {
+	identity, err := NewProviderRequestIdentity(" rail-cr ", " req-1 ", OperationConfirmReservation, " idem-1 ", " corr-1 ", " segment-booking:sb-1 ")
+	if err != nil {
+		t.Fatalf("identity should be valid: %v", err)
+	}
+	if identity.ProviderID != "rail-cr" {
+		t.Fatalf("provider id was not normalized: %q", identity.ProviderID)
+	}
+	if identity.IdempotencyScope() != "rail-cr:CONFIRM_PROVIDER_RESERVATION:idem-1" {
+		t.Fatalf("unexpected idempotency scope: %s", identity.IdempotencyScope())
+	}
+
+	callback, err := NewProviderCallbackIdentity("pay-channel", "event-9", "merchant-credential:v2", "idem-cb-9", "corr-9")
+	if err != nil {
+		t.Fatalf("callback identity should be valid: %v", err)
+	}
+	if callback.InboxKey() != "pay-channel:merchant-credential:v2:event-9" {
+		t.Fatalf("unexpected inbox key: %s", callback.InboxKey())
+	}
+
+	archive, err := NewRawArchiveReference("raw-1", RawArchiveWebhook, "archive://provider/raw-1", "abc123", "provider.schema.v1")
+	if err != nil {
+		t.Fatalf("archive should be valid: %v", err)
+	}
+	if archive.Kind != RawArchiveWebhook {
+		t.Fatalf("unexpected archive kind: %s", archive.Kind)
+	}
+
+	if _, err := NewProviderRequestIdentity("", "req-1", OperationConfirmReservation, "idem-1", "corr-1", "segment-booking:sb-1"); err == nil {
+		t.Fatalf("missing provider id should be rejected")
+	}
+	if _, err := NewRawArchiveReference("raw-1", "RAW_MUTABLE_PAYLOAD", "archive://provider/raw-1", "abc123", "provider.schema.v1"); err == nil {
+		t.Fatalf("unsupported raw archive kind should be rejected")
+	}
+}
+
+func TestMapsExternalStatusesToInternalFacts(t *testing.T) {
+	catalog := mustCatalog(t)
+
+	cases := []struct {
+		name              string
+		operation         Operation
+		rawStatus         string
+		providerReference ProviderReference
+		wantFact          InternalFactKind
+	}{
+		{
+			name:              "provider reservation confirmed",
+			operation:         OperationConfirmReservation,
+			rawStatus:         "CONFIRMED",
+			providerReference: "PNR-123",
+			wantFact:          FactProviderReservationConfirmed,
+		},
+		{
+			name:              "provider reservation failed",
+			operation:         OperationConfirmReservation,
+			rawStatus:         "REJECTED",
+			providerReference: "",
+			wantFact:          FactProviderReservationFailed,
+		},
+		{
+			name:              "channel payment captured",
+			operation:         OperationCapturePayment,
+			rawStatus:         "CAPTURED",
+			providerReference: "txn-123",
+			wantFact:          FactChannelPaymentCaptured,
+		},
+		{
+			name:              "channel refund settled",
+			operation:         OperationSettleRefund,
+			rawStatus:         "REFUND_SUCCESS",
+			providerReference: "refund-123",
+			wantFact:          FactChannelRefundSettled,
+		},
+		{
+			name:              "supplier ticket issued",
+			operation:         OperationIssueTicket,
+			rawStatus:         "TICKETED",
+			providerReference: "ticket-123",
+			wantFact:          FactSupplierTicketIssued,
+		},
+		{
+			name:              "provider boarding accepted",
+			operation:         OperationAcceptBoarding,
+			rawStatus:         "BOARDED",
+			providerReference: "gate-pass-123",
+			wantFact:          FactProviderBoardingAccepted,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status := mustExternalStatus(t, tc.operation, tc.rawStatus, tc.providerReference)
+			decision, err := catalog.Map(status)
+			if err != nil {
+				t.Fatalf("mapping failed: %v", err)
+			}
+			if decision.Kind != DecisionMapped {
+				t.Fatalf("expected mapped decision, got %s", decision.Kind)
+			}
+			if decision.Fact == nil {
+				t.Fatalf("expected mapped fact")
+			}
+			if decision.Fact.Kind != tc.wantFact {
+				t.Fatalf("unexpected fact: got %s want %s", decision.Fact.Kind, tc.wantFact)
+			}
+			if decision.Fact.BusinessRef != "segment-booking:sb-1" {
+				t.Fatalf("business ref should remain a reference, got %q", decision.Fact.BusinessRef)
+			}
+			if decision.Fact.Archive.ArchiveID == "" {
+				t.Fatalf("mapped fact must keep raw archive reference")
+			}
+		})
+	}
+}
+
+func TestUnmappedRawStatusIsQuarantinedAndDoesNotLeakAsFact(t *testing.T) {
+	catalog := mustCatalog(t)
+	status := mustExternalStatus(t, OperationIssueTicket, "SUPPLIER_MAGIC_STATE", "ticket-123")
+
+	decision, err := catalog.Map(status)
+	if err != nil {
+		t.Fatalf("mapping should produce quarantine decision: %v", err)
+	}
+	if decision.Kind != DecisionQuarantine {
+		t.Fatalf("expected quarantine, got %s", decision.Kind)
+	}
+	if decision.Fact != nil {
+		t.Fatalf("unmapped raw status must not produce a core domain fact")
+	}
+	if decision.Error != ErrorUnmappedProviderStatus {
+		t.Fatalf("unexpected error classification: %s", decision.Error)
+	}
+	if decision.Quarantine == nil {
+		t.Fatalf("quarantine details are required")
+	}
+	if decision.Quarantine.RawStatusCode != "SUPPLIER_MAGIC_STATE" {
+		t.Fatalf("raw status should be retained only in quarantine: %q", decision.Quarantine.RawStatusCode)
+	}
+	if decision.NextAction != NextActionManualReview {
+		t.Fatalf("unmapped status should require manual review, got %s", decision.NextAction)
+	}
+	if decision.Confidence.Level != MappingConfidenceQuarantined || decision.Confidence.Score != 0 {
+		t.Fatalf("unexpected quarantine confidence: %+v", decision.Confidence)
+	}
+}
+
+func TestAmbiguousStatusProducesReviewDirective(t *testing.T) {
+	catalog := mustCatalog(t)
+	status := mustExternalStatus(t, OperationCapturePayment, "PROCESSING", "txn-123")
+
+	decision, err := catalog.Map(status)
+	if err != nil {
+		t.Fatalf("mapping ambiguous status failed: %v", err)
+	}
+	if decision.Kind != DecisionAmbiguous {
+		t.Fatalf("expected ambiguous decision, got %s", decision.Kind)
+	}
+	if decision.Fact != nil {
+		t.Fatalf("ambiguous status must not produce a core domain fact")
+	}
+	if decision.NextAction != NextActionQueryStatus {
+		t.Fatalf("expected status query next action, got %s", decision.NextAction)
+	}
+	if decision.Error != ErrorAmbiguousResult {
+		t.Fatalf("expected ambiguous result classification, got %s", decision.Error)
+	}
+	if decision.Review == nil || decision.Review.BusinessRef != "segment-booking:sb-1" {
+		t.Fatalf("review directive should carry traceable references: %+v", decision.Review)
+	}
+}
+
+func TestRetryDirectiveRequiresSafeClassification(t *testing.T) {
+	identity := mustIdentity(t, OperationQueryStatus)
+	_, err := NewRetryDirective(identity, 1, 3, time.Date(2026, 7, 3, 12, 5, 0, 0, time.UTC), ErrorRetryableTechnical, "provider rate limited")
+	if err != nil {
+		t.Fatalf("retryable technical error should allow retry directive: %v", err)
+	}
+
+	if _, err := NewRetryDirective(identity, 0, 3, time.Now(), ErrorRetryableTechnical, "provider rate limited"); err == nil {
+		t.Fatalf("zero retry attempt should be rejected")
+	}
+	if _, err := NewRetryDirective(identity, 1, 3, time.Now(), ErrorBusinessRejected, "no seats"); err == nil {
+		t.Fatalf("business rejection should not allow retry directive")
+	}
+}
+
+func TestMappingRuleValidation(t *testing.T) {
+	exact := mustConfidence(t, MappingConfidenceExact, 1, "")
+	if _, err := NewStatusMappingRule("rail-cr", OperationConfirmReservation, "CONFIRMED", FactProviderReservationConfirmed, "", exact, NextActionStop, "map-v1"); err != nil {
+		t.Fatalf("valid mapped rule rejected: %v", err)
+	}
+
+	if _, err := NewMappingConfidence(MappingConfidenceLow, 0.4, ""); err == nil {
+		t.Fatalf("low confidence without reason should be rejected")
+	}
+	if _, err := NewMappingConfidence(MappingConfidenceQuarantined, 0.1, "unknown"); err == nil {
+		t.Fatalf("quarantined confidence with non-zero score should be rejected")
+	}
+	if _, err := NewStatusMappingRule("rail-cr", OperationConfirmReservation, "WAIT", "", ErrorBusinessRejected, exact, NextActionQueryStatus, "map-v1"); err == nil {
+		t.Fatalf("query status rule without ambiguous/conflict classification should be rejected")
+	}
+}
+
+func mustCatalog(t *testing.T) StatusMappingCatalog {
+	t.Helper()
+	exact := mustConfidence(t, MappingConfidenceExact, 1, "")
+	ambiguous := mustConfidence(t, MappingConfidenceLow, 0.35, "provider still processing; query final status")
+	rules := []StatusMappingRule{
+		mustRule(t, "rail-cr", OperationConfirmReservation, "CONFIRMED", FactProviderReservationConfirmed, "", exact, NextActionStop),
+		mustRule(t, "rail-cr", OperationConfirmReservation, "REJECTED", FactProviderReservationFailed, ErrorBusinessRejected, exact, NextActionStop),
+		mustRule(t, "rail-cr", OperationCapturePayment, "CAPTURED", FactChannelPaymentCaptured, "", exact, NextActionStop),
+		mustRule(t, "rail-cr", OperationCapturePayment, "PROCESSING", "", ErrorAmbiguousResult, ambiguous, NextActionQueryStatus),
+		mustRule(t, "rail-cr", OperationSettleRefund, "REFUND_SUCCESS", FactChannelRefundSettled, "", exact, NextActionStop),
+		mustRule(t, "rail-cr", OperationIssueTicket, "TICKETED", FactSupplierTicketIssued, "", exact, NextActionStop),
+		mustRule(t, "rail-cr", OperationAcceptBoarding, "BOARDED", FactProviderBoardingAccepted, "", exact, NextActionStop),
+	}
+	catalog, err := NewStatusMappingCatalog(rules)
+	if err != nil {
+		t.Fatalf("catalog should be valid: %v", err)
+	}
+	return catalog
+}
+
+func mustRule(t *testing.T, providerID ProviderID, operation Operation, rawStatus string, factKind InternalFactKind, errorClass ErrorClassification, confidence MappingConfidence, nextAction NextAction) StatusMappingRule {
+	t.Helper()
+	rule, err := NewStatusMappingRule(providerID, operation, rawStatus, factKind, errorClass, confidence, nextAction, "map-v1")
+	if err != nil {
+		t.Fatalf("rule should be valid: %v", err)
+	}
+	return rule
+}
+
+func mustExternalStatus(t *testing.T, operation Operation, rawStatus string, providerReference ProviderReference) ExternalProviderStatus {
+	t.Helper()
+	status, err := NewExternalProviderStatus(
+		mustIdentity(t, operation),
+		rawStatus,
+		"provider status text",
+		providerReference,
+		time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC),
+		mustArchive(t),
+	)
+	if err != nil {
+		t.Fatalf("external status should be valid: %v", err)
+	}
+	return status
+}
+
+func mustIdentity(t *testing.T, operation Operation) ProviderRequestIdentity {
+	t.Helper()
+	identity, err := NewProviderRequestIdentity("rail-cr", "req-1", operation, "idem-1", "corr-1", "segment-booking:sb-1")
+	if err != nil {
+		t.Fatalf("identity should be valid: %v", err)
+	}
+	return identity
+}
+
+func mustArchive(t *testing.T) RawArchiveReference {
+	t.Helper()
+	archive, err := NewRawArchiveReference("raw-1", RawArchiveStatus, "archive://provider/raw-1", "abc123", "provider.schema.v1")
+	if err != nil {
+		t.Fatalf("archive should be valid: %v", err)
+	}
+	return archive
+}
+
+func mustConfidence(t *testing.T, level MappingConfidenceLevel, score float64, reason string) MappingConfidence {
+	t.Helper()
+	confidence, err := NewMappingConfidence(level, score, reason)
+	if err != nil {
+		t.Fatalf("confidence should be valid: %v", err)
+	}
+	return confidence
+}

--- a/services/provider-integration/internal/domain/profile.go
+++ b/services/provider-integration/internal/domain/profile.go
@@ -14,9 +14,16 @@ func Profile() ServiceProfile {
 		ServiceID:    "provider-integration",
 		Domain:       "Provider Integration",
 		Language:     "golang",
-		Phase:        "phase-1-support",
-		WorkPackages: []string{"WP-11"},
-		Owns:         []string{"adapter protocol", "signature verification", "raw archive", "external status mapping"},
+		Phase:        "phase-1-acl-foundation",
+		WorkPackages: []string{"REQ-015"},
+		Owns: []string{
+			"provider request and callback identity",
+			"idempotency scope",
+			"raw archive references",
+			"external status and error mapping",
+			"unmapped status quarantine",
+			"retry and manual-review directives",
+		},
 	}
 }
 
@@ -24,5 +31,5 @@ func Health() string {
 	return "ok"
 }
 
-const WorkPackageSummary = "WP-11"
-const OwnershipSummary = "adapter protocol, signature verification, raw archive, external status mapping"
+const WorkPackageSummary = "REQ-015 Provider Integration ACL foundation"
+const OwnershipSummary = "provider request/callback identity, idempotency scope, raw archive references, status/error mapping, unmapped status quarantine, retry/manual review directives"

--- a/services/provider-integration/internal/domain/profile_test.go
+++ b/services/provider-integration/internal/domain/profile_test.go
@@ -2,13 +2,22 @@ package domain
 
 import "testing"
 
-func TestSkeletonProfileMatchesDomain(t *testing.T) {
+func TestProfileMatchesProviderACLFoundation(t *testing.T) {
 	profile := Profile()
 	if profile.ServiceID != "provider-integration" {
 		t.Fatalf("unexpected service id: %s", profile.ServiceID)
 	}
 	if profile.Domain != "Provider Integration" {
 		t.Fatalf("unexpected domain: %s", profile.Domain)
+	}
+	if profile.Phase != "phase-1-acl-foundation" {
+		t.Fatalf("unexpected phase: %s", profile.Phase)
+	}
+	if len(profile.WorkPackages) != 1 || profile.WorkPackages[0] != "REQ-015" {
+		t.Fatalf("unexpected work packages: %#v", profile.WorkPackages)
+	}
+	if WorkPackageSummary != "REQ-015 Provider Integration ACL foundation" {
+		t.Fatalf("unexpected work package summary: %s", WorkPackageSummary)
 	}
 	if Health() != "ok" {
 		t.Fatalf("unexpected health value")


### PR DESCRIPTION
## Summary
- Add Provider Integration ACL domain primitives for request/callback identity, idempotency scope, raw archive references, error classification, and mapping confidence.
- Map reviewed provider/channel statuses to normalized internal facts and quarantine unmapped raw statuses.
- Represent ambiguous outcomes with query/manual-review directives and retry directives, and update README/profile metadata to REQ-015.

## Validation
- cd services/provider-integration && go test ./...
- make check-strict