### PR TITLE
STAB-011: Add Python FastAPI runtime framework

### DIFF
--- a/services/disruption-recovery/pyproject.toml
+++ b/services/disruption-recovery/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+  "httpx2>=2.5.0",
   "pytest==9.1.1",
 ]
 

--- a/services/disruption-recovery/src/disruption_recovery/__init__.py
+++ b/services/disruption-recovery/src/disruption_recovery/__init__.py
@@ -1,40 +1,10 @@
-from typing import List, TypedDict
+from .api import create_app
+from .runtime import SERVICE_PROFILE, ServiceProfile, health, profile
 
-from fastapi import FastAPI
-
-
-class ServiceProfile(TypedDict):
-    service_id: str
-    domain: str
-    language: str
-    phase: str
-    work_packages: List[str]
-    owns: List[str]
-
-
-SERVICE_PROFILE: ServiceProfile = {
-    "service_id": "disruption-recovery",
-    "domain": "Disruption Recovery",
-    "language": "python",
-    "phase": "future-scope",
-    "work_packages": [],
-    "owns": ["RecoveryCase", "RecoveryOption", "CompensationDecision"],
-}
-
-
-def health() -> str:
-    return "ok"
-
-
-def profile() -> ServiceProfile:
-    return dict(SERVICE_PROFILE)  # type: ignore[return-value]
-
-
-def create_app() -> FastAPI:
-    app = FastAPI(title="Disruption Recovery", version="0.1.0")
-
-    @app.get("/health")
-    def health_endpoint() -> dict[str, object]:
-        return {"status": health(), "service": profile()}
-
-    return app
+__all__ = [
+    'SERVICE_PROFILE',
+    'ServiceProfile',
+    'create_app',
+    'health',
+    'profile',
+]

--- a/services/disruption-recovery/src/disruption_recovery/api.py
+++ b/services/disruption-recovery/src/disruption_recovery/api.py
@@ -1,0 +1,72 @@
+from collections.abc import Callable, Mapping
+from typing import Any
+from uuid import uuid4
+
+from fastapi import FastAPI, Request
+
+from .runtime import health, profile
+
+REQUEST_ID_HEADER = "X-Request-ID"
+CORRELATION_ID_HEADER = "X-Correlation-ID"
+TraceHook = Callable[[str, Mapping[str, object]], None]
+
+
+def _emit_trace(tracer: TraceHook | None, event: str, attributes: Mapping[str, object]) -> None:
+    if tracer is not None:
+        tracer(event, dict(attributes))
+
+
+def _request_identifiers(request: Request) -> tuple[str, str]:
+    request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid4())
+    correlation_id = request.headers.get(CORRELATION_ID_HEADER) or request_id
+    return request_id, correlation_id
+
+
+def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None) -> None:
+    @app.middleware("http")
+    async def request_context_middleware(request: Request, call_next: Any):
+        request_id, correlation_id = _request_identifiers(request)
+        request.state.request_id = request_id
+        request.state.correlation_id = correlation_id
+        trace_attributes = {
+            "request_id": request_id,
+            "correlation_id": correlation_id,
+            "method": request.method,
+            "path": request.url.path,
+        }
+        _emit_trace(tracer, "http.request.start", trace_attributes)
+        try:
+            response = await call_next(request)
+        except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
+            _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
+            raise
+        response.headers[REQUEST_ID_HEADER] = request_id
+        response.headers[CORRELATION_ID_HEADER] = correlation_id
+        _emit_trace(
+            tracer,
+            "http.request.complete",
+            {**trace_attributes, "status_code": response.status_code},
+        )
+        return response
+
+    @app.get("/health")
+    def health_endpoint() -> dict[str, object]:
+        return {"status": health(), "service": profile()}
+
+    @app.get("/live")
+    def live_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
+    @app.get("/ready")
+    def ready_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
+    @app.get("/metadata")
+    def metadata_endpoint() -> dict[str, object]:
+        return {"service": profile(), "observability": {"tracing": "opt-in", "default": "noop"}}
+
+
+def create_app(tracer: TraceHook | None = None) -> FastAPI:
+    app = FastAPI(title='Disruption Recovery', version="0.1.0")
+    configure_runtime_endpoints(app, tracer)
+    return app

--- a/services/disruption-recovery/src/disruption_recovery/runtime.py
+++ b/services/disruption-recovery/src/disruption_recovery/runtime.py
@@ -1,0 +1,22 @@
+from typing import List, NotRequired, TypedDict
+
+
+class ServiceProfile(TypedDict):
+    service_id: str
+    domain: str
+    language: str
+    phase: str
+    work_packages: List[str]
+    owns: List[str]
+    boundary: NotRequired[str]
+
+
+SERVICE_PROFILE: ServiceProfile = {'service_id': 'disruption-recovery', 'domain': 'Disruption Recovery', 'language': 'python', 'phase': 'future-scope', 'work_packages': [], 'owns': ['RecoveryCase', 'RecoveryOption', 'CompensationDecision']}
+
+
+def health() -> str:
+    return "ok"
+
+
+def profile() -> ServiceProfile:
+    return dict(SERVICE_PROFILE)  # type: ignore[return-value]

--- a/services/disruption-recovery/tests/test_skeleton.py
+++ b/services/disruption-recovery/tests/test_skeleton.py
@@ -1,19 +1,55 @@
 import unittest
 
+from fastapi.testclient import TestClient
+
 from disruption_recovery import create_app, health, profile
 
 
 class SkeletonTest(unittest.TestCase):
     def test_profile_matches_domain(self) -> None:
         service_profile = profile()
-        self.assertEqual(service_profile["service_id"], "disruption-recovery")
-        self.assertEqual(service_profile["domain"], "Disruption Recovery")
+        self.assertEqual(service_profile["service_id"], 'disruption-recovery')
+        self.assertEqual(service_profile["domain"], 'Disruption Recovery')
         self.assertEqual(health(), "ok")
 
-    def test_fastapi_health_route_is_registered(self) -> None:
+    def test_fastapi_runtime_routes_are_registered(self) -> None:
         app = create_app()
         routes = {route.path for route in app.routes}
         self.assertIn("/health", routes)
