### PR TITLE
REQ-015B: Provider Integration code review cleanup

### DIFF
--- a/services/provider-integration/internal/domain/clock.go
+++ b/services/provider-integration/internal/domain/clock.go
@@ -1,0 +1,7 @@
+package domain
+
+import "time"
+
+// timeNow is a package-level clock variable that can be overridden in tests
+// to make time-based behaviour deterministic.
+var timeNow = time.Now

--- a/services/provider-integration/internal/domain/provider_adapter.go
+++ b/services/provider-integration/internal/domain/provider_adapter.go
@@ -57,33 +57,33 @@ type AuthConfig struct {
 
 // SlaPolicy defines service-level agreement parameters for an adapter.
 type SlaPolicy struct {
-	P95LatencyMs    int
-	SuccessRate     float64
-	MaxConcurrency  int
-	DailyQuota      int
-	MaintenanceWin  string
+	P95LatencyMs   int
+	SuccessRate    float64
+	MaxConcurrency int
+	DailyQuota     int
+	MaintenanceWin string
 }
 
 // CapabilityMatrix declares which capabilities a provider supports.
 type CapabilityMatrix struct {
 	Version      string
-	Capabilites map[Capability]bool
+	Capabilities map[Capability]bool
 }
 
 // ProviderAdapter is the aggregate root for a provider's integration adapter.
 // It owns registration, version, capability declaration, health status,
 // authentication configuration, and SLA policy.
 type ProviderAdapter struct {
-	ProviderID         ProviderID
-	ProviderType       ProviderType
-	AdapterVersion     AdapterVersion
-	Status             ProviderAdapterStatus
-	AuthConfig         AuthConfig
-	CapabilityMatrix   CapabilityMatrix
-	SlaPolicy          SlaPolicy
-	HealthStatus       string
-	RegisteredAt       time.Time
-	LastHealthCheckAt  *time.Time
+	ProviderID        ProviderID
+	ProviderType      ProviderType
+	AdapterVersion    AdapterVersion
+	Status            ProviderAdapterStatus
+	AuthConfig        AuthConfig
+	CapabilityMatrix  CapabilityMatrix
+	SlaPolicy         SlaPolicy
+	HealthStatus      string
+	RegisteredAt      time.Time
+	LastHealthCheckAt *time.Time
 }
 
 // NewProviderAdapter creates a validated ProviderAdapter aggregate.
@@ -104,7 +104,7 @@ func NewProviderAdapter(
 		CapabilityMatrix: capabilityMatrix,
 		SlaPolicy:        slaPolicy,
 		HealthStatus:     "unknown",
-		RegisteredAt:     time.Now().UTC(),
+		RegisteredAt:     timeNow().UTC(),
 	}
 	if err := adapter.Validate(); err != nil {
 		return ProviderAdapter{}, err
@@ -129,10 +129,10 @@ func (a ProviderAdapter) Validate() error {
 	if a.AuthConfig.AuthType == "" {
 		return fmt.Errorf("auth config type is required for an active adapter")
 	}
-	if len(a.CapabilityMatrix.Capabilites) == 0 {
+	if len(a.CapabilityMatrix.Capabilities) == 0 {
 		return fmt.Errorf("capability matrix must declare at least one capability")
 	}
-	for cap := range a.CapabilityMatrix.Capabilites {
+	for cap := range a.CapabilityMatrix.Capabilities {
 		if !validCapability(cap) {
 			return fmt.Errorf("unsupported capability: %q", cap)
 		}
@@ -151,16 +151,19 @@ func (a *ProviderAdapter) Enable() error {
 
 // Disable transitions the adapter to disabled status. No new commands are accepted.
 func (a *ProviderAdapter) Disable() error {
+	if a.Status == ProviderAdapterStatusDisabled {
+		return fmt.Errorf("adapter is already disabled")
+	}
 	a.Status = ProviderAdapterStatusDisabled
 	return nil
 }
 
 // UpdateCapabilityMatrix replaces the current capability matrix.
 func (a *ProviderAdapter) UpdateCapabilityMatrix(matrix CapabilityMatrix) error {
-	if len(matrix.Capabilites) == 0 {
+	if len(matrix.Capabilities) == 0 {
 		return fmt.Errorf("capability matrix must declare at least one capability")
 	}
-	for cap := range matrix.Capabilites {
+	for cap := range matrix.Capabilities {
 		if !validCapability(cap) {
 			return fmt.Errorf("unsupported capability: %q", cap)
 		}

--- a/services/provider-integration/internal/domain/provider_adapter_test.go
+++ b/services/provider-integration/internal/domain/provider_adapter_test.go
@@ -8,8 +8,8 @@ import (
 func TestNewProviderAdapterValidates(t *testing.T) {
 	matrix := CapabilityMatrix{
 		Version: "1.0",
-		Capabilites: map[Capability]bool{
-			CapabilityReserve: true,
+		Capabilities: map[Capability]bool{
+			CapabilityReserve:         true,
 			CapabilityIssueCredential: true,
 		},
 	}
@@ -37,8 +37,8 @@ func TestNewProviderAdapterValidates(t *testing.T) {
 
 func TestNewProviderAdapterRejectsMissingFields(t *testing.T) {
 	matrix := CapabilityMatrix{
-		Version: "1.0",
-		Capabilites: map[Capability]bool{CapabilityReserve: true},
+		Version:      "1.0",
+		Capabilities: map[Capability]bool{CapabilityReserve: true},
 	}
 	_, err := NewProviderAdapter("", ProviderTypeRail, "1.0.0", AuthConfig{AuthType: "key", Credentials: nil}, matrix, SlaPolicy{})
 	if err == nil || !strings.Contains(err.Error(), "provider id is required") {
@@ -58,8 +58,8 @@ func TestNewProviderAdapterRejectsMissingFields(t *testing.T) {
 
 func TestProviderAdapterEnableDisable(t *testing.T) {
 	matrix := CapabilityMatrix{
-		Version: "1.0",
-		Capabilites: map[Capability]bool{CapabilityReserve: true},
+		Version:      "1.0",
+		Capabilities: map[Capability]bool{CapabilityReserve: true},
 	}
 	adapter, _ := NewProviderAdapter("cr", ProviderTypeRail, "1.0.0", AuthConfig{AuthType: "key"}, matrix, SlaPolicy{})
 
@@ -77,15 +77,15 @@ func TestProviderAdapterEnableDisable(t *testing.T) {
 
 func TestProviderAdapterUpdateCapabilityMatrix(t *testing.T) {
 	matrix := CapabilityMatrix{
-		Version: "1.0",
-		Capabilites: map[Capability]bool{CapabilityReserve: true},
+		Version:      "1.0",
+		Capabilities: map[Capability]bool{CapabilityReserve: true},
 	}
 	adapter, _ := NewProviderAdapter("cr", ProviderTypeRail, "1.0.0", AuthConfig{AuthType: "key"}, matrix, SlaPolicy{})
 
 	newMatrix := CapabilityMatrix{
 		Version: "2.0",
-		Capabilites: map[Capability]bool{
-			CapabilityReserve: true,
+		Capabilities: map[Capability]bool{
+			CapabilityReserve:           true,
 			CapabilityCancelReservation: true,
 		},
 	}
@@ -100,8 +100,8 @@ func TestProviderAdapterUpdateCapabilityMatrix(t *testing.T) {
 func TestProviderAdapterRejectsUnsupportedCapability(t *testing.T) {
 	matrix := CapabilityMatrix{
 		Version: "1.0",
-		Capabilites: map[Capability]bool{
-			CapabilityReserve: true,
+		Capabilities: map[Capability]bool{
+			CapabilityReserve:   true,
 			"UnknownCapability": true,
 		},
 	}
@@ -113,8 +113,8 @@ func TestProviderAdapterRejectsUnsupportedCapability(t *testing.T) {
 
 func TestProviderAdapterRejectsUnsupportedProviderType(t *testing.T) {
 	matrix := CapabilityMatrix{
-		Version: "1.0",
-		Capabilites: map[Capability]bool{CapabilityReserve: true},
+		Version:      "1.0",
+		Capabilities: map[Capability]bool{CapabilityReserve: true},
 	}
 	_, err := NewProviderAdapter("test", ProviderType("UNKNOWN"), "1.0.0", AuthConfig{AuthType: "key"}, matrix, SlaPolicy{})
 	if err == nil || !strings.Contains(err.Error(), "unsupported provider type") {
@@ -124,8 +124,8 @@ func TestProviderAdapterRejectsUnsupportedProviderType(t *testing.T) {
 
 func TestProviderAdapterUpdateSlaPolicy(t *testing.T) {
 	matrix := CapabilityMatrix{
-		Version: "1.0",
-		Capabilites: map[Capability]bool{CapabilityReserve: true},
+		Version:      "1.0",
+		Capabilities: map[Capability]bool{CapabilityReserve: true},
 	}
 	adapter, _ := NewProviderAdapter("cr", ProviderTypeRail, "1.0.0", AuthConfig{AuthType: "key"}, matrix, SlaPolicy{})
 
@@ -138,8 +138,8 @@ func TestProviderAdapterUpdateSlaPolicy(t *testing.T) {
 
 func TestProviderAdapterRegisteredAtSet(t *testing.T) {
 	matrix := CapabilityMatrix{
-		Version: "1.0",
-		Capabilites: map[Capability]bool{CapabilityReserve: true},
+		Version:      "1.0",
+		Capabilities: map[Capability]bool{CapabilityReserve: true},
 	}
 	adapter, _ := NewProviderAdapter("cr", ProviderTypeRail, "1.0.0", AuthConfig{AuthType: "key"}, matrix, SlaPolicy{})
 	if adapter.RegisteredAt.IsZero() {

--- a/services/provider-integration/internal/domain/provider_outbox.go
+++ b/services/provider-integration/internal/domain/provider_outbox.go
@@ -43,7 +43,7 @@ func NewProviderOutbox(outboxID string, sourceLogID string, sourceType string, m
 		CorrelationID:   strings.TrimSpace(correlationID),
 		IdempotencyKey:  strings.TrimSpace(idempotencyKey),
 		Status:          OutboxEnqueued,
-		CreatedAt:       time.Now().UTC(),
+		CreatedAt:       timeNow().UTC(),
 	}
 	if err := outbox.Validate(); err != nil {
 		return ProviderOutbox{}, err
@@ -74,7 +74,7 @@ func (o *ProviderOutbox) MarkPublished() error {
 	if o.Status != OutboxEnqueued && o.Status != OutboxDeliveryFailed {
 		return fmt.Errorf("cannot mark published from status %q", o.Status)
 	}
-	now := time.Now().UTC()
+	now := timeNow().UTC()
 	o.Status = OutboxPublished
 	o.PublishedAt = &now
 	return nil

--- a/services/provider-integration/internal/domain/provider_reconciliation.go
+++ b/services/provider-integration/internal/domain/provider_reconciliation.go
@@ -67,7 +67,7 @@ func NewProviderReconciliationBatch(batchID string, providerID ProviderID, state
 		FileName:        strings.TrimSpace(fileName),
 		Status:          BatchImported,
 		Records:         nil,
-		ImportedAt:      time.Now().UTC(),
+		ImportedAt:      timeNow().UTC(),
 	}
 	if err := batch.Validate(); err != nil {
 		return ProviderReconciliationBatch{}, err
@@ -114,7 +114,7 @@ func (b *ProviderReconciliationBatch) Complete() error {
 	if b.Status != BatchMatched {
 		return fmt.Errorf("cannot complete batch from status %q", b.Status)
 	}
-	now := time.Now().UTC()
+	now := timeNow().UTC()
 	b.Status = BatchCompleted
 	b.CompletedAt = &now
 	return nil

--- a/services/provider-integration/internal/domain/provider_reconciliation_test.go
+++ b/services/provider-integration/internal/domain/provider_reconciliation_test.go
@@ -54,15 +54,15 @@ func TestProviderReconciliationBatchAddAndMatchRecords(t *testing.T) {
 	batch, _ := NewProviderReconciliationBatch("batch-002", "cr", "2026-06", "hash", "file.csv")
 
 	record := ReconciliationRecord{
-		RecordKey:       "rec-001",
-		RecordType:      RecordReservation,
-		ProviderRef:     "CNF-001",
-		PlatformRef:     "booking-001",
-		ProviderAmount:  "100.00",
-		PlatformAmount:  "100.00",
-		ProviderStatus:  "confirmed",
-		PlatformStatus:  "confirmed",
-		Matched:         true,
+		RecordKey:      "rec-001",
+		RecordType:     RecordReservation,
+		ProviderRef:    "CNF-001",
+		PlatformRef:    "booking-001",
+		ProviderAmount: "100.00",
+		PlatformAmount: "100.00",
+		ProviderStatus: "confirmed",
+		PlatformStatus: "confirmed",
+		Matched:        true,
 	}
 	if err := batch.AddRecord(record); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/services/provider-integration/internal/domain/provider_request_log.go
+++ b/services/provider-integration/internal/domain/provider_request_log.go
@@ -21,16 +21,16 @@ const (
 type ProviderRequestLogStatus string
 
 const (
-	RequestCreated    ProviderRequestLogStatus = "CREATED"
-	RequestSent       ProviderRequestLogStatus = "SENT"
-	RequestSucceeded  ProviderRequestLogStatus = "SUCCEEDED"
-	RequestRejected   ProviderRequestLogStatus = "REJECTED"
-	RequestFailed     ProviderRequestLogStatus = "FAILED"
-	RequestRetrying   ProviderRequestLogStatus = "RETRYING"
-	RequestTimedOut   ProviderRequestLogStatus = "TIMED_OUT"
-	RequestAmbiguous  ProviderRequestLogStatus = "AMBIGUOUS"
-	RequestProbing    ProviderRequestLogStatus = "PROBING"
-	RequestConflict   ProviderRequestLogStatus = "CONFLICT"
+	RequestCreated   ProviderRequestLogStatus = "CREATED"
+	RequestSent      ProviderRequestLogStatus = "SENT"
+	RequestSucceeded ProviderRequestLogStatus = "SUCCEEDED"
+	RequestRejected  ProviderRequestLogStatus = "REJECTED"
+	RequestFailed    ProviderRequestLogStatus = "FAILED"
+	RequestRetrying  ProviderRequestLogStatus = "RETRYING"
+	RequestTimedOut  ProviderRequestLogStatus = "TIMED_OUT"
+	RequestAmbiguous ProviderRequestLogStatus = "AMBIGUOUS"
+	RequestProbing   ProviderRequestLogStatus = "PROBING"
+	RequestConflict  ProviderRequestLogStatus = "CONFLICT"
 )
 
 // ProviderRef holds the external provider's reference identifiers (struct version).
@@ -63,23 +63,23 @@ type RetryAttempt struct {
 // It is the authoritative interaction log containing idempotency keys,
 // correlation IDs, raw data, retry chain, and the final mapped outcome.
 type ProviderRequestLog struct {
-	LogID             string
-	ProviderID        ProviderID
-	Operation         Operation
-	IdempotencyKey    string
-	CorrelationID     string
-	BusinessRef       string
-	Status            ProviderRequestLogStatus
-	Outcome           *RequestOutcome
-	ProviderRef       *ProviderRef
-	ErrorType         *ErrorClassification
-	ErrorMessage      string
-	NextAction        string
-	RawArchive        *RawArchive
-	RetryAttempts     []RetryAttempt
-	CreatedAt         time.Time
-	SentAt            *time.Time
-	CompletedAt       *time.Time
+	LogID          string
+	ProviderID     ProviderID
+	Operation      Operation
+	IdempotencyKey string
+	CorrelationID  string
+	BusinessRef    string
+	Status         ProviderRequestLogStatus
+	Outcome        *RequestOutcome
+	ProviderRef    *ProviderRef
+	ErrorType      *ErrorClassification
+	ErrorMessage   string
+	NextAction     string
+	RawArchive     *RawArchive
+	RetryAttempts  []RetryAttempt
+	CreatedAt      time.Time
+	SentAt         *time.Time
+	CompletedAt    *time.Time
 }
 
 // NewProviderRequestLog creates a validated ProviderRequestLog aggregate.
@@ -93,7 +93,7 @@ func NewProviderRequestLog(logID string, providerID ProviderID, operation Operat
 		BusinessRef:    strings.TrimSpace(businessRef),
 		Status:         RequestCreated,
 		RetryAttempts:  nil,
-		CreatedAt:      time.Now().UTC(),
+		CreatedAt:      timeNow().UTC(),
 	}
 	if err := log.Validate(); err != nil {
 		return ProviderRequestLog{}, err
@@ -124,7 +124,7 @@ func (l *ProviderRequestLog) MarkSent() error {
 	if l.Status != RequestCreated && l.Status != RequestRetrying {
 		return fmt.Errorf("cannot mark sent from status %q", l.Status)
 	}
-	now := time.Now().UTC()
+	now := timeNow().UTC()
 	l.Status = RequestSent
 	l.SentAt = &now
 	return nil
@@ -134,7 +134,7 @@ func (l *ProviderRequestLog) MarkSucceeded(ref *ProviderRef) error {
 	if l.Status != RequestSent && l.Status != RequestProbing {
 		return fmt.Errorf("cannot mark succeeded from status %q", l.Status)
 	}
-	now := time.Now().UTC()
+	now := timeNow().UTC()
 	l.Status = RequestSucceeded
 	outcome := OutcomeSuccess
 	l.Outcome = &outcome
@@ -147,7 +147,7 @@ func (l *ProviderRequestLog) MarkRejected(errorType ErrorClassification, message
 	if l.Status != RequestSent && l.Status != RequestProbing {
 		return fmt.Errorf("cannot mark rejected from status %q", l.Status)
 	}
-	now := time.Now().UTC()
+	now := timeNow().UTC()
 	l.Status = RequestRejected
 	outcome := OutcomeRejected
 	l.Outcome = &outcome
@@ -161,7 +161,7 @@ func (l *ProviderRequestLog) MarkFailed(errorType ErrorClassification, message s
 	if l.Status != RequestSent {
 		return fmt.Errorf("cannot mark failed from status %q", l.Status)
 	}
-	now := time.Now().UTC()
+	now := timeNow().UTC()
 	l.Status = RequestFailed
 	outcome := OutcomeFailed
 	l.Outcome = &outcome
@@ -178,7 +178,7 @@ func (l *ProviderRequestLog) MarkRetrying(attemptNo int) error {
 	l.Status = RequestRetrying
 	l.RetryAttempts = append(l.RetryAttempts, RetryAttempt{
 		AttemptNo:   attemptNo,
-		RequestedAt: time.Now().UTC(),
+		RequestedAt: timeNow().UTC(),
 	})
 	return nil
 }
@@ -213,7 +213,7 @@ func (l *ProviderRequestLog) MarkConflict(message string) error {
 	if l.Status != RequestProbing && l.Status != RequestAmbiguous {
 		return fmt.Errorf("cannot mark conflict from status %q", l.Status)
 	}
-	now := time.Now().UTC()
+	now := timeNow().UTC()
 	l.Status = RequestConflict
 	outcome := OutcomeConflict
 	l.Outcome = &outcome

--- a/services/provider-integration/internal/domain/provider_status_probe.go
+++ b/services/provider-integration/internal/domain/provider_status_probe.go
@@ -68,7 +68,7 @@ func NewProviderStatusProbe(probeID string, sourceLogID string, providerID Provi
 		AttemptNo:       0,
 		MaxAttempts:     maxAttempts,
 		IntervalSeconds: intervalSeconds,
-		ScheduledAt:     time.Now().UTC(),
+		ScheduledAt:     timeNow().UTC(),
 	}
 	if err := probe.Validate(); err != nil {
 		return ProviderStatusProbe{}, err
@@ -108,7 +108,7 @@ func (p *ProviderStatusProbe) Execute() error {
 	if p.Status != ProbeScheduled && p.Status != ProbeStillProcessing {
 		return fmt.Errorf("cannot execute probe from status %q", p.Status)
 	}
-	now := time.Now().UTC()
+	now := timeNow().UTC()
 	p.Status = ProbeRunning
 	p.AttemptNo++
 	p.LastExecutedAt = &now
@@ -119,7 +119,7 @@ func (p *ProviderStatusProbe) CompleteSuccess() error {
 	if p.Status != ProbeRunning {
 		return fmt.Errorf("cannot complete probe from status %q", p.Status)
 	}
-	now := time.Now().UTC()
+	now := timeNow().UTC()
 	p.Status = ProbeResolvedSuccess
 	outcome := OutcomeSuccess
 	p.Outcome = &outcome
@@ -131,7 +131,7 @@ func (p *ProviderStatusProbe) CompleteRejection() error {
 	if p.Status != ProbeRunning {
 		return fmt.Errorf("cannot complete probe from status %q", p.Status)
 	}
-	now := time.Now().UTC()
+	now := timeNow().UTC()
 	p.Status = ProbeResolvedRejection
 	outcome := OutcomeRejected
 	p.Outcome = &outcome
@@ -155,7 +155,7 @@ func (p *ProviderStatusProbe) Escalate(message string) error {
 	if p.Status != ProbeExhausted && p.Status != ProbeRunning {
 		return fmt.Errorf("cannot escalate probe from status %q", p.Status)
 	}
-	now := time.Now().UTC()
+	now := timeNow().UTC()
 	p.Status = ProbeEscalated
 	p.ErrorMessage = message
 	p.CompletedAt = &now

--- a/services/provider-integration/internal/domain/webhook_inbox.go
+++ b/services/provider-integration/internal/domain/webhook_inbox.go
@@ -23,20 +23,20 @@ const (
 // provider. Webhooks must be signature-verified before processing. The same
 // providerId + eventId is idempotent.
 type WebhookInbox struct {
-	InboxID          string
-	ProviderID       ProviderID
-	EventID          string
-	Signature        string
-	RawPayload       string
-	SchemaVersion    string
-	MappingVersion   string
-	Status           WebhookInboxStatus
-	VerifiedAt       *time.Time
-	MappedEventType  string
-	MappedPayload    string
-	RejectionReason  string
-	ReceivedAt       time.Time
-	PublishedAt      *time.Time
+	InboxID         string
+	ProviderID      ProviderID
+	EventID         string
+	Signature       string
+	RawPayload      string
+	SchemaVersion   string
+	MappingVersion  string
+	Status          WebhookInboxStatus
+	VerifiedAt      *time.Time
+	MappedEventType string
+	MappedPayload   string
+	RejectionReason string
+	ReceivedAt      time.Time
+	PublishedAt     *time.Time
 }
 
 // NewWebhookInbox creates a validated WebhookInbox aggregate.
@@ -49,7 +49,7 @@ func NewWebhookInbox(inboxID string, providerID ProviderID, eventID string, sign
 		RawPayload:    rawPayload,
 		SchemaVersion: strings.TrimSpace(schemaVersion),
 		Status:        WebhookReceived,
-		ReceivedAt:    time.Now().UTC(),
+		ReceivedAt:    timeNow().UTC(),
 	}
 	if err := inbox.Validate(); err != nil {
 		return WebhookInbox{}, err
@@ -77,7 +77,7 @@ func (w *WebhookInbox) Verify() error {
 	if w.Status != WebhookReceived {
 		return fmt.Errorf("cannot verify webhook from status %q", w.Status)
 	}
-	now := time.Now().UTC()
+	now := timeNow().UTC()
 	w.Status = WebhookVerified
 	w.VerifiedAt = &now
 	return nil
@@ -115,7 +115,7 @@ func (w *WebhookInbox) MarkPublished() error {
 	if w.Status != WebhookMapped && w.Status != WebhookPublishFailed {
 		return fmt.Errorf("cannot mark published from status %q", w.Status)
 	}
-	now := time.Now().UTC()
+	now := timeNow().UTC()
 	w.Status = WebhookPublished
 	w.PublishedAt = &now
 	return nil


### PR DESCRIPTION
Code review fixes for provider-integration domain:

1. Renamed `Capabilites` → `Capabilities` (typo)
2. Added package-level `timeNow` clock variable for deterministic tests
3. Replaced all `time.Now().UTC()` calls with `timeNow().UTC()`
4. Added guard to `Disable()` to prevent double-disabling
5. Ran gofmt on all touched files