### PR TITLE
STAB-015 OpenTelemetry runtime adapter baseline

### DIFF
--- a/docs/07-observability/README.md
+++ b/docs/07-observability/README.md
@@ -66,20 +66,38 @@ OTEL_LOGS_EXPORTER=otlp
 Inside a compose network, use `http://otel-collector:4318` for
 `OTEL_EXPORTER_OTLP_ENDPOINT`.
 
-## Runtime Seams
+## Runtime Adapters
 
-Language runtime baselines keep OpenTelemetry optional by default:
+Language runtime baselines keep OpenTelemetry optional by default and now include
+OpenTelemetry API adapters that bind to the existing runtime seams:
 
-- Go services use `platform/go-runtime` middleware for request and correlation
-  identifiers plus an observer hook.
-- Python FastAPI services expose a `tracer` hook on `create_app`.
-- TypeScript Fastify services expose `createApp({ onRequest, startSpan })`.
-- Java Spring services expose `RuntimeTracer` with a default no-op bean.
-- Rust Axum-compatible modules expose the shared-kernel observer seam.
+- Go services call `goruntime.ObserverFromEnv(serviceID)`. It returns the no-op
+  observer unless `OTEL_TRACES_EXPORTER` is set to a value other than `none`;
+  when enabled it starts server spans with the global OpenTelemetry tracer.
+- Python FastAPI services accept an optional `otel_tracer` on `create_app()` and
+  can discover `opentelemetry.trace.get_tracer()` from `OTEL_TRACES_EXPORTER`
+  when the optional OpenTelemetry API package is installed.
+- TypeScript Fastify services export `opentelemetryInstrumentationFromEnv()` to
+  adapt an OpenTelemetry API tracer to `createApp({ startSpan })`; without an
+  injected tracer or enabled exporter it returns empty hooks.
+- Java Spring services provide `OpenTelemetryRuntimeTracer`, activated only when
+  `otel.traces.exporter=otlp` / `OTEL_TRACES_EXPORTER=otlp` is selected;
+  `NoOpRuntimeTracer` remains the default bean.
+- Rust Axum-compatible modules use `OpenTelemetryObserver::from_env(service_id)`
+  from `platform/shared-kernel-rust`, returning `NoopObserver` unless tracing is
+  explicitly enabled.
 
-Tests use the no-op/default path or in-memory recording adapters. Real
-OpenTelemetry SDK adapters should bind to these seams and export OTLP to the
-collector using the environment contract above.
+The adapters use only OpenTelemetry API surfaces in the runtime baseline. A
+service deployment that needs real export must install/configure the language
+SDK and OTLP exporter in bootstrap or packaging, using the `OTEL_*` contract
+above. With no SDK provider installed, API spans are non-recording and tests do
+not require a collector.
+
+All HTTP server spans/events include service name where available, HTTP
+method/path/status, request ID, and correlation ID using stable attributes such
+as `service.name`, `http.request.method`, `url.path`,
+`http.response.status_code`, `http.request_id`, and `http.correlation_id` (with
+legacy `http.method` / `http.status_code` aliases during the baseline).
 
 ## Rules
 

--- a/platform/go-runtime/go.mod
+++ b/platform/go-runtime/go.mod
@@ -2,7 +2,11 @@ module github.com/trainticket/greenfield/platform/go-runtime
 
 go 1.26
 