+        self.assertIn("/live", routes)
+        self.assertIn("/ready", routes)
+        self.assertIn("/metadata", routes)
+
+    def test_request_and_correlation_ids_are_propagated(self) -> None:
+        client = TestClient(create_app())
+        response = client.get(
+            "/health",
+            headers={"X-Request-ID": "req-123", "X-Correlation-ID": "corr-456"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["X-Request-ID"], "req-123")
+        self.assertEqual(response.headers["X-Correlation-ID"], "corr-456")
+
+    def test_request_and_correlation_ids_are_generated(self) -> None:
+        client = TestClient(create_app())
+        response = client.get("/live")
+        self.assertEqual(response.status_code, 200)
+        request_id = response.headers["X-Request-ID"]
+        self.assertTrue(request_id)
+        self.assertEqual(response.headers["X-Correlation-ID"], request_id)
+
+    def test_observability_trace_hook_is_opt_in(self) -> None:
+        events: list[tuple[str, dict[str, object]]] = []
+
+        def tracer(event: str, attributes: dict[str, object]) -> None:
+            events.append((event, attributes))
+
+        client = TestClient(create_app(tracer=tracer))
+        response = client.get("/metadata", headers={"X-Request-ID": "req-trace"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([event for event, _ in events], ["http.request.start", "http.request.complete"])
+        self.assertEqual(events[0][1]["request_id"], "req-trace")
+        self.assertEqual(events[1][1]["status_code"], 200)
 
 
 if __name__ == "__main__":

--- a/services/disruption-recovery/uv.lock
+++ b/services/disruption-recovery/uv.lock
@@ -52,6 +52,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx2" },
     { name = "pytest" },
 ]
 
@@ -59,7 +60,10 @@ dev = [
 requires-dist = [{ name = "fastapi", specifier = "==0.138.1" }]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = "==9.1.1" }]
+dev = [
+    { name = "httpx2", specifier = ">=2.5.0" },
+    { name = "pytest", specifier = "==9.1.1" },
+]
 
 [[package]]
 name = "fastapi"
@@ -75,6 +79,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/c9/5e8defe249899c0dc900643695fc07829a67fc88b4ff2cdb03fcbdbf5a4b/fastapi-0.138.1.tar.gz", hash = "sha256:96e3702dce09ee0dce48856135620d3d865ca684a79fe7513fd7b13a12f82862", size = 419646, upload-time = "2026-06-25T15:40:42.115Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/a9/69a6924f645eb4dd8cd625bf255b3625990eb3e14e073438a53c405dcd3e/fastapi-0.138.1-py3-none-any.whl", hash = "sha256:b994cae7ba8b82c976a728b544244de31333fa5f7d261f9a1dffe526444cae23", size = 129182, upload-time = "2026-06-25T15:40:40.771Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/5c12df521b5322fb1114a83d46911b2fbcb8855ddb3a635f11c01a214af5/httpcore2-2.5.0.tar.gz", hash = "sha256:88aa170137c17328d5ac44234f9fd10706466d5fb347f3edac4d39b91137b09d", size = 64808, upload-time = "2026-06-25T14:16:56.472Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/a1/7564199d1a8728fe737b0a72e5b3f8d92dfe085a74ddf7cdd83bce5f206d/httpcore2-2.5.0-py3-none-any.whl", hash = "sha256:5ce35188de461d31e8d000bfb8ef8bf22c6c16587a211e5571deaa5e9bdf842a", size = 80330, upload-time = "2026-06-25T14:16:53.634Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/e2/b5dedc0cf35aa65de5f541ccd30d2bc1fd7f1d43c9ab09f8ed9a7342317b/httpx2-2.5.0.tar.gz", hash = "sha256:e2df9cb4611021527ff8a675b1c320b610a2ec397acc8d6fe6e91df2d9b33c29", size = 83121, upload-time = "2026-06-25T14:16:57.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/22/859d8252dad9bc9adee34b52e62cde621ece07b042ccb2ab4da1be46695f/httpx2-2.5.0-py3-none-any.whl", hash = "sha256:3d2d4d9cf4b61f1a1f46a95947cfdb47e80cb56a2f91c6256ac8f58e4891df41", size = 76652, upload-time = "2026-06-25T14:16:55.23Z" },
 ]
 
 [[package]]
@@ -266,6 +308,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/services/fare-pricing/pyproject.toml
+++ b/services/fare-pricing/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+  "httpx2>=2.5.0",
   "pytest==9.1.1",
 ]
 

--- a/services/fare-pricing/src/fare_pricing/__init__.py
+++ b/services/fare-pricing/src/fare_pricing/__init__.py
@@ -1,7 +1,4 @@
-from typing import List, TypedDict
-
-from fastapi import FastAPI
-
+from .api import create_app
 from .domain import (
     AdjustmentQuote,
     AssessmentPurpose,
@@ -23,49 +20,31 @@ from .domain import (
     assess_refund,
     calculate_fare_quote,
 )
+from .runtime import SERVICE_PROFILE, ServiceProfile, health, profile
 
-
-class ServiceProfile(TypedDict):
-    service_id: str
-    domain: str
-    language: str
-    phase: str
-    work_packages: List[str]
-    owns: List[str]
-
-
-SERVICE_PROFILE: ServiceProfile = {
-    "service_id": "fare-pricing",
-    "domain": "Fare & Pricing",
-    "language": "python",
-    "phase": "phase-1-core",
-    "work_packages": ["REQ-007", "WP-04"],
-    "owns": [
-        "FareRuleSet",
-        "FareRule",
-        "FareQuote",
-        "RuleSnapshot",
-        "FareBreakdown",
-        "PriceExplanation",
-        "FeeAssessment",
-        "AdjustmentQuote",
-    ],
-}
-
-
-def health() -> str:
-    return "ok"
-
-
-def profile() -> ServiceProfile:
-    return dict(SERVICE_PROFILE)  # type: ignore[return-value]
-
-
-def create_app() -> FastAPI:
-    app = FastAPI(title="Fare & Pricing", version="0.1.0")
-
-    @app.get("/health")
-    def health_endpoint() -> dict[str, object]:
-        return {"status": health(), "service": profile()}
-
-    return app
+__all__ = [
+    'AdjustmentQuote',
+    'AssessmentPurpose',
+    'FareBreakdown',
+    'FareQuote',
+    'FareRule',
+    'FareRuleSet',
+    'FeeAssessment',
+    'Money',
+    'PriceComponent',
+    'PriceExplanation',
+    'PricingError',
+    'QuoteStatus',
+    'RuleKind',
+    'RuleSetStatus',
+    'RuleSnapshot',
+    'ValidityWindow',
+    'assess_change',
+    'assess_refund',
+    'calculate_fare_quote',
+    'create_app',
+    'health',
+    'profile',
+    'SERVICE_PROFILE',
+    'ServiceProfile',
+]

--- a/services/fare-pricing/src/fare_pricing/api.py
+++ b/services/fare-pricing/src/fare_pricing/api.py
@@ -1,0 +1,72 @@
+from collections.abc import Callable, Mapping
+from typing import Any
+from uuid import uuid4
+
+from fastapi import FastAPI, Request
+
+from .runtime import health, profile
+
+REQUEST_ID_HEADER = "X-Request-ID"
+CORRELATION_ID_HEADER = "X-Correlation-ID"
+TraceHook = Callable[[str, Mapping[str, object]], None]
+
+
+def _emit_trace(tracer: TraceHook | None, event: str, attributes: Mapping[str, object]) -> None:
+    if tracer is not None:
+        tracer(event, dict(attributes))
+
+
+def _request_identifiers(request: Request) -> tuple[str, str]:
+    request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid4())
+    correlation_id = request.headers.get(CORRELATION_ID_HEADER) or request_id
+    return request_id, correlation_id
+
+
+def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None) -> None:
+    @app.middleware("http")
+    async def request_context_middleware(request: Request, call_next: Any):
+        request_id, correlation_id = _request_identifiers(request)
+        request.state.request_id = request_id
+        request.state.correlation_id = correlation_id
+        trace_attributes = {
+            "request_id": request_id,
+            "correlation_id": correlation_id,
+            "method": request.method,
+            "path": request.url.path,
+        }
+        _emit_trace(tracer, "http.request.start", trace_attributes)
+        try:
+            response = await call_next(request)
+        except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
+            _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
+            raise
+        response.headers[REQUEST_ID_HEADER] = request_id
+        response.headers[CORRELATION_ID_HEADER] = correlation_id
+        _emit_trace(
+            tracer,
+            "http.request.complete",
+            {**trace_attributes, "status_code": response.status_code},
+        )
+        return response
+
+    @app.get("/health")
+    def health_endpoint() -> dict[str, object]:
+        return {"status": health(), "service": profile()}
+
+    @app.get("/live")
+    def live_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
+    @app.get("/ready")
+    def ready_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
+    @app.get("/metadata")
+    def metadata_endpoint() -> dict[str, object]:
+        return {"service": profile(), "observability": {"tracing": "opt-in", "default": "noop"}}
+
+
+def create_app(tracer: TraceHook | None = None) -> FastAPI:
+    app = FastAPI(title='Fare & Pricing', version="0.1.0")
+    configure_runtime_endpoints(app, tracer)
+    return app

