### PR TITLE
STAB-012 Standardize TypeScript service runtime framework

### DIFF
--- a/services/README.md
+++ b/services/README.md
@@ -47,13 +47,15 @@ The root `service-catalog.json` is the machine-readable source of this table.
 
 ## TypeScript Operational Foundation
 
-TypeScript services expose app construction separately from service/domain exports. The shared skeleton contract is intentionally small:
+TypeScript services expose app construction, bootstrap defaults, service profile metadata, and domain exports separately. The shared skeleton contract is intentionally small:
 
 - `createApp()` returns a Fastify instance without opening a socket.
-- `/health` remains the compatibility health endpoint.
-- `/livez` and `/readyz` expose the same current skeleton readiness status.
+- `bootstrap()` applies environment/default host and port settings for runtime startup.
+- `/health` remains the compatibility health endpoint and includes the service profile.
+- `/live`, `/livez`, `/ready`, and `/readyz` expose the current skeleton probe status.
+- `/metadata` exposes service profile metadata and the observability contract.
 - `x-request-id` is propagated when supplied, generated otherwise, and returned on every response.
 - `x-correlation-id` is propagated when supplied and otherwise defaults to the request id.
 - Missing routes and unhandled errors use `{ "error": { "code", "message", "requestId", "correlationId" } }`.
 
-Instrumentation is a seam, not a dependency, in this slice: `createApp({ onRequest })` lets future OpenTelemetry wiring observe request/correlation ids without adding heavy OTel packages to skeleton services.
+Instrumentation is a seam, not a dependency, in this slice: `createApp({ onRequest, startSpan })` lets future OpenTelemetry wiring observe request/correlation ids and span completion without adding heavy OTel packages to skeleton services. The default is no-op and requires no external infrastructure in tests.