-require github.com/gin-gonic/gin v1.12.0
+require (
+	github.com/gin-gonic/gin v1.12.0
+	go.opentelemetry.io/otel v1.38.0
+	go.opentelemetry.io/otel/trace v1.38.0
+)
 
 require (
 	github.com/bytedance/gopkg v0.1.3 // indirect
@@ -11,6 +15,8 @@ require (
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.30.1 // indirect
@@ -28,6 +34,8 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel/metric v1.38.0 // indirect
 	golang.org/x/arch v0.22.0 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/net v0.51.0 // indirect

--- a/platform/go-runtime/go.sum
+++ b/platform/go-runtime/go.sum
@@ -15,6 +15,11 @@ github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.12.0 h1:b3YAbrZtnf8N//yjKeU2+MQsh2mY5htkZidOM7O0wG8=
 github.com/gin-gonic/gin v1.12.0/go.mod h1:VxccKfsSllpKshkBWgVgRniFFAzFb9csfngsqANjnLc=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
+github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
@@ -68,6 +73,14 @@ github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
+go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
+go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
+go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=
+go.opentelemetry.io/otel v1.38.0/go.mod h1:zcmtmQ1+YmQM9wrNsTGV/q/uyusom3P8RxwExxkZhjM=
+go.opentelemetry.io/otel/metric v1.38.0 h1:Kl6lzIYGAh5M159u9NgiRkmoMKjvbsKtYRwgfrA6WpA=
+go.opentelemetry.io/otel/metric v1.38.0/go.mod h1:kB5n/QoRM8YwmUahxvI3bO34eVtQf2i4utNVLr9gEmI=
+go.opentelemetry.io/otel/trace v1.38.0 h1:Fxk5bKrDZJUH+AMyyIXGcFAPah0oRcT+LuNtJrmcNLE=
+go.opentelemetry.io/otel/trace v1.38.0/go.mod h1:j1P9ivuFsTceSWe1oY+EeW3sc+Pp42sO++GHkg4wwhs=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 golang.org/x/arch v0.22.0 h1:c/Zle32i5ttqRXjdLyyHZESLD/bB90DCU1g9l/0YBDI=

--- a/platform/go-runtime/runtime.go
+++ b/platform/go-runtime/runtime.go
@@ -8,10 +8,15 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -52,6 +57,97 @@ func (noopSpan) End(error) {}
 
 // NoopObserver is the default observer for tests and services that have not opted into tracing.
 func NoopObserver() Observer { return noopObserver{} }
+
+// OTelObserverConfig configures the OpenTelemetry API adapter. It intentionally
+// uses the global OpenTelemetry tracer provider so SDK/exporter setup remains an
+// opt-in bootstrap concern controlled by standard OTEL_* environment variables.
+type OTelObserverConfig struct {
+	ServiceName string
+	TracerName  string
+}
+
+type otelObserver struct {
+	serviceName string
+	tracer      trace.Tracer
+}
+
+type otelSpan struct{ span trace.Span }
+
+// NewOTelObserver adapts the runtime observer seam to the OpenTelemetry API.
+// Without an installed SDK provider, OpenTelemetry's global default provider is
+// non-recording, preserving no-op behavior and avoiding collector dependencies
+// in unit tests.
+func NewOTelObserver(config OTelObserverConfig) Observer {
+	tracerName := strings.TrimSpace(config.TracerName)
+	if tracerName == "" {
+		tracerName = "github.com/trainticket/greenfield/platform/go-runtime"
+	}
+	return otelObserver{serviceName: strings.TrimSpace(config.ServiceName), tracer: otel.Tracer(tracerName)}
+}
+
+// ObserverFromEnv returns an OpenTelemetry observer only when tracing is
+// explicitly selected. Set OTEL_TRACES_EXPORTER to any value other than "none"
+// and install an SDK/exporter in service bootstrap to emit OTLP using the
+// standard OTEL_EXPORTER_OTLP_* environment contract.
+func ObserverFromEnv(serviceName string) Observer {
+	if !otelTracingEnabled() {
+		return NoopObserver()
+	}
+	if strings.TrimSpace(serviceName) == "" {
+		serviceName = strings.TrimSpace(env("OTEL_SERVICE_NAME"))
+	}
+	return NewOTelObserver(OTelObserverConfig{ServiceName: serviceName})
+}
+
+func otelTracingEnabled() bool {
+	value := strings.TrimSpace(strings.ToLower(env("OTEL_TRACES_EXPORTER")))
+	return value != "" && value != "none"
+}
+
+var env = os.Getenv
+
+func (observer otelObserver) Start(ctx context.Context, operation string) (context.Context, Span) {
+	attrs := []attribute.KeyValue{
+		attribute.String("http.route", operation),
+		attribute.String("url.path", operation),
+		attribute.String("http.request_id", RequestID(ctx)),
+		attribute.String("http.correlation_id", CorrelationID(ctx)),
+	}
+	if observer.serviceName != "" {
+		attrs = append(attrs, attribute.String("service.name", observer.serviceName))
+	}
+	ctx, span := observer.tracer.Start(ctx, operation, trace.WithSpanKind(trace.SpanKindServer), trace.WithAttributes(attrs...))
+	return ctx, otelSpan{span: span}
+}
+
+func (span otelSpan) End(err error) {
+	if err != nil {
+		span.span.RecordError(err)
+		span.span.SetStatus(codes.Error, err.Error())
+	}
+	span.span.End()
+}
+
+// SetSpanHTTPAttributes enriches the active OpenTelemetry span, when one is
+// recording, with the HTTP dimensions required by the runtime baseline.
+func SetSpanHTTPAttributes(ctx context.Context, method, path string, statusCode int) {
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String("http.request.method", method),
+		attribute.String("http.method", method),
+		attribute.String("url.path", path),
+		attribute.String("http.route", path),
+		attribute.Int("http.response.status_code", statusCode),
+		attribute.Int("http.status_code", statusCode),
+	}
+	span.SetAttributes(attrs...)
+	if statusCode >= http.StatusInternalServerError {
+		span.SetStatus(codes.Error, fmt.Sprintf("http status %d", statusCode))
+	}
+}
 
 // GinConfig configures a service router using the shared runtime baseline.
 type GinConfig struct {
@@ -153,12 +249,14 @@ func TracingMiddleware(observer Observer) gin.HandlerFunc {
 		requestContext, span := observer.Start(ctx.Request.Context(), operation)
 		ctx.Request = ctx.Request.WithContext(requestContext)
 		ctx.Next()
+		status := ctx.Writer.Status()
+		SetSpanHTTPAttributes(ctx.Request.Context(), ctx.Request.Method, operation, status)
 		var err error
 		if len(ctx.Errors) > 0 {
 			err = errors.New(ctx.Errors.String())
 		}
-		if ctx.Writer.Status() >= http.StatusInternalServerError && err == nil {
-			err = fmt.Errorf("http status %d", ctx.Writer.Status())
+		if status >= http.StatusInternalServerError && err == nil {
+			err = fmt.Errorf("http status %d", status)
 		}
 		span.End(err)
 	}

--- a/platform/shared-kernel-rust/Cargo.lock
+++ b/platform/shared-kernel-rust/Cargo.lock
@@ -61,10 +61,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "form_urlencoded"
@@ -89,6 +101,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -195,6 +213,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +271,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +313,12 @@ checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -348,6 +397,7 @@ name = "shared-kernel"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "opentelemetry",
  "serde",
  "serde_json",
  "tokio",
@@ -392,6 +442,26 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tokio"
@@ -477,6 +547,51 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "windows-link"

--- a/platform/shared-kernel-rust/Cargo.toml
+++ b/platform/shared-kernel-rust/Cargo.toml
@@ -8,6 +8,7 @@ name = "shared_kernel"
 path = "src/lib.rs"
 
 [dependencies]
+opentelemetry = "0.32.0"
 axum = "0.8.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/platform/shared-kernel-rust/src/lib.rs
+++ b/platform/shared-kernel-rust/src/lib.rs
@@ -12,6 +12,10 @@ use axum::{
     response::Response,
     routing::get,
 };
+use opentelemetry::{
+    KeyValue, global,
+    trace::{Span as OTelSpanTrait, Tracer},
+};
 use serde::Serialize;
 use serde_json::{Value, json};
 
@@ -81,11 +85,11 @@ impl RequestContext {
 
 /// A no-op-by-default observability seam for opt-in tracing adapters.
 pub trait Observer: Send + Sync + 'static {
-    fn start(&self, context: &RequestContext, operation: &str) -> Box<dyn Span>;
+    fn start(&self, context: &RequestContext, operation: &str, method: &str) -> Box<dyn Span>;
 }
 
 pub trait Span: Send + Sync + 'static {
-    fn end(&self, status: StatusCode);
+    fn end(&mut self, status: StatusCode);
 }
 
 #[derive(Debug, Clone, Default)]
@@ -95,13 +99,92 @@ pub struct NoopObserver;
 struct NoopSpan;
 
 impl Observer for NoopObserver {
-    fn start(&self, _context: &RequestContext, _operation: &str) -> Box<dyn Span> {
+    fn start(&self, _context: &RequestContext, _operation: &str, _method: &str) -> Box<dyn Span> {
         Box::new(NoopSpan)
     }
 }
 
 impl Span for NoopSpan {
-    fn end(&self, _status: StatusCode) {}
+    fn end(&mut self, _status: StatusCode) {}
+}
+
+#[derive(Debug, Clone)]
+pub struct OpenTelemetryObserver {
+    service_name: String,
+    tracer_name: &'static str,
+}
+
+struct OpenTelemetrySpan {
+    span: opentelemetry::global::BoxedSpan,
+}
+
+impl OpenTelemetryObserver {
+    pub fn new(service_name: impl Into<String>) -> Self {
+        Self {
+            service_name: service_name.into(),
+            tracer_name: "shared-kernel-rust",
+        }
+    }
+
+    pub fn from_env(service_name: impl Into<String>) -> Arc<dyn Observer> {
+        let exporter = std::env::var("OTEL_TRACES_EXPORTER")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase();
+        if exporter.is_empty() || exporter == "none" {
+            Arc::new(NoopObserver)
+        } else {
+            let configured = std::env::var("OTEL_SERVICE_NAME").unwrap_or_default();
+            let fallback = service_name.into();
+            let service_name = if configured.trim().is_empty() {
+                fallback
+            } else {
+                configured
+            };
+            Arc::new(Self::new(service_name))
+        }
+    }
+}
+
+impl Observer for OpenTelemetryObserver {
+    fn start(&self, context: &RequestContext, operation: &str, method: &str) -> Box<dyn Span> {
+        let tracer = global::tracer(self.tracer_name);
+        let span = tracer
+            .span_builder(operation.to_owned())
+            .with_kind(opentelemetry::trace::SpanKind::Server)
+            .with_attributes(vec![
+                KeyValue::new("service.name", self.service_name.clone()),
+                KeyValue::new("http.route", operation.to_owned()),
+                KeyValue::new("url.path", operation.to_owned()),
+                KeyValue::new("http.request.method", method.to_owned()),
+                KeyValue::new("http.method", method.to_owned()),
+                KeyValue::new("http.request_id", context.request_id().to_owned()),
+                KeyValue::new("http.correlation_id", context.correlation_id().to_owned()),
+            ])
+            .start(&tracer);
+        Box::new(OpenTelemetrySpan { span })
+    }
+}
+
+impl Span for OpenTelemetrySpan {
+    fn end(&mut self, status: StatusCode) {
+        self.span.set_attribute(KeyValue::new(
+            "http.response.status_code",
+            i64::from(status.as_u16()),
+        ));
+        self.span.set_attribute(KeyValue::new(
+            "http.status_code",
+            i64::from(status.as_u16()),
+        ));
+        if status.is_server_error() {
+            self.span
+                .set_status(opentelemetry::trace::Status::error(format!(
+                    "http status {}",
+                    status.as_u16()
+                )));
+        }
+        self.span.end();
+    }
 }
 
 #[derive(Clone)]
@@ -183,7 +266,9 @@ async fn runtime_middleware(
         header_value(&request, CORRELATION_ID_HEADER).unwrap_or_else(|| request_id.clone());
     let context = RequestContext::new(request_id.clone(), correlation_id.clone());
     let operation = request.uri().path().to_string();
-    let span = config.observer.start(&context, &operation);
+    let mut span = config
+        .observer
+        .start(&context, &operation, request.method().as_str());
 
     request.extensions_mut().insert(context);
     let mut response = next.run(request).await;
@@ -550,7 +635,12 @@ mod tests {
         }
 
         impl Observer for RecordingObserver {
-            fn start(&self, context: &RequestContext, operation: &str) -> Box<dyn Span> {
+            fn start(
+                &self,
+                context: &RequestContext,
+                operation: &str,
+                _method: &str,
+            ) -> Box<dyn Span> {
                 self.operations.lock().unwrap().push(format!(
                     "{}:{}",
                     operation,

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -218,7 +218,7 @@ requirements:
 
   - id: REQ-016
     title: "OpenTelemetry collection baseline"
-    description: "Provide a local OpenTelemetry collector configuration and a stable service-side OTLP environment contract for all language runtime baselines."
+    description: "Provide a local OpenTelemetry collector configuration, stable service-side OTLP environment contract, and opt-in OpenTelemetry API adapters for all language runtime baselines."
     priority: P0
     status: implemented
     code:
@@ -230,6 +230,12 @@ requirements:
         description: "Shared OTEL_* environment contract for service runtime adapters."
       - path: Makefile
         description: "Observability compose validation, startup, and shutdown targets."
+      - path: platform/go-runtime/runtime.go
+        description: "Go observer seam adapter for OpenTelemetry API spans, selected by standard OTEL_* environment configuration."
+      - path: platform/shared-kernel-rust/src/lib.rs
+        description: "Rust shared-kernel observer adapter for OpenTelemetry API spans with no-op default behavior."
+      - path: services
+        description: "Python, TypeScript, Java, Go, and Rust service runtime seams wired to optional OpenTelemetry adapters while retaining no-op defaults."
     tests:
       - path: Makefile
         description: "`make observability-config` validates compose rendering; `make observability-validate` validates the collector configuration with the collector binary."

--- a/services/account/src/app.ts
+++ b/services/account/src/app.ts
@@ -56,6 +56,46 @@ export type InstrumentationHooks = Readonly<{
   startSpan?: (context: RequestTraceContext) => void | TraceSpan | Promise<void | TraceSpan>;
 }>;
 
+type OTelSpan = Readonly<{
+  setAttribute?: (key: string, value: string | number) => void;
+  setAttributes?: (attributes: Record<string, string | number>) => void;
+  end?: () => void;
+}>;
+
+type OTelTracer = Readonly<{
+  startSpan: (name: string, options?: Record<string, unknown>) => OTelSpan;
+}>;
+
+export function opentelemetryInstrumentationFromEnv(tracer?: OTelTracer): InstrumentationHooks {
+  const exporter = process.env.OTEL_TRACES_EXPORTER?.trim().toLowerCase();
+  if (!exporter || exporter === "none" || tracer === undefined) {
+    return {};
+  }
+  return {
+    startSpan: (context) => {
+      const path = context.url.split("?")[0] || context.url;
+      const attributes: Record<string, string | number> = {
+        "service.name": serviceProfile.serviceId,
+        "http.request.method": context.method,
+        "http.method": context.method,
+        "url.path": path,
+        "http.route": path,
+        "http.request_id": context.requestId,
+        "http.correlation_id": context.correlationId,
+      };
+      const span = tracer.startSpan(`${context.method} ${path}`, { attributes, kind: "server" });
+      span.setAttributes?.(attributes);
+      return {
+        end: (result) => {
+          span.setAttribute?.("http.response.status_code", result.statusCode);
+          span.setAttribute?.("http.status_code", result.statusCode);
+          span.end?.();
+        },
+      };
+    },
+  };
+}
+
 export function health(): "ok" {
   return "ok";
 }

--- a/services/account/src/bootstrap.ts
+++ b/services/account/src/bootstrap.ts
@@ -1,4 +1,4 @@
-import { createApp, type InstrumentationHooks } from "./app.js";
+import { createApp, opentelemetryInstrumentationFromEnv, type InstrumentationHooks } from "./app.js";
 
 export type BootstrapOptions = Readonly<{
   host?: string;
@@ -19,7 +19,7 @@ export function runtimePort(options: Pick<BootstrapOptions, "port"> = {}): numbe
 }
 
 export async function bootstrap(options: BootstrapOptions = {}) {
-  const app = createApp(options.instrumentation);
+  const app = createApp(options.instrumentation ?? opentelemetryInstrumentationFromEnv());
   await app.listen({ host: runtimeHost(options), port: runtimePort(options) });
   return app;
 }

--- a/services/account/src/index.ts
+++ b/services/account/src/index.ts
@@ -2,6 +2,7 @@ export {
   createApp,
   health,
   metadata,
+  opentelemetryInstrumentationFromEnv,
   type ErrorEnvelope,
   type HealthStatus,
   type InstrumentationHooks,

--- a/services/admin-audit/pom.xml
+++ b/services/admin-audit/pom.xml
@@ -22,6 +22,11 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <version>1.46.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/OpenTelemetryRuntimeTracer.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/OpenTelemetryRuntimeTracer.java
@@ -1,0 +1,70 @@
+package com.trainticket.adminaudit;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+// Spring relaxed binding also accepts OTEL_TRACES_EXPORTER=otlp.
+@ConditionalOnProperty(name = "otel.traces.exporter", havingValue = "otlp")
+public class OpenTelemetryRuntimeTracer implements RuntimeTracer {
+    private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
+    private static final AttributeKey<String> HTTP_METHOD = AttributeKey.stringKey("http.request.method");
+    private static final AttributeKey<String> LEGACY_HTTP_METHOD = AttributeKey.stringKey("http.method");
+    private static final AttributeKey<String> URL_PATH = AttributeKey.stringKey("url.path");
+    private static final AttributeKey<String> HTTP_ROUTE = AttributeKey.stringKey("http.route");
+    private static final AttributeKey<String> REQUEST_ID = AttributeKey.stringKey("http.request_id");
+    private static final AttributeKey<String> CORRELATION_ID = AttributeKey.stringKey("http.correlation_id");
+    private static final AttributeKey<Long> HTTP_STATUS = AttributeKey.longKey("http.response.status_code");
+    private static final AttributeKey<Long> LEGACY_HTTP_STATUS = AttributeKey.longKey("http.status_code");
+    static final String REQUEST_ATTRIBUTE = OpenTelemetryRuntimeTracer.class.getName() + ".span";
+
+    private final Tracer tracer;
+    private final HttpServletRequest request;
+    private final String serviceName;
+
+    public OpenTelemetryRuntimeTracer(HttpServletRequest request) {
+        this.request = request;
+        this.serviceName = Optional.ofNullable(System.getenv("OTEL_SERVICE_NAME"))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElse(Application.profile().serviceId());
+        this.tracer = GlobalOpenTelemetry.getTracer(serviceName);
+    }
+
+    @Override
+    public void requestStarted(RequestTraceContext context) {
+        Span span = tracer.spanBuilder(context.method() + " " + context.path())
+            .setSpanKind(SpanKind.SERVER)
+            .setAttribute(SERVICE_NAME, serviceName)
+            .setAttribute(HTTP_METHOD, context.method())
+            .setAttribute(LEGACY_HTTP_METHOD, context.method())
+            .setAttribute(URL_PATH, context.path())
+            .setAttribute(HTTP_ROUTE, context.path())
+            .setAttribute(REQUEST_ID, context.requestId())
+            .setAttribute(CORRELATION_ID, context.correlationId())
+            .startSpan();
+        request.setAttribute(REQUEST_ATTRIBUTE, span);
+    }
+
+    @Override
+    public void requestCompleted(RequestTraceContext context, int statusCode) {
+        Object current = request.getAttribute(REQUEST_ATTRIBUTE);
+        if (current instanceof Span span) {
+            span.setAttribute(HTTP_STATUS, statusCode);
+            span.setAttribute(LEGACY_HTTP_STATUS, statusCode);
+            if (statusCode >= 500) {
+                span.setStatus(StatusCode.ERROR, "http status " + statusCode);
+            }
+            span.end();
+            request.removeAttribute(REQUEST_ATTRIBUTE);
+        }
+    }
+}

--- a/services/ancillary-service/src/app.ts
+++ b/services/ancillary-service/src/app.ts
@@ -56,6 +56,46 @@ export type InstrumentationHooks = Readonly<{
   startSpan?: (context: RequestTraceContext) => void | TraceSpan | Promise<void | TraceSpan>;
 }>;
 
+type OTelSpan = Readonly<{
+  setAttribute?: (key: string, value: string | number) => void;
+  setAttributes?: (attributes: Record<string, string | number>) => void;
+  end?: () => void;
+}>;
+
+type OTelTracer = Readonly<{
+  startSpan: (name: string, options?: Record<string, unknown>) => OTelSpan;
+}>;
+
+export function opentelemetryInstrumentationFromEnv(tracer?: OTelTracer): InstrumentationHooks {
+  const exporter = process.env.OTEL_TRACES_EXPORTER?.trim().toLowerCase();
+  if (!exporter || exporter === "none" || tracer === undefined) {
+    return {};
+  }
+  return {
+    startSpan: (context) => {
+      const path = context.url.split("?")[0] || context.url;
+      const attributes: Record<string, string | number> = {
+        "service.name": serviceProfile.serviceId,
+        "http.request.method": context.method,
+        "http.method": context.method,
+        "url.path": path,
+        "http.route": path,
+        "http.request_id": context.requestId,
+        "http.correlation_id": context.correlationId,
+      };
+      const span = tracer.startSpan(`${context.method} ${path}`, { attributes, kind: "server" });
+      span.setAttributes?.(attributes);
+      return {
+        end: (result) => {
+          span.setAttribute?.("http.response.status_code", result.statusCode);
+          span.setAttribute?.("http.status_code", result.statusCode);
+          span.end?.();
+        },
+      };
+    },
+  };
+}
+
 export function health(): "ok" {
   return "ok";
 }

--- a/services/ancillary-service/src/bootstrap.ts
+++ b/services/ancillary-service/src/bootstrap.ts
@@ -1,4 +1,4 @@
-import { createApp, type InstrumentationHooks } from "./app.js";
+import { createApp, opentelemetryInstrumentationFromEnv, type InstrumentationHooks } from "./app.js";
 
 export type BootstrapOptions = Readonly<{
   host?: string;
@@ -19,7 +19,7 @@ export function runtimePort(options: Pick<BootstrapOptions, "port"> = {}): numbe
 }
 
 export async function bootstrap(options: BootstrapOptions = {}) {
-  const app = createApp(options.instrumentation);
+  const app = createApp(options.instrumentation ?? opentelemetryInstrumentationFromEnv());
   await app.listen({ host: runtimeHost(options), port: runtimePort(options) });
   return app;
 }

--- a/services/ancillary-service/src/index.ts
+++ b/services/ancillary-service/src/index.ts
@@ -2,6 +2,7 @@ export {
   createApp,
   health,
   metadata,
+  opentelemetryInstrumentationFromEnv,
   type ErrorEnvelope,
   type HealthStatus,
   type InstrumentationHooks,

--- a/services/booking-orchestration/pom.xml
+++ b/services/booking-orchestration/pom.xml
@@ -22,6 +22,11 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <version>1.46.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/OpenTelemetryRuntimeTracer.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/OpenTelemetryRuntimeTracer.java
@@ -1,0 +1,70 @@
+package com.trainticket.bookingorchestration;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+// Spring relaxed binding also accepts OTEL_TRACES_EXPORTER=otlp.
+@ConditionalOnProperty(name = "otel.traces.exporter", havingValue = "otlp")
+public class OpenTelemetryRuntimeTracer implements RuntimeTracer {
+    private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
+    private static final AttributeKey<String> HTTP_METHOD = AttributeKey.stringKey("http.request.method");
+    private static final AttributeKey<String> LEGACY_HTTP_METHOD = AttributeKey.stringKey("http.method");
+    private static final AttributeKey<String> URL_PATH = AttributeKey.stringKey("url.path");
+    private static final AttributeKey<String> HTTP_ROUTE = AttributeKey.stringKey("http.route");
+    private static final AttributeKey<String> REQUEST_ID = AttributeKey.stringKey("http.request_id");
+    private static final AttributeKey<String> CORRELATION_ID = AttributeKey.stringKey("http.correlation_id");
+    private static final AttributeKey<Long> HTTP_STATUS = AttributeKey.longKey("http.response.status_code");
+    private static final AttributeKey<Long> LEGACY_HTTP_STATUS = AttributeKey.longKey("http.status_code");
+    static final String REQUEST_ATTRIBUTE = OpenTelemetryRuntimeTracer.class.getName() + ".span";
+
+    private final Tracer tracer;
+    private final HttpServletRequest request;
+    private final String serviceName;
+
+    public OpenTelemetryRuntimeTracer(HttpServletRequest request) {
+        this.request = request;
+        this.serviceName = Optional.ofNullable(System.getenv("OTEL_SERVICE_NAME"))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElse(Application.profile().serviceId());
+        this.tracer = GlobalOpenTelemetry.getTracer(serviceName);
+    }
+
+    @Override
+    public void requestStarted(RequestTraceContext context) {
+        Span span = tracer.spanBuilder(context.method() + " " + context.path())
+            .setSpanKind(SpanKind.SERVER)
+            .setAttribute(SERVICE_NAME, serviceName)
+            .setAttribute(HTTP_METHOD, context.method())
+            .setAttribute(LEGACY_HTTP_METHOD, context.method())
+            .setAttribute(URL_PATH, context.path())
+            .setAttribute(HTTP_ROUTE, context.path())
+            .setAttribute(REQUEST_ID, context.requestId())
+            .setAttribute(CORRELATION_ID, context.correlationId())
+            .startSpan();
+        request.setAttribute(REQUEST_ATTRIBUTE, span);
+    }
+
+    @Override
+    public void requestCompleted(RequestTraceContext context, int statusCode) {
+        Object current = request.getAttribute(REQUEST_ATTRIBUTE);
+        if (current instanceof Span span) {
+            span.setAttribute(HTTP_STATUS, statusCode);
+            span.setAttribute(LEGACY_HTTP_STATUS, statusCode);
+            if (statusCode >= 500) {
+                span.setStatus(StatusCode.ERROR, "http status " + statusCode);
+            }
+            span.end();
+            request.removeAttribute(REQUEST_ATTRIBUTE);
+        }
+    }
+}

--- a/services/capacity-availability/Cargo.lock
+++ b/services/capacity-availability/Cargo.lock
@@ -61,6 +61,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,11 +77,18 @@ name = "capacity-availability"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "opentelemetry",
  "serde",
  "shared-kernel",
  "tokio",
  "tower",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "form_urlencoded"
@@ -100,6 +113,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -206,6 +225,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +283,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +325,12 @@ checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -359,6 +409,7 @@ name = "shared-kernel"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "opentelemetry",
  "serde",
  "serde_json",
 ]
@@ -401,6 +452,26 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tokio"
@@ -486,6 +557,51 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "windows-link"

--- a/services/capacity-availability/Cargo.toml
+++ b/services/capacity-availability/Cargo.toml
@@ -8,6 +8,7 @@ name = "capacity_availability"
 path = "src/lib.rs"
 
 [dependencies]
+opentelemetry = "0.32.0"
 axum = "0.8.9"
 serde = { version = "1.0", features = ["derive"] }
 shared-kernel = { path = "../../platform/shared-kernel-rust" }

--- a/services/capacity-availability/src/lib.rs
+++ b/services/capacity-availability/src/lib.rs
@@ -1,6 +1,6 @@
 use axum::Router;
 use serde::Serialize;
-use shared_kernel::{RuntimeConfig, apply_runtime, router_with_config};
+use shared_kernel::{OpenTelemetryObserver, RuntimeConfig, apply_runtime, router_with_config};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -39,6 +39,7 @@ pub fn metadata() -> ServiceProfile {
 
 pub fn runtime_config() -> RuntimeConfig {
     RuntimeConfig::from_metadata(metadata())
+        .with_observer(OpenTelemetryObserver::from_env(profile().service_id))
 }
 
 pub fn router() -> Router {

--- a/services/customer-service/src/app.ts
+++ b/services/customer-service/src/app.ts
@@ -56,6 +56,46 @@ export type InstrumentationHooks = Readonly<{
   startSpan?: (context: RequestTraceContext) => void | TraceSpan | Promise<void | TraceSpan>;
 }>;
 
+type OTelSpan = Readonly<{
+  setAttribute?: (key: string, value: string | number) => void;
+  setAttributes?: (attributes: Record<string, string | number>) => void;
+  end?: () => void;
+}>;
+
+type OTelTracer = Readonly<{
+  startSpan: (name: string, options?: Record<string, unknown>) => OTelSpan;
+}>;
+
+export function opentelemetryInstrumentationFromEnv(tracer?: OTelTracer): InstrumentationHooks {
+  const exporter = process.env.OTEL_TRACES_EXPORTER?.trim().toLowerCase();
+  if (!exporter || exporter === "none" || tracer === undefined) {
+    return {};
+  }
+  return {
+    startSpan: (context) => {
+      const path = context.url.split("?")[0] || context.url;
+      const attributes: Record<string, string | number> = {
+        "service.name": serviceProfile.serviceId,
+        "http.request.method": context.method,
+        "http.method": context.method,
+        "url.path": path,
+        "http.route": path,
+        "http.request_id": context.requestId,
+        "http.correlation_id": context.correlationId,
+      };
+      const span = tracer.startSpan(`${context.method} ${path}`, { attributes, kind: "server" });
+      span.setAttributes?.(attributes);
+      return {
+        end: (result) => {
+          span.setAttribute?.("http.response.status_code", result.statusCode);
+          span.setAttribute?.("http.status_code", result.statusCode);
+          span.end?.();
+        },
+      };
+    },
+  };
+}
+
 export function health(): "ok" {
   return "ok";
 }

--- a/services/customer-service/src/bootstrap.ts
+++ b/services/customer-service/src/bootstrap.ts
@@ -1,4 +1,4 @@
-import { createApp, type InstrumentationHooks } from "./app.js";
+import { createApp, opentelemetryInstrumentationFromEnv, type InstrumentationHooks } from "./app.js";
 
 export type BootstrapOptions = Readonly<{
   host?: string;
@@ -19,7 +19,7 @@ export function runtimePort(options: Pick<BootstrapOptions, "port"> = {}): numbe
 }
 
 export async function bootstrap(options: BootstrapOptions = {}) {
-  const app = createApp(options.instrumentation);
+  const app = createApp(options.instrumentation ?? opentelemetryInstrumentationFromEnv());
   await app.listen({ host: runtimeHost(options), port: runtimePort(options) });
   return app;
 }

--- a/services/customer-service/src/index.ts
+++ b/services/customer-service/src/index.ts
@@ -2,6 +2,7 @@ export {
   createApp,
   health,
   metadata,
+  opentelemetryInstrumentationFromEnv,
   type ErrorEnvelope,
   type HealthStatus,
   type InstrumentationHooks,

--- a/services/dispatch/go.mod
+++ b/services/dispatch/go.mod
@@ -2,17 +2,15 @@ module github.com/trainticket/greenfield/services/dispatch
 
 go 1.26
 
-require (
-	github.com/gin-gonic/gin v1.12.0
-	go.opentelemetry.io/otel v1.38.0
-	go.opentelemetry.io/otel/trace v1.38.0
-)
+require github.com/gin-gonic/gin v1.12.0
 
 require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel v1.38.0 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
+	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 )
 
 require (

--- a/services/dispatch/go.mod
+++ b/services/dispatch/go.mod
@@ -2,7 +2,18 @@ module github.com/trainticket/greenfield/services/dispatch
 
 go 1.26
 
-require github.com/gin-gonic/gin v1.12.0
+require (
+	github.com/gin-gonic/gin v1.12.0
+	go.opentelemetry.io/otel v1.38.0
+	go.opentelemetry.io/otel/trace v1.38.0
+)
+
+require (
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel/metric v1.38.0 // indirect
+)
 
 require (
 	github.com/bytedance/gopkg v0.1.3 // indirect

--- a/services/dispatch/go.sum
+++ b/services/dispatch/go.sum
@@ -15,6 +15,11 @@ github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.12.0 h1:b3YAbrZtnf8N//yjKeU2+MQsh2mY5htkZidOM7O0wG8=
 github.com/gin-gonic/gin v1.12.0/go.mod h1:VxccKfsSllpKshkBWgVgRniFFAzFb9csfngsqANjnLc=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
+github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
@@ -68,6 +73,14 @@ github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
+go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
+go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
+go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=
+go.opentelemetry.io/otel v1.38.0/go.mod h1:zcmtmQ1+YmQM9wrNsTGV/q/uyusom3P8RxwExxkZhjM=
+go.opentelemetry.io/otel/metric v1.38.0 h1:Kl6lzIYGAh5M159u9NgiRkmoMKjvbsKtYRwgfrA6WpA=
+go.opentelemetry.io/otel/metric v1.38.0/go.mod h1:kB5n/QoRM8YwmUahxvI3bO34eVtQf2i4utNVLr9gEmI=
+go.opentelemetry.io/otel/trace v1.38.0 h1:Fxk5bKrDZJUH+AMyyIXGcFAPah0oRcT+LuNtJrmcNLE=
+go.opentelemetry.io/otel/trace v1.38.0/go.mod h1:j1P9ivuFsTceSWe1oY+EeW3sc+Pp42sO++GHkg4wwhs=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 golang.org/x/arch v0.22.0 h1:c/Zle32i5ttqRXjdLyyHZESLD/bB90DCU1g9l/0YBDI=

--- a/services/dispatch/internal/http/router.go
+++ b/services/dispatch/internal/http/router.go
@@ -9,9 +9,11 @@ import (
 )
 
 func Router() *gin.Engine {
+	profile := domain.Profile()
 	return goruntime.NewGinRouter(goruntime.GinConfig{
-		ServiceID:    domain.Profile().ServiceID,
-		Metadata:     domain.Profile(),
+		ServiceID:    profile.ServiceID,
+		Metadata:     profile,
 		HealthStatus: domain.Health(),
+		Observer:     goruntime.ObserverFromEnv(profile.ServiceID),
 	})
 }

--- a/services/disruption-recovery/src/disruption_recovery/api.py
+++ b/services/disruption-recovery/src/disruption_recovery/api.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Mapping
-from typing import Any
+from contextlib import AbstractContextManager, nullcontext
+from typing import Any, Protocol
 from uuid import uuid4
 
 from fastapi import FastAPI, Request
@@ -11,9 +12,50 @@ CORRELATION_ID_HEADER = "X-Correlation-ID"
 TraceHook = Callable[[str, Mapping[str, object]], None]
 
 
+class RuntimeSpan(AbstractContextManager["RuntimeSpan"], Protocol):
+    def set_attribute(self, key: str, value: object) -> None: ...
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool | None: ...
+
+
+class RuntimeTracer(Protocol):
+    def start_as_current_span(self, name: str) -> RuntimeSpan: ...
+
+
 def _emit_trace(tracer: TraceHook | None, event: str, attributes: Mapping[str, object]) -> None:
     if tracer is not None:
         tracer(event, dict(attributes))
+
+
+def opentelemetry_tracer_from_env(service_name: str) -> RuntimeTracer | None:
+    """Return an OpenTelemetry API tracer only when OTEL_TRACES_EXPORTER is enabled.
+
+    The OpenTelemetry API defaults to non-recording spans unless a service
+    bootstrap installs an SDK/exporter. That keeps tests collector-free while
+    allowing OTEL_* environment configuration to drive real deployments.
+    """
+    import os
+
+    exporter = os.getenv("OTEL_TRACES_EXPORTER", "").strip().lower()
+    if not exporter or exporter == "none":
+        return None
+    configured_service = os.getenv("OTEL_SERVICE_NAME", "").strip() or service_name
+    try:
+        from opentelemetry import trace
+    except ImportError:  # pragma: no cover - optional adapter dependency
+        return None
+    return trace.get_tracer(configured_service)
+
+
+def _span_context(tracer: RuntimeTracer | None, name: str) -> AbstractContextManager[RuntimeSpan | None]:
+    if tracer is None:
+        return nullcontext(None)
+    return tracer.start_as_current_span(name)
+
+
+def _set_span_attribute(span: RuntimeSpan | None, key: str, value: object) -> None:
+    if span is not None:
+        span.set_attribute(key, value)
 
 
 def _request_identifiers(request: Request) -> tuple[str, str]:
@@ -22,32 +64,45 @@ def _request_identifiers(request: Request) -> tuple[str, str]:
     return request_id, correlation_id
 
 
-def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None) -> None:
+def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None) -> None:
     @app.middleware("http")
     async def request_context_middleware(request: Request, call_next: Any):
         request_id, correlation_id = _request_identifiers(request)
         request.state.request_id = request_id
         request.state.correlation_id = correlation_id
+        service_name = profile()["service_id"]
+        path = request.url.path
         trace_attributes = {
+            "service.name": service_name,
             "request_id": request_id,
             "correlation_id": correlation_id,
-            "method": request.method,
-            "path": request.url.path,
+            "http.request.method": request.method,
+            "http.method": request.method,
+            "url.path": path,
+            "http.route": path,
+            "http.request_id": request_id,
+            "http.correlation_id": correlation_id,
         }
         _emit_trace(tracer, "http.request.start", trace_attributes)
-        try:
-            response = await call_next(request)
-        except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
-            _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
-            raise
-        response.headers[REQUEST_ID_HEADER] = request_id
-        response.headers[CORRELATION_ID_HEADER] = correlation_id
-        _emit_trace(
-            tracer,
-            "http.request.complete",
-            {**trace_attributes, "status_code": response.status_code},
-        )
-        return response
+        with _span_context(otel_tracer, f"{request.method} {path}") as span:
+            for key, value in trace_attributes.items():
+                _set_span_attribute(span, key, value)
+            try:
+                response = await call_next(request)
+            except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
+                _set_span_attribute(span, "error.type", exc.__class__.__name__)
+                _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
+                raise
+            response.headers[REQUEST_ID_HEADER] = request_id
+            response.headers[CORRELATION_ID_HEADER] = correlation_id
+            _set_span_attribute(span, "http.response.status_code", response.status_code)
+            _set_span_attribute(span, "http.status_code", response.status_code)
+            _emit_trace(
+                tracer,
+                "http.request.complete",
+                {**trace_attributes, "status_code": response.status_code},
+            )
+            return response
 
     @app.get("/health")
     def health_endpoint() -> dict[str, object]:
@@ -66,7 +121,7 @@ def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None) -
         return {"service": profile(), "observability": {"tracing": "opt-in", "default": "noop"}}
 
 
-def create_app(tracer: TraceHook | None = None) -> FastAPI:
+def create_app(tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None) -> FastAPI:
     app = FastAPI(title='Disruption Recovery', version="0.1.0")
-    configure_runtime_endpoints(app, tracer)
+    configure_runtime_endpoints(app, tracer, otel_tracer or opentelemetry_tracer_from_env(profile()["service_id"]))
     return app

--- a/services/entitlement-ticketing/Cargo.lock
+++ b/services/entitlement-ticketing/Cargo.lock
@@ -61,16 +61,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "entitlement-ticketing"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "opentelemetry",
  "serde",
  "shared-kernel",
  "tokio",
@@ -100,6 +113,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -206,6 +225,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +283,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +325,12 @@ checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -359,6 +409,7 @@ name = "shared-kernel"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "opentelemetry",
  "serde",
  "serde_json",
 ]
@@ -401,6 +452,26 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tokio"
@@ -486,6 +557,51 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "windows-link"

--- a/services/entitlement-ticketing/Cargo.toml
+++ b/services/entitlement-ticketing/Cargo.toml
@@ -8,6 +8,7 @@ name = "entitlement_ticketing"
 path = "src/lib.rs"
 
 [dependencies]
+opentelemetry = "0.32.0"
 axum = "0.8.9"
 serde = { version = "1.0", features = ["derive"] }
 shared-kernel = { path = "../../platform/shared-kernel-rust" }

--- a/services/entitlement-ticketing/src/lib.rs
+++ b/services/entitlement-ticketing/src/lib.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use axum::Router;
 use serde::Serialize;
-use shared_kernel::{RuntimeConfig, apply_runtime, router_with_config};
+use shared_kernel::{OpenTelemetryObserver, RuntimeConfig, apply_runtime, router_with_config};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ServiceProfile {
@@ -42,6 +42,7 @@ pub fn metadata() -> ServiceProfile {
 
 pub fn runtime_config() -> RuntimeConfig {
     RuntimeConfig::from_metadata(metadata())
+        .with_observer(OpenTelemetryObserver::from_env(profile().service_id))
 }
 
 pub fn router() -> Router {

--- a/services/fare-pricing/src/fare_pricing/api.py
+++ b/services/fare-pricing/src/fare_pricing/api.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Mapping
-from typing import Any
+from contextlib import AbstractContextManager, nullcontext
+from typing import Any, Protocol
 from uuid import uuid4
 
 from fastapi import FastAPI, Request
@@ -11,9 +12,50 @@ CORRELATION_ID_HEADER = "X-Correlation-ID"
 TraceHook = Callable[[str, Mapping[str, object]], None]
 
 
+class RuntimeSpan(AbstractContextManager["RuntimeSpan"], Protocol):
+    def set_attribute(self, key: str, value: object) -> None: ...
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool | None: ...
+
+
+class RuntimeTracer(Protocol):
+    def start_as_current_span(self, name: str) -> RuntimeSpan: ...
+
+
 def _emit_trace(tracer: TraceHook | None, event: str, attributes: Mapping[str, object]) -> None:
     if tracer is not None:
         tracer(event, dict(attributes))
+
+
+def opentelemetry_tracer_from_env(service_name: str) -> RuntimeTracer | None:
+    """Return an OpenTelemetry API tracer only when OTEL_TRACES_EXPORTER is enabled.
+
+    The OpenTelemetry API defaults to non-recording spans unless a service
+    bootstrap installs an SDK/exporter. That keeps tests collector-free while
+    allowing OTEL_* environment configuration to drive real deployments.
+    """
+    import os
+
+    exporter = os.getenv("OTEL_TRACES_EXPORTER", "").strip().lower()
+    if not exporter or exporter == "none":
+        return None
+    configured_service = os.getenv("OTEL_SERVICE_NAME", "").strip() or service_name
+    try:
+        from opentelemetry import trace
+    except ImportError:  # pragma: no cover - optional adapter dependency
+        return None
+    return trace.get_tracer(configured_service)
+
+
+def _span_context(tracer: RuntimeTracer | None, name: str) -> AbstractContextManager[RuntimeSpan | None]:
+    if tracer is None:
+        return nullcontext(None)
+    return tracer.start_as_current_span(name)
+
+
+def _set_span_attribute(span: RuntimeSpan | None, key: str, value: object) -> None:
+    if span is not None:
+        span.set_attribute(key, value)
 
 
 def _request_identifiers(request: Request) -> tuple[str, str]:
@@ -22,32 +64,45 @@ def _request_identifiers(request: Request) -> tuple[str, str]:
     return request_id, correlation_id
 
 
-def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None) -> None:
+def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None) -> None:
     @app.middleware("http")
     async def request_context_middleware(request: Request, call_next: Any):
         request_id, correlation_id = _request_identifiers(request)
         request.state.request_id = request_id
         request.state.correlation_id = correlation_id
+        service_name = profile()["service_id"]
+        path = request.url.path
         trace_attributes = {
+            "service.name": service_name,
             "request_id": request_id,
             "correlation_id": correlation_id,
-            "method": request.method,
-            "path": request.url.path,
+            "http.request.method": request.method,
+            "http.method": request.method,
+            "url.path": path,
+            "http.route": path,
+            "http.request_id": request_id,
+            "http.correlation_id": correlation_id,
         }
         _emit_trace(tracer, "http.request.start", trace_attributes)
-        try:
-            response = await call_next(request)
-        except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
-            _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
-            raise
-        response.headers[REQUEST_ID_HEADER] = request_id
-        response.headers[CORRELATION_ID_HEADER] = correlation_id
-        _emit_trace(
-            tracer,
-            "http.request.complete",
-            {**trace_attributes, "status_code": response.status_code},
-        )
-        return response
+        with _span_context(otel_tracer, f"{request.method} {path}") as span:
+            for key, value in trace_attributes.items():
+                _set_span_attribute(span, key, value)
+            try:
+                response = await call_next(request)
+            except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
+                _set_span_attribute(span, "error.type", exc.__class__.__name__)
+                _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
+                raise
+            response.headers[REQUEST_ID_HEADER] = request_id
+            response.headers[CORRELATION_ID_HEADER] = correlation_id
+            _set_span_attribute(span, "http.response.status_code", response.status_code)
+            _set_span_attribute(span, "http.status_code", response.status_code)
+            _emit_trace(
+                tracer,
+                "http.request.complete",
+                {**trace_attributes, "status_code": response.status_code},
+            )
+            return response
 
     @app.get("/health")
     def health_endpoint() -> dict[str, object]:
@@ -66,7 +121,7 @@ def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None) -
         return {"service": profile(), "observability": {"tracing": "opt-in", "default": "noop"}}
 
 
-def create_app(tracer: TraceHook | None = None) -> FastAPI:
+def create_app(tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None) -> FastAPI:
     app = FastAPI(title='Fare & Pricing', version="0.1.0")
-    configure_runtime_endpoints(app, tracer)
+    configure_runtime_endpoints(app, tracer, otel_tracer or opentelemetry_tracer_from_env(profile()["service_id"]))
     return app

--- a/services/finance-settlement/pom.xml
+++ b/services/finance-settlement/pom.xml
@@ -22,6 +22,11 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <version>1.46.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/OpenTelemetryRuntimeTracer.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/OpenTelemetryRuntimeTracer.java
@@ -1,0 +1,70 @@
+package com.trainticket.financesettlement;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+// Spring relaxed binding also accepts OTEL_TRACES_EXPORTER=otlp.
+@ConditionalOnProperty(name = "otel.traces.exporter", havingValue = "otlp")
+public class OpenTelemetryRuntimeTracer implements RuntimeTracer {
+    private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
+    private static final AttributeKey<String> HTTP_METHOD = AttributeKey.stringKey("http.request.method");
+    private static final AttributeKey<String> LEGACY_HTTP_METHOD = AttributeKey.stringKey("http.method");
+    private static final AttributeKey<String> URL_PATH = AttributeKey.stringKey("url.path");
+    private static final AttributeKey<String> HTTP_ROUTE = AttributeKey.stringKey("http.route");
+    private static final AttributeKey<String> REQUEST_ID = AttributeKey.stringKey("http.request_id");
+    private static final AttributeKey<String> CORRELATION_ID = AttributeKey.stringKey("http.correlation_id");
+    private static final AttributeKey<Long> HTTP_STATUS = AttributeKey.longKey("http.response.status_code");
+    private static final AttributeKey<Long> LEGACY_HTTP_STATUS = AttributeKey.longKey("http.status_code");
+    static final String REQUEST_ATTRIBUTE = OpenTelemetryRuntimeTracer.class.getName() + ".span";
+
+    private final Tracer tracer;
+    private final HttpServletRequest request;
+    private final String serviceName;
+
+    public OpenTelemetryRuntimeTracer(HttpServletRequest request) {
+        this.request = request;
+        this.serviceName = Optional.ofNullable(System.getenv("OTEL_SERVICE_NAME"))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElse(Application.profile().serviceId());
+        this.tracer = GlobalOpenTelemetry.getTracer(serviceName);
+    }
+
+    @Override
+    public void requestStarted(RequestTraceContext context) {
+        Span span = tracer.spanBuilder(context.method() + " " + context.path())
+            .setSpanKind(SpanKind.SERVER)
+            .setAttribute(SERVICE_NAME, serviceName)
+            .setAttribute(HTTP_METHOD, context.method())
+            .setAttribute(LEGACY_HTTP_METHOD, context.method())
+            .setAttribute(URL_PATH, context.path())
+            .setAttribute(HTTP_ROUTE, context.path())
+            .setAttribute(REQUEST_ID, context.requestId())
+            .setAttribute(CORRELATION_ID, context.correlationId())
+            .startSpan();
+        request.setAttribute(REQUEST_ATTRIBUTE, span);
+    }
+
+    @Override
+    public void requestCompleted(RequestTraceContext context, int statusCode) {
+        Object current = request.getAttribute(REQUEST_ATTRIBUTE);
+        if (current instanceof Span span) {
+            span.setAttribute(HTTP_STATUS, statusCode);
+            span.setAttribute(LEGACY_HTTP_STATUS, statusCode);
+            if (statusCode >= 500) {
+                span.setStatus(StatusCode.ERROR, "http status " + statusCode);
+            }
+            span.end();
+            request.removeAttribute(REQUEST_ATTRIBUTE);
+        }
+    }
+}

--- a/services/fulfillment/go.mod
+++ b/services/fulfillment/go.mod
@@ -2,17 +2,15 @@ module github.com/trainticket/greenfield/services/fulfillment
 
 go 1.26
 
-require (
-	github.com/gin-gonic/gin v1.12.0
-	go.opentelemetry.io/otel v1.38.0
-	go.opentelemetry.io/otel/trace v1.38.0
-)
+require github.com/gin-gonic/gin v1.12.0
 
 require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel v1.38.0 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
+	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 )
 
 require (

--- a/services/fulfillment/go.mod
+++ b/services/fulfillment/go.mod
@@ -2,7 +2,18 @@ module github.com/trainticket/greenfield/services/fulfillment
 
 go 1.26
 
-require github.com/gin-gonic/gin v1.12.0
+require (
+	github.com/gin-gonic/gin v1.12.0
+	go.opentelemetry.io/otel v1.38.0
+	go.opentelemetry.io/otel/trace v1.38.0
+)
+
+require (
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel/metric v1.38.0 // indirect
+)
 
 require (
 	github.com/bytedance/gopkg v0.1.3 // indirect

--- a/services/fulfillment/go.sum
+++ b/services/fulfillment/go.sum
@@ -15,6 +15,11 @@ github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.12.0 h1:b3YAbrZtnf8N//yjKeU2+MQsh2mY5htkZidOM7O0wG8=
 github.com/gin-gonic/gin v1.12.0/go.mod h1:VxccKfsSllpKshkBWgVgRniFFAzFb9csfngsqANjnLc=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
+github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
@@ -68,6 +73,14 @@ github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
+go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
+go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
+go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=
+go.opentelemetry.io/otel v1.38.0/go.mod h1:zcmtmQ1+YmQM9wrNsTGV/q/uyusom3P8RxwExxkZhjM=
+go.opentelemetry.io/otel/metric v1.38.0 h1:Kl6lzIYGAh5M159u9NgiRkmoMKjvbsKtYRwgfrA6WpA=
+go.opentelemetry.io/otel/metric v1.38.0/go.mod h1:kB5n/QoRM8YwmUahxvI3bO34eVtQf2i4utNVLr9gEmI=
+go.opentelemetry.io/otel/trace v1.38.0 h1:Fxk5bKrDZJUH+AMyyIXGcFAPah0oRcT+LuNtJrmcNLE=
+go.opentelemetry.io/otel/trace v1.38.0/go.mod h1:j1P9ivuFsTceSWe1oY+EeW3sc+Pp42sO++GHkg4wwhs=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 golang.org/x/arch v0.22.0 h1:c/Zle32i5ttqRXjdLyyHZESLD/bB90DCU1g9l/0YBDI=

--- a/services/fulfillment/internal/http/router.go
+++ b/services/fulfillment/internal/http/router.go
@@ -9,9 +9,11 @@ import (
 )
 
 func Router() *gin.Engine {
+	profile := domain.Profile()
 	return goruntime.NewGinRouter(goruntime.GinConfig{
-		ServiceID:    domain.Profile().ServiceID,
-		Metadata:     domain.Profile(),
+		ServiceID:    profile.ServiceID,
+		Metadata:     profile,
 		HealthStatus: domain.Health(),
+		Observer:     goruntime.ObserverFromEnv(profile.ServiceID),
 	})
 }

--- a/services/journey-order/pom.xml
+++ b/services/journey-order/pom.xml
@@ -22,6 +22,11 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <version>1.46.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/OpenTelemetryRuntimeTracer.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/OpenTelemetryRuntimeTracer.java
@@ -1,0 +1,70 @@
+package com.trainticket.journeyorder;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+// Spring relaxed binding also accepts OTEL_TRACES_EXPORTER=otlp.
+@ConditionalOnProperty(name = "otel.traces.exporter", havingValue = "otlp")
+public class OpenTelemetryRuntimeTracer implements RuntimeTracer {
+    private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
+    private static final AttributeKey<String> HTTP_METHOD = AttributeKey.stringKey("http.request.method");
+    private static final AttributeKey<String> LEGACY_HTTP_METHOD = AttributeKey.stringKey("http.method");
+    private static final AttributeKey<String> URL_PATH = AttributeKey.stringKey("url.path");
+    private static final AttributeKey<String> HTTP_ROUTE = AttributeKey.stringKey("http.route");
+    private static final AttributeKey<String> REQUEST_ID = AttributeKey.stringKey("http.request_id");
+    private static final AttributeKey<String> CORRELATION_ID = AttributeKey.stringKey("http.correlation_id");
+    private static final AttributeKey<Long> HTTP_STATUS = AttributeKey.longKey("http.response.status_code");
+    private static final AttributeKey<Long> LEGACY_HTTP_STATUS = AttributeKey.longKey("http.status_code");
+    static final String REQUEST_ATTRIBUTE = OpenTelemetryRuntimeTracer.class.getName() + ".span";
+
+    private final Tracer tracer;
+    private final HttpServletRequest request;
+    private final String serviceName;
+
+    public OpenTelemetryRuntimeTracer(HttpServletRequest request) {
+        this.request = request;
+        this.serviceName = Optional.ofNullable(System.getenv("OTEL_SERVICE_NAME"))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElse(Application.profile().serviceId());
+        this.tracer = GlobalOpenTelemetry.getTracer(serviceName);
+    }
+
+    @Override
+    public void requestStarted(RequestTraceContext context) {
+        Span span = tracer.spanBuilder(context.method() + " " + context.path())
+            .setSpanKind(SpanKind.SERVER)
+            .setAttribute(SERVICE_NAME, serviceName)
+            .setAttribute(HTTP_METHOD, context.method())
+            .setAttribute(LEGACY_HTTP_METHOD, context.method())
+            .setAttribute(URL_PATH, context.path())
+            .setAttribute(HTTP_ROUTE, context.path())
+            .setAttribute(REQUEST_ID, context.requestId())
+            .setAttribute(CORRELATION_ID, context.correlationId())
+            .startSpan();
+        request.setAttribute(REQUEST_ATTRIBUTE, span);
+    }
+
+    @Override
+    public void requestCompleted(RequestTraceContext context, int statusCode) {
+        Object current = request.getAttribute(REQUEST_ATTRIBUTE);
+        if (current instanceof Span span) {
+            span.setAttribute(HTTP_STATUS, statusCode);
+            span.setAttribute(LEGACY_HTTP_STATUS, statusCode);
+            if (statusCode >= 500) {
+                span.setStatus(StatusCode.ERROR, "http status " + statusCode);
+            }
+            span.end();
+            request.removeAttribute(REQUEST_ATTRIBUTE);
+        }
+    }
+}

--- a/services/notification/src/app.ts
+++ b/services/notification/src/app.ts
@@ -56,6 +56,46 @@ export type InstrumentationHooks = Readonly<{
   startSpan?: (context: RequestTraceContext) => void | TraceSpan | Promise<void | TraceSpan>;
 }>;
 
+type OTelSpan = Readonly<{
+  setAttribute?: (key: string, value: string | number) => void;
+  setAttributes?: (attributes: Record<string, string | number>) => void;
+  end?: () => void;
+}>;
+
+type OTelTracer = Readonly<{
+  startSpan: (name: string, options?: Record<string, unknown>) => OTelSpan;
+}>;
+
+export function opentelemetryInstrumentationFromEnv(tracer?: OTelTracer): InstrumentationHooks {
+  const exporter = process.env.OTEL_TRACES_EXPORTER?.trim().toLowerCase();
+  if (!exporter || exporter === "none" || tracer === undefined) {
+    return {};
+  }
+  return {
+    startSpan: (context) => {
+      const path = context.url.split("?")[0] || context.url;
+      const attributes: Record<string, string | number> = {
+        "service.name": serviceProfile.serviceId,
+        "http.request.method": context.method,
+        "http.method": context.method,
+        "url.path": path,
+        "http.route": path,
+        "http.request_id": context.requestId,
+        "http.correlation_id": context.correlationId,
+      };
+      const span = tracer.startSpan(`${context.method} ${path}`, { attributes, kind: "server" });
+      span.setAttributes?.(attributes);
+      return {
+        end: (result) => {
+          span.setAttribute?.("http.response.status_code", result.statusCode);
+          span.setAttribute?.("http.status_code", result.statusCode);
+          span.end?.();
+        },
+      };
+    },
+  };
+}
+
 export function health(): "ok" {
   return "ok";
 }

--- a/services/notification/src/bootstrap.ts
+++ b/services/notification/src/bootstrap.ts
@@ -1,4 +1,4 @@
-import { createApp, type InstrumentationHooks } from "./app.js";
+import { createApp, opentelemetryInstrumentationFromEnv, type InstrumentationHooks } from "./app.js";
 
 export type BootstrapOptions = Readonly<{
   host?: string;
@@ -19,7 +19,7 @@ export function runtimePort(options: Pick<BootstrapOptions, "port"> = {}): numbe
 }
 
 export async function bootstrap(options: BootstrapOptions = {}) {
-  const app = createApp(options.instrumentation);
+  const app = createApp(options.instrumentation ?? opentelemetryInstrumentationFromEnv());
   await app.listen({ host: runtimeHost(options), port: runtimePort(options) });
   return app;
 }

--- a/services/notification/src/index.ts
+++ b/services/notification/src/index.ts
@@ -2,6 +2,7 @@ export {
   createApp,
   health,
   metadata,
+  opentelemetryInstrumentationFromEnv,
   type ErrorEnvelope,
   type HealthStatus,
   type InstrumentationHooks,

--- a/services/offer-management/src/app.ts
+++ b/services/offer-management/src/app.ts
@@ -56,6 +56,46 @@ export type InstrumentationHooks = Readonly<{
   startSpan?: (context: RequestTraceContext) => void | TraceSpan | Promise<void | TraceSpan>;
 }>;
 
+type OTelSpan = Readonly<{
+  setAttribute?: (key: string, value: string | number) => void;
+  setAttributes?: (attributes: Record<string, string | number>) => void;
+  end?: () => void;
+}>;
+
+type OTelTracer = Readonly<{
+  startSpan: (name: string, options?: Record<string, unknown>) => OTelSpan;
+}>;
+
+export function opentelemetryInstrumentationFromEnv(tracer?: OTelTracer): InstrumentationHooks {
+  const exporter = process.env.OTEL_TRACES_EXPORTER?.trim().toLowerCase();
+  if (!exporter || exporter === "none" || tracer === undefined) {
+    return {};
+  }
+  return {
+    startSpan: (context) => {
+      const path = context.url.split("?")[0] || context.url;
+      const attributes: Record<string, string | number> = {
+        "service.name": serviceProfile.serviceId,
+        "http.request.method": context.method,
+        "http.method": context.method,
+        "url.path": path,
+        "http.route": path,
+        "http.request_id": context.requestId,
+        "http.correlation_id": context.correlationId,
+      };
+      const span = tracer.startSpan(`${context.method} ${path}`, { attributes, kind: "server" });
+      span.setAttributes?.(attributes);
+      return {
+        end: (result) => {
+          span.setAttribute?.("http.response.status_code", result.statusCode);
+          span.setAttribute?.("http.status_code", result.statusCode);
+          span.end?.();
+        },
+      };
+    },
+  };
+}
+
 export function health(): "ok" {
   return "ok";
 }

--- a/services/offer-management/src/bootstrap.ts
+++ b/services/offer-management/src/bootstrap.ts
@@ -1,4 +1,4 @@
-import { createApp, type InstrumentationHooks } from "./app.js";
+import { createApp, opentelemetryInstrumentationFromEnv, type InstrumentationHooks } from "./app.js";
 
 export type BootstrapOptions = Readonly<{
   host?: string;
@@ -19,7 +19,7 @@ export function runtimePort(options: Pick<BootstrapOptions, "port"> = {}): numbe
 }
 
 export async function bootstrap(options: BootstrapOptions = {}) {
-  const app = createApp(options.instrumentation);
+  const app = createApp(options.instrumentation ?? opentelemetryInstrumentationFromEnv());
   await app.listen({ host: runtimeHost(options), port: runtimePort(options) });
   return app;
 }

--- a/services/offer-management/src/index.ts
+++ b/services/offer-management/src/index.ts
@@ -2,6 +2,7 @@ export {
   createApp,
   health,
   metadata,
+  opentelemetryInstrumentationFromEnv,
   type ErrorEnvelope,
   type HealthStatus,
   type InstrumentationHooks,

--- a/services/payment/pom.xml
+++ b/services/payment/pom.xml
@@ -22,6 +22,11 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <version>1.46.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/services/payment/src/main/java/com/trainticket/payment/OpenTelemetryRuntimeTracer.java
+++ b/services/payment/src/main/java/com/trainticket/payment/OpenTelemetryRuntimeTracer.java
@@ -1,0 +1,70 @@
+package com.trainticket.payment;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+// Spring relaxed binding also accepts OTEL_TRACES_EXPORTER=otlp.
+@ConditionalOnProperty(name = "otel.traces.exporter", havingValue = "otlp")
+public class OpenTelemetryRuntimeTracer implements RuntimeTracer {
+    private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
+    private static final AttributeKey<String> HTTP_METHOD = AttributeKey.stringKey("http.request.method");
+    private static final AttributeKey<String> LEGACY_HTTP_METHOD = AttributeKey.stringKey("http.method");
+    private static final AttributeKey<String> URL_PATH = AttributeKey.stringKey("url.path");
+    private static final AttributeKey<String> HTTP_ROUTE = AttributeKey.stringKey("http.route");
+    private static final AttributeKey<String> REQUEST_ID = AttributeKey.stringKey("http.request_id");
+    private static final AttributeKey<String> CORRELATION_ID = AttributeKey.stringKey("http.correlation_id");
+    private static final AttributeKey<Long> HTTP_STATUS = AttributeKey.longKey("http.response.status_code");
+    private static final AttributeKey<Long> LEGACY_HTTP_STATUS = AttributeKey.longKey("http.status_code");
+    static final String REQUEST_ATTRIBUTE = OpenTelemetryRuntimeTracer.class.getName() + ".span";
+
+    private final Tracer tracer;
+    private final HttpServletRequest request;
+    private final String serviceName;
+
+    public OpenTelemetryRuntimeTracer(HttpServletRequest request) {
+        this.request = request;
+        this.serviceName = Optional.ofNullable(System.getenv("OTEL_SERVICE_NAME"))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElse(Application.profile().serviceId());
+        this.tracer = GlobalOpenTelemetry.getTracer(serviceName);
+    }
+
+    @Override
+    public void requestStarted(RequestTraceContext context) {
+        Span span = tracer.spanBuilder(context.method() + " " + context.path())
+            .setSpanKind(SpanKind.SERVER)
+            .setAttribute(SERVICE_NAME, serviceName)
+            .setAttribute(HTTP_METHOD, context.method())
+            .setAttribute(LEGACY_HTTP_METHOD, context.method())
+            .setAttribute(URL_PATH, context.path())
+            .setAttribute(HTTP_ROUTE, context.path())
+            .setAttribute(REQUEST_ID, context.requestId())
+            .setAttribute(CORRELATION_ID, context.correlationId())
+            .startSpan();
+        request.setAttribute(REQUEST_ATTRIBUTE, span);
+    }
+
+    @Override
+    public void requestCompleted(RequestTraceContext context, int statusCode) {
+        Object current = request.getAttribute(REQUEST_ATTRIBUTE);
+        if (current instanceof Span span) {
+            span.setAttribute(HTTP_STATUS, statusCode);
+            span.setAttribute(LEGACY_HTTP_STATUS, statusCode);
+            if (statusCode >= 500) {
+                span.setStatus(StatusCode.ERROR, "http status " + statusCode);
+            }
+            span.end();
+            request.removeAttribute(REQUEST_ATTRIBUTE);
+        }
+    }
+}

--- a/services/place-network/go.mod
+++ b/services/place-network/go.mod
@@ -2,7 +2,18 @@ module github.com/trainticket/greenfield/services/place-network
 
 go 1.26
 
-require github.com/gin-gonic/gin v1.12.0
+require (
+	github.com/gin-gonic/gin v1.12.0
+	go.opentelemetry.io/otel v1.38.0
+	go.opentelemetry.io/otel/trace v1.38.0
+)
+
+require (
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel/metric v1.38.0 // indirect
+)
 
 require (
 	github.com/bytedance/gopkg v0.1.3 // indirect

--- a/services/place-network/go.mod
+++ b/services/place-network/go.mod
@@ -2,17 +2,15 @@ module github.com/trainticket/greenfield/services/place-network
 
 go 1.26
 
-require (
-	github.com/gin-gonic/gin v1.12.0
-	go.opentelemetry.io/otel v1.38.0
-	go.opentelemetry.io/otel/trace v1.38.0
-)
+require github.com/gin-gonic/gin v1.12.0
 
 require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel v1.38.0 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
+	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 )
 
 require (

--- a/services/place-network/go.sum
+++ b/services/place-network/go.sum
@@ -15,6 +15,11 @@ github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.12.0 h1:b3YAbrZtnf8N//yjKeU2+MQsh2mY5htkZidOM7O0wG8=
 github.com/gin-gonic/gin v1.12.0/go.mod h1:VxccKfsSllpKshkBWgVgRniFFAzFb9csfngsqANjnLc=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
+github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
@@ -68,6 +73,14 @@ github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
+go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
+go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
+go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=
+go.opentelemetry.io/otel v1.38.0/go.mod h1:zcmtmQ1+YmQM9wrNsTGV/q/uyusom3P8RxwExxkZhjM=
+go.opentelemetry.io/otel/metric v1.38.0 h1:Kl6lzIYGAh5M159u9NgiRkmoMKjvbsKtYRwgfrA6WpA=
+go.opentelemetry.io/otel/metric v1.38.0/go.mod h1:kB5n/QoRM8YwmUahxvI3bO34eVtQf2i4utNVLr9gEmI=
+go.opentelemetry.io/otel/trace v1.38.0 h1:Fxk5bKrDZJUH+AMyyIXGcFAPah0oRcT+LuNtJrmcNLE=
+go.opentelemetry.io/otel/trace v1.38.0/go.mod h1:j1P9ivuFsTceSWe1oY+EeW3sc+Pp42sO++GHkg4wwhs=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 golang.org/x/arch v0.22.0 h1:c/Zle32i5ttqRXjdLyyHZESLD/bB90DCU1g9l/0YBDI=

--- a/services/place-network/internal/http/router.go
+++ b/services/place-network/internal/http/router.go
@@ -9,9 +9,11 @@ import (
 )
 
 func Router() *gin.Engine {
+	profile := domain.Profile()
 	return goruntime.NewGinRouter(goruntime.GinConfig{
-		ServiceID:    domain.Profile().ServiceID,
-		Metadata:     domain.Profile(),
+		ServiceID:    profile.ServiceID,
+		Metadata:     profile,
 		HealthStatus: domain.Health(),
+		Observer:     goruntime.ObserverFromEnv(profile.ServiceID),
 	})
 }

--- a/services/post-sales/pom.xml
+++ b/services/post-sales/pom.xml
@@ -22,6 +22,11 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <version>1.46.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/services/post-sales/src/main/java/com/trainticket/postsales/OpenTelemetryRuntimeTracer.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/OpenTelemetryRuntimeTracer.java
@@ -1,0 +1,70 @@
+package com.trainticket.postsales;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+// Spring relaxed binding also accepts OTEL_TRACES_EXPORTER=otlp.
+@ConditionalOnProperty(name = "otel.traces.exporter", havingValue = "otlp")
+public class OpenTelemetryRuntimeTracer implements RuntimeTracer {
+    private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
+    private static final AttributeKey<String> HTTP_METHOD = AttributeKey.stringKey("http.request.method");
+    private static final AttributeKey<String> LEGACY_HTTP_METHOD = AttributeKey.stringKey("http.method");
+    private static final AttributeKey<String> URL_PATH = AttributeKey.stringKey("url.path");
+    private static final AttributeKey<String> HTTP_ROUTE = AttributeKey.stringKey("http.route");
+    private static final AttributeKey<String> REQUEST_ID = AttributeKey.stringKey("http.request_id");
+    private static final AttributeKey<String> CORRELATION_ID = AttributeKey.stringKey("http.correlation_id");
+    private static final AttributeKey<Long> HTTP_STATUS = AttributeKey.longKey("http.response.status_code");
+    private static final AttributeKey<Long> LEGACY_HTTP_STATUS = AttributeKey.longKey("http.status_code");
+    static final String REQUEST_ATTRIBUTE = OpenTelemetryRuntimeTracer.class.getName() + ".span";
+
+    private final Tracer tracer;
+    private final HttpServletRequest request;
+    private final String serviceName;
+
+    public OpenTelemetryRuntimeTracer(HttpServletRequest request) {
+        this.request = request;
+        this.serviceName = Optional.ofNullable(System.getenv("OTEL_SERVICE_NAME"))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElse(Application.profile().serviceId());
+        this.tracer = GlobalOpenTelemetry.getTracer(serviceName);
+    }
+
+    @Override
+    public void requestStarted(RequestTraceContext context) {
+        Span span = tracer.spanBuilder(context.method() + " " + context.path())
+            .setSpanKind(SpanKind.SERVER)
+            .setAttribute(SERVICE_NAME, serviceName)
+            .setAttribute(HTTP_METHOD, context.method())
+            .setAttribute(LEGACY_HTTP_METHOD, context.method())
+            .setAttribute(URL_PATH, context.path())
+            .setAttribute(HTTP_ROUTE, context.path())
+            .setAttribute(REQUEST_ID, context.requestId())
+            .setAttribute(CORRELATION_ID, context.correlationId())
+            .startSpan();
+        request.setAttribute(REQUEST_ATTRIBUTE, span);
+    }
+
+    @Override
+    public void requestCompleted(RequestTraceContext context, int statusCode) {
+        Object current = request.getAttribute(REQUEST_ATTRIBUTE);
+        if (current instanceof Span span) {
+            span.setAttribute(HTTP_STATUS, statusCode);
+            span.setAttribute(LEGACY_HTTP_STATUS, statusCode);
+            if (statusCode >= 500) {
+                span.setStatus(StatusCode.ERROR, "http status " + statusCode);
+            }
+            span.end();
+            request.removeAttribute(REQUEST_ATTRIBUTE);
+        }
+    }
+}

--- a/services/provider-integration/go.mod
+++ b/services/provider-integration/go.mod
@@ -2,7 +2,18 @@ module github.com/trainticket/greenfield/services/provider-integration
 
 go 1.26
 
-require github.com/gin-gonic/gin v1.12.0
+require (
+	github.com/gin-gonic/gin v1.12.0
+	go.opentelemetry.io/otel v1.38.0
+	go.opentelemetry.io/otel/trace v1.38.0
+)
+
+require (
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel/metric v1.38.0 // indirect
+)
 
 require (
 	github.com/bytedance/gopkg v0.1.3 // indirect

--- a/services/provider-integration/go.mod
+++ b/services/provider-integration/go.mod
@@ -2,17 +2,15 @@ module github.com/trainticket/greenfield/services/provider-integration
 
 go 1.26
 
-require (
-	github.com/gin-gonic/gin v1.12.0
-	go.opentelemetry.io/otel v1.38.0
-	go.opentelemetry.io/otel/trace v1.38.0
-)
+require github.com/gin-gonic/gin v1.12.0
 
 require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel v1.38.0 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
+	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 )
 
 require (

--- a/services/provider-integration/go.sum
+++ b/services/provider-integration/go.sum
@@ -15,6 +15,11 @@ github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.12.0 h1:b3YAbrZtnf8N//yjKeU2+MQsh2mY5htkZidOM7O0wG8=
 github.com/gin-gonic/gin v1.12.0/go.mod h1:VxccKfsSllpKshkBWgVgRniFFAzFb9csfngsqANjnLc=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
+github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
@@ -68,6 +73,14 @@ github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
+go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
+go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
+go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=
+go.opentelemetry.io/otel v1.38.0/go.mod h1:zcmtmQ1+YmQM9wrNsTGV/q/uyusom3P8RxwExxkZhjM=
+go.opentelemetry.io/otel/metric v1.38.0 h1:Kl6lzIYGAh5M159u9NgiRkmoMKjvbsKtYRwgfrA6WpA=
+go.opentelemetry.io/otel/metric v1.38.0/go.mod h1:kB5n/QoRM8YwmUahxvI3bO34eVtQf2i4utNVLr9gEmI=
+go.opentelemetry.io/otel/trace v1.38.0 h1:Fxk5bKrDZJUH+AMyyIXGcFAPah0oRcT+LuNtJrmcNLE=
+go.opentelemetry.io/otel/trace v1.38.0/go.mod h1:j1P9ivuFsTceSWe1oY+EeW3sc+Pp42sO++GHkg4wwhs=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 golang.org/x/arch v0.22.0 h1:c/Zle32i5ttqRXjdLyyHZESLD/bB90DCU1g9l/0YBDI=

--- a/services/provider-integration/internal/http/router.go
+++ b/services/provider-integration/internal/http/router.go
@@ -9,9 +9,11 @@ import (
 )
 
 func Router() *gin.Engine {
+	profile := domain.Profile()
 	return goruntime.NewGinRouter(goruntime.GinConfig{
-		ServiceID:    domain.Profile().ServiceID,
-		Metadata:     domain.Profile(),
+		ServiceID:    profile.ServiceID,
+		Metadata:     profile,
 		HealthStatus: domain.Health(),
+		Observer:     goruntime.ObserverFromEnv(profile.ServiceID),
 	})
 }

--- a/services/reporting/src/reporting/api.py
+++ b/services/reporting/src/reporting/api.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Mapping
-from typing import Any
+from contextlib import AbstractContextManager, nullcontext
+from typing import Any, Protocol
 from uuid import uuid4
 
 from fastapi import FastAPI, Request
@@ -11,9 +12,50 @@ CORRELATION_ID_HEADER = "X-Correlation-ID"
 TraceHook = Callable[[str, Mapping[str, object]], None]
 
 
+class RuntimeSpan(AbstractContextManager["RuntimeSpan"], Protocol):
+    def set_attribute(self, key: str, value: object) -> None: ...
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool | None: ...
+
+
+class RuntimeTracer(Protocol):
+    def start_as_current_span(self, name: str) -> RuntimeSpan: ...
+
+
 def _emit_trace(tracer: TraceHook | None, event: str, attributes: Mapping[str, object]) -> None:
     if tracer is not None:
         tracer(event, dict(attributes))
+
+
+def opentelemetry_tracer_from_env(service_name: str) -> RuntimeTracer | None:
+    """Return an OpenTelemetry API tracer only when OTEL_TRACES_EXPORTER is enabled.
+
+    The OpenTelemetry API defaults to non-recording spans unless a service
+    bootstrap installs an SDK/exporter. That keeps tests collector-free while
+    allowing OTEL_* environment configuration to drive real deployments.
+    """
+    import os
+
+    exporter = os.getenv("OTEL_TRACES_EXPORTER", "").strip().lower()
+    if not exporter or exporter == "none":
+        return None
+    configured_service = os.getenv("OTEL_SERVICE_NAME", "").strip() or service_name
+    try:
+        from opentelemetry import trace
+    except ImportError:  # pragma: no cover - optional adapter dependency
+        return None
+    return trace.get_tracer(configured_service)
+
+
+def _span_context(tracer: RuntimeTracer | None, name: str) -> AbstractContextManager[RuntimeSpan | None]:
+    if tracer is None:
+        return nullcontext(None)
+    return tracer.start_as_current_span(name)
+
+
+def _set_span_attribute(span: RuntimeSpan | None, key: str, value: object) -> None:
+    if span is not None:
+        span.set_attribute(key, value)
 
 
 def _request_identifiers(request: Request) -> tuple[str, str]:
@@ -22,32 +64,45 @@ def _request_identifiers(request: Request) -> tuple[str, str]:
     return request_id, correlation_id
 
 
-def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None) -> None:
+def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None) -> None:
     @app.middleware("http")
     async def request_context_middleware(request: Request, call_next: Any):
         request_id, correlation_id = _request_identifiers(request)
         request.state.request_id = request_id
         request.state.correlation_id = correlation_id
+        service_name = profile()["service_id"]
+        path = request.url.path
         trace_attributes = {
+            "service.name": service_name,
             "request_id": request_id,
             "correlation_id": correlation_id,
-            "method": request.method,
-            "path": request.url.path,
+            "http.request.method": request.method,
+            "http.method": request.method,
+            "url.path": path,
+            "http.route": path,
+            "http.request_id": request_id,
+            "http.correlation_id": correlation_id,
         }
         _emit_trace(tracer, "http.request.start", trace_attributes)
-        try:
-            response = await call_next(request)
-        except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
-            _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
-            raise
-        response.headers[REQUEST_ID_HEADER] = request_id
-        response.headers[CORRELATION_ID_HEADER] = correlation_id
-        _emit_trace(
-            tracer,
-            "http.request.complete",
-            {**trace_attributes, "status_code": response.status_code},
-        )
-        return response
+        with _span_context(otel_tracer, f"{request.method} {path}") as span:
+            for key, value in trace_attributes.items():
+                _set_span_attribute(span, key, value)
+            try:
+                response = await call_next(request)
+            except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
+                _set_span_attribute(span, "error.type", exc.__class__.__name__)
+                _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
+                raise
+            response.headers[REQUEST_ID_HEADER] = request_id
+            response.headers[CORRELATION_ID_HEADER] = correlation_id
+            _set_span_attribute(span, "http.response.status_code", response.status_code)
+            _set_span_attribute(span, "http.status_code", response.status_code)
+            _emit_trace(
+                tracer,
+                "http.request.complete",
+                {**trace_attributes, "status_code": response.status_code},
+            )
+            return response
 
     @app.get("/health")
     def health_endpoint() -> dict[str, object]:
@@ -66,7 +121,7 @@ def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None) -
         return {"service": profile(), "observability": {"tracing": "opt-in", "default": "noop"}}
 
 
-def create_app(tracer: TraceHook | None = None) -> FastAPI:
+def create_app(tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None) -> FastAPI:
     app = FastAPI(title='Reporting', version="0.1.0")
-    configure_runtime_endpoints(app, tracer)
+    configure_runtime_endpoints(app, tracer, otel_tracer or opentelemetry_tracer_from_env(profile()["service_id"]))
     return app

--- a/services/risk-compliance/src/risk_compliance/api.py
+++ b/services/risk-compliance/src/risk_compliance/api.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Mapping
-from typing import Any
+from contextlib import AbstractContextManager, nullcontext
+from typing import Any, Protocol
 from uuid import uuid4
 
 from fastapi import FastAPI, Request
@@ -11,9 +12,50 @@ CORRELATION_ID_HEADER = "X-Correlation-ID"
 TraceHook = Callable[[str, Mapping[str, object]], None]
 
 
+class RuntimeSpan(AbstractContextManager["RuntimeSpan"], Protocol):
+    def set_attribute(self, key: str, value: object) -> None: ...
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool | None: ...
+
+
+class RuntimeTracer(Protocol):
+    def start_as_current_span(self, name: str) -> RuntimeSpan: ...
+
+
 def _emit_trace(tracer: TraceHook | None, event: str, attributes: Mapping[str, object]) -> None:
     if tracer is not None:
         tracer(event, dict(attributes))
+
+
+def opentelemetry_tracer_from_env(service_name: str) -> RuntimeTracer | None:
+    """Return an OpenTelemetry API tracer only when OTEL_TRACES_EXPORTER is enabled.
+
+    The OpenTelemetry API defaults to non-recording spans unless a service
+    bootstrap installs an SDK/exporter. That keeps tests collector-free while
+    allowing OTEL_* environment configuration to drive real deployments.
+    """
+    import os
+
+    exporter = os.getenv("OTEL_TRACES_EXPORTER", "").strip().lower()
+    if not exporter or exporter == "none":
+        return None
+    configured_service = os.getenv("OTEL_SERVICE_NAME", "").strip() or service_name
+    try:
+        from opentelemetry import trace
+    except ImportError:  # pragma: no cover - optional adapter dependency
+        return None
+    return trace.get_tracer(configured_service)
+
+
+def _span_context(tracer: RuntimeTracer | None, name: str) -> AbstractContextManager[RuntimeSpan | None]:
+    if tracer is None:
+        return nullcontext(None)
+    return tracer.start_as_current_span(name)
+
+
+def _set_span_attribute(span: RuntimeSpan | None, key: str, value: object) -> None:
+    if span is not None:
+        span.set_attribute(key, value)
 
 
 def _request_identifiers(request: Request) -> tuple[str, str]:
@@ -22,32 +64,45 @@ def _request_identifiers(request: Request) -> tuple[str, str]:
     return request_id, correlation_id
 
 
-def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None) -> None:
+def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None) -> None:
     @app.middleware("http")
     async def request_context_middleware(request: Request, call_next: Any):
         request_id, correlation_id = _request_identifiers(request)
         request.state.request_id = request_id
         request.state.correlation_id = correlation_id
+        service_name = profile()["service_id"]
+        path = request.url.path
         trace_attributes = {
+            "service.name": service_name,
             "request_id": request_id,
             "correlation_id": correlation_id,
-            "method": request.method,
-            "path": request.url.path,
+            "http.request.method": request.method,
+            "http.method": request.method,
+            "url.path": path,
+            "http.route": path,
+            "http.request_id": request_id,
+            "http.correlation_id": correlation_id,
         }
         _emit_trace(tracer, "http.request.start", trace_attributes)
-        try:
-            response = await call_next(request)
-        except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
-            _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
-            raise
-        response.headers[REQUEST_ID_HEADER] = request_id
-        response.headers[CORRELATION_ID_HEADER] = correlation_id
-        _emit_trace(
-            tracer,
-            "http.request.complete",
-            {**trace_attributes, "status_code": response.status_code},
-        )
-        return response
+        with _span_context(otel_tracer, f"{request.method} {path}") as span:
+            for key, value in trace_attributes.items():
+                _set_span_attribute(span, key, value)
+            try:
+                response = await call_next(request)
+            except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
+                _set_span_attribute(span, "error.type", exc.__class__.__name__)
+                _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
+                raise
+            response.headers[REQUEST_ID_HEADER] = request_id
+            response.headers[CORRELATION_ID_HEADER] = correlation_id
+            _set_span_attribute(span, "http.response.status_code", response.status_code)
+            _set_span_attribute(span, "http.status_code", response.status_code)
+            _emit_trace(
+                tracer,
+                "http.request.complete",
+                {**trace_attributes, "status_code": response.status_code},
+            )
+            return response
 
     @app.get("/health")
     def health_endpoint() -> dict[str, object]:
@@ -66,7 +121,7 @@ def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None) -
         return {"service": profile(), "observability": {"tracing": "opt-in", "default": "noop"}}
 
 
-def create_app(tracer: TraceHook | None = None) -> FastAPI:
+def create_app(tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None) -> FastAPI:
     app = FastAPI(title='Risk & Compliance', version="0.1.0")
-    configure_runtime_endpoints(app, tracer)
+    configure_runtime_endpoints(app, tracer, otel_tracer or opentelemetry_tracer_from_env(profile()["service_id"]))
     return app

--- a/services/service-plan/go.mod
+++ b/services/service-plan/go.mod
@@ -2,17 +2,15 @@ module github.com/trainticket/greenfield/services/service-plan
 
 go 1.26
 
-require (
-	github.com/gin-gonic/gin v1.12.0
-	go.opentelemetry.io/otel v1.38.0
-	go.opentelemetry.io/otel/trace v1.38.0
-)
+require github.com/gin-gonic/gin v1.12.0
 
 require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel v1.38.0 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
+	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 )
 
 require (

--- a/services/service-plan/go.mod
+++ b/services/service-plan/go.mod
@@ -2,7 +2,18 @@ module github.com/trainticket/greenfield/services/service-plan
 
 go 1.26
 
-require github.com/gin-gonic/gin v1.12.0
+require (
+	github.com/gin-gonic/gin v1.12.0
+	go.opentelemetry.io/otel v1.38.0
+	go.opentelemetry.io/otel/trace v1.38.0
+)
+
+require (
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel/metric v1.38.0 // indirect
+)
 
 require (
 	github.com/bytedance/gopkg v0.1.3 // indirect

--- a/services/service-plan/go.sum
+++ b/services/service-plan/go.sum
@@ -15,6 +15,11 @@ github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.12.0 h1:b3YAbrZtnf8N//yjKeU2+MQsh2mY5htkZidOM7O0wG8=
 github.com/gin-gonic/gin v1.12.0/go.mod h1:VxccKfsSllpKshkBWgVgRniFFAzFb9csfngsqANjnLc=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
+github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
@@ -68,6 +73,14 @@ github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
+go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
+go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
+go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=
+go.opentelemetry.io/otel v1.38.0/go.mod h1:zcmtmQ1+YmQM9wrNsTGV/q/uyusom3P8RxwExxkZhjM=
+go.opentelemetry.io/otel/metric v1.38.0 h1:Kl6lzIYGAh5M159u9NgiRkmoMKjvbsKtYRwgfrA6WpA=
+go.opentelemetry.io/otel/metric v1.38.0/go.mod h1:kB5n/QoRM8YwmUahxvI3bO34eVtQf2i4utNVLr9gEmI=
+go.opentelemetry.io/otel/trace v1.38.0 h1:Fxk5bKrDZJUH+AMyyIXGcFAPah0oRcT+LuNtJrmcNLE=
+go.opentelemetry.io/otel/trace v1.38.0/go.mod h1:j1P9ivuFsTceSWe1oY+EeW3sc+Pp42sO++GHkg4wwhs=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 golang.org/x/arch v0.22.0 h1:c/Zle32i5ttqRXjdLyyHZESLD/bB90DCU1g9l/0YBDI=

--- a/services/service-plan/internal/http/router.go
+++ b/services/service-plan/internal/http/router.go
@@ -9,9 +9,11 @@ import (
 )
 
 func Router() *gin.Engine {
+	profile := domain.Profile()
 	return goruntime.NewGinRouter(goruntime.GinConfig{
-		ServiceID:    domain.Profile().ServiceID,
-		Metadata:     domain.Profile(),
+		ServiceID:    profile.ServiceID,
+		Metadata:     profile,
 		HealthStatus: domain.Health(),
+		Observer:     goruntime.ObserverFromEnv(profile.ServiceID),
 	})
 }

--- a/services/supplier-catalog/go.mod
+++ b/services/supplier-catalog/go.mod
@@ -2,17 +2,15 @@ module github.com/trainticket/greenfield/services/supplier-catalog
 
 go 1.26
 
-require (
-	github.com/gin-gonic/gin v1.12.0
-	go.opentelemetry.io/otel v1.38.0
-	go.opentelemetry.io/otel/trace v1.38.0
-)
+require github.com/gin-gonic/gin v1.12.0
 
 require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel v1.38.0 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
+	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 )
 
 require (

--- a/services/supplier-catalog/go.mod
+++ b/services/supplier-catalog/go.mod
@@ -2,7 +2,18 @@ module github.com/trainticket/greenfield/services/supplier-catalog
 
 go 1.26
 
-require github.com/gin-gonic/gin v1.12.0
+require (
+	github.com/gin-gonic/gin v1.12.0
+	go.opentelemetry.io/otel v1.38.0
+	go.opentelemetry.io/otel/trace v1.38.0
+)
+
+require (
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
+	go.opentelemetry.io/otel/metric v1.38.0 // indirect
+)
 
 require (
 	github.com/bytedance/gopkg v0.1.3 // indirect

--- a/services/supplier-catalog/go.sum
+++ b/services/supplier-catalog/go.sum
@@ -15,6 +15,11 @@ github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.12.0 h1:b3YAbrZtnf8N//yjKeU2+MQsh2mY5htkZidOM7O0wG8=
 github.com/gin-gonic/gin v1.12.0/go.mod h1:VxccKfsSllpKshkBWgVgRniFFAzFb9csfngsqANjnLc=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
+github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
@@ -68,6 +73,14 @@ github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=
 go.mongodb.org/mongo-driver/v2 v2.5.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
+go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
+go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
+go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=
+go.opentelemetry.io/otel v1.38.0/go.mod h1:zcmtmQ1+YmQM9wrNsTGV/q/uyusom3P8RxwExxkZhjM=
+go.opentelemetry.io/otel/metric v1.38.0 h1:Kl6lzIYGAh5M159u9NgiRkmoMKjvbsKtYRwgfrA6WpA=
+go.opentelemetry.io/otel/metric v1.38.0/go.mod h1:kB5n/QoRM8YwmUahxvI3bO34eVtQf2i4utNVLr9gEmI=
+go.opentelemetry.io/otel/trace v1.38.0 h1:Fxk5bKrDZJUH+AMyyIXGcFAPah0oRcT+LuNtJrmcNLE=
+go.opentelemetry.io/otel/trace v1.38.0/go.mod h1:j1P9ivuFsTceSWe1oY+EeW3sc+Pp42sO++GHkg4wwhs=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 golang.org/x/arch v0.22.0 h1:c/Zle32i5ttqRXjdLyyHZESLD/bB90DCU1g9l/0YBDI=

--- a/services/supplier-catalog/internal/http/router.go
+++ b/services/supplier-catalog/internal/http/router.go
@@ -9,9 +9,11 @@ import (
 )
 
 func Router() *gin.Engine {
+	profile := domain.Profile()
 	return goruntime.NewGinRouter(goruntime.GinConfig{
-		ServiceID:    domain.Profile().ServiceID,
-		Metadata:     domain.Profile(),
+		ServiceID:    profile.ServiceID,
+		Metadata:     profile,
 		HealthStatus: domain.Health(),
+		Observer:     goruntime.ObserverFromEnv(profile.ServiceID),
 	})
 }

--- a/services/transfer-management/src/transfer_management/api.py
+++ b/services/transfer-management/src/transfer_management/api.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Mapping
-from typing import Any
+from contextlib import AbstractContextManager, nullcontext
+from typing import Any, Protocol
 from uuid import uuid4
 
 from fastapi import FastAPI, Request
@@ -11,9 +12,50 @@ CORRELATION_ID_HEADER = "X-Correlation-ID"
 TraceHook = Callable[[str, Mapping[str, object]], None]
 
 
+class RuntimeSpan(AbstractContextManager["RuntimeSpan"], Protocol):
+    def set_attribute(self, key: str, value: object) -> None: ...
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool | None: ...
+
+
+class RuntimeTracer(Protocol):
+    def start_as_current_span(self, name: str) -> RuntimeSpan: ...
+
+
 def _emit_trace(tracer: TraceHook | None, event: str, attributes: Mapping[str, object]) -> None:
     if tracer is not None:
         tracer(event, dict(attributes))
+
+
+def opentelemetry_tracer_from_env(service_name: str) -> RuntimeTracer | None:
+    """Return an OpenTelemetry API tracer only when OTEL_TRACES_EXPORTER is enabled.
+
+    The OpenTelemetry API defaults to non-recording spans unless a service
+    bootstrap installs an SDK/exporter. That keeps tests collector-free while
+    allowing OTEL_* environment configuration to drive real deployments.
+    """
+    import os
+
+    exporter = os.getenv("OTEL_TRACES_EXPORTER", "").strip().lower()
+    if not exporter or exporter == "none":
+        return None
+    configured_service = os.getenv("OTEL_SERVICE_NAME", "").strip() or service_name
+    try:
+        from opentelemetry import trace
+    except ImportError:  # pragma: no cover - optional adapter dependency
+        return None
+    return trace.get_tracer(configured_service)
+
+
+def _span_context(tracer: RuntimeTracer | None, name: str) -> AbstractContextManager[RuntimeSpan | None]:
+    if tracer is None:
+        return nullcontext(None)
+    return tracer.start_as_current_span(name)
+
+
+def _set_span_attribute(span: RuntimeSpan | None, key: str, value: object) -> None:
+    if span is not None:
+        span.set_attribute(key, value)
 
 
 def _request_identifiers(request: Request) -> tuple[str, str]:
@@ -22,32 +64,45 @@ def _request_identifiers(request: Request) -> tuple[str, str]:
     return request_id, correlation_id
 
 
-def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None) -> None:
+def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None) -> None:
     @app.middleware("http")
     async def request_context_middleware(request: Request, call_next: Any):
         request_id, correlation_id = _request_identifiers(request)
         request.state.request_id = request_id
         request.state.correlation_id = correlation_id
+        service_name = profile()["service_id"]
+        path = request.url.path
         trace_attributes = {
+            "service.name": service_name,
             "request_id": request_id,
             "correlation_id": correlation_id,
-            "method": request.method,
-            "path": request.url.path,
+            "http.request.method": request.method,
+            "http.method": request.method,
+            "url.path": path,
+            "http.route": path,
+            "http.request_id": request_id,
+            "http.correlation_id": correlation_id,
         }
         _emit_trace(tracer, "http.request.start", trace_attributes)
-        try:
-            response = await call_next(request)
-        except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
-            _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
-            raise
-        response.headers[REQUEST_ID_HEADER] = request_id
-        response.headers[CORRELATION_ID_HEADER] = correlation_id
-        _emit_trace(
-            tracer,
-            "http.request.complete",
-            {**trace_attributes, "status_code": response.status_code},
-        )
-        return response
+        with _span_context(otel_tracer, f"{request.method} {path}") as span:
+            for key, value in trace_attributes.items():
+                _set_span_attribute(span, key, value)
+            try:
+                response = await call_next(request)
+            except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
+                _set_span_attribute(span, "error.type", exc.__class__.__name__)
+                _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
+                raise
+            response.headers[REQUEST_ID_HEADER] = request_id
+            response.headers[CORRELATION_ID_HEADER] = correlation_id
+            _set_span_attribute(span, "http.response.status_code", response.status_code)
+            _set_span_attribute(span, "http.status_code", response.status_code)
+            _emit_trace(
+                tracer,
+                "http.request.complete",
+                {**trace_attributes, "status_code": response.status_code},
+            )
+            return response
 
     @app.get("/health")
     def health_endpoint() -> dict[str, object]:
@@ -66,7 +121,7 @@ def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None) -
         return {"service": profile(), "observability": {"tracing": "opt-in", "default": "noop"}}
 
 
-def create_app(tracer: TraceHook | None = None) -> FastAPI:
+def create_app(tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None) -> FastAPI:
     app = FastAPI(title='Transfer Management', version="0.1.0")
-    configure_runtime_endpoints(app, tracer)
+    configure_runtime_endpoints(app, tracer, otel_tracer or opentelemetry_tracer_from_env(profile()["service_id"]))
     return app

--- a/services/traveler-profile/pom.xml
+++ b/services/traveler-profile/pom.xml
@@ -22,6 +22,11 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <version>1.46.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/OpenTelemetryRuntimeTracer.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/OpenTelemetryRuntimeTracer.java
@@ -1,0 +1,70 @@
+package com.trainticket.travelerprofile;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+// Spring relaxed binding also accepts OTEL_TRACES_EXPORTER=otlp.
+@ConditionalOnProperty(name = "otel.traces.exporter", havingValue = "otlp")
+public class OpenTelemetryRuntimeTracer implements RuntimeTracer {
+    private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
+    private static final AttributeKey<String> HTTP_METHOD = AttributeKey.stringKey("http.request.method");
+    private static final AttributeKey<String> LEGACY_HTTP_METHOD = AttributeKey.stringKey("http.method");
+    private static final AttributeKey<String> URL_PATH = AttributeKey.stringKey("url.path");
+    private static final AttributeKey<String> HTTP_ROUTE = AttributeKey.stringKey("http.route");
+    private static final AttributeKey<String> REQUEST_ID = AttributeKey.stringKey("http.request_id");
+    private static final AttributeKey<String> CORRELATION_ID = AttributeKey.stringKey("http.correlation_id");
+    private static final AttributeKey<Long> HTTP_STATUS = AttributeKey.longKey("http.response.status_code");
+    private static final AttributeKey<Long> LEGACY_HTTP_STATUS = AttributeKey.longKey("http.status_code");
+    static final String REQUEST_ATTRIBUTE = OpenTelemetryRuntimeTracer.class.getName() + ".span";
+
+    private final Tracer tracer;
+    private final HttpServletRequest request;
+    private final String serviceName;
+
+    public OpenTelemetryRuntimeTracer(HttpServletRequest request) {
+        this.request = request;
+        this.serviceName = Optional.ofNullable(System.getenv("OTEL_SERVICE_NAME"))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElse(Application.profile().serviceId());
+        this.tracer = GlobalOpenTelemetry.getTracer(serviceName);
+    }
+
+    @Override
+    public void requestStarted(RequestTraceContext context) {
+        Span span = tracer.spanBuilder(context.method() + " " + context.path())
+            .setSpanKind(SpanKind.SERVER)
+            .setAttribute(SERVICE_NAME, serviceName)
+            .setAttribute(HTTP_METHOD, context.method())
+            .setAttribute(LEGACY_HTTP_METHOD, context.method())
+            .setAttribute(URL_PATH, context.path())
+            .setAttribute(HTTP_ROUTE, context.path())
+            .setAttribute(REQUEST_ID, context.requestId())
+            .setAttribute(CORRELATION_ID, context.correlationId())
+            .startSpan();
+        request.setAttribute(REQUEST_ATTRIBUTE, span);
+    }
+
+    @Override
+    public void requestCompleted(RequestTraceContext context, int statusCode) {
+        Object current = request.getAttribute(REQUEST_ATTRIBUTE);
+        if (current instanceof Span span) {
+            span.setAttribute(HTTP_STATUS, statusCode);
+            span.setAttribute(LEGACY_HTTP_STATUS, statusCode);
+            if (statusCode >= 500) {
+                span.setStatus(StatusCode.ERROR, "http status " + statusCode);
+            }
+            span.end();
+            request.removeAttribute(REQUEST_ATTRIBUTE);
+        }
+    }
+}

--- a/services/trip-planning/src/trip_planning/api.py
+++ b/services/trip-planning/src/trip_planning/api.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Mapping
-from typing import Any
+from contextlib import AbstractContextManager, nullcontext
+from typing import Any, Protocol
 from uuid import uuid4
 
 from fastapi import FastAPI, Request
@@ -11,9 +12,50 @@ CORRELATION_ID_HEADER = "X-Correlation-ID"
 TraceHook = Callable[[str, Mapping[str, object]], None]
 
 
+class RuntimeSpan(AbstractContextManager["RuntimeSpan"], Protocol):
+    def set_attribute(self, key: str, value: object) -> None: ...
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool | None: ...
+
+
+class RuntimeTracer(Protocol):
+    def start_as_current_span(self, name: str) -> RuntimeSpan: ...
+
+
 def _emit_trace(tracer: TraceHook | None, event: str, attributes: Mapping[str, object]) -> None:
     if tracer is not None:
         tracer(event, dict(attributes))
+
+
+def opentelemetry_tracer_from_env(service_name: str) -> RuntimeTracer | None:
+    """Return an OpenTelemetry API tracer only when OTEL_TRACES_EXPORTER is enabled.
+
+    The OpenTelemetry API defaults to non-recording spans unless a service
+    bootstrap installs an SDK/exporter. That keeps tests collector-free while
+    allowing OTEL_* environment configuration to drive real deployments.
+    """
+    import os
+
+    exporter = os.getenv("OTEL_TRACES_EXPORTER", "").strip().lower()
+    if not exporter or exporter == "none":
+        return None
+    configured_service = os.getenv("OTEL_SERVICE_NAME", "").strip() or service_name
+    try:
+        from opentelemetry import trace
+    except ImportError:  # pragma: no cover - optional adapter dependency
+        return None
+    return trace.get_tracer(configured_service)
+
+
+def _span_context(tracer: RuntimeTracer | None, name: str) -> AbstractContextManager[RuntimeSpan | None]:
+    if tracer is None:
+        return nullcontext(None)
+    return tracer.start_as_current_span(name)
+
+
+def _set_span_attribute(span: RuntimeSpan | None, key: str, value: object) -> None:
+    if span is not None:
+        span.set_attribute(key, value)
 
 
 def _request_identifiers(request: Request) -> tuple[str, str]:
@@ -22,32 +64,45 @@ def _request_identifiers(request: Request) -> tuple[str, str]:
     return request_id, correlation_id
 
 
-def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None) -> None:
+def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None) -> None:
     @app.middleware("http")
     async def request_context_middleware(request: Request, call_next: Any):
         request_id, correlation_id = _request_identifiers(request)
         request.state.request_id = request_id
         request.state.correlation_id = correlation_id
+        service_name = profile()["service_id"]
+        path = request.url.path
         trace_attributes = {
+            "service.name": service_name,
             "request_id": request_id,
             "correlation_id": correlation_id,
-            "method": request.method,
-            "path": request.url.path,
+            "http.request.method": request.method,
+            "http.method": request.method,
+            "url.path": path,
+            "http.route": path,
+            "http.request_id": request_id,
+            "http.correlation_id": correlation_id,
         }
         _emit_trace(tracer, "http.request.start", trace_attributes)
-        try:
-            response = await call_next(request)
-        except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
-            _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
-            raise
-        response.headers[REQUEST_ID_HEADER] = request_id
-        response.headers[CORRELATION_ID_HEADER] = correlation_id
-        _emit_trace(
-            tracer,
-            "http.request.complete",
-            {**trace_attributes, "status_code": response.status_code},
-        )
-        return response
+        with _span_context(otel_tracer, f"{request.method} {path}") as span:
+            for key, value in trace_attributes.items():
+                _set_span_attribute(span, key, value)
+            try:
+                response = await call_next(request)
+            except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
+                _set_span_attribute(span, "error.type", exc.__class__.__name__)
+                _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
+                raise
+            response.headers[REQUEST_ID_HEADER] = request_id
+            response.headers[CORRELATION_ID_HEADER] = correlation_id
+            _set_span_attribute(span, "http.response.status_code", response.status_code)
+            _set_span_attribute(span, "http.status_code", response.status_code)
+            _emit_trace(
+                tracer,
+                "http.request.complete",
+                {**trace_attributes, "status_code": response.status_code},
+            )
+            return response
 
     @app.get("/health")
     def health_endpoint() -> dict[str, object]:
@@ -71,9 +126,9 @@ from .application import search_itineraries_from_payload
 from .domain import TripPlanningValidationError
 
 
-def create_app(tracer: TraceHook | None = None) -> FastAPI:
+def create_app(tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None) -> FastAPI:
     app = FastAPI(title='Trip Planning', version="0.1.0")
-    configure_runtime_endpoints(app, tracer)
+    configure_runtime_endpoints(app, tracer, otel_tracer or opentelemetry_tracer_from_env(profile()["service_id"]))
 
     @app.post("/search")
     def search_endpoint(payload: dict[str, object]) -> dict[str, object]:

--- a/services/waitlist/Cargo.lock
+++ b/services/waitlist/Cargo.lock
@@ -61,10 +61,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "form_urlencoded"
@@ -89,6 +101,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -195,6 +213,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +271,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +313,12 @@ checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -348,6 +397,7 @@ name = "shared-kernel"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "opentelemetry",
  "serde",
  "serde_json",
 ]
@@ -390,6 +440,26 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tokio"
@@ -475,6 +545,7 @@ name = "waitlist"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "opentelemetry",
  "serde",
  "shared-kernel",
  "tokio",
@@ -486,6 +557,51 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "windows-link"

--- a/services/waitlist/Cargo.toml
+++ b/services/waitlist/Cargo.toml
@@ -8,6 +8,7 @@ name = "waitlist"
 path = "src/lib.rs"
 
 [dependencies]
+opentelemetry = "0.32.0"
 axum = "0.8.9"
 serde = { version = "1.0", features = ["derive"] }
 shared-kernel = { path = "../../platform/shared-kernel-rust" }

--- a/services/waitlist/src/lib.rs
+++ b/services/waitlist/src/lib.rs
@@ -1,6 +1,6 @@
 use axum::Router;
 use serde::Serialize;
-use shared_kernel::{RuntimeConfig, apply_runtime, router_with_config};
+use shared_kernel::{OpenTelemetryObserver, RuntimeConfig, apply_runtime, router_with_config};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ServiceProfile {
@@ -33,6 +33,7 @@ pub fn metadata() -> ServiceProfile {
 
 pub fn runtime_config() -> RuntimeConfig {
     RuntimeConfig::from_metadata(metadata())
+        .with_observer(OpenTelemetryObserver::from_env(profile().service_id))
 }
 
 pub fn router() -> Router {

--- a/services/wallet-promotion/pom.xml
+++ b/services/wallet-promotion/pom.xml
@@ -22,6 +22,11 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <version>1.46.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/OpenTelemetryRuntimeTracer.java
+++ b/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/OpenTelemetryRuntimeTracer.java
@@ -1,0 +1,70 @@
+package com.trainticket.walletpromotion;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+// Spring relaxed binding also accepts OTEL_TRACES_EXPORTER=otlp.
+@ConditionalOnProperty(name = "otel.traces.exporter", havingValue = "otlp")
+public class OpenTelemetryRuntimeTracer implements RuntimeTracer {
+    private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
+    private static final AttributeKey<String> HTTP_METHOD = AttributeKey.stringKey("http.request.method");
+    private static final AttributeKey<String> LEGACY_HTTP_METHOD = AttributeKey.stringKey("http.method");
+    private static final AttributeKey<String> URL_PATH = AttributeKey.stringKey("url.path");
+    private static final AttributeKey<String> HTTP_ROUTE = AttributeKey.stringKey("http.route");
+    private static final AttributeKey<String> REQUEST_ID = AttributeKey.stringKey("http.request_id");
+    private static final AttributeKey<String> CORRELATION_ID = AttributeKey.stringKey("http.correlation_id");
+    private static final AttributeKey<Long> HTTP_STATUS = AttributeKey.longKey("http.response.status_code");
+    private static final AttributeKey<Long> LEGACY_HTTP_STATUS = AttributeKey.longKey("http.status_code");
+    static final String REQUEST_ATTRIBUTE = OpenTelemetryRuntimeTracer.class.getName() + ".span";
+
+    private final Tracer tracer;
+    private final HttpServletRequest request;
+    private final String serviceName;
+
+    public OpenTelemetryRuntimeTracer(HttpServletRequest request) {
+        this.request = request;
+        this.serviceName = Optional.ofNullable(System.getenv("OTEL_SERVICE_NAME"))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElse(Application.profile().serviceId());
+        this.tracer = GlobalOpenTelemetry.getTracer(serviceName);
+    }
+
+    @Override
+    public void requestStarted(RequestTraceContext context) {
+        Span span = tracer.spanBuilder(context.method() + " " + context.path())
+            .setSpanKind(SpanKind.SERVER)
+            .setAttribute(SERVICE_NAME, serviceName)
+            .setAttribute(HTTP_METHOD, context.method())
+            .setAttribute(LEGACY_HTTP_METHOD, context.method())
+            .setAttribute(URL_PATH, context.path())
+            .setAttribute(HTTP_ROUTE, context.path())
+            .setAttribute(REQUEST_ID, context.requestId())
+            .setAttribute(CORRELATION_ID, context.correlationId())
+            .startSpan();
+        request.setAttribute(REQUEST_ATTRIBUTE, span);
+    }
+
+    @Override
+    public void requestCompleted(RequestTraceContext context, int statusCode) {
+        Object current = request.getAttribute(REQUEST_ATTRIBUTE);
+        if (current instanceof Span span) {
+            span.setAttribute(HTTP_STATUS, statusCode);
+            span.setAttribute(LEGACY_HTTP_STATUS, statusCode);
+            if (statusCode >= 500) {
+                span.setStatus(StatusCode.ERROR, "http status " + statusCode);
+            }
+            span.end();
+            request.removeAttribute(REQUEST_ATTRIBUTE);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add opt-in OpenTelemetry API adapters for Go, Python, TypeScript, Java, and Rust runtime seams while preserving no-op defaults.
- Wire current service baselines to environment-selected adapters and include HTTP/request/correlation span attributes.
- Document runtime adapter baseline and update project-index traceability.

## Validation
- make observability-config
- make observability-validate *(failed: Docker daemon unavailable in sandbox)*
- make check-devcontainer *(failed: Docker daemon unavailable in sandbox)*
- python3 /Users/bytedance/.codex/repos/autoharness/scripts/validate_index.py project-index.yaml *(failed: script path unavailable in sandbox)*
- go test ./platform/go-runtime
- go test ./services/dispatch/... and remaining Go services
- uv run python -m unittest discover -s tests for Python services
- npm test for TypeScript services
- mvn -q test for Java services
- cargo test for Rust platform/services