--- a/services/fare-pricing/src/fare_pricing/runtime.py
+++ b/services/fare-pricing/src/fare_pricing/runtime.py
@@ -1,0 +1,22 @@
+from typing import List, NotRequired, TypedDict
+
+
+class ServiceProfile(TypedDict):
+    service_id: str
+    domain: str
+    language: str
+    phase: str
+    work_packages: List[str]
+    owns: List[str]
+    boundary: NotRequired[str]
+
+
+SERVICE_PROFILE: ServiceProfile = {'service_id': 'fare-pricing', 'domain': 'Fare & Pricing', 'language': 'python', 'phase': 'phase-1-core', 'work_packages': ['REQ-007', 'WP-04'], 'owns': ['FareRuleSet', 'FareRule', 'FareQuote', 'RuleSnapshot', 'FareBreakdown', 'PriceExplanation', 'FeeAssessment', 'AdjustmentQuote']}
+
+
+def health() -> str:
+    return "ok"
+
+
+def profile() -> ServiceProfile:
+    return dict(SERVICE_PROFILE)  # type: ignore[return-value]

--- a/services/fare-pricing/tests/test_skeleton.py
+++ b/services/fare-pricing/tests/test_skeleton.py
@@ -1,19 +1,55 @@
 import unittest
 
+from fastapi.testclient import TestClient
+
 from fare_pricing import create_app, health, profile
 
 
 class SkeletonTest(unittest.TestCase):
     def test_profile_matches_domain(self) -> None:
         service_profile = profile()
-        self.assertEqual(service_profile["service_id"], "fare-pricing")
-        self.assertEqual(service_profile["domain"], "Fare & Pricing")
+        self.assertEqual(service_profile["service_id"], 'fare-pricing')
+        self.assertEqual(service_profile["domain"], 'Fare & Pricing')
         self.assertEqual(health(), "ok")
 
-    def test_fastapi_health_route_is_registered(self) -> None:
+    def test_fastapi_runtime_routes_are_registered(self) -> None:
         app = create_app()
         routes = {route.path for route in app.routes}
         self.assertIn("/health", routes)
+        self.assertIn("/live", routes)
+        self.assertIn("/ready", routes)
+        self.assertIn("/metadata", routes)
+
+    def test_request_and_correlation_ids_are_propagated(self) -> None:
+        client = TestClient(create_app())
+        response = client.get(
+            "/health",
+            headers={"X-Request-ID": "req-123", "X-Correlation-ID": "corr-456"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["X-Request-ID"], "req-123")
+        self.assertEqual(response.headers["X-Correlation-ID"], "corr-456")
+
+    def test_request_and_correlation_ids_are_generated(self) -> None:
+        client = TestClient(create_app())
+        response = client.get("/live")
+        self.assertEqual(response.status_code, 200)
+        request_id = response.headers["X-Request-ID"]
+        self.assertTrue(request_id)
+        self.assertEqual(response.headers["X-Correlation-ID"], request_id)
+
+    def test_observability_trace_hook_is_opt_in(self) -> None:
+        events: list[tuple[str, dict[str, object]]] = []
+
+        def tracer(event: str, attributes: dict[str, object]) -> None:
+            events.append((event, attributes))
+
+        client = TestClient(create_app(tracer=tracer))
+        response = client.get("/metadata", headers={"X-Request-ID": "req-trace"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([event for event, _ in events], ["http.request.start", "http.request.complete"])
+        self.assertEqual(events[0][1]["request_id"], "req-trace")
+        self.assertEqual(events[1][1]["status_code"], 200)
 
 
 if __name__ == "__main__":

--- a/services/fare-pricing/uv.lock
+++ b/services/fare-pricing/uv.lock
@@ -52,6 +52,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx2" },
     { name = "pytest" },
 ]
 
@@ -59,7 +60,10 @@ dev = [
 requires-dist = [{ name = "fastapi", specifier = "==0.138.1" }]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = "==9.1.1" }]
+dev = [
+    { name = "httpx2", specifier = ">=2.5.0" },
+    { name = "pytest", specifier = "==9.1.1" },
+]
 
 [[package]]
 name = "fastapi"
@@ -75,6 +79,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/c9/5e8defe249899c0dc900643695fc07829a67fc88b4ff2cdb03fcbdbf5a4b/fastapi-0.138.1.tar.gz", hash = "sha256:96e3702dce09ee0dce48856135620d3d865ca684a79fe7513fd7b13a12f82862", size = 419646, upload-time = "2026-06-25T15:40:42.115Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/a9/69a6924f645eb4dd8cd625bf255b3625990eb3e14e073438a53c405dcd3e/fastapi-0.138.1-py3-none-any.whl", hash = "sha256:b994cae7ba8b82c976a728b544244de31333fa5f7d261f9a1dffe526444cae23", size = 129182, upload-time = "2026-06-25T15:40:40.771Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/5c12df521b5322fb1114a83d46911b2fbcb8855ddb3a635f11c01a214af5/httpcore2-2.5.0.tar.gz", hash = "sha256:88aa170137c17328d5ac44234f9fd10706466d5fb347f3edac4d39b91137b09d", size = 64808, upload-time = "2026-06-25T14:16:56.472Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/a1/7564199d1a8728fe737b0a72e5b3f8d92dfe085a74ddf7cdd83bce5f206d/httpcore2-2.5.0-py3-none-any.whl", hash = "sha256:5ce35188de461d31e8d000bfb8ef8bf22c6c16587a211e5571deaa5e9bdf842a", size = 80330, upload-time = "2026-06-25T14:16:53.634Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/e2/b5dedc0cf35aa65de5f541ccd30d2bc1fd7f1d43c9ab09f8ed9a7342317b/httpx2-2.5.0.tar.gz", hash = "sha256:e2df9cb4611021527ff8a675b1c320b610a2ec397acc8d6fe6e91df2d9b33c29", size = 83121, upload-time = "2026-06-25T14:16:57.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/22/859d8252dad9bc9adee34b52e62cde621ece07b042ccb2ab4da1be46695f/httpx2-2.5.0-py3-none-any.whl", hash = "sha256:3d2d4d9cf4b61f1a1f46a95947cfdb47e80cb56a2f91c6256ac8f58e4891df41", size = 76652, upload-time = "2026-06-25T14:16:55.23Z" },
 ]
 
 [[package]]
@@ -266,6 +308,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/services/reporting/pyproject.toml
+++ b/services/reporting/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+  "httpx2>=2.5.0",
   "pytest==9.1.1",
 ]
 

--- a/services/reporting/src/reporting/__init__.py
+++ b/services/reporting/src/reporting/__init__.py
@@ -1,40 +1,10 @@
-from typing import List, TypedDict
+from .api import create_app
+from .runtime import SERVICE_PROFILE, ServiceProfile, health, profile
 
-from fastapi import FastAPI
-
-
-class ServiceProfile(TypedDict):
-    service_id: str
-    domain: str
-    language: str
-    phase: str
-    work_packages: List[str]
-    owns: List[str]
-
-
-SERVICE_PROFILE: ServiceProfile = {
-    "service_id": "reporting",
-    "domain": "Reporting",
-    "language": "python",
-    "phase": "phase-1-limited",
-    "work_packages": ["WP-22"],
-    "owns": ["MetricDefinition", "DashboardReadModel", "FunnelView"],
-}
-
-
-def health() -> str:
-    return "ok"
-
-
-def profile() -> ServiceProfile:
-    return dict(SERVICE_PROFILE)  # type: ignore[return-value]
-
-
-def create_app() -> FastAPI:
-    app = FastAPI(title="Reporting", version="0.1.0")
-
-    @app.get("/health")
-    def health_endpoint() -> dict[str, object]:
-        return {"status": health(), "service": profile()}
-
-    return app
+__all__ = [
+    'SERVICE_PROFILE',
+    'ServiceProfile',
+    'create_app',
+    'health',
+    'profile',
+]

--- a/services/reporting/src/reporting/api.py
+++ b/services/reporting/src/reporting/api.py
@@ -1,0 +1,72 @@
+from collections.abc import Callable, Mapping
+from typing import Any
+from uuid import uuid4
+
+from fastapi import FastAPI, Request
+
+from .runtime import health, profile
+
+REQUEST_ID_HEADER = "X-Request-ID"
+CORRELATION_ID_HEADER = "X-Correlation-ID"
+TraceHook = Callable[[str, Mapping[str, object]], None]
+
+
+def _emit_trace(tracer: TraceHook | None, event: str, attributes: Mapping[str, object]) -> None:
+    if tracer is not None:
+        tracer(event, dict(attributes))
+
+
+def _request_identifiers(request: Request) -> tuple[str, str]:
+    request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid4())
+    correlation_id = request.headers.get(CORRELATION_ID_HEADER) or request_id
+    return request_id, correlation_id
+
+
+def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None) -> None:
+    @app.middleware("http")
+    async def request_context_middleware(request: Request, call_next: Any):
+        request_id, correlation_id = _request_identifiers(request)
+        request.state.request_id = request_id
+        request.state.correlation_id = correlation_id
+        trace_attributes = {
+            "request_id": request_id,
+            "correlation_id": correlation_id,
+            "method": request.method,
+            "path": request.url.path,
+        }
+        _emit_trace(tracer, "http.request.start", trace_attributes)
+        try:
+            response = await call_next(request)
+        except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
+            _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
+            raise
+        response.headers[REQUEST_ID_HEADER] = request_id
+        response.headers[CORRELATION_ID_HEADER] = correlation_id
+        _emit_trace(
+            tracer,
+            "http.request.complete",
+            {**trace_attributes, "status_code": response.status_code},
+        )
+        return response
+
+    @app.get("/health")
+    def health_endpoint() -> dict[str, object]:
+        return {"status": health(), "service": profile()}
+
+    @app.get("/live")
+    def live_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
+    @app.get("/ready")
+    def ready_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
+    @app.get("/metadata")
+    def metadata_endpoint() -> dict[str, object]:
+        return {"service": profile(), "observability": {"tracing": "opt-in", "default": "noop"}}
+
+
+def create_app(tracer: TraceHook | None = None) -> FastAPI:
+    app = FastAPI(title='Reporting', version="0.1.0")
+    configure_runtime_endpoints(app, tracer)
+    return app

--- a/services/reporting/src/reporting/runtime.py
+++ b/services/reporting/src/reporting/runtime.py
@@ -1,0 +1,22 @@
+from typing import List, NotRequired, TypedDict
+
+
+class ServiceProfile(TypedDict):
+    service_id: str
+    domain: str
+    language: str
+    phase: str
+    work_packages: List[str]
+    owns: List[str]
+    boundary: NotRequired[str]
+
+
+SERVICE_PROFILE: ServiceProfile = {'service_id': 'reporting', 'domain': 'Reporting', 'language': 'python', 'phase': 'phase-1-limited', 'work_packages': ['WP-22'], 'owns': ['MetricDefinition', 'DashboardReadModel', 'FunnelView']}
+
+
+def health() -> str:
+    return "ok"
+
+
+def profile() -> ServiceProfile:
+    return dict(SERVICE_PROFILE)  # type: ignore[return-value]

--- a/services/reporting/tests/test_skeleton.py
+++ b/services/reporting/tests/test_skeleton.py
@@ -1,19 +1,55 @@
 import unittest
 
+from fastapi.testclient import TestClient
+
 from reporting import create_app, health, profile
 
 
 class SkeletonTest(unittest.TestCase):
     def test_profile_matches_domain(self) -> None:
         service_profile = profile()
-        self.assertEqual(service_profile["service_id"], "reporting")
-        self.assertEqual(service_profile["domain"], "Reporting")
+        self.assertEqual(service_profile["service_id"], 'reporting')
+        self.assertEqual(service_profile["domain"], 'Reporting')
         self.assertEqual(health(), "ok")
 
-    def test_fastapi_health_route_is_registered(self) -> None:
+    def test_fastapi_runtime_routes_are_registered(self) -> None:
         app = create_app()
         routes = {route.path for route in app.routes}
         self.assertIn("/health", routes)
+        self.assertIn("/live", routes)
+        self.assertIn("/ready", routes)
+        self.assertIn("/metadata", routes)
+
+    def test_request_and_correlation_ids_are_propagated(self) -> None:
+        client = TestClient(create_app())
+        response = client.get(
+            "/health",
+            headers={"X-Request-ID": "req-123", "X-Correlation-ID": "corr-456"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["X-Request-ID"], "req-123")
+        self.assertEqual(response.headers["X-Correlation-ID"], "corr-456")
+
+    def test_request_and_correlation_ids_are_generated(self) -> None:
+        client = TestClient(create_app())
+        response = client.get("/live")
+        self.assertEqual(response.status_code, 200)
+        request_id = response.headers["X-Request-ID"]
+        self.assertTrue(request_id)
+        self.assertEqual(response.headers["X-Correlation-ID"], request_id)
+
+    def test_observability_trace_hook_is_opt_in(self) -> None:
+        events: list[tuple[str, dict[str, object]]] = []
+
+        def tracer(event: str, attributes: dict[str, object]) -> None:
+            events.append((event, attributes))
+
+        client = TestClient(create_app(tracer=tracer))
+        response = client.get("/metadata", headers={"X-Request-ID": "req-trace"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([event for event, _ in events], ["http.request.start", "http.request.complete"])
+        self.assertEqual(events[0][1]["request_id"], "req-trace")
+        self.assertEqual(events[1][1]["status_code"], 200)
 
 
 if __name__ == "__main__":

--- a/services/reporting/uv.lock
+++ b/services/reporting/uv.lock
@@ -59,6 +59,44 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/5c12df521b5322fb1114a83d46911b2fbcb8855ddb3a635f11c01a214af5/httpcore2-2.5.0.tar.gz", hash = "sha256:88aa170137c17328d5ac44234f9fd10706466d5fb347f3edac4d39b91137b09d", size = 64808, upload-time = "2026-06-25T14:16:56.472Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/a1/7564199d1a8728fe737b0a72e5b3f8d92dfe085a74ddf7cdd83bce5f206d/httpcore2-2.5.0-py3-none-any.whl", hash = "sha256:5ce35188de461d31e8d000bfb8ef8bf22c6c16587a211e5571deaa5e9bdf842a", size = 80330, upload-time = "2026-06-25T14:16:53.634Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/e2/b5dedc0cf35aa65de5f541ccd30d2bc1fd7f1d43c9ab09f8ed9a7342317b/httpx2-2.5.0.tar.gz", hash = "sha256:e2df9cb4611021527ff8a675b1c320b610a2ec397acc8d6fe6e91df2d9b33c29", size = 83121, upload-time = "2026-06-25T14:16:57.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/22/859d8252dad9bc9adee34b52e62cde621ece07b042ccb2ab4da1be46695f/httpx2-2.5.0-py3-none-any.whl", hash = "sha256:3d2d4d9cf4b61f1a1f46a95947cfdb47e80cb56a2f91c6256ac8f58e4891df41", size = 76652, upload-time = "2026-06-25T14:16:55.23Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -246,6 +284,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx2" },
     { name = "pytest" },
 ]
 
@@ -253,7 +292,10 @@ dev = [
 requires-dist = [{ name = "fastapi", specifier = "==0.138.1" }]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = "==9.1.1" }]
+dev = [
+    { name = "httpx2", specifier = ">=2.5.0" },
+    { name = "pytest", specifier = "==9.1.1" },
+]
 
 [[package]]
 name = "starlette"
@@ -266,6 +308,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/services/risk-compliance/pyproject.toml
+++ b/services/risk-compliance/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+  "httpx2>=2.5.0",
   "pytest==9.1.1",
 ]
 

--- a/services/risk-compliance/src/risk_compliance/__init__.py
+++ b/services/risk-compliance/src/risk_compliance/__init__.py
@@ -1,40 +1,10 @@
-from typing import List, TypedDict
+from .api import create_app
+from .runtime import SERVICE_PROFILE, ServiceProfile, health, profile
 
-from fastapi import FastAPI
-
-
-class ServiceProfile(TypedDict):
-    service_id: str
-    domain: str
-    language: str
-    phase: str
-    work_packages: List[str]
-    owns: List[str]
-
-
-SERVICE_PROFILE: ServiceProfile = {
-    "service_id": "risk-compliance",
-    "domain": "Risk & Compliance",
-    "language": "python",
-    "phase": "phase-1-support",
-    "work_packages": ["WP-17"],
-    "owns": ["RiskAssessment", "Challenge", "BlockDecision", "EvidenceSummary"],
-}
-
-
-def health() -> str:
-    return "ok"
-
-
-def profile() -> ServiceProfile:
-    return dict(SERVICE_PROFILE)  # type: ignore[return-value]
-
-
-def create_app() -> FastAPI:
-    app = FastAPI(title="Risk & Compliance", version="0.1.0")
-
-    @app.get("/health")
-    def health_endpoint() -> dict[str, object]:
-        return {"status": health(), "service": profile()}
-
-    return app
+__all__ = [
+    'SERVICE_PROFILE',
+    'ServiceProfile',
+    'create_app',
+    'health',
+    'profile',
+]

--- a/services/risk-compliance/src/risk_compliance/api.py
+++ b/services/risk-compliance/src/risk_compliance/api.py
@@ -1,0 +1,72 @@
+from collections.abc import Callable, Mapping
+from typing import Any
+from uuid import uuid4
+
+from fastapi import FastAPI, Request
+
+from .runtime import health, profile
+
+REQUEST_ID_HEADER = "X-Request-ID"
+CORRELATION_ID_HEADER = "X-Correlation-ID"
+TraceHook = Callable[[str, Mapping[str, object]], None]
+
+
+def _emit_trace(tracer: TraceHook | None, event: str, attributes: Mapping[str, object]) -> None:
+    if tracer is not None:
+        tracer(event, dict(attributes))
+
+
+def _request_identifiers(request: Request) -> tuple[str, str]:
+    request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid4())
+    correlation_id = request.headers.get(CORRELATION_ID_HEADER) or request_id
+    return request_id, correlation_id
+
+
+def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None) -> None:
+    @app.middleware("http")
+    async def request_context_middleware(request: Request, call_next: Any):
+        request_id, correlation_id = _request_identifiers(request)
+        request.state.request_id = request_id
+        request.state.correlation_id = correlation_id
+        trace_attributes = {
+            "request_id": request_id,
+            "correlation_id": correlation_id,
+            "method": request.method,
+            "path": request.url.path,
+        }
+        _emit_trace(tracer, "http.request.start", trace_attributes)
+        try:
+            response = await call_next(request)
+        except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
+            _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
+            raise
+        response.headers[REQUEST_ID_HEADER] = request_id
+        response.headers[CORRELATION_ID_HEADER] = correlation_id
+        _emit_trace(
+            tracer,
+            "http.request.complete",
+            {**trace_attributes, "status_code": response.status_code},
+        )
+        return response
+
+    @app.get("/health")
+    def health_endpoint() -> dict[str, object]:
+        return {"status": health(), "service": profile()}
+
+    @app.get("/live")
+    def live_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
+    @app.get("/ready")
+    def ready_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
+    @app.get("/metadata")
+    def metadata_endpoint() -> dict[str, object]:
+        return {"service": profile(), "observability": {"tracing": "opt-in", "default": "noop"}}
+
+
+def create_app(tracer: TraceHook | None = None) -> FastAPI:
+    app = FastAPI(title='Risk & Compliance', version="0.1.0")
+    configure_runtime_endpoints(app, tracer)
+    return app

--- a/services/risk-compliance/src/risk_compliance/runtime.py
+++ b/services/risk-compliance/src/risk_compliance/runtime.py
@@ -1,0 +1,22 @@
+from typing import List, NotRequired, TypedDict
+
+
+class ServiceProfile(TypedDict):
+    service_id: str
+    domain: str
+    language: str
+    phase: str
+    work_packages: List[str]
+    owns: List[str]
+    boundary: NotRequired[str]
+
+
+SERVICE_PROFILE: ServiceProfile = {'service_id': 'risk-compliance', 'domain': 'Risk & Compliance', 'language': 'python', 'phase': 'phase-1-support', 'work_packages': ['WP-17'], 'owns': ['RiskAssessment', 'Challenge', 'BlockDecision', 'EvidenceSummary']}
+
+
+def health() -> str:
+    return "ok"
+
+
+def profile() -> ServiceProfile:
+    return dict(SERVICE_PROFILE)  # type: ignore[return-value]

--- a/services/risk-compliance/tests/test_skeleton.py
+++ b/services/risk-compliance/tests/test_skeleton.py
@@ -1,19 +1,55 @@
 import unittest
 
+from fastapi.testclient import TestClient
+
 from risk_compliance import create_app, health, profile
 
 
 class SkeletonTest(unittest.TestCase):
     def test_profile_matches_domain(self) -> None:
         service_profile = profile()
-        self.assertEqual(service_profile["service_id"], "risk-compliance")
-        self.assertEqual(service_profile["domain"], "Risk & Compliance")
+        self.assertEqual(service_profile["service_id"], 'risk-compliance')
+        self.assertEqual(service_profile["domain"], 'Risk & Compliance')
         self.assertEqual(health(), "ok")
 
-    def test_fastapi_health_route_is_registered(self) -> None:
+    def test_fastapi_runtime_routes_are_registered(self) -> None:
         app = create_app()
         routes = {route.path for route in app.routes}
         self.assertIn("/health", routes)
+        self.assertIn("/live", routes)
+        self.assertIn("/ready", routes)
+        self.assertIn("/metadata", routes)
+
+    def test_request_and_correlation_ids_are_propagated(self) -> None:
+        client = TestClient(create_app())
+        response = client.get(
+            "/health",
+            headers={"X-Request-ID": "req-123", "X-Correlation-ID": "corr-456"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["X-Request-ID"], "req-123")
+        self.assertEqual(response.headers["X-Correlation-ID"], "corr-456")
+
+    def test_request_and_correlation_ids_are_generated(self) -> None:
+        client = TestClient(create_app())
+        response = client.get("/live")
+        self.assertEqual(response.status_code, 200)
+        request_id = response.headers["X-Request-ID"]
+        self.assertTrue(request_id)
+        self.assertEqual(response.headers["X-Correlation-ID"], request_id)
+
+    def test_observability_trace_hook_is_opt_in(self) -> None:
+        events: list[tuple[str, dict[str, object]]] = []
+
+        def tracer(event: str, attributes: dict[str, object]) -> None:
+            events.append((event, attributes))
+
+        client = TestClient(create_app(tracer=tracer))
+        response = client.get("/metadata", headers={"X-Request-ID": "req-trace"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([event for event, _ in events], ["http.request.start", "http.request.complete"])
+        self.assertEqual(events[0][1]["request_id"], "req-trace")
+        self.assertEqual(events[1][1]["status_code"], 200)
 
 
 if __name__ == "__main__":

--- a/services/risk-compliance/uv.lock
+++ b/services/risk-compliance/uv.lock
@@ -59,6 +59,44 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/5c12df521b5322fb1114a83d46911b2fbcb8855ddb3a635f11c01a214af5/httpcore2-2.5.0.tar.gz", hash = "sha256:88aa170137c17328d5ac44234f9fd10706466d5fb347f3edac4d39b91137b09d", size = 64808, upload-time = "2026-06-25T14:16:56.472Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/a1/7564199d1a8728fe737b0a72e5b3f8d92dfe085a74ddf7cdd83bce5f206d/httpcore2-2.5.0-py3-none-any.whl", hash = "sha256:5ce35188de461d31e8d000bfb8ef8bf22c6c16587a211e5571deaa5e9bdf842a", size = 80330, upload-time = "2026-06-25T14:16:53.634Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/e2/b5dedc0cf35aa65de5f541ccd30d2bc1fd7f1d43c9ab09f8ed9a7342317b/httpx2-2.5.0.tar.gz", hash = "sha256:e2df9cb4611021527ff8a675b1c320b610a2ec397acc8d6fe6e91df2d9b33c29", size = 83121, upload-time = "2026-06-25T14:16:57.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/22/859d8252dad9bc9adee34b52e62cde621ece07b042ccb2ab4da1be46695f/httpx2-2.5.0-py3-none-any.whl", hash = "sha256:3d2d4d9cf4b61f1a1f46a95947cfdb47e80cb56a2f91c6256ac8f58e4891df41", size = 76652, upload-time = "2026-06-25T14:16:55.23Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -246,6 +284,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx2" },
     { name = "pytest" },
 ]
 
@@ -253,7 +292,10 @@ dev = [
 requires-dist = [{ name = "fastapi", specifier = "==0.138.1" }]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = "==9.1.1" }]
+dev = [
+    { name = "httpx2", specifier = ">=2.5.0" },
+    { name = "pytest", specifier = "==9.1.1" },
+]
 
 [[package]]
 name = "starlette"
@@ -266,6 +308,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/services/transfer-management/pyproject.toml
+++ b/services/transfer-management/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+  "httpx2>=2.5.0",
   "pytest==9.1.1",
 ]
 