--- a/services/account/src/app.test.ts
+++ b/services/account/src/app.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from "node:test";
 import { createApp } from "./index.js";
 
 describe("account service operational foundation", () => {
-  it("serves health, liveness, and readiness with request correlation headers", async () => {
+  it("serves health, liveness, readiness, and metadata with request correlation headers", async () => {
     const app = createApp();
 
     const response = await app.inject({
@@ -19,11 +19,32 @@ describe("account service operational foundation", () => {
     assert.equal(response.statusCode, 200);
     assert.equal(response.headers["x-request-id"], "req-account-1");
     assert.equal(response.headers["x-correlation-id"], "corr-account-1");
-    assert.equal(response.json().status, "ok");
-    assert.equal(response.json().service.serviceId, "account");
+    assert.deepEqual(response.json(), { status: "ok", probe: "ready" });
 
-    assert.equal((await app.inject("/health")).statusCode, 200);
-    assert.equal((await app.inject("/livez")).statusCode, 200);
+    const health = await app.inject("/health");
+    assert.equal(health.statusCode, 200);
+    assert.equal(health.json().status, "ok");
+    assert.equal(health.json().service.serviceId, "account");
+
+    assert.deepEqual((await app.inject("/live")).json(), { status: "ok", probe: "live" });
+    assert.deepEqual((await app.inject("/livez")).json(), { status: "ok", probe: "live" });
+    assert.deepEqual((await app.inject("/ready")).json(), { status: "ok", probe: "ready" });
+
+    const metadata = await app.inject("/metadata");
+    assert.equal(metadata.statusCode, 200);
+    assert.equal(metadata.json().service.serviceId, "account");
+    assert.deepEqual(metadata.json().observability, { tracing: "opt-in", default: "noop" });
+  });
+
+  it("generates request and correlation ids when headers are absent", async () => {
+    const app = createApp();
+
+    const response = await app.inject("/livez");
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(typeof response.headers["x-request-id"], "string");
+    assert.notEqual(response.headers["x-request-id"], "");
+    assert.equal(response.headers["x-correlation-id"], response.headers["x-request-id"]);
   });
 
   it("returns the standard error envelope for missing routes", async () => {
@@ -44,5 +65,47 @@ describe("account service operational foundation", () => {
         correlationId: "req-account-404",
       },
     });
+  });
+
+  it("exposes a no-op-by-default opt-in tracing seam", async () => {
+    const seenRequests: Array<{ requestId: string; correlationId: string }> = [];
+    const endedSpans: Array<{ method: string; url: string; statusCode: number; requestId: string; correlationId: string }> = [];
+    const app = createApp({
+      onRequest: (context) => {
+        seenRequests.push(context);
+      },
+      startSpan: (context) => {
+        assert.equal(context.method, "GET");
+        assert.equal(context.url, "/health");
+        return {
+          end: (result) => {
+            endedSpans.push(result);
+          },
+        };
+      },
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/health",
+      headers: {
+        "x-request-id": "req-account-trace",
+        "x-correlation-id": "corr-account-trace",
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(seenRequests, [{ requestId: "req-account-trace", correlationId: "corr-account-trace" }]);
+    assert.deepEqual(endedSpans, [
+      {
+        method: "GET",
+        url: "/health",
+        statusCode: 200,
+        requestId: "req-account-trace",
+        correlationId: "corr-account-trace",
+      },
+    ]);
+
+    assert.equal((await createApp().inject("/health")).statusCode, 200);
   });
 });

--- a/services/account/src/app.ts
+++ b/services/account/src/app.ts
@@ -9,6 +9,19 @@ export type HealthStatus = Readonly<{
   service: typeof serviceProfile;
 }>;
 
+export type ProbeStatus = Readonly<{
+  status: "ok";
+  probe: "live" | "ready";
+}>;
+
+export type ServiceMetadata = Readonly<{
+  service: typeof serviceProfile;
+  observability: Readonly<{
+    tracing: "opt-in";
+    default: "noop";
+  }>;
+}>;
+
 export type ErrorEnvelope = Readonly<{
   error: Readonly<{
     code: string;
@@ -18,32 +31,74 @@ export type ErrorEnvelope = Readonly<{
   }>;
 }>;
 
-export type InstrumentationHooks = Readonly<{
-  onRequest?: (context: RequestContext) => void | Promise<void>;
-}>;
-
 export type RequestContext = Readonly<{
   requestId: string;
   correlationId: string;
+}>;
+
+export type RequestTraceContext = RequestContext &
+  Readonly<{
+    method: string;
+    url: string;
+  }>;
+
+export type TraceResult = RequestTraceContext &
+  Readonly<{
+    statusCode: number;
+  }>;
+
+export type TraceSpan = Readonly<{
+  end?: (result: TraceResult) => void | Promise<void>;
+}>;
+
+export type InstrumentationHooks = Readonly<{
+  onRequest?: (context: RequestContext) => void | Promise<void>;
+  startSpan?: (context: RequestTraceContext) => void | TraceSpan | Promise<void | TraceSpan>;
 }>;
 
 export function health(): "ok" {
   return "ok";
 }
 
+export function metadata(): ServiceMetadata {
+  return {
+    service: serviceProfile,
+    observability: {
+      tracing: "opt-in",
+      default: "noop",
+    },
+  };
+}
+
 export function createApp(instrumentation: InstrumentationHooks = {}): FastifyInstance {
   const app: FastifyInstance = Fastify({ logger: false });
+  const spans = new WeakMap<FastifyRequest, TraceSpan>();
 
   app.addHook("onRequest", async (request, reply) => {
     const context = requestContext(request);
     reply.header("x-request-id", context.requestId);
     reply.header("x-correlation-id", context.correlationId);
     await instrumentation.onRequest?.(context);
+
+    const span = await instrumentation.startSpan?.(traceContext(request, context));
+    if (span) {
+      spans.set(request, span);
+    }
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const span = spans.get(request);
+    spans.delete(request);
+    await span?.end?.({ ...traceContext(request), statusCode: reply.statusCode });
   });
 
   app.get("/health", async () => healthBody());
-  app.get("/livez", async () => healthBody());
-  app.get("/readyz", async () => healthBody());
+  app.get("/metadata", async () => metadata());
+
+  app.get("/live", async () => probeBody("live"));
+  app.get("/livez", async () => probeBody("live"));
+  app.get("/ready", async () => probeBody("ready"));
+  app.get("/readyz", async () => probeBody("ready"));
 
   app.setNotFoundHandler((request, reply) => {
     sendError(reply, 404, "NOT_FOUND", `Route ${request.method} ${request.url} was not found`, requestContext(request));
@@ -64,6 +119,17 @@ function healthBody(): HealthStatus {
   return { status: health(), service: serviceProfile };
 }
 
+function probeBody(probe: ProbeStatus["probe"]): ProbeStatus {
+  return { status: health(), probe };
+}
+
+function traceContext(request: AppRequest, context: RequestContext = requestContext(request)): RequestTraceContext {
+  return {
+    ...context,
+    method: request.method,
+    url: request.url,
+  };
+}
 
 function requestContext(request: AppRequest): RequestContext {
   const requestId = headerValue(request.headers["x-request-id"]) ?? request.id ?? randomUUID();

--- a/services/account/src/bootstrap.ts
+++ b/services/account/src/bootstrap.ts
@@ -1,0 +1,25 @@
+import { createApp, type InstrumentationHooks } from "./app.js";
+
+export type BootstrapOptions = Readonly<{
+  host?: string;
+  port?: number;
+  instrumentation?: InstrumentationHooks;
+}>;
+
+export function runtimeHost(options: Pick<BootstrapOptions, "host"> = {}): string {
+  return options.host ?? process.env.HOST ?? "0.0.0.0";
+}
+
+export function runtimePort(options: Pick<BootstrapOptions, "port"> = {}): number {
+  if (options.port !== undefined) {
+    return options.port;
+  }
+  const configured = Number.parseInt(process.env.PORT ?? "", 10);
+  return Number.isFinite(configured) ? configured : 8080;
+}
+
+export async function bootstrap(options: BootstrapOptions = {}) {
+  const app = createApp(options.instrumentation);
+  await app.listen({ host: runtimeHost(options), port: runtimePort(options) });
+  return app;
+}

--- a/services/account/src/index.ts
+++ b/services/account/src/index.ts
@@ -1,2 +1,16 @@
-export { createApp, health, type ErrorEnvelope, type HealthStatus, type InstrumentationHooks, type RequestContext } from "./app.js";
+export {
+  createApp,
+  health,
+  metadata,
+  type ErrorEnvelope,
+  type HealthStatus,
+  type InstrumentationHooks,
+  type ProbeStatus,
+  type RequestContext,
+  type RequestTraceContext,
+  type ServiceMetadata,
+  type TraceResult,
+  type TraceSpan,
+} from "./app.js";
+export { bootstrap, runtimeHost, runtimePort, type BootstrapOptions } from "./bootstrap.js";
 export { serviceProfile, type ServiceProfile } from "./profile.js";

--- a/services/ancillary-service/src/app.test.ts
+++ b/services/ancillary-service/src/app.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from "node:test";
 import { createApp } from "./index.js";
 
 describe("ancillary-service operational foundation", () => {
-  it("serves health, liveness, and readiness with request correlation headers", async () => {
+  it("serves health, liveness, readiness, and metadata with request correlation headers", async () => {
     const app = createApp();
 
     const response = await app.inject({
@@ -19,11 +19,32 @@ describe("ancillary-service operational foundation", () => {
     assert.equal(response.statusCode, 200);
     assert.equal(response.headers["x-request-id"], "req-ancillary-service-1");
     assert.equal(response.headers["x-correlation-id"], "corr-ancillary-service-1");
-    assert.equal(response.json().status, "ok");
-    assert.equal(response.json().service.serviceId, "ancillary-service");
+    assert.deepEqual(response.json(), { status: "ok", probe: "ready" });
 
-    assert.equal((await app.inject("/health")).statusCode, 200);
-    assert.equal((await app.inject("/livez")).statusCode, 200);
+    const health = await app.inject("/health");
+    assert.equal(health.statusCode, 200);
+    assert.equal(health.json().status, "ok");
+    assert.equal(health.json().service.serviceId, "ancillary-service");
+
+    assert.deepEqual((await app.inject("/live")).json(), { status: "ok", probe: "live" });
+    assert.deepEqual((await app.inject("/livez")).json(), { status: "ok", probe: "live" });
+    assert.deepEqual((await app.inject("/ready")).json(), { status: "ok", probe: "ready" });
+
+    const metadata = await app.inject("/metadata");
+    assert.equal(metadata.statusCode, 200);
+    assert.equal(metadata.json().service.serviceId, "ancillary-service");
+    assert.deepEqual(metadata.json().observability, { tracing: "opt-in", default: "noop" });
+  });
+
+  it("generates request and correlation ids when headers are absent", async () => {
+    const app = createApp();
+
+    const response = await app.inject("/livez");
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(typeof response.headers["x-request-id"], "string");
+    assert.notEqual(response.headers["x-request-id"], "");
+    assert.equal(response.headers["x-correlation-id"], response.headers["x-request-id"]);
   });
 
   it("returns the standard error envelope for missing routes", async () => {
@@ -44,5 +65,47 @@ describe("ancillary-service operational foundation", () => {
         correlationId: "req-ancillary-service-404",
       },
     });
+  });
+
+  it("exposes a no-op-by-default opt-in tracing seam", async () => {
+    const seenRequests: Array<{ requestId: string; correlationId: string }> = [];
+    const endedSpans: Array<{ method: string; url: string; statusCode: number; requestId: string; correlationId: string }> = [];
+    const app = createApp({
+      onRequest: (context) => {
+        seenRequests.push(context);
+      },
+      startSpan: (context) => {
+        assert.equal(context.method, "GET");
+        assert.equal(context.url, "/health");
+        return {
+          end: (result) => {
+            endedSpans.push(result);
+          },
+        };
+      },
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/health",
+      headers: {
+        "x-request-id": "req-ancillary-service-trace",
+        "x-correlation-id": "corr-ancillary-service-trace",
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(seenRequests, [{ requestId: "req-ancillary-service-trace", correlationId: "corr-ancillary-service-trace" }]);
+    assert.deepEqual(endedSpans, [
+      {
+        method: "GET",
+        url: "/health",
+        statusCode: 200,
+        requestId: "req-ancillary-service-trace",
+        correlationId: "corr-ancillary-service-trace",
+      },
+    ]);
+
+    assert.equal((await createApp().inject("/health")).statusCode, 200);
   });
 });

--- a/services/ancillary-service/src/app.ts
+++ b/services/ancillary-service/src/app.ts
@@ -9,6 +9,19 @@ export type HealthStatus = Readonly<{
   service: typeof serviceProfile;
 }>;
 
+export type ProbeStatus = Readonly<{
+  status: "ok";
+  probe: "live" | "ready";
+}>;
+
+export type ServiceMetadata = Readonly<{
+  service: typeof serviceProfile;
+  observability: Readonly<{
+    tracing: "opt-in";
+    default: "noop";
+  }>;
+}>;
+
 export type ErrorEnvelope = Readonly<{
   error: Readonly<{
     code: string;
@@ -18,32 +31,74 @@ export type ErrorEnvelope = Readonly<{
   }>;
 }>;
 
-export type InstrumentationHooks = Readonly<{
-  onRequest?: (context: RequestContext) => void | Promise<void>;
-}>;
-
 export type RequestContext = Readonly<{
   requestId: string;
   correlationId: string;
+}>;
+
+export type RequestTraceContext = RequestContext &
+  Readonly<{
+    method: string;
+    url: string;
+  }>;
+
+export type TraceResult = RequestTraceContext &
+  Readonly<{
+    statusCode: number;
+  }>;
+
+export type TraceSpan = Readonly<{
+  end?: (result: TraceResult) => void | Promise<void>;
+}>;
+
+export type InstrumentationHooks = Readonly<{
+  onRequest?: (context: RequestContext) => void | Promise<void>;
+  startSpan?: (context: RequestTraceContext) => void | TraceSpan | Promise<void | TraceSpan>;
 }>;
 
 export function health(): "ok" {
   return "ok";
 }
 
+export function metadata(): ServiceMetadata {
+  return {
+    service: serviceProfile,
+    observability: {
+      tracing: "opt-in",
+      default: "noop",
+    },
+  };
+}
+
 export function createApp(instrumentation: InstrumentationHooks = {}): FastifyInstance {
   const app: FastifyInstance = Fastify({ logger: false });
+  const spans = new WeakMap<FastifyRequest, TraceSpan>();
 
   app.addHook("onRequest", async (request, reply) => {
     const context = requestContext(request);
     reply.header("x-request-id", context.requestId);
     reply.header("x-correlation-id", context.correlationId);
     await instrumentation.onRequest?.(context);
+
+    const span = await instrumentation.startSpan?.(traceContext(request, context));
+    if (span) {
+      spans.set(request, span);
+    }
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const span = spans.get(request);
+    spans.delete(request);
+    await span?.end?.({ ...traceContext(request), statusCode: reply.statusCode });
   });
 
   app.get("/health", async () => healthBody());
-  app.get("/livez", async () => healthBody());
-  app.get("/readyz", async () => healthBody());
+  app.get("/metadata", async () => metadata());
+
+  app.get("/live", async () => probeBody("live"));
+  app.get("/livez", async () => probeBody("live"));
+  app.get("/ready", async () => probeBody("ready"));
+  app.get("/readyz", async () => probeBody("ready"));
 
   app.setNotFoundHandler((request, reply) => {
     sendError(reply, 404, "NOT_FOUND", `Route ${request.method} ${request.url} was not found`, requestContext(request));
@@ -64,6 +119,17 @@ function healthBody(): HealthStatus {
   return { status: health(), service: serviceProfile };
 }
 
+function probeBody(probe: ProbeStatus["probe"]): ProbeStatus {
+  return { status: health(), probe };
+}
+
+function traceContext(request: AppRequest, context: RequestContext = requestContext(request)): RequestTraceContext {
+  return {
+    ...context,
+    method: request.method,
+    url: request.url,
+  };
+}
 
 function requestContext(request: AppRequest): RequestContext {
   const requestId = headerValue(request.headers["x-request-id"]) ?? request.id ?? randomUUID();

--- a/services/ancillary-service/src/bootstrap.ts
+++ b/services/ancillary-service/src/bootstrap.ts
@@ -1,0 +1,25 @@
+import { createApp, type InstrumentationHooks } from "./app.js";
+
+export type BootstrapOptions = Readonly<{
+  host?: string;
+  port?: number;
+  instrumentation?: InstrumentationHooks;
+}>;
+
+export function runtimeHost(options: Pick<BootstrapOptions, "host"> = {}): string {
+  return options.host ?? process.env.HOST ?? "0.0.0.0";
+}
+
+export function runtimePort(options: Pick<BootstrapOptions, "port"> = {}): number {
+  if (options.port !== undefined) {
+    return options.port;
+  }
+  const configured = Number.parseInt(process.env.PORT ?? "", 10);
+  return Number.isFinite(configured) ? configured : 8080;
+}
+
+export async function bootstrap(options: BootstrapOptions = {}) {
+  const app = createApp(options.instrumentation);
+  await app.listen({ host: runtimeHost(options), port: runtimePort(options) });
+  return app;
+}

--- a/services/ancillary-service/src/index.ts
+++ b/services/ancillary-service/src/index.ts
@@ -1,2 +1,16 @@
-export { createApp, health, type ErrorEnvelope, type HealthStatus, type InstrumentationHooks, type RequestContext } from "./app.js";
+export {
+  createApp,
+  health,
+  metadata,
+  type ErrorEnvelope,
+  type HealthStatus,
+  type InstrumentationHooks,
+  type ProbeStatus,
+  type RequestContext,
+  type RequestTraceContext,
+  type ServiceMetadata,
+  type TraceResult,
+  type TraceSpan,
+} from "./app.js";
+export { bootstrap, runtimeHost, runtimePort, type BootstrapOptions } from "./bootstrap.js";
 export { serviceProfile, type ServiceProfile } from "./profile.js";

--- a/services/customer-service/src/app.test.ts
+++ b/services/customer-service/src/app.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from "node:test";
 import { createApp } from "./index.js";
 
 describe("customer-service operational foundation", () => {
-  it("serves health, liveness, and readiness with request correlation headers", async () => {
+  it("serves health, liveness, readiness, and metadata with request correlation headers", async () => {
     const app = createApp();
 
     const response = await app.inject({
@@ -19,11 +19,32 @@ describe("customer-service operational foundation", () => {
     assert.equal(response.statusCode, 200);
     assert.equal(response.headers["x-request-id"], "req-customer-service-1");
     assert.equal(response.headers["x-correlation-id"], "corr-customer-service-1");
-    assert.equal(response.json().status, "ok");
-    assert.equal(response.json().service.serviceId, "customer-service");
+    assert.deepEqual(response.json(), { status: "ok", probe: "ready" });
 
-    assert.equal((await app.inject("/health")).statusCode, 200);
-    assert.equal((await app.inject("/livez")).statusCode, 200);
+    const health = await app.inject("/health");
+    assert.equal(health.statusCode, 200);
+    assert.equal(health.json().status, "ok");
+    assert.equal(health.json().service.serviceId, "customer-service");
+
+    assert.deepEqual((await app.inject("/live")).json(), { status: "ok", probe: "live" });
+    assert.deepEqual((await app.inject("/livez")).json(), { status: "ok", probe: "live" });
+    assert.deepEqual((await app.inject("/ready")).json(), { status: "ok", probe: "ready" });
+
+    const metadata = await app.inject("/metadata");
+    assert.equal(metadata.statusCode, 200);
+    assert.equal(metadata.json().service.serviceId, "customer-service");
+    assert.deepEqual(metadata.json().observability, { tracing: "opt-in", default: "noop" });
+  });
+
+  it("generates request and correlation ids when headers are absent", async () => {
+    const app = createApp();
+
+    const response = await app.inject("/livez");
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(typeof response.headers["x-request-id"], "string");
+    assert.notEqual(response.headers["x-request-id"], "");
+    assert.equal(response.headers["x-correlation-id"], response.headers["x-request-id"]);
   });
 
   it("returns the standard error envelope for missing routes", async () => {
@@ -44,5 +65,47 @@ describe("customer-service operational foundation", () => {
         correlationId: "req-customer-service-404",
       },
     });
+  });
+
+  it("exposes a no-op-by-default opt-in tracing seam", async () => {
+    const seenRequests: Array<{ requestId: string; correlationId: string }> = [];
+    const endedSpans: Array<{ method: string; url: string; statusCode: number; requestId: string; correlationId: string }> = [];
+    const app = createApp({
+      onRequest: (context) => {
+        seenRequests.push(context);
+      },
+      startSpan: (context) => {
+        assert.equal(context.method, "GET");
+        assert.equal(context.url, "/health");
+        return {
+          end: (result) => {
+            endedSpans.push(result);
+          },
+        };
+      },
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/health",
+      headers: {
+        "x-request-id": "req-customer-service-trace",
+        "x-correlation-id": "corr-customer-service-trace",
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(seenRequests, [{ requestId: "req-customer-service-trace", correlationId: "corr-customer-service-trace" }]);
+    assert.deepEqual(endedSpans, [
+      {
+        method: "GET",
+        url: "/health",
+        statusCode: 200,
+        requestId: "req-customer-service-trace",
+        correlationId: "corr-customer-service-trace",
+      },
+    ]);
+
+    assert.equal((await createApp().inject("/health")).statusCode, 200);
   });
 });

--- a/services/customer-service/src/app.ts
+++ b/services/customer-service/src/app.ts
@@ -9,6 +9,19 @@ export type HealthStatus = Readonly<{
   service: typeof serviceProfile;
 }>;
 
+export type ProbeStatus = Readonly<{
+  status: "ok";
+  probe: "live" | "ready";
+}>;
+
+export type ServiceMetadata = Readonly<{
+  service: typeof serviceProfile;
+  observability: Readonly<{
+    tracing: "opt-in";
+    default: "noop";
+  }>;
+}>;
+
 export type ErrorEnvelope = Readonly<{
   error: Readonly<{
     code: string;
@@ -18,32 +31,74 @@ export type ErrorEnvelope = Readonly<{
   }>;
 }>;
 
-export type InstrumentationHooks = Readonly<{
-  onRequest?: (context: RequestContext) => void | Promise<void>;
-}>;
-
 export type RequestContext = Readonly<{
   requestId: string;
   correlationId: string;
+}>;
+
+export type RequestTraceContext = RequestContext &
+  Readonly<{
+    method: string;
+    url: string;
+  }>;
+
+export type TraceResult = RequestTraceContext &
+  Readonly<{
+    statusCode: number;
+  }>;
+
+export type TraceSpan = Readonly<{
+  end?: (result: TraceResult) => void | Promise<void>;
+}>;
+
+export type InstrumentationHooks = Readonly<{
+  onRequest?: (context: RequestContext) => void | Promise<void>;
+  startSpan?: (context: RequestTraceContext) => void | TraceSpan | Promise<void | TraceSpan>;
 }>;
 
 export function health(): "ok" {
   return "ok";
 }
 
+export function metadata(): ServiceMetadata {
+  return {
+    service: serviceProfile,
+    observability: {
+      tracing: "opt-in",
+      default: "noop",
+    },
+  };
+}
+
 export function createApp(instrumentation: InstrumentationHooks = {}): FastifyInstance {
   const app: FastifyInstance = Fastify({ logger: false });
+  const spans = new WeakMap<FastifyRequest, TraceSpan>();
 
   app.addHook("onRequest", async (request, reply) => {
     const context = requestContext(request);
     reply.header("x-request-id", context.requestId);
     reply.header("x-correlation-id", context.correlationId);
     await instrumentation.onRequest?.(context);
+
+    const span = await instrumentation.startSpan?.(traceContext(request, context));
+    if (span) {
+      spans.set(request, span);
+    }
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const span = spans.get(request);
+    spans.delete(request);
+    await span?.end?.({ ...traceContext(request), statusCode: reply.statusCode });
   });
 
   app.get("/health", async () => healthBody());
-  app.get("/livez", async () => healthBody());
-  app.get("/readyz", async () => healthBody());
+  app.get("/metadata", async () => metadata());
+
+  app.get("/live", async () => probeBody("live"));
+  app.get("/livez", async () => probeBody("live"));
+  app.get("/ready", async () => probeBody("ready"));
+  app.get("/readyz", async () => probeBody("ready"));
 
   app.setNotFoundHandler((request, reply) => {
     sendError(reply, 404, "NOT_FOUND", `Route ${request.method} ${request.url} was not found`, requestContext(request));
@@ -64,6 +119,17 @@ function healthBody(): HealthStatus {
   return { status: health(), service: serviceProfile };
 }
 
+function probeBody(probe: ProbeStatus["probe"]): ProbeStatus {
+  return { status: health(), probe };
+}
+
+function traceContext(request: AppRequest, context: RequestContext = requestContext(request)): RequestTraceContext {
+  return {
+    ...context,
+    method: request.method,
+    url: request.url,
+  };
+}
 
 function requestContext(request: AppRequest): RequestContext {
   const requestId = headerValue(request.headers["x-request-id"]) ?? request.id ?? randomUUID();

--- a/services/customer-service/src/bootstrap.ts
+++ b/services/customer-service/src/bootstrap.ts
@@ -1,0 +1,25 @@
+import { createApp, type InstrumentationHooks } from "./app.js";
+
+export type BootstrapOptions = Readonly<{
+  host?: string;
+  port?: number;
+  instrumentation?: InstrumentationHooks;
+}>;
+
+export function runtimeHost(options: Pick<BootstrapOptions, "host"> = {}): string {
+  return options.host ?? process.env.HOST ?? "0.0.0.0";
+}
+
+export function runtimePort(options: Pick<BootstrapOptions, "port"> = {}): number {
+  if (options.port !== undefined) {
+    return options.port;
+  }
+  const configured = Number.parseInt(process.env.PORT ?? "", 10);
+  return Number.isFinite(configured) ? configured : 8080;
+}
+
+export async function bootstrap(options: BootstrapOptions = {}) {
+  const app = createApp(options.instrumentation);
+  await app.listen({ host: runtimeHost(options), port: runtimePort(options) });
+  return app;
+}

--- a/services/customer-service/src/index.ts
+++ b/services/customer-service/src/index.ts
@@ -1,2 +1,16 @@
-export { createApp, health, type ErrorEnvelope, type HealthStatus, type InstrumentationHooks, type RequestContext } from "./app.js";
+export {
+  createApp,
+  health,
+  metadata,
+  type ErrorEnvelope,
+  type HealthStatus,
+  type InstrumentationHooks,
+  type ProbeStatus,
+  type RequestContext,
+  type RequestTraceContext,
+  type ServiceMetadata,
+  type TraceResult,
+  type TraceSpan,
+} from "./app.js";
+export { bootstrap, runtimeHost, runtimePort, type BootstrapOptions } from "./bootstrap.js";
 export { serviceProfile, type ServiceProfile } from "./profile.js";

--- a/services/notification/src/app.test.ts
+++ b/services/notification/src/app.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from "node:test";
 import { createApp } from "./index.js";
 
 describe("notification service operational foundation", () => {
-  it("serves health, liveness, and readiness with request correlation headers", async () => {
+  it("serves health, liveness, readiness, and metadata with request correlation headers", async () => {
     const app = createApp();
 
     const response = await app.inject({
@@ -19,11 +19,32 @@ describe("notification service operational foundation", () => {
     assert.equal(response.statusCode, 200);
     assert.equal(response.headers["x-request-id"], "req-notification-1");
     assert.equal(response.headers["x-correlation-id"], "corr-notification-1");
-    assert.equal(response.json().status, "ok");
-    assert.equal(response.json().service.serviceId, "notification");
+    assert.deepEqual(response.json(), { status: "ok", probe: "ready" });
 
-    assert.equal((await app.inject("/health")).statusCode, 200);
-    assert.equal((await app.inject("/livez")).statusCode, 200);
+    const health = await app.inject("/health");
+    assert.equal(health.statusCode, 200);
+    assert.equal(health.json().status, "ok");
+    assert.equal(health.json().service.serviceId, "notification");
+
+    assert.deepEqual((await app.inject("/live")).json(), { status: "ok", probe: "live" });
+    assert.deepEqual((await app.inject("/livez")).json(), { status: "ok", probe: "live" });
+    assert.deepEqual((await app.inject("/ready")).json(), { status: "ok", probe: "ready" });
+
+    const metadata = await app.inject("/metadata");
+    assert.equal(metadata.statusCode, 200);
+    assert.equal(metadata.json().service.serviceId, "notification");
+    assert.deepEqual(metadata.json().observability, { tracing: "opt-in", default: "noop" });
+  });
+
+  it("generates request and correlation ids when headers are absent", async () => {
+    const app = createApp();
+
+    const response = await app.inject("/livez");
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(typeof response.headers["x-request-id"], "string");
+    assert.notEqual(response.headers["x-request-id"], "");
+    assert.equal(response.headers["x-correlation-id"], response.headers["x-request-id"]);
   });
 
   it("returns the standard error envelope for missing routes", async () => {
@@ -44,5 +65,47 @@ describe("notification service operational foundation", () => {
         correlationId: "req-notification-404",
       },
     });
+  });
+
+  it("exposes a no-op-by-default opt-in tracing seam", async () => {
+    const seenRequests: Array<{ requestId: string; correlationId: string }> = [];
+    const endedSpans: Array<{ method: string; url: string; statusCode: number; requestId: string; correlationId: string }> = [];
+    const app = createApp({
+      onRequest: (context) => {
+        seenRequests.push(context);
+      },
+      startSpan: (context) => {
+        assert.equal(context.method, "GET");
+        assert.equal(context.url, "/health");
+        return {
+          end: (result) => {
+            endedSpans.push(result);
+          },
+        };
+      },
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/health",
+      headers: {
+        "x-request-id": "req-notification-trace",
+        "x-correlation-id": "corr-notification-trace",
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(seenRequests, [{ requestId: "req-notification-trace", correlationId: "corr-notification-trace" }]);
+    assert.deepEqual(endedSpans, [
+      {
+        method: "GET",
+        url: "/health",
+        statusCode: 200,
+        requestId: "req-notification-trace",
+        correlationId: "corr-notification-trace",
+      },
+    ]);
+
+    assert.equal((await createApp().inject("/health")).statusCode, 200);
   });
 });

--- a/services/notification/src/app.ts
+++ b/services/notification/src/app.ts
@@ -9,6 +9,19 @@ export type HealthStatus = Readonly<{
   service: typeof serviceProfile;
 }>;
 
+export type ProbeStatus = Readonly<{
+  status: "ok";
+  probe: "live" | "ready";
+}>;
+
+export type ServiceMetadata = Readonly<{
+  service: typeof serviceProfile;
+  observability: Readonly<{
+    tracing: "opt-in";
+    default: "noop";
+  }>;
+}>;
+
 export type ErrorEnvelope = Readonly<{
   error: Readonly<{
     code: string;
@@ -18,32 +31,74 @@ export type ErrorEnvelope = Readonly<{
   }>;
 }>;
 
-export type InstrumentationHooks = Readonly<{
-  onRequest?: (context: RequestContext) => void | Promise<void>;
-}>;
-
 export type RequestContext = Readonly<{
   requestId: string;
   correlationId: string;
+}>;
+
+export type RequestTraceContext = RequestContext &
+  Readonly<{
+    method: string;
+    url: string;
+  }>;
+
+export type TraceResult = RequestTraceContext &
+  Readonly<{
+    statusCode: number;
+  }>;
+
+export type TraceSpan = Readonly<{
+  end?: (result: TraceResult) => void | Promise<void>;
+}>;
+
+export type InstrumentationHooks = Readonly<{
+  onRequest?: (context: RequestContext) => void | Promise<void>;
+  startSpan?: (context: RequestTraceContext) => void | TraceSpan | Promise<void | TraceSpan>;
 }>;
 
 export function health(): "ok" {
   return "ok";
 }
 
+export function metadata(): ServiceMetadata {
+  return {
+    service: serviceProfile,
+    observability: {
+      tracing: "opt-in",
+      default: "noop",
+    },
+  };
+}
+
 export function createApp(instrumentation: InstrumentationHooks = {}): FastifyInstance {
   const app: FastifyInstance = Fastify({ logger: false });
+  const spans = new WeakMap<FastifyRequest, TraceSpan>();
 
   app.addHook("onRequest", async (request, reply) => {
     const context = requestContext(request);
     reply.header("x-request-id", context.requestId);
     reply.header("x-correlation-id", context.correlationId);
     await instrumentation.onRequest?.(context);
+
+    const span = await instrumentation.startSpan?.(traceContext(request, context));
+    if (span) {
+      spans.set(request, span);
+    }
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const span = spans.get(request);
+    spans.delete(request);
+    await span?.end?.({ ...traceContext(request), statusCode: reply.statusCode });
   });
 
   app.get("/health", async () => healthBody());
-  app.get("/livez", async () => healthBody());
-  app.get("/readyz", async () => healthBody());
+  app.get("/metadata", async () => metadata());
+
+  app.get("/live", async () => probeBody("live"));
+  app.get("/livez", async () => probeBody("live"));
+  app.get("/ready", async () => probeBody("ready"));
+  app.get("/readyz", async () => probeBody("ready"));
 
   app.setNotFoundHandler((request, reply) => {
     sendError(reply, 404, "NOT_FOUND", `Route ${request.method} ${request.url} was not found`, requestContext(request));
@@ -64,6 +119,17 @@ function healthBody(): HealthStatus {
   return { status: health(), service: serviceProfile };
 }
 
+function probeBody(probe: ProbeStatus["probe"]): ProbeStatus {
+  return { status: health(), probe };
+}
+
+function traceContext(request: AppRequest, context: RequestContext = requestContext(request)): RequestTraceContext {
+  return {
+    ...context,
+    method: request.method,
+    url: request.url,
+  };
+}
 
 function requestContext(request: AppRequest): RequestContext {
   const requestId = headerValue(request.headers["x-request-id"]) ?? request.id ?? randomUUID();

--- a/services/notification/src/bootstrap.ts
+++ b/services/notification/src/bootstrap.ts
@@ -1,0 +1,25 @@
+import { createApp, type InstrumentationHooks } from "./app.js";
+
+export type BootstrapOptions = Readonly<{
+  host?: string;
+  port?: number;
+  instrumentation?: InstrumentationHooks;
+}>;
+
+export function runtimeHost(options: Pick<BootstrapOptions, "host"> = {}): string {
+  return options.host ?? process.env.HOST ?? "0.0.0.0";
+}
+
+export function runtimePort(options: Pick<BootstrapOptions, "port"> = {}): number {
+  if (options.port !== undefined) {
+    return options.port;
+  }
+  const configured = Number.parseInt(process.env.PORT ?? "", 10);
+  return Number.isFinite(configured) ? configured : 8080;
+}
+
+export async function bootstrap(options: BootstrapOptions = {}) {
+  const app = createApp(options.instrumentation);
+  await app.listen({ host: runtimeHost(options), port: runtimePort(options) });
+  return app;
+}

--- a/services/notification/src/index.ts
+++ b/services/notification/src/index.ts
@@ -1,2 +1,16 @@
-export { createApp, health, type ErrorEnvelope, type HealthStatus, type InstrumentationHooks, type RequestContext } from "./app.js";
+export {
+  createApp,
+  health,
+  metadata,
+  type ErrorEnvelope,
+  type HealthStatus,
+  type InstrumentationHooks,
+  type ProbeStatus,
+  type RequestContext,
+  type RequestTraceContext,
+  type ServiceMetadata,
+  type TraceResult,
+  type TraceSpan,
+} from "./app.js";
+export { bootstrap, runtimeHost, runtimePort, type BootstrapOptions } from "./bootstrap.js";
 export { serviceProfile, type ServiceProfile } from "./profile.js";

--- a/services/offer-management/src/app.test.ts
+++ b/services/offer-management/src/app.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from "node:test";
 import { createApp } from "./index.js";
 
 describe("offer-management service operational foundation", () => {
-  it("serves health, liveness, and readiness with request correlation headers", async () => {
+  it("serves health, liveness, readiness, and metadata with request correlation headers", async () => {
     const app = createApp();
 
     const response = await app.inject({
@@ -19,11 +19,32 @@ describe("offer-management service operational foundation", () => {
     assert.equal(response.statusCode, 200);
     assert.equal(response.headers["x-request-id"], "req-offer-management-1");
     assert.equal(response.headers["x-correlation-id"], "corr-offer-management-1");
-    assert.equal(response.json().status, "ok");
-    assert.equal(response.json().service.serviceId, "offer-management");
+    assert.deepEqual(response.json(), { status: "ok", probe: "ready" });
 
-    assert.equal((await app.inject("/health")).statusCode, 200);
-    assert.equal((await app.inject("/livez")).statusCode, 200);
+    const health = await app.inject("/health");
+    assert.equal(health.statusCode, 200);
+    assert.equal(health.json().status, "ok");
+    assert.equal(health.json().service.serviceId, "offer-management");
+
+    assert.deepEqual((await app.inject("/live")).json(), { status: "ok", probe: "live" });
+    assert.deepEqual((await app.inject("/livez")).json(), { status: "ok", probe: "live" });
+    assert.deepEqual((await app.inject("/ready")).json(), { status: "ok", probe: "ready" });
+
+    const metadata = await app.inject("/metadata");
+    assert.equal(metadata.statusCode, 200);
+    assert.equal(metadata.json().service.serviceId, "offer-management");
+    assert.deepEqual(metadata.json().observability, { tracing: "opt-in", default: "noop" });
+  });
+
+  it("generates request and correlation ids when headers are absent", async () => {
+    const app = createApp();
+
+    const response = await app.inject("/livez");
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(typeof response.headers["x-request-id"], "string");
+    assert.notEqual(response.headers["x-request-id"], "");
+    assert.equal(response.headers["x-correlation-id"], response.headers["x-request-id"]);
   });
 
   it("returns the standard error envelope for missing routes", async () => {
@@ -44,5 +65,47 @@ describe("offer-management service operational foundation", () => {
         correlationId: "req-offer-management-404",
       },
     });
+  });
+
+  it("exposes a no-op-by-default opt-in tracing seam", async () => {
+    const seenRequests: Array<{ requestId: string; correlationId: string }> = [];
+    const endedSpans: Array<{ method: string; url: string; statusCode: number; requestId: string; correlationId: string }> = [];
+    const app = createApp({
+      onRequest: (context) => {
+        seenRequests.push(context);
+      },
+      startSpan: (context) => {
+        assert.equal(context.method, "GET");
+        assert.equal(context.url, "/health");
+        return {
+          end: (result) => {
+            endedSpans.push(result);
+          },
+        };
+      },
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/health",
+      headers: {
+        "x-request-id": "req-offer-management-trace",
+        "x-correlation-id": "corr-offer-management-trace",
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(seenRequests, [{ requestId: "req-offer-management-trace", correlationId: "corr-offer-management-trace" }]);
+    assert.deepEqual(endedSpans, [
+      {
+        method: "GET",
+        url: "/health",
+        statusCode: 200,
+        requestId: "req-offer-management-trace",
+        correlationId: "corr-offer-management-trace",
+      },
+    ]);
+
+    assert.equal((await createApp().inject("/health")).statusCode, 200);
   });
 });

--- a/services/offer-management/src/app.ts
+++ b/services/offer-management/src/app.ts
@@ -9,6 +9,19 @@ export type HealthStatus = Readonly<{
   service: typeof serviceProfile;
 }>;
 
+export type ProbeStatus = Readonly<{
+  status: "ok";
+  probe: "live" | "ready";
+}>;
+
+export type ServiceMetadata = Readonly<{
+  service: typeof serviceProfile;
+  observability: Readonly<{
+    tracing: "opt-in";
+    default: "noop";
+  }>;
+}>;
+
 export type ErrorEnvelope = Readonly<{
   error: Readonly<{
     code: string;
@@ -18,32 +31,74 @@ export type ErrorEnvelope = Readonly<{
   }>;
 }>;
 
-export type InstrumentationHooks = Readonly<{
-  onRequest?: (context: RequestContext) => void | Promise<void>;
-}>;
-
 export type RequestContext = Readonly<{
   requestId: string;
   correlationId: string;
+}>;
+
+export type RequestTraceContext = RequestContext &
+  Readonly<{
+    method: string;
+    url: string;
+  }>;
+
+export type TraceResult = RequestTraceContext &
+  Readonly<{
+    statusCode: number;
+  }>;
+
+export type TraceSpan = Readonly<{
+  end?: (result: TraceResult) => void | Promise<void>;
+}>;
+
+export type InstrumentationHooks = Readonly<{
+  onRequest?: (context: RequestContext) => void | Promise<void>;
+  startSpan?: (context: RequestTraceContext) => void | TraceSpan | Promise<void | TraceSpan>;
 }>;
 
 export function health(): "ok" {
   return "ok";
 }
 
+export function metadata(): ServiceMetadata {
+  return {
+    service: serviceProfile,
+    observability: {
+      tracing: "opt-in",
+      default: "noop",
+    },
+  };
+}
+
 export function createApp(instrumentation: InstrumentationHooks = {}): FastifyInstance {
   const app: FastifyInstance = Fastify({ logger: false });
+  const spans = new WeakMap<FastifyRequest, TraceSpan>();
 
   app.addHook("onRequest", async (request, reply) => {
     const context = requestContext(request);
     reply.header("x-request-id", context.requestId);
     reply.header("x-correlation-id", context.correlationId);
     await instrumentation.onRequest?.(context);
+
+    const span = await instrumentation.startSpan?.(traceContext(request, context));
+    if (span) {
+      spans.set(request, span);
+    }
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const span = spans.get(request);
+    spans.delete(request);
+    await span?.end?.({ ...traceContext(request), statusCode: reply.statusCode });
   });
 
   app.get("/health", async () => healthBody());
-  app.get("/livez", async () => healthBody());
-  app.get("/readyz", async () => healthBody());
+  app.get("/metadata", async () => metadata());
+
+  app.get("/live", async () => probeBody("live"));
+  app.get("/livez", async () => probeBody("live"));
+  app.get("/ready", async () => probeBody("ready"));
+  app.get("/readyz", async () => probeBody("ready"));
 
   app.setNotFoundHandler((request, reply) => {
     sendError(reply, 404, "NOT_FOUND", `Route ${request.method} ${request.url} was not found`, requestContext(request));
@@ -64,6 +119,17 @@ function healthBody(): HealthStatus {
   return { status: health(), service: serviceProfile };
 }
 
+function probeBody(probe: ProbeStatus["probe"]): ProbeStatus {
+  return { status: health(), probe };
+}
+
+function traceContext(request: AppRequest, context: RequestContext = requestContext(request)): RequestTraceContext {
+  return {
+    ...context,
+    method: request.method,
+    url: request.url,
+  };
+}
 
 function requestContext(request: AppRequest): RequestContext {
   const requestId = headerValue(request.headers["x-request-id"]) ?? request.id ?? randomUUID();

--- a/services/offer-management/src/bootstrap.ts
+++ b/services/offer-management/src/bootstrap.ts
@@ -1,0 +1,25 @@
+import { createApp, type InstrumentationHooks } from "./app.js";
+
+export type BootstrapOptions = Readonly<{
+  host?: string;
+  port?: number;
+  instrumentation?: InstrumentationHooks;
+}>;
+
+export function runtimeHost(options: Pick<BootstrapOptions, "host"> = {}): string {
+  return options.host ?? process.env.HOST ?? "0.0.0.0";
+}
+
+export function runtimePort(options: Pick<BootstrapOptions, "port"> = {}): number {
+  if (options.port !== undefined) {
+    return options.port;
+  }
+  const configured = Number.parseInt(process.env.PORT ?? "", 10);
+  return Number.isFinite(configured) ? configured : 8080;
+}
+
+export async function bootstrap(options: BootstrapOptions = {}) {
+  const app = createApp(options.instrumentation);
+  await app.listen({ host: runtimeHost(options), port: runtimePort(options) });
+  return app;
+}

--- a/services/offer-management/src/index.ts
+++ b/services/offer-management/src/index.ts
@@ -1,4 +1,18 @@
-export { createApp, health, type ErrorEnvelope, type HealthStatus, type InstrumentationHooks, type RequestContext } from "./app.js";
+export {
+  createApp,
+  health,
+  metadata,
+  type ErrorEnvelope,
+  type HealthStatus,
+  type InstrumentationHooks,
+  type ProbeStatus,
+  type RequestContext,
+  type RequestTraceContext,
+  type ServiceMetadata,
+  type TraceResult,
+  type TraceSpan,
+} from "./app.js";
+export { bootstrap, runtimeHost, runtimePort, type BootstrapOptions } from "./bootstrap.js";
 export {
   DomainError,
   Offer,


### PR DESCRIPTION
## Summary
- Standardize TypeScript Fastify runtime endpoints across account, ancillary-service, customer-service, notification, and offer-management
- Add bootstrap separation and no-op-by-default tracing seam
- Extend tests for metadata, live/ready aliases, generated/propagated request IDs, error envelopes, and tracing hooks

## Validation
- cd services/account && npm test
- cd services/ancillary-service && npm test
- cd services/customer-service && npm test
- cd services/notification && npm test
- cd services/offer-management && npm test
- make check