### PR TITLE
STAB-013 Standardize Java service runtime framework

### DIFF
--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/HealthController.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/HealthController.java
@@ -1,13 +1,43 @@
 package com.trainticket.adminaudit;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.Map;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HealthController {
+    private final Clock clock;
+
+    public HealthController() {
+        this(Clock.systemUTC());
+    }
+
+    HealthController(Clock clock) {
+        this.clock = clock;
+    }
+
     @GetMapping("/health")
     public Map<String, Object> health() {
         return Map.of("status", "ok", "service", Application.profile());
+    }
+
+    @GetMapping({"/live", "/livez"})
+    public Map<String, Object> live() {
+        return Map.of("status", "live", "serviceId", Application.profile().serviceId());
+    }
+
+    @GetMapping({"/ready", "/readyz"})
+    public Map<String, Object> ready() {
+        return Map.of("status", "ready", "serviceId", Application.profile().serviceId());
+    }
+
+    @GetMapping("/metadata")
+    public Map<String, Object> metadata() {
+        return Map.of(
+            "service", Application.profile(),
+            "generatedAt", Instant.now(clock).toString()
+        );
     }
 }

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/NoOpRuntimeTracer.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/NoOpRuntimeTracer.java
@@ -1,0 +1,18 @@
+package com.trainticket.adminaudit;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnMissingBean(RuntimeTracer.class)
+public class NoOpRuntimeTracer implements RuntimeTracer {
+    @Override
+    public void requestStarted(RequestTraceContext context) {
+        // Default seam intentionally does nothing; services can provide a RuntimeTracer bean to opt in.
+    }
+
+    @Override
+    public void requestCompleted(RequestTraceContext context, int statusCode) {
+        // Default seam intentionally does nothing; services can provide a RuntimeTracer bean to opt in.
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/RequestContextFilter.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/RequestContextFilter.java
@@ -1,0 +1,67 @@
+package com.trainticket.adminaudit;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class RequestContextFilter extends OncePerRequestFilter {
+    public static final String REQUEST_ID_HEADER = "X-Request-Id";
+    public static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
+
+    private final RuntimeTracer tracer;
+
+    public RequestContextFilter(RuntimeTracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        String requestId = headerOrGenerated(request, REQUEST_ID_HEADER);
+        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, requestId);
+        RequestTraceContext context = new RequestTraceContext(
+            requestId,
+            correlationId,
+            request.getMethod(),
+            request.getRequestURI()
+        );
+
+        response.setHeader(REQUEST_ID_HEADER, requestId);
+        response.setHeader(CORRELATION_ID_HEADER, correlationId);
+        MDC.put("requestId", requestId);
+        MDC.put("correlationId", correlationId);
+        tracer.requestStarted(context);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            tracer.requestCompleted(context, response.getStatus());
+            MDC.remove("requestId");
+            MDC.remove("correlationId");
+        }
+    }
+
+    private static String headerOrGenerated(HttpServletRequest request, String headerName) {
+        return Optional.ofNullable(request.getHeader(headerName))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElseGet(() -> UUID.randomUUID().toString());
+    }
+
+    private static String headerOrDefault(HttpServletRequest request, String headerName, String defaultValue) {
+        return Optional.ofNullable(request.getHeader(headerName))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElse(defaultValue);
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/RequestTraceContext.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/RequestTraceContext.java
@@ -1,0 +1,9 @@
+package com.trainticket.adminaudit;
+
+public record RequestTraceContext(
+    String requestId,
+    String correlationId,
+    String method,
+    String path
+) {
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/RuntimeTracer.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/RuntimeTracer.java
@@ -1,0 +1,7 @@
+package com.trainticket.adminaudit;
+
+public interface RuntimeTracer {
+    void requestStarted(RequestTraceContext context);
+
+    void requestCompleted(RequestTraceContext context, int statusCode);
+}

--- a/services/admin-audit/src/test/java/com/trainticket/adminaudit/ApplicationTest.java
+++ b/services/admin-audit/src/test/java/com/trainticket/adminaudit/ApplicationTest.java
@@ -1,10 +1,23 @@
 package com.trainticket.adminaudit;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 class ApplicationTest {
     @Test
@@ -14,5 +27,66 @@ class ApplicationTest {
         assertEquals("ok", response.get("status"));
         ServiceProfile profile = assertInstanceOf(ServiceProfile.class, response.get("service"));
         assertEquals("admin-audit", profile.serviceId());
+    }
+
+    @Test
+    void runtimeEndpointsUseConsistentShape() {
+        HealthController controller = new HealthController(
+            Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC)
+        );
+
+        assertEquals("live", controller.live().get("status"));
+        assertEquals("ready", controller.ready().get("status"));
+        Map<String, Object> metadata = controller.metadata();
+        assertEquals("2026-01-01T00:00:00Z", metadata.get("generatedAt"));
+        assertEquals("admin-audit", assertInstanceOf(ServiceProfile.class, metadata.get("service")).serviceId());
+    }
+
+    @Test
+    void requestContextFilterPropagatesExistingIds() throws ServletException, IOException {
+        RecordingTracer tracer = new RecordingTracer();
+        RequestContextFilter filter = new RequestContextFilter(tracer);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/health");
+        request.addHeader(RequestContextFilter.REQUEST_ID_HEADER, "request-123");
+        request.addHeader(RequestContextFilter.CORRELATION_ID_HEADER, "correlation-456");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals("request-123", response.getHeader(RequestContextFilter.REQUEST_ID_HEADER));
+        assertEquals("correlation-456", response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+        assertEquals(1, tracer.started.size());
+        assertEquals("request-123", tracer.started.getFirst().requestId());
+        assertEquals("correlation-456", tracer.started.getFirst().correlationId());
+        assertEquals(200, tracer.completedStatusCodes.getFirst());
+    }
+
+    @Test
+    void requestContextFilterGeneratesMissingIdsAndNoOpTracerIsSafe() throws ServletException, IOException {
+        RequestContextFilter filter = new RequestContextFilter(new NoOpRuntimeTracer());
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/metadata");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertDoesNotThrow(() -> filter.doFilter(request, response, new MockFilterChain()));
+
+        String requestId = response.getHeader(RequestContextFilter.REQUEST_ID_HEADER);
+        assertNotNull(requestId);
+        assertFalse(requestId.isBlank());
+        assertEquals(requestId, response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+    }
+
+    private static final class RecordingTracer implements RuntimeTracer {
+        private final List<RequestTraceContext> started = new ArrayList<>();
+        private final List<Integer> completedStatusCodes = new ArrayList<>();
+
+        @Override
+        public void requestStarted(RequestTraceContext context) {
+            started.add(context);
+        }
+
+        @Override
+        public void requestCompleted(RequestTraceContext context, int statusCode) {
+            completedStatusCodes.add(statusCode);
+        }
     }
 }

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/HealthController.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/HealthController.java
@@ -1,13 +1,43 @@
 package com.trainticket.bookingorchestration;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.Map;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HealthController {
+    private final Clock clock;
+
+    public HealthController() {
+        this(Clock.systemUTC());
+    }
+
+    HealthController(Clock clock) {
+        this.clock = clock;
+    }
+
     @GetMapping("/health")
     public Map<String, Object> health() {
         return Map.of("status", "ok", "service", Application.profile());
+    }
+
+    @GetMapping({"/live", "/livez"})
+    public Map<String, Object> live() {
+        return Map.of("status", "live", "serviceId", Application.profile().serviceId());
+    }
+
+    @GetMapping({"/ready", "/readyz"})
+    public Map<String, Object> ready() {
+        return Map.of("status", "ready", "serviceId", Application.profile().serviceId());
+    }
+
+    @GetMapping("/metadata")
+    public Map<String, Object> metadata() {
+        return Map.of(
+            "service", Application.profile(),
+            "generatedAt", Instant.now(clock).toString()
+        );
     }
 }

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/NoOpRuntimeTracer.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/NoOpRuntimeTracer.java
@@ -1,0 +1,18 @@
+package com.trainticket.bookingorchestration;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnMissingBean(RuntimeTracer.class)
+public class NoOpRuntimeTracer implements RuntimeTracer {
+    @Override
+    public void requestStarted(RequestTraceContext context) {
+        // Default seam intentionally does nothing; services can provide a RuntimeTracer bean to opt in.
+    }
+
+    @Override
+    public void requestCompleted(RequestTraceContext context, int statusCode) {
+        // Default seam intentionally does nothing; services can provide a RuntimeTracer bean to opt in.
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/RequestContextFilter.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/RequestContextFilter.java
@@ -1,0 +1,67 @@
+package com.trainticket.bookingorchestration;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class RequestContextFilter extends OncePerRequestFilter {
+    public static final String REQUEST_ID_HEADER = "X-Request-Id";
+    public static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
+
+    private final RuntimeTracer tracer;
+
+    public RequestContextFilter(RuntimeTracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        String requestId = headerOrGenerated(request, REQUEST_ID_HEADER);
+        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, requestId);
+        RequestTraceContext context = new RequestTraceContext(
+            requestId,
+            correlationId,
+            request.getMethod(),
+            request.getRequestURI()
+        );
+
+        response.setHeader(REQUEST_ID_HEADER, requestId);
+        response.setHeader(CORRELATION_ID_HEADER, correlationId);
+        MDC.put("requestId", requestId);
+        MDC.put("correlationId", correlationId);
+        tracer.requestStarted(context);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            tracer.requestCompleted(context, response.getStatus());
+            MDC.remove("requestId");
+            MDC.remove("correlationId");
+        }
+    }
+
+    private static String headerOrGenerated(HttpServletRequest request, String headerName) {
+        return Optional.ofNullable(request.getHeader(headerName))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElseGet(() -> UUID.randomUUID().toString());
+    }
+
+    private static String headerOrDefault(HttpServletRequest request, String headerName, String defaultValue) {
+        return Optional.ofNullable(request.getHeader(headerName))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElse(defaultValue);
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/RequestTraceContext.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/RequestTraceContext.java
@@ -1,0 +1,9 @@
+package com.trainticket.bookingorchestration;
+
+public record RequestTraceContext(
+    String requestId,
+    String correlationId,
+    String method,
+    String path
+) {
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/RuntimeTracer.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/RuntimeTracer.java
@@ -1,0 +1,7 @@
+package com.trainticket.bookingorchestration;
+
+public interface RuntimeTracer {
+    void requestStarted(RequestTraceContext context);
+
+    void requestCompleted(RequestTraceContext context, int statusCode);
+}

--- a/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/ApplicationTest.java
+++ b/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/ApplicationTest.java
@@ -1,10 +1,23 @@
 package com.trainticket.bookingorchestration;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 class ApplicationTest {
     @Test
@@ -14,5 +27,66 @@ class ApplicationTest {
         assertEquals("ok", response.get("status"));
         ServiceProfile profile = assertInstanceOf(ServiceProfile.class, response.get("service"));
         assertEquals("booking-orchestration", profile.serviceId());
+    }
+
+    @Test
+    void runtimeEndpointsUseConsistentShape() {
+        HealthController controller = new HealthController(
+            Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC)
+        );
+
+        assertEquals("live", controller.live().get("status"));
+        assertEquals("ready", controller.ready().get("status"));
+        Map<String, Object> metadata = controller.metadata();
+        assertEquals("2026-01-01T00:00:00Z", metadata.get("generatedAt"));
+        assertEquals("booking-orchestration", assertInstanceOf(ServiceProfile.class, metadata.get("service")).serviceId());
+    }
+
+    @Test
+    void requestContextFilterPropagatesExistingIds() throws ServletException, IOException {
+        RecordingTracer tracer = new RecordingTracer();
+        RequestContextFilter filter = new RequestContextFilter(tracer);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/health");
+        request.addHeader(RequestContextFilter.REQUEST_ID_HEADER, "request-123");
+        request.addHeader(RequestContextFilter.CORRELATION_ID_HEADER, "correlation-456");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals("request-123", response.getHeader(RequestContextFilter.REQUEST_ID_HEADER));
+        assertEquals("correlation-456", response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+        assertEquals(1, tracer.started.size());
+        assertEquals("request-123", tracer.started.getFirst().requestId());
+        assertEquals("correlation-456", tracer.started.getFirst().correlationId());
+        assertEquals(200, tracer.completedStatusCodes.getFirst());
+    }
+
+    @Test
+    void requestContextFilterGeneratesMissingIdsAndNoOpTracerIsSafe() throws ServletException, IOException {
+        RequestContextFilter filter = new RequestContextFilter(new NoOpRuntimeTracer());
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/metadata");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertDoesNotThrow(() -> filter.doFilter(request, response, new MockFilterChain()));
+
+        String requestId = response.getHeader(RequestContextFilter.REQUEST_ID_HEADER);
+        assertNotNull(requestId);
+        assertFalse(requestId.isBlank());
+        assertEquals(requestId, response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+    }
+
+    private static final class RecordingTracer implements RuntimeTracer {
+        private final List<RequestTraceContext> started = new ArrayList<>();
+        private final List<Integer> completedStatusCodes = new ArrayList<>();
+
+        @Override
+        public void requestStarted(RequestTraceContext context) {
+            started.add(context);
+        }
+
+        @Override
+        public void requestCompleted(RequestTraceContext context, int statusCode) {
+            completedStatusCodes.add(statusCode);
+        }
     }
 }

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/HealthController.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/HealthController.java
@@ -1,13 +1,43 @@
 package com.trainticket.financesettlement;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.Map;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HealthController {
+    private final Clock clock;
+
+    public HealthController() {
+        this(Clock.systemUTC());
+    }
+
+    HealthController(Clock clock) {
+        this.clock = clock;
+    }
+
     @GetMapping("/health")
     public Map<String, Object> health() {
         return Map.of("status", "ok", "service", Application.profile());
+    }
+
+    @GetMapping({"/live", "/livez"})
+    public Map<String, Object> live() {
+        return Map.of("status", "live", "serviceId", Application.profile().serviceId());
+    }
+
+    @GetMapping({"/ready", "/readyz"})
+    public Map<String, Object> ready() {
+        return Map.of("status", "ready", "serviceId", Application.profile().serviceId());
+    }
+
+    @GetMapping("/metadata")
+    public Map<String, Object> metadata() {
+        return Map.of(
+            "service", Application.profile(),
+            "generatedAt", Instant.now(clock).toString()
+        );
     }
 }

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/NoOpRuntimeTracer.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/NoOpRuntimeTracer.java
@@ -1,0 +1,18 @@
+package com.trainticket.financesettlement;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnMissingBean(RuntimeTracer.class)
+public class NoOpRuntimeTracer implements RuntimeTracer {
+    @Override
+    public void requestStarted(RequestTraceContext context) {
+        // Default seam intentionally does nothing; services can provide a RuntimeTracer bean to opt in.
+    }
+
+    @Override
+    public void requestCompleted(RequestTraceContext context, int statusCode) {
+        // Default seam intentionally does nothing; services can provide a RuntimeTracer bean to opt in.
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/RequestContextFilter.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/RequestContextFilter.java
@@ -1,0 +1,67 @@
+package com.trainticket.financesettlement;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class RequestContextFilter extends OncePerRequestFilter {
+    public static final String REQUEST_ID_HEADER = "X-Request-Id";
+    public static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
+
+    private final RuntimeTracer tracer;
+
+    public RequestContextFilter(RuntimeTracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        String requestId = headerOrGenerated(request, REQUEST_ID_HEADER);
+        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, requestId);
+        RequestTraceContext context = new RequestTraceContext(
+            requestId,
+            correlationId,
+            request.getMethod(),
+            request.getRequestURI()
+        );
+
+        response.setHeader(REQUEST_ID_HEADER, requestId);
+        response.setHeader(CORRELATION_ID_HEADER, correlationId);
+        MDC.put("requestId", requestId);
+        MDC.put("correlationId", correlationId);
+        tracer.requestStarted(context);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            tracer.requestCompleted(context, response.getStatus());
+            MDC.remove("requestId");
+            MDC.remove("correlationId");
+        }
+    }
+
+    private static String headerOrGenerated(HttpServletRequest request, String headerName) {
+        return Optional.ofNullable(request.getHeader(headerName))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElseGet(() -> UUID.randomUUID().toString());
+    }
+
+    private static String headerOrDefault(HttpServletRequest request, String headerName, String defaultValue) {
+        return Optional.ofNullable(request.getHeader(headerName))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElse(defaultValue);
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/RequestTraceContext.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/RequestTraceContext.java
@@ -1,0 +1,9 @@
+package com.trainticket.financesettlement;
+
+public record RequestTraceContext(
+    String requestId,
+    String correlationId,
+    String method,
+    String path
+) {
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/RuntimeTracer.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/RuntimeTracer.java
@@ -1,0 +1,7 @@
+package com.trainticket.financesettlement;
+
+public interface RuntimeTracer {
+    void requestStarted(RequestTraceContext context);
+
+    void requestCompleted(RequestTraceContext context, int statusCode);
+}

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/ApplicationTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/ApplicationTest.java
@@ -1,10 +1,23 @@
 package com.trainticket.financesettlement;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 class ApplicationTest {
     @Test
@@ -14,5 +27,66 @@ class ApplicationTest {
         assertEquals("ok", response.get("status"));
         ServiceProfile profile = assertInstanceOf(ServiceProfile.class, response.get("service"));
         assertEquals("finance-settlement", profile.serviceId());
+    }
+
+    @Test
+    void runtimeEndpointsUseConsistentShape() {
+        HealthController controller = new HealthController(
+            Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC)
+        );
+
+        assertEquals("live", controller.live().get("status"));
+        assertEquals("ready", controller.ready().get("status"));
+        Map<String, Object> metadata = controller.metadata();
+        assertEquals("2026-01-01T00:00:00Z", metadata.get("generatedAt"));
+        assertEquals("finance-settlement", assertInstanceOf(ServiceProfile.class, metadata.get("service")).serviceId());
+    }
+
+    @Test
+    void requestContextFilterPropagatesExistingIds() throws ServletException, IOException {
+        RecordingTracer tracer = new RecordingTracer();
+        RequestContextFilter filter = new RequestContextFilter(tracer);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/health");
+        request.addHeader(RequestContextFilter.REQUEST_ID_HEADER, "request-123");
+        request.addHeader(RequestContextFilter.CORRELATION_ID_HEADER, "correlation-456");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals("request-123", response.getHeader(RequestContextFilter.REQUEST_ID_HEADER));
+        assertEquals("correlation-456", response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+        assertEquals(1, tracer.started.size());
+        assertEquals("request-123", tracer.started.getFirst().requestId());
+        assertEquals("correlation-456", tracer.started.getFirst().correlationId());
+        assertEquals(200, tracer.completedStatusCodes.getFirst());
+    }
+
+    @Test
+    void requestContextFilterGeneratesMissingIdsAndNoOpTracerIsSafe() throws ServletException, IOException {
+        RequestContextFilter filter = new RequestContextFilter(new NoOpRuntimeTracer());
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/metadata");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertDoesNotThrow(() -> filter.doFilter(request, response, new MockFilterChain()));
+
+        String requestId = response.getHeader(RequestContextFilter.REQUEST_ID_HEADER);
+        assertNotNull(requestId);
+        assertFalse(requestId.isBlank());
+        assertEquals(requestId, response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+    }
+
+    private static final class RecordingTracer implements RuntimeTracer {
+        private final List<RequestTraceContext> started = new ArrayList<>();
+        private final List<Integer> completedStatusCodes = new ArrayList<>();
+
+        @Override
+        public void requestStarted(RequestTraceContext context) {
+            started.add(context);
+        }
+
+        @Override
+        public void requestCompleted(RequestTraceContext context, int statusCode) {
+            completedStatusCodes.add(statusCode);
+        }
     }
 }

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/HealthController.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/HealthController.java
@@ -1,13 +1,43 @@
 package com.trainticket.journeyorder;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.Map;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HealthController {
+    private final Clock clock;
+
+    public HealthController() {
+        this(Clock.systemUTC());
+    }
+
+    HealthController(Clock clock) {
+        this.clock = clock;
+    }
+
     @GetMapping("/health")
     public Map<String, Object> health() {
         return Map.of("status", "ok", "service", Application.profile());
+    }
+
+    @GetMapping({"/live", "/livez"})
+    public Map<String, Object> live() {
+        return Map.of("status", "live", "serviceId", Application.profile().serviceId());
+    }
+
+    @GetMapping({"/ready", "/readyz"})
+    public Map<String, Object> ready() {
+        return Map.of("status", "ready", "serviceId", Application.profile().serviceId());
+    }
+
+    @GetMapping("/metadata")
+    public Map<String, Object> metadata() {
+        return Map.of(
+            "service", Application.profile(),
+            "generatedAt", Instant.now(clock).toString()
+        );
     }
 }

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/NoOpRuntimeTracer.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/NoOpRuntimeTracer.java
@@ -1,0 +1,18 @@
+package com.trainticket.journeyorder;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnMissingBean(RuntimeTracer.class)
+public class NoOpRuntimeTracer implements RuntimeTracer {
+    @Override
+    public void requestStarted(RequestTraceContext context) {
+        // Default seam intentionally does nothing; services can provide a RuntimeTracer bean to opt in.
+    }
+
+    @Override
+    public void requestCompleted(RequestTraceContext context, int statusCode) {
+        // Default seam intentionally does nothing; services can provide a RuntimeTracer bean to opt in.
+    }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/RequestContextFilter.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/RequestContextFilter.java
@@ -1,0 +1,67 @@
+package com.trainticket.journeyorder;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class RequestContextFilter extends OncePerRequestFilter {
+    public static final String REQUEST_ID_HEADER = "X-Request-Id";
+    public static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
+
+    private final RuntimeTracer tracer;
+
+    public RequestContextFilter(RuntimeTracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        String requestId = headerOrGenerated(request, REQUEST_ID_HEADER);
+        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, requestId);
+        RequestTraceContext context = new RequestTraceContext(
+            requestId,
+            correlationId,
+            request.getMethod(),
+            request.getRequestURI()
+        );
+
+        response.setHeader(REQUEST_ID_HEADER, requestId);
+        response.setHeader(CORRELATION_ID_HEADER, correlationId);
+        MDC.put("requestId", requestId);
+        MDC.put("correlationId", correlationId);
+        tracer.requestStarted(context);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            tracer.requestCompleted(context, response.getStatus());
+            MDC.remove("requestId");
+            MDC.remove("correlationId");
+        }
+    }
+
+    private static String headerOrGenerated(HttpServletRequest request, String headerName) {
+        return Optional.ofNullable(request.getHeader(headerName))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElseGet(() -> UUID.randomUUID().toString());
+    }
+
+    private static String headerOrDefault(HttpServletRequest request, String headerName, String defaultValue) {
+        return Optional.ofNullable(request.getHeader(headerName))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElse(defaultValue);
+    }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/RequestTraceContext.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/RequestTraceContext.java
@@ -1,0 +1,9 @@
+package com.trainticket.journeyorder;
+
+public record RequestTraceContext(
+    String requestId,
+    String correlationId,
+    String method,
+    String path
+) {
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/RuntimeTracer.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/RuntimeTracer.java
@@ -1,0 +1,7 @@
+package com.trainticket.journeyorder;
+
+public interface RuntimeTracer {
+    void requestStarted(RequestTraceContext context);
+
+    void requestCompleted(RequestTraceContext context, int statusCode);
+}

--- a/services/journey-order/src/test/java/com/trainticket/journeyorder/ApplicationTest.java
+++ b/services/journey-order/src/test/java/com/trainticket/journeyorder/ApplicationTest.java
@@ -1,10 +1,23 @@
 package com.trainticket.journeyorder;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 class ApplicationTest {
     @Test
@@ -14,5 +27,66 @@ class ApplicationTest {
         assertEquals("ok", response.get("status"));
         ServiceProfile profile = assertInstanceOf(ServiceProfile.class, response.get("service"));
         assertEquals("journey-order", profile.serviceId());
+    }
+
+    @Test
+    void runtimeEndpointsUseConsistentShape() {
+        HealthController controller = new HealthController(
+            Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC)
+        );
+
+        assertEquals("live", controller.live().get("status"));
+        assertEquals("ready", controller.ready().get("status"));
+        Map<String, Object> metadata = controller.metadata();
+        assertEquals("2026-01-01T00:00:00Z", metadata.get("generatedAt"));
+        assertEquals("journey-order", assertInstanceOf(ServiceProfile.class, metadata.get("service")).serviceId());
+    }
+
+    @Test
+    void requestContextFilterPropagatesExistingIds() throws ServletException, IOException {
+        RecordingTracer tracer = new RecordingTracer();
+        RequestContextFilter filter = new RequestContextFilter(tracer);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/health");
+        request.addHeader(RequestContextFilter.REQUEST_ID_HEADER, "request-123");
+        request.addHeader(RequestContextFilter.CORRELATION_ID_HEADER, "correlation-456");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals("request-123", response.getHeader(RequestContextFilter.REQUEST_ID_HEADER));
+        assertEquals("correlation-456", response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+        assertEquals(1, tracer.started.size());
+        assertEquals("request-123", tracer.started.getFirst().requestId());
+        assertEquals("correlation-456", tracer.started.getFirst().correlationId());
+        assertEquals(200, tracer.completedStatusCodes.getFirst());
+    }
+
+    @Test
+    void requestContextFilterGeneratesMissingIdsAndNoOpTracerIsSafe() throws ServletException, IOException {
+        RequestContextFilter filter = new RequestContextFilter(new NoOpRuntimeTracer());
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/metadata");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertDoesNotThrow(() -> filter.doFilter(request, response, new MockFilterChain()));
+
+        String requestId = response.getHeader(RequestContextFilter.REQUEST_ID_HEADER);
+        assertNotNull(requestId);
+        assertFalse(requestId.isBlank());
+        assertEquals(requestId, response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+    }
+
+    private static final class RecordingTracer implements RuntimeTracer {
+        private final List<RequestTraceContext> started = new ArrayList<>();
+        private final List<Integer> completedStatusCodes = new ArrayList<>();
+
+        @Override
+        public void requestStarted(RequestTraceContext context) {
+            started.add(context);
+        }
+
+        @Override
+        public void requestCompleted(RequestTraceContext context, int statusCode) {
+            completedStatusCodes.add(statusCode);
+        }
     }
 }

--- a/services/payment/src/main/java/com/trainticket/payment/HealthController.java
+++ b/services/payment/src/main/java/com/trainticket/payment/HealthController.java
@@ -1,13 +1,43 @@
 package com.trainticket.payment;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.Map;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HealthController {
+    private final Clock clock;
+
+    public HealthController() {
+        this(Clock.systemUTC());
+    }
+
+    HealthController(Clock clock) {
+        this.clock = clock;
+    }
+
     @GetMapping("/health")
     public Map<String, Object> health() {
         return Map.of("status", "ok", "service", Application.profile());
+    }
+
+    @GetMapping({"/live", "/livez"})
+    public Map<String, Object> live() {
+        return Map.of("status", "live", "serviceId", Application.profile().serviceId());
+    }
+
+    @GetMapping({"/ready", "/readyz"})
+    public Map<String, Object> ready() {
+        return Map.of("status", "ready", "serviceId", Application.profile().serviceId());
+    }
+
+    @GetMapping("/metadata")
+    public Map<String, Object> metadata() {
+        return Map.of(
+            "service", Application.profile(),
+            "generatedAt", Instant.now(clock).toString()
+        );
     }
 }

--- a/services/payment/src/main/java/com/trainticket/payment/NoOpRuntimeTracer.java
+++ b/services/payment/src/main/java/com/trainticket/payment/NoOpRuntimeTracer.java
@@ -1,0 +1,18 @@
+package com.trainticket.payment;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnMissingBean(RuntimeTracer.class)
+public class NoOpRuntimeTracer implements RuntimeTracer {
+    @Override
+    public void requestStarted(RequestTraceContext context) {
+        // Default seam intentionally does nothing; services can provide a RuntimeTracer bean to opt in.
+    }
+
+    @Override
+    public void requestCompleted(RequestTraceContext context, int statusCode) {
+        // Default seam intentionally does nothing; services can provide a RuntimeTracer bean to opt in.
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/RequestContextFilter.java
+++ b/services/payment/src/main/java/com/trainticket/payment/RequestContextFilter.java
@@ -1,0 +1,67 @@
+package com.trainticket.payment;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class RequestContextFilter extends OncePerRequestFilter {
+    public static final String REQUEST_ID_HEADER = "X-Request-Id";
+    public static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
+
+    private final RuntimeTracer tracer;
+
+    public RequestContextFilter(RuntimeTracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        String requestId = headerOrGenerated(request, REQUEST_ID_HEADER);
+        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, requestId);
+        RequestTraceContext context = new RequestTraceContext(
+            requestId,
+            correlationId,
+            request.getMethod(),
+            request.getRequestURI()
+        );
+
+        response.setHeader(REQUEST_ID_HEADER, requestId);
+        response.setHeader(CORRELATION_ID_HEADER, correlationId);
+        MDC.put("requestId", requestId);
+        MDC.put("correlationId", correlationId);
+        tracer.requestStarted(context);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            tracer.requestCompleted(context, response.getStatus());
+            MDC.remove("requestId");
+            MDC.remove("correlationId");
+        }
+    }
+
+    private static String headerOrGenerated(HttpServletRequest request, String headerName) {
+        return Optional.ofNullable(request.getHeader(headerName))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElseGet(() -> UUID.randomUUID().toString());
+    }
+
+    private static String headerOrDefault(HttpServletRequest request, String headerName, String defaultValue) {
+        return Optional.ofNullable(request.getHeader(headerName))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElse(defaultValue);
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/RequestTraceContext.java
+++ b/services/payment/src/main/java/com/trainticket/payment/RequestTraceContext.java
@@ -1,0 +1,9 @@
+package com.trainticket.payment;
+
+public record RequestTraceContext(
+    String requestId,
+    String correlationId,
+    String method,
+    String path
+) {
+}

--- a/services/payment/src/main/java/com/trainticket/payment/RuntimeTracer.java
+++ b/services/payment/src/main/java/com/trainticket/payment/RuntimeTracer.java
@@ -1,0 +1,7 @@
+package com.trainticket.payment;
+
+public interface RuntimeTracer {
+    void requestStarted(RequestTraceContext context);
+
+    void requestCompleted(RequestTraceContext context, int statusCode);
+}

--- a/services/payment/src/test/java/com/trainticket/payment/ApplicationTest.java
+++ b/services/payment/src/test/java/com/trainticket/payment/ApplicationTest.java
@@ -1,10 +1,23 @@
 package com.trainticket.payment;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 class ApplicationTest {
     @Test
@@ -14,5 +27,66 @@ class ApplicationTest {
         assertEquals("ok", response.get("status"));
         ServiceProfile profile = assertInstanceOf(ServiceProfile.class, response.get("service"));
         assertEquals("payment", profile.serviceId());
+    }
+
+    @Test
+    void runtimeEndpointsUseConsistentShape() {
+        HealthController controller = new HealthController(
+            Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC)
+        );
+
+        assertEquals("live", controller.live().get("status"));
+        assertEquals("ready", controller.ready().get("status"));
+        Map<String, Object> metadata = controller.metadata();
+        assertEquals("2026-01-01T00:00:00Z", metadata.get("generatedAt"));
+        assertEquals("payment", assertInstanceOf(ServiceProfile.class, metadata.get("service")).serviceId());
+    }
+
+    @Test
+    void requestContextFilterPropagatesExistingIds() throws ServletException, IOException {
+        RecordingTracer tracer = new RecordingTracer();
+        RequestContextFilter filter = new RequestContextFilter(tracer);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/health");
+        request.addHeader(RequestContextFilter.REQUEST_ID_HEADER, "request-123");
+        request.addHeader(RequestContextFilter.CORRELATION_ID_HEADER, "correlation-456");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals("request-123", response.getHeader(RequestContextFilter.REQUEST_ID_HEADER));
+        assertEquals("correlation-456", response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+        assertEquals(1, tracer.started.size());
+        assertEquals("request-123", tracer.started.getFirst().requestId());
+        assertEquals("correlation-456", tracer.started.getFirst().correlationId());
+        assertEquals(200, tracer.completedStatusCodes.getFirst());
+    }
+
+    @Test
+    void requestContextFilterGeneratesMissingIdsAndNoOpTracerIsSafe() throws ServletException, IOException {
+        RequestContextFilter filter = new RequestContextFilter(new NoOpRuntimeTracer());
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/metadata");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertDoesNotThrow(() -> filter.doFilter(request, response, new MockFilterChain()));
+
+        String requestId = response.getHeader(RequestContextFilter.REQUEST_ID_HEADER);
+        assertNotNull(requestId);
+        assertFalse(requestId.isBlank());
+        assertEquals(requestId, response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+    }
+
+    private static final class RecordingTracer implements RuntimeTracer {
+        private final List<RequestTraceContext> started = new ArrayList<>();
+        private final List<Integer> completedStatusCodes = new ArrayList<>();
+
+        @Override
+        public void requestStarted(RequestTraceContext context) {
+            started.add(context);
+        }
+
+        @Override
+        public void requestCompleted(RequestTraceContext context, int statusCode) {
+            completedStatusCodes.add(statusCode);
+        }
     }
 }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/HealthController.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/HealthController.java
@@ -1,13 +1,43 @@
 package com.trainticket.postsales;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.Map;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HealthController {
+    private final Clock clock;
+
+    public HealthController() {
+        this(Clock.systemUTC());
+    }
+
+    HealthController(Clock clock) {
+        this.clock = clock;
+    }
+
     @GetMapping("/health")
     public Map<String, Object> health() {
         return Map.of("status", "ok", "service", Application.profile());
+    }
+
+    @GetMapping({"/live", "/livez"})
+    public Map<String, Object> live() {
+        return Map.of("status", "live", "serviceId", Application.profile().serviceId());
+    }
+
+    @GetMapping({"/ready", "/readyz"})
+    public Map<String, Object> ready() {
+        return Map.of("status", "ready", "serviceId", Application.profile().serviceId());
+    }
+
+    @GetMapping("/metadata")
+    public Map<String, Object> metadata() {
+        return Map.of(
+            "service", Application.profile(),
+            "generatedAt", Instant.now(clock).toString()
+        );
     }
 }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/NoOpRuntimeTracer.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/NoOpRuntimeTracer.java
@@ -1,0 +1,18 @@
+package com.trainticket.postsales;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnMissingBean(RuntimeTracer.class)
+public class NoOpRuntimeTracer implements RuntimeTracer {
+    @Override
+    public void requestStarted(RequestTraceContext context) {
+        // Default seam intentionally does nothing; services can provide a RuntimeTracer bean to opt in.
+    }
+
+    @Override
+    public void requestCompleted(RequestTraceContext context, int statusCode) {
+        // Default seam intentionally does nothing; services can provide a RuntimeTracer bean to opt in.
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/RequestContextFilter.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/RequestContextFilter.java
@@ -1,0 +1,67 @@
+package com.trainticket.postsales;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class RequestContextFilter extends OncePerRequestFilter {
+    public static final String REQUEST_ID_HEADER = "X-Request-Id";
+    public static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
+
+    private final RuntimeTracer tracer;
+
+    public RequestContextFilter(RuntimeTracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        String requestId = headerOrGenerated(request, REQUEST_ID_HEADER);
+        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, requestId);
+        RequestTraceContext context = new RequestTraceContext(
+            requestId,
+            correlationId,
+            request.getMethod(),
+            request.getRequestURI()
+        );
+
+        response.setHeader(REQUEST_ID_HEADER, requestId);
+        response.setHeader(CORRELATION_ID_HEADER, correlationId);
+        MDC.put("requestId", requestId);
+        MDC.put("correlationId", correlationId);
+        tracer.requestStarted(context);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            tracer.requestCompleted(context, response.getStatus());
+            MDC.remove("requestId");
+            MDC.remove("correlationId");
+        }
+    }
+
+    private static String headerOrGenerated(HttpServletRequest request, String headerName) {
+        return Optional.ofNullable(request.getHeader(headerName))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElseGet(() -> UUID.randomUUID().toString());
+    }
+
+    private static String headerOrDefault(HttpServletRequest request, String headerName, String defaultValue) {
+        return Optional.ofNullable(request.getHeader(headerName))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElse(defaultValue);
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/RequestTraceContext.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/RequestTraceContext.java
@@ -1,0 +1,9 @@
+package com.trainticket.postsales;
+
+public record RequestTraceContext(
+    String requestId,
+    String correlationId,
+    String method,
+    String path
+) {
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/RuntimeTracer.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/RuntimeTracer.java
@@ -1,0 +1,7 @@
+package com.trainticket.postsales;
+
+public interface RuntimeTracer {
+    void requestStarted(RequestTraceContext context);
+
+    void requestCompleted(RequestTraceContext context, int statusCode);
+}

--- a/services/post-sales/src/test/java/com/trainticket/postsales/ApplicationTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/ApplicationTest.java
@@ -1,10 +1,23 @@
 package com.trainticket.postsales;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 class ApplicationTest {
     @Test
@@ -14,5 +27,66 @@ class ApplicationTest {
         assertEquals("ok", response.get("status"));
         ServiceProfile profile = assertInstanceOf(ServiceProfile.class, response.get("service"));
         assertEquals("post-sales", profile.serviceId());
+    }
+
+    @Test
+    void runtimeEndpointsUseConsistentShape() {
+        HealthController controller = new HealthController(
+            Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC)
+        );
+
+        assertEquals("live", controller.live().get("status"));
+        assertEquals("ready", controller.ready().get("status"));
+        Map<String, Object> metadata = controller.metadata();
+        assertEquals("2026-01-01T00:00:00Z", metadata.get("generatedAt"));
+        assertEquals("post-sales", assertInstanceOf(ServiceProfile.class, metadata.get("service")).serviceId());
+    }
+
+    @Test
+    void requestContextFilterPropagatesExistingIds() throws ServletException, IOException {
+        RecordingTracer tracer = new RecordingTracer();
+        RequestContextFilter filter = new RequestContextFilter(tracer);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/health");
+        request.addHeader(RequestContextFilter.REQUEST_ID_HEADER, "request-123");
+        request.addHeader(RequestContextFilter.CORRELATION_ID_HEADER, "correlation-456");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals("request-123", response.getHeader(RequestContextFilter.REQUEST_ID_HEADER));
+        assertEquals("correlation-456", response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+        assertEquals(1, tracer.started.size());
+        assertEquals("request-123", tracer.started.getFirst().requestId());
+        assertEquals("correlation-456", tracer.started.getFirst().correlationId());
+        assertEquals(200, tracer.completedStatusCodes.getFirst());
+    }
+
+    @Test
+    void requestContextFilterGeneratesMissingIdsAndNoOpTracerIsSafe() throws ServletException, IOException {
+        RequestContextFilter filter = new RequestContextFilter(new NoOpRuntimeTracer());
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/metadata");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertDoesNotThrow(() -> filter.doFilter(request, response, new MockFilterChain()));
+
+        String requestId = response.getHeader(RequestContextFilter.REQUEST_ID_HEADER);
+        assertNotNull(requestId);
+        assertFalse(requestId.isBlank());
+        assertEquals(requestId, response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+    }
+
+    private static final class RecordingTracer implements RuntimeTracer {
+        private final List<RequestTraceContext> started = new ArrayList<>();
+        private final List<Integer> completedStatusCodes = new ArrayList<>();
+
+        @Override
+        public void requestStarted(RequestTraceContext context) {
+            started.add(context);
+        }
+
+        @Override
+        public void requestCompleted(RequestTraceContext context, int statusCode) {
+            completedStatusCodes.add(statusCode);
+        }
     }
 }

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/HealthController.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/HealthController.java
@@ -1,13 +1,43 @@
 package com.trainticket.travelerprofile;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.Map;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HealthController {
+    private final Clock clock;
+
+    public HealthController() {
+        this(Clock.systemUTC());
+    }
+
+    HealthController(Clock clock) {
+        this.clock = clock;
+    }
+
     @GetMapping("/health")
     public Map<String, Object> health() {
         return Map.of("status", "ok", "service", Application.profile());
+    }
+
+    @GetMapping({"/live", "/livez"})
+    public Map<String, Object> live() {
+        return Map.of("status", "live", "serviceId", Application.profile().serviceId());
+    }
+
+    @GetMapping({"/ready", "/readyz"})
+    public Map<String, Object> ready() {
+        return Map.of("status", "ready", "serviceId", Application.profile().serviceId());
+    }
+
+    @GetMapping("/metadata")
+    public Map<String, Object> metadata() {
+        return Map.of(
+            "service", Application.profile(),
+            "generatedAt", Instant.now(clock).toString()
+        );
     }
 }

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/NoOpRuntimeTracer.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/NoOpRuntimeTracer.java
@@ -1,0 +1,18 @@
+package com.trainticket.travelerprofile;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnMissingBean(RuntimeTracer.class)
+public class NoOpRuntimeTracer implements RuntimeTracer {
+    @Override
+    public void requestStarted(RequestTraceContext context) {
+        // Default seam intentionally does nothing; services can provide a RuntimeTracer bean to opt in.
+    }
+
+    @Override
+    public void requestCompleted(RequestTraceContext context, int statusCode) {
+        // Default seam intentionally does nothing; services can provide a RuntimeTracer bean to opt in.
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/RequestContextFilter.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/RequestContextFilter.java
@@ -1,0 +1,67 @@
+package com.trainticket.travelerprofile;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class RequestContextFilter extends OncePerRequestFilter {
+    public static final String REQUEST_ID_HEADER = "X-Request-Id";
+    public static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
+
+    private final RuntimeTracer tracer;
+
+    public RequestContextFilter(RuntimeTracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        String requestId = headerOrGenerated(request, REQUEST_ID_HEADER);
+        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, requestId);
+        RequestTraceContext context = new RequestTraceContext(
+            requestId,
+            correlationId,
+            request.getMethod(),
+            request.getRequestURI()
+        );
+
+        response.setHeader(REQUEST_ID_HEADER, requestId);
+        response.setHeader(CORRELATION_ID_HEADER, correlationId);
+        MDC.put("requestId", requestId);
+        MDC.put("correlationId", correlationId);
+        tracer.requestStarted(context);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            tracer.requestCompleted(context, response.getStatus());
+            MDC.remove("requestId");
+            MDC.remove("correlationId");
+        }
+    }
+
+    private static String headerOrGenerated(HttpServletRequest request, String headerName) {
+        return Optional.ofNullable(request.getHeader(headerName))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElseGet(() -> UUID.randomUUID().toString());
+    }
+
+    private static String headerOrDefault(HttpServletRequest request, String headerName, String defaultValue) {
+        return Optional.ofNullable(request.getHeader(headerName))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElse(defaultValue);
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/RequestTraceContext.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/RequestTraceContext.java
@@ -1,0 +1,9 @@
+package com.trainticket.travelerprofile;
+
+public record RequestTraceContext(
+    String requestId,
+    String correlationId,
+    String method,
+    String path
+) {
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/RuntimeTracer.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/RuntimeTracer.java
@@ -1,0 +1,7 @@
+package com.trainticket.travelerprofile;
+
+public interface RuntimeTracer {
+    void requestStarted(RequestTraceContext context);
+
+    void requestCompleted(RequestTraceContext context, int statusCode);
+}

--- a/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/ApplicationTest.java
+++ b/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/ApplicationTest.java
@@ -1,10 +1,23 @@
 package com.trainticket.travelerprofile;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 class ApplicationTest {
     @Test
@@ -14,5 +27,66 @@ class ApplicationTest {
         assertEquals("ok", response.get("status"));
         ServiceProfile profile = assertInstanceOf(ServiceProfile.class, response.get("service"));
         assertEquals("traveler-profile", profile.serviceId());
+    }
+
+    @Test
+    void runtimeEndpointsUseConsistentShape() {
+        HealthController controller = new HealthController(
+            Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC)
+        );
+
+        assertEquals("live", controller.live().get("status"));
+        assertEquals("ready", controller.ready().get("status"));
+        Map<String, Object> metadata = controller.metadata();
+        assertEquals("2026-01-01T00:00:00Z", metadata.get("generatedAt"));
+        assertEquals("traveler-profile", assertInstanceOf(ServiceProfile.class, metadata.get("service")).serviceId());
+    }
+
+    @Test
+    void requestContextFilterPropagatesExistingIds() throws ServletException, IOException {
+        RecordingTracer tracer = new RecordingTracer();
+        RequestContextFilter filter = new RequestContextFilter(tracer);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/health");
+        request.addHeader(RequestContextFilter.REQUEST_ID_HEADER, "request-123");
+        request.addHeader(RequestContextFilter.CORRELATION_ID_HEADER, "correlation-456");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals("request-123", response.getHeader(RequestContextFilter.REQUEST_ID_HEADER));
+        assertEquals("correlation-456", response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+        assertEquals(1, tracer.started.size());
+        assertEquals("request-123", tracer.started.getFirst().requestId());
+        assertEquals("correlation-456", tracer.started.getFirst().correlationId());
+        assertEquals(200, tracer.completedStatusCodes.getFirst());
+    }
+
+    @Test
+    void requestContextFilterGeneratesMissingIdsAndNoOpTracerIsSafe() throws ServletException, IOException {
+        RequestContextFilter filter = new RequestContextFilter(new NoOpRuntimeTracer());
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/metadata");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertDoesNotThrow(() -> filter.doFilter(request, response, new MockFilterChain()));
+
+        String requestId = response.getHeader(RequestContextFilter.REQUEST_ID_HEADER);
+        assertNotNull(requestId);
+        assertFalse(requestId.isBlank());
+        assertEquals(requestId, response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+    }
+
+    private static final class RecordingTracer implements RuntimeTracer {
+        private final List<RequestTraceContext> started = new ArrayList<>();
+        private final List<Integer> completedStatusCodes = new ArrayList<>();
+
+        @Override
+        public void requestStarted(RequestTraceContext context) {
+            started.add(context);
+        }
+
+        @Override
+        public void requestCompleted(RequestTraceContext context, int statusCode) {
+            completedStatusCodes.add(statusCode);
+        }
     }
 }

--- a/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/HealthController.java
+++ b/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/HealthController.java
@@ -1,13 +1,43 @@
 package com.trainticket.walletpromotion;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.Map;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HealthController {
+    private final Clock clock;
+
+    public HealthController() {
+        this(Clock.systemUTC());
+    }
+
+    HealthController(Clock clock) {
+        this.clock = clock;
+    }
+
     @GetMapping("/health")
     public Map<String, Object> health() {
         return Map.of("status", "ok", "service", Application.profile());
+    }
+
+    @GetMapping({"/live", "/livez"})
+    public Map<String, Object> live() {
+        return Map.of("status", "live", "serviceId", Application.profile().serviceId());
+    }
+
+    @GetMapping({"/ready", "/readyz"})
+    public Map<String, Object> ready() {
+        return Map.of("status", "ready", "serviceId", Application.profile().serviceId());
+    }
+
+    @GetMapping("/metadata")
+    public Map<String, Object> metadata() {
+        return Map.of(
+            "service", Application.profile(),
+            "generatedAt", Instant.now(clock).toString()
+        );
     }
 }

--- a/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/NoOpRuntimeTracer.java
+++ b/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/NoOpRuntimeTracer.java
@@ -1,0 +1,18 @@
+package com.trainticket.walletpromotion;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnMissingBean(RuntimeTracer.class)
+public class NoOpRuntimeTracer implements RuntimeTracer {
+    @Override
+    public void requestStarted(RequestTraceContext context) {
+        // Default seam intentionally does nothing; services can provide a RuntimeTracer bean to opt in.
+    }
+
+    @Override
+    public void requestCompleted(RequestTraceContext context, int statusCode) {
+        // Default seam intentionally does nothing; services can provide a RuntimeTracer bean to opt in.
+    }
+}

--- a/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/RequestContextFilter.java
+++ b/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/RequestContextFilter.java
@@ -1,0 +1,67 @@
+package com.trainticket.walletpromotion;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class RequestContextFilter extends OncePerRequestFilter {
+    public static final String REQUEST_ID_HEADER = "X-Request-Id";
+    public static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
+
+    private final RuntimeTracer tracer;
+
+    public RequestContextFilter(RuntimeTracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+        String requestId = headerOrGenerated(request, REQUEST_ID_HEADER);
+        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, requestId);
+        RequestTraceContext context = new RequestTraceContext(
+            requestId,
+            correlationId,
+            request.getMethod(),
+            request.getRequestURI()
+        );
+
+        response.setHeader(REQUEST_ID_HEADER, requestId);
+        response.setHeader(CORRELATION_ID_HEADER, correlationId);
+        MDC.put("requestId", requestId);
+        MDC.put("correlationId", correlationId);
+        tracer.requestStarted(context);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            tracer.requestCompleted(context, response.getStatus());
+            MDC.remove("requestId");
+            MDC.remove("correlationId");
+        }
+    }
+
+    private static String headerOrGenerated(HttpServletRequest request, String headerName) {
+        return Optional.ofNullable(request.getHeader(headerName))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElseGet(() -> UUID.randomUUID().toString());
+    }
+
+    private static String headerOrDefault(HttpServletRequest request, String headerName, String defaultValue) {
+        return Optional.ofNullable(request.getHeader(headerName))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElse(defaultValue);
+    }
+}

--- a/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/RequestTraceContext.java
+++ b/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/RequestTraceContext.java
@@ -1,0 +1,9 @@
+package com.trainticket.walletpromotion;
+
+public record RequestTraceContext(
+    String requestId,
+    String correlationId,
+    String method,
+    String path
+) {
+}

--- a/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/RuntimeTracer.java
+++ b/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/RuntimeTracer.java
@@ -1,0 +1,7 @@
+package com.trainticket.walletpromotion;
+
+public interface RuntimeTracer {
+    void requestStarted(RequestTraceContext context);
+
+    void requestCompleted(RequestTraceContext context, int statusCode);
+}

--- a/services/wallet-promotion/src/test/java/com/trainticket/walletpromotion/ApplicationTest.java
+++ b/services/wallet-promotion/src/test/java/com/trainticket/walletpromotion/ApplicationTest.java
@@ -1,10 +1,23 @@
 package com.trainticket.walletpromotion;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 class ApplicationTest {
     @Test
@@ -14,5 +27,66 @@ class ApplicationTest {
         assertEquals("ok", response.get("status"));
         ServiceProfile profile = assertInstanceOf(ServiceProfile.class, response.get("service"));
         assertEquals("wallet-promotion", profile.serviceId());
+    }
+
+    @Test
+    void runtimeEndpointsUseConsistentShape() {
+        HealthController controller = new HealthController(
+            Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC)
+        );
+
+        assertEquals("live", controller.live().get("status"));
+        assertEquals("ready", controller.ready().get("status"));
+        Map<String, Object> metadata = controller.metadata();
+        assertEquals("2026-01-01T00:00:00Z", metadata.get("generatedAt"));
+        assertEquals("wallet-promotion", assertInstanceOf(ServiceProfile.class, metadata.get("service")).serviceId());
+    }
+
+    @Test
+    void requestContextFilterPropagatesExistingIds() throws ServletException, IOException {
+        RecordingTracer tracer = new RecordingTracer();
+        RequestContextFilter filter = new RequestContextFilter(tracer);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/health");
+        request.addHeader(RequestContextFilter.REQUEST_ID_HEADER, "request-123");
+        request.addHeader(RequestContextFilter.CORRELATION_ID_HEADER, "correlation-456");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertEquals("request-123", response.getHeader(RequestContextFilter.REQUEST_ID_HEADER));
+        assertEquals("correlation-456", response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+        assertEquals(1, tracer.started.size());
+        assertEquals("request-123", tracer.started.getFirst().requestId());
+        assertEquals("correlation-456", tracer.started.getFirst().correlationId());
+        assertEquals(200, tracer.completedStatusCodes.getFirst());
+    }
+
+    @Test
+    void requestContextFilterGeneratesMissingIdsAndNoOpTracerIsSafe() throws ServletException, IOException {
+        RequestContextFilter filter = new RequestContextFilter(new NoOpRuntimeTracer());
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/metadata");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertDoesNotThrow(() -> filter.doFilter(request, response, new MockFilterChain()));
+
+        String requestId = response.getHeader(RequestContextFilter.REQUEST_ID_HEADER);
+        assertNotNull(requestId);
+        assertFalse(requestId.isBlank());
+        assertEquals(requestId, response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+    }
+
+    private static final class RecordingTracer implements RuntimeTracer {
+        private final List<RequestTraceContext> started = new ArrayList<>();
+        private final List<Integer> completedStatusCodes = new ArrayList<>();
+
+        @Override
+        public void requestStarted(RequestTraceContext context) {
+            started.add(context);
+        }
+
+        @Override
+        public void requestCompleted(RequestTraceContext context, int statusCode) {
+            completedStatusCodes.add(statusCode);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- standardize Java service runtime endpoints with /health, /live(/livez), /ready(/readyz), and /metadata
- add request/correlation ID propagation with generated fallbacks across Java services
- add no-op RuntimeTracer seam and coverage for propagation/default behavior

## Validation
- cd services/admin-audit && mvn -q test
- cd services/booking-orchestration && mvn -q test
- cd services/finance-settlement && mvn -q test
- cd services/journey-order && mvn -q test
- cd services/payment && mvn -q test
- cd services/post-sales && mvn -q test
- cd services/traveler-profile && mvn -q test
- cd services/wallet-promotion && mvn -q test
- make check