--- a/services/transfer-management/src/transfer_management/__init__.py
+++ b/services/transfer-management/src/transfer_management/__init__.py
@@ -1,40 +1,10 @@
-from typing import List, TypedDict
+from .api import create_app
+from .runtime import SERVICE_PROFILE, ServiceProfile, health, profile
 
-from fastapi import FastAPI
-
-
-class ServiceProfile(TypedDict):
-    service_id: str
-    domain: str
-    language: str
-    phase: str
-    work_packages: List[str]
-    owns: List[str]
-
-
-SERVICE_PROFILE: ServiceProfile = {
-    "service_id": "transfer-management",
-    "domain": "Transfer Management",
-    "language": "python",
-    "phase": "future-scope",
-    "work_packages": [],
-    "owns": ["ConnectionContract", "MctVersion", "ProtectedConnection"],
-}
-
-
-def health() -> str:
-    return "ok"
-
-
-def profile() -> ServiceProfile:
-    return dict(SERVICE_PROFILE)  # type: ignore[return-value]
-
-
-def create_app() -> FastAPI:
-    app = FastAPI(title="Transfer Management", version="0.1.0")
-
-    @app.get("/health")
-    def health_endpoint() -> dict[str, object]:
-        return {"status": health(), "service": profile()}
-
-    return app
+__all__ = [
+    'SERVICE_PROFILE',
+    'ServiceProfile',
+    'create_app',
+    'health',
+    'profile',
+]

--- a/services/transfer-management/src/transfer_management/api.py
+++ b/services/transfer-management/src/transfer_management/api.py
@@ -1,0 +1,72 @@
+from collections.abc import Callable, Mapping
+from typing import Any
+from uuid import uuid4
+
+from fastapi import FastAPI, Request
+
+from .runtime import health, profile
+
+REQUEST_ID_HEADER = "X-Request-ID"
+CORRELATION_ID_HEADER = "X-Correlation-ID"
+TraceHook = Callable[[str, Mapping[str, object]], None]
+
+
+def _emit_trace(tracer: TraceHook | None, event: str, attributes: Mapping[str, object]) -> None:
+    if tracer is not None:
+        tracer(event, dict(attributes))
+
+
+def _request_identifiers(request: Request) -> tuple[str, str]:
+    request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid4())
+    correlation_id = request.headers.get(CORRELATION_ID_HEADER) or request_id
+    return request_id, correlation_id
+
+
+def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None) -> None:
+    @app.middleware("http")
+    async def request_context_middleware(request: Request, call_next: Any):
+        request_id, correlation_id = _request_identifiers(request)
+        request.state.request_id = request_id
+        request.state.correlation_id = correlation_id
+        trace_attributes = {
+            "request_id": request_id,
+            "correlation_id": correlation_id,
+            "method": request.method,
+            "path": request.url.path,
+        }
+        _emit_trace(tracer, "http.request.start", trace_attributes)
+        try:
+            response = await call_next(request)
+        except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
+            _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
+            raise
+        response.headers[REQUEST_ID_HEADER] = request_id
+        response.headers[CORRELATION_ID_HEADER] = correlation_id
+        _emit_trace(
+            tracer,
+            "http.request.complete",
+            {**trace_attributes, "status_code": response.status_code},
+        )
+        return response
+
+    @app.get("/health")
+    def health_endpoint() -> dict[str, object]:
+        return {"status": health(), "service": profile()}
+
+    @app.get("/live")
+    def live_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
+    @app.get("/ready")
+    def ready_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
+    @app.get("/metadata")
+    def metadata_endpoint() -> dict[str, object]:
+        return {"service": profile(), "observability": {"tracing": "opt-in", "default": "noop"}}
+
+
+def create_app(tracer: TraceHook | None = None) -> FastAPI:
+    app = FastAPI(title='Transfer Management', version="0.1.0")
+    configure_runtime_endpoints(app, tracer)
+    return app

--- a/services/transfer-management/src/transfer_management/runtime.py
+++ b/services/transfer-management/src/transfer_management/runtime.py
@@ -1,0 +1,22 @@
+from typing import List, NotRequired, TypedDict
+
+
+class ServiceProfile(TypedDict):
+    service_id: str
+    domain: str
+    language: str
+    phase: str
+    work_packages: List[str]
+    owns: List[str]
+    boundary: NotRequired[str]
+
+
+SERVICE_PROFILE: ServiceProfile = {'service_id': 'transfer-management', 'domain': 'Transfer Management', 'language': 'python', 'phase': 'future-scope', 'work_packages': [], 'owns': ['ConnectionContract', 'MctVersion', 'ProtectedConnection']}
+
+
+def health() -> str:
+    return "ok"
+
+
+def profile() -> ServiceProfile:
+    return dict(SERVICE_PROFILE)  # type: ignore[return-value]

--- a/services/transfer-management/tests/test_skeleton.py
+++ b/services/transfer-management/tests/test_skeleton.py
@@ -1,19 +1,55 @@
 import unittest
 
+from fastapi.testclient import TestClient
+
 from transfer_management import create_app, health, profile
 
 
 class SkeletonTest(unittest.TestCase):
     def test_profile_matches_domain(self) -> None:
         service_profile = profile()
-        self.assertEqual(service_profile["service_id"], "transfer-management")
-        self.assertEqual(service_profile["domain"], "Transfer Management")
+        self.assertEqual(service_profile["service_id"], 'transfer-management')
+        self.assertEqual(service_profile["domain"], 'Transfer Management')
         self.assertEqual(health(), "ok")
 
-    def test_fastapi_health_route_is_registered(self) -> None:
+    def test_fastapi_runtime_routes_are_registered(self) -> None:
         app = create_app()
         routes = {route.path for route in app.routes}
         self.assertIn("/health", routes)
+        self.assertIn("/live", routes)
+        self.assertIn("/ready", routes)
+        self.assertIn("/metadata", routes)
+
+    def test_request_and_correlation_ids_are_propagated(self) -> None:
+        client = TestClient(create_app())
+        response = client.get(
+            "/health",
+            headers={"X-Request-ID": "req-123", "X-Correlation-ID": "corr-456"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["X-Request-ID"], "req-123")
+        self.assertEqual(response.headers["X-Correlation-ID"], "corr-456")
+
+    def test_request_and_correlation_ids_are_generated(self) -> None:
+        client = TestClient(create_app())
+        response = client.get("/live")
+        self.assertEqual(response.status_code, 200)
+        request_id = response.headers["X-Request-ID"]
+        self.assertTrue(request_id)
+        self.assertEqual(response.headers["X-Correlation-ID"], request_id)
+
+    def test_observability_trace_hook_is_opt_in(self) -> None:
+        events: list[tuple[str, dict[str, object]]] = []
+
+        def tracer(event: str, attributes: dict[str, object]) -> None:
+            events.append((event, attributes))
+
+        client = TestClient(create_app(tracer=tracer))
+        response = client.get("/metadata", headers={"X-Request-ID": "req-trace"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([event for event, _ in events], ["http.request.start", "http.request.complete"])
+        self.assertEqual(events[0][1]["request_id"], "req-trace")
+        self.assertEqual(events[1][1]["status_code"], 200)
 
 
 if __name__ == "__main__":

--- a/services/transfer-management/uv.lock
+++ b/services/transfer-management/uv.lock
@@ -59,6 +59,44 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/5c12df521b5322fb1114a83d46911b2fbcb8855ddb3a635f11c01a214af5/httpcore2-2.5.0.tar.gz", hash = "sha256:88aa170137c17328d5ac44234f9fd10706466d5fb347f3edac4d39b91137b09d", size = 64808, upload-time = "2026-06-25T14:16:56.472Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/a1/7564199d1a8728fe737b0a72e5b3f8d92dfe085a74ddf7cdd83bce5f206d/httpcore2-2.5.0-py3-none-any.whl", hash = "sha256:5ce35188de461d31e8d000bfb8ef8bf22c6c16587a211e5571deaa5e9bdf842a", size = 80330, upload-time = "2026-06-25T14:16:53.634Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/e2/b5dedc0cf35aa65de5f541ccd30d2bc1fd7f1d43c9ab09f8ed9a7342317b/httpx2-2.5.0.tar.gz", hash = "sha256:e2df9cb4611021527ff8a675b1c320b610a2ec397acc8d6fe6e91df2d9b33c29", size = 83121, upload-time = "2026-06-25T14:16:57.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/22/859d8252dad9bc9adee34b52e62cde621ece07b042ccb2ab4da1be46695f/httpx2-2.5.0-py3-none-any.whl", hash = "sha256:3d2d4d9cf4b61f1a1f46a95947cfdb47e80cb56a2f91c6256ac8f58e4891df41", size = 76652, upload-time = "2026-06-25T14:16:55.23Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -259,6 +297,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx2" },
     { name = "pytest" },
 ]
 
@@ -266,7 +305,19 @@ dev = [
 requires-dist = [{ name = "fastapi", specifier = "==0.138.1" }]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = "==9.1.1" }]
+dev = [
+    { name = "httpx2", specifier = ">=2.5.0" },
+    { name = "pytest", specifier = "==9.1.1" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
 
 [[package]]
 name = "typing-extensions"

--- a/services/trip-planning/pyproject.toml
+++ b/services/trip-planning/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+  "httpx2>=2.5.0",
   "pytest==9.1.1",
 ]
 

--- a/services/trip-planning/src/trip_planning/__init__.py
+++ b/services/trip-planning/src/trip_planning/__init__.py
@@ -1,32 +1,4 @@
-from typing import List, TypedDict
-
-try:  # FastAPI is used in runtime images; tests can run without installed deps.
-    from fastapi import FastAPI, HTTPException
-except ModuleNotFoundError:  # pragma: no cover - compatibility shim for stdlib-only validation
-    class HTTPException(Exception):
-        def __init__(self, status_code: int, detail: str) -> None:
-            super().__init__(detail)
-            self.status_code = status_code
-            self.detail = detail
-
-    class _Route:
-        def __init__(self, path: str) -> None:
-            self.path = path
-
-    class FastAPI:  # type: ignore[no-redef]
-        def __init__(self, title: str, version: str) -> None:
-            self.title = title
-            self.version = version
-            self.routes: list[_Route] = []
-
-        def get(self, path: str):
-            self.routes.append(_Route(path))
-            return lambda func: func
-
-        def post(self, path: str):
-            self.routes.append(_Route(path))
-            return lambda func: func
-
+from .api import create_app
 from .application import search_itineraries_from_payload
 from .domain import (
     AvailabilityHint,
@@ -37,69 +9,20 @@ from .domain import (
     TripIntent,
     TripPlanningValidationError,
 )
-
-
-class ServiceProfile(TypedDict):
-    service_id: str
-    domain: str
-    language: str
-    phase: str
-    work_packages: List[str]
-    owns: List[str]
-    boundary: str
-
-
-SERVICE_PROFILE: ServiceProfile = {
-    "service_id": "trip-planning",
-    "domain": "Trip Planning",
-    "language": "python",
-    "phase": "phase-1-search-foundation",
-    "work_packages": ["REQ-008-Trip-Planning-search-foundation"],
-    "owns": [
-        "TripIntent validation",
-        "Itinerary candidates",
-        "SearchResult ranking explanations",
-        "Non-authoritative PriceHint and AvailabilityHint snapshots",
-    ],
-    "boundary": "Search candidates only: no Offer, CapacityHold, order, payment, ticket, or provider integration.",
-}
-
-
-def health() -> str:
-    return "ok"
-
-
-def profile() -> ServiceProfile:
-    return dict(SERVICE_PROFILE)  # type: ignore[return-value]
-
-
-def create_app() -> FastAPI:
-    app = FastAPI(title="Trip Planning", version="0.1.0")
-
-    @app.get("/health")
-    def health_endpoint() -> dict[str, object]:
-        return {"status": health(), "service": profile()}
-
-    @app.post("/search")
-    def search_endpoint(payload: dict[str, object]) -> dict[str, object]:
-        try:
-            return search_itineraries_from_payload(payload)
-        except TripPlanningValidationError as exc:
-            raise HTTPException(status_code=422, detail=str(exc)) from exc
-
-    return app
-
+from .runtime import SERVICE_PROFILE, ServiceProfile, health, profile
 
 __all__ = [
-    "AvailabilityHint",
-    "Itinerary",
-    "LegCandidate",
-    "PreferenceConstraints",
-    "PriceHint",
-    "TripIntent",
-    "TripPlanningValidationError",
-    "create_app",
-    "health",
-    "profile",
-    "search_itineraries_from_payload",
+    'AvailabilityHint',
+    'Itinerary',
+    'LegCandidate',
+    'PreferenceConstraints',
+    'PriceHint',
+    'TripIntent',
+    'TripPlanningValidationError',
+    'create_app',
+    'health',
+    'profile',
+    'search_itineraries_from_payload',
+    'SERVICE_PROFILE',
+    'ServiceProfile',
 ]

--- a/services/trip-planning/src/trip_planning/api.py
+++ b/services/trip-planning/src/trip_planning/api.py
@@ -1,0 +1,85 @@
+from collections.abc import Callable, Mapping
+from typing import Any
+from uuid import uuid4
+
+from fastapi import FastAPI, Request
+
+from .runtime import health, profile
+
+REQUEST_ID_HEADER = "X-Request-ID"
+CORRELATION_ID_HEADER = "X-Correlation-ID"
+TraceHook = Callable[[str, Mapping[str, object]], None]
+
+
+def _emit_trace(tracer: TraceHook | None, event: str, attributes: Mapping[str, object]) -> None:
+    if tracer is not None:
+        tracer(event, dict(attributes))
+
+
+def _request_identifiers(request: Request) -> tuple[str, str]:
+    request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid4())
+    correlation_id = request.headers.get(CORRELATION_ID_HEADER) or request_id
+    return request_id, correlation_id
+
+
+def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None) -> None:
+    @app.middleware("http")
+    async def request_context_middleware(request: Request, call_next: Any):
+        request_id, correlation_id = _request_identifiers(request)
+        request.state.request_id = request_id
+        request.state.correlation_id = correlation_id
+        trace_attributes = {
+            "request_id": request_id,
+            "correlation_id": correlation_id,
+            "method": request.method,
+            "path": request.url.path,
+        }
+        _emit_trace(tracer, "http.request.start", trace_attributes)
+        try:
+            response = await call_next(request)
+        except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
+            _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
+            raise
+        response.headers[REQUEST_ID_HEADER] = request_id
+        response.headers[CORRELATION_ID_HEADER] = correlation_id
+        _emit_trace(
+            tracer,
+            "http.request.complete",
+            {**trace_attributes, "status_code": response.status_code},
+        )
+        return response
+
+    @app.get("/health")
+    def health_endpoint() -> dict[str, object]:
+        return {"status": health(), "service": profile()}
+
+    @app.get("/live")
+    def live_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
+    @app.get("/ready")
+    def ready_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
+    @app.get("/metadata")
+    def metadata_endpoint() -> dict[str, object]:
+        return {"service": profile(), "observability": {"tracing": "opt-in", "default": "noop"}}
+
+from fastapi import HTTPException
+
+from .application import search_itineraries_from_payload
+from .domain import TripPlanningValidationError
+
+
+def create_app(tracer: TraceHook | None = None) -> FastAPI:
+    app = FastAPI(title='Trip Planning', version="0.1.0")
+    configure_runtime_endpoints(app, tracer)
+
+    @app.post("/search")
+    def search_endpoint(payload: dict[str, object]) -> dict[str, object]:
+        try:
+            return search_itineraries_from_payload(payload)
+        except TripPlanningValidationError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    return app

--- a/services/trip-planning/src/trip_planning/runtime.py
+++ b/services/trip-planning/src/trip_planning/runtime.py
@@ -1,0 +1,22 @@
+from typing import List, NotRequired, TypedDict
+
+
+class ServiceProfile(TypedDict):
+    service_id: str
+    domain: str
+    language: str
+    phase: str
+    work_packages: List[str]
+    owns: List[str]
+    boundary: NotRequired[str]
+
+
+SERVICE_PROFILE: ServiceProfile = {'service_id': 'trip-planning', 'domain': 'Trip Planning', 'language': 'python', 'phase': 'phase-1-search-foundation', 'work_packages': ['REQ-008-Trip-Planning-search-foundation'], 'owns': ['TripIntent validation', 'Itinerary candidates', 'SearchResult ranking explanations', 'Non-authoritative PriceHint and AvailabilityHint snapshots'], 'boundary': 'Search candidates only: no Offer, CapacityHold, order, payment, ticket, or provider integration.'}
+
+
+def health() -> str:
+    return "ok"
+
+
+def profile() -> ServiceProfile:
+    return dict(SERVICE_PROFILE)  # type: ignore[return-value]

--- a/services/trip-planning/tests/test_skeleton.py
+++ b/services/trip-planning/tests/test_skeleton.py
@@ -1,19 +1,55 @@
 import unittest
 
+from fastapi.testclient import TestClient
+
 from trip_planning import create_app, health, profile
 
 
 class SkeletonTest(unittest.TestCase):
     def test_profile_matches_domain(self) -> None:
         service_profile = profile()
-        self.assertEqual(service_profile["service_id"], "trip-planning")
-        self.assertEqual(service_profile["domain"], "Trip Planning")
+        self.assertEqual(service_profile["service_id"], 'trip-planning')
+        self.assertEqual(service_profile["domain"], 'Trip Planning')
         self.assertEqual(health(), "ok")
 
-    def test_fastapi_health_route_is_registered(self) -> None:
+    def test_fastapi_runtime_routes_are_registered(self) -> None:
         app = create_app()
         routes = {route.path for route in app.routes}
         self.assertIn("/health", routes)
+        self.assertIn("/live", routes)
+        self.assertIn("/ready", routes)
+        self.assertIn("/metadata", routes)
+
+    def test_request_and_correlation_ids_are_propagated(self) -> None:
+        client = TestClient(create_app())
+        response = client.get(
+            "/health",
+            headers={"X-Request-ID": "req-123", "X-Correlation-ID": "corr-456"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["X-Request-ID"], "req-123")
+        self.assertEqual(response.headers["X-Correlation-ID"], "corr-456")
+
+    def test_request_and_correlation_ids_are_generated(self) -> None:
+        client = TestClient(create_app())
+        response = client.get("/live")
+        self.assertEqual(response.status_code, 200)
+        request_id = response.headers["X-Request-ID"]
+        self.assertTrue(request_id)
+        self.assertEqual(response.headers["X-Correlation-ID"], request_id)
+
+    def test_observability_trace_hook_is_opt_in(self) -> None:
+        events: list[tuple[str, dict[str, object]]] = []
+
+        def tracer(event: str, attributes: dict[str, object]) -> None:
+            events.append((event, attributes))
+
+        client = TestClient(create_app(tracer=tracer))
+        response = client.get("/metadata", headers={"X-Request-ID": "req-trace"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([event for event, _ in events], ["http.request.start", "http.request.complete"])
+        self.assertEqual(events[0][1]["request_id"], "req-trace")
+        self.assertEqual(events[1][1]["status_code"], 200)
 
 
 if __name__ == "__main__":

--- a/services/trip-planning/uv.lock
+++ b/services/trip-planning/uv.lock
@@ -59,6 +59,44 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/5c12df521b5322fb1114a83d46911b2fbcb8855ddb3a635f11c01a214af5/httpcore2-2.5.0.tar.gz", hash = "sha256:88aa170137c17328d5ac44234f9fd10706466d5fb347f3edac4d39b91137b09d", size = 64808, upload-time = "2026-06-25T14:16:56.472Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/a1/7564199d1a8728fe737b0a72e5b3f8d92dfe085a74ddf7cdd83bce5f206d/httpcore2-2.5.0-py3-none-any.whl", hash = "sha256:5ce35188de461d31e8d000bfb8ef8bf22c6c16587a211e5571deaa5e9bdf842a", size = 80330, upload-time = "2026-06-25T14:16:53.634Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/e2/b5dedc0cf35aa65de5f541ccd30d2bc1fd7f1d43c9ab09f8ed9a7342317b/httpx2-2.5.0.tar.gz", hash = "sha256:e2df9cb4611021527ff8a675b1c320b610a2ec397acc8d6fe6e91df2d9b33c29", size = 83121, upload-time = "2026-06-25T14:16:57.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/22/859d8252dad9bc9adee34b52e62cde621ece07b042ccb2ab4da1be46695f/httpx2-2.5.0-py3-none-any.whl", hash = "sha256:3d2d4d9cf4b61f1a1f46a95947cfdb47e80cb56a2f91c6256ac8f58e4891df41", size = 76652, upload-time = "2026-06-25T14:16:55.23Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -259,6 +297,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx2" },
     { name = "pytest" },
 ]
 
@@ -266,7 +305,19 @@ dev = [
 requires-dist = [{ name = "fastapi", specifier = "==0.138.1" }]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = "==9.1.1" }]
+dev = [
+    { name = "httpx2", specifier = ">=2.5.0" },
+    { name = "pytest", specifier = "==9.1.1" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
 
 [[package]]
 name = "typing-extensions"


### PR DESCRIPTION
## Summary
- Move Python service FastAPI app creation into explicit api modules while preserving public create_app, health, and profile imports.
- Add standardized /health, /live, /ready, and /metadata endpoints with request/correlation ID middleware.
- Add opt-in no-op tracing seam and runtime tests for all scoped Python services.

## Validation
- cd services/fare-pricing && uv run python -m unittest discover -s tests
- cd services/trip-planning && uv run python -m unittest discover -s tests
- cd services/risk-compliance && uv run python -m unittest discover -s tests
- cd services/reporting && uv run python -m unittest discover -s tests
- cd services/disruption-recovery && uv run python -m unittest discover -s tests
- cd services/transfer-management && uv run python -m unittest discover -s tests
- make check