### PR TITLE
feat(traveler-profile): implement domain foundation (REQ-017)

### DIFF
--- a/project-index.yaml
+++ b/project-index.yaml
@@ -247,6 +247,41 @@ requirements:
         description: "Unit tests for ProviderRequestLog state machine and idempotency."
       - path: services/provider-integration/internal/domain/provider_status_probe_test.go
         description: "Unit tests for ProviderStatusProbe scheduling and execution."
+
+  - id: REQ-017
+    title: "Traveler Profile domain foundation"
+    description: "Implement the Traveler Profile domain foundation in Java. This domain owns traveler master data: TravelerProfile aggregates, identity documents, eligibility summaries, and preference snapshots consumed by Fare & Pricing and Entitlement issuance."
+    priority: P0
+    status: implemented
+    code:
+      - path: services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfile.java
+        description: "TravelerProfile aggregate root with lifecycle, document, eligibility, and preference management."
+      - path: services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/Document.java
+        description: "Identity document aggregate with verification, expiry, revocation lifecycle."
+      - path: services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/EligibilitySummary.java
+        description: "Eligibility facts with validity windows and revocation."
+      - path: services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/PreferenceSnapshot.java
+        description: "Immutable preference snapshots with versioning."
+      - path: services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfileEvent.java
+        description: "Sealed event interface with 13 event types."
+      - path: services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/EventMetadata.java
+        description: "Standard event metadata envelope."
+      - path: services/traveler-profile/src/main/java/com/trainticket/travelerprofile/ServiceProfile.java
+        description: "Service profile with REQ-017 ownership."
+      - path: services/traveler-profile/README.md
+        description: "Service README with domain documentation."
+    tests:
+      - path: services/traveler-profile/src/test/java/com/trainticket/travelerprofile/domain/TravelerProfileTest.java
+        description: "38 unit tests for domain invariants, document lifecycle, eligibility, preferences, and booking validation."
+      - path: services/traveler-profile/src/test/java/com/trainticket/travelerprofile/ApplicationTest.java
+        description: "4 application skeleton tests (health, runtime endpoints, context filter, tracing seam)."
+    docs:
+      - path: docs/02-domains/traveler-profile.md
+      - path: docs/03-ddd-final/phase-1-contract.md
+    depends_on: [REQ-003]
+    confidence: confirmed
+    source: "docs/02-domains/traveler-profile.md, docs/03-ddd-final/phase-1-contract.md, docs/03-ddd-final/implementation-roadmap.md"
+
       - path: services/provider-integration/internal/domain/webhook_inbox_test.go
         description: "Unit tests for WebhookInbox verification, mapping, and publishing."
       - path: services/provider-integration/internal/domain/provider_outbox_test.go

--- a/service-catalog.json
+++ b/service-catalog.json
@@ -400,11 +400,11 @@
       "domain": "Traveler Profile",
       "language": "java",
       "runtime": "jvm",
-      "phase": "phase-1-support",
-      "status": "skeleton",
+      "phase": "phase-1-domain-foundation",
+      "status": "implemented",
       "priority": "P0",
       "workPackages": [
-        "WP-16"
+        "REQ-017"
       ],
       "docs": [
         "docs/02-domains/traveler-profile.md"

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/Document.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/Document.java
@@ -1,0 +1,118 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public final class Document {
+    private final String documentId;
+    private final DocumentType documentType;
+    private final String documentNumber;
+    private final String documentNumberHash;
+    private final String issuingCountry;
+    private final Instant issuedAt;
+    private final Instant expiresAt;
+    private final String displayName;
+    private final boolean primaryDocument;
+    private DocumentStatus status;
+    private String statusReason;
+    private Instant verifiedAt;
+    private String verifier;
+
+    public Document(
+        String documentId,
+        DocumentType documentType,
+        String documentNumber,
+        String issuingCountry,
+        Instant issuedAt,
+        Instant expiresAt,
+        String displayName,
+        boolean primaryDocument
+    ) {
+        this.documentId = requireText(documentId, "documentId");
+        this.documentType = Objects.requireNonNull(documentType, "documentType is required");
+        this.documentNumber = requireText(documentNumber, "documentNumber");
+        this.documentNumberHash = Integer.toHexString(Objects.hash(documentNumber));
+        this.issuingCountry = requireText(issuingCountry, "issuingCountry");
+        this.issuedAt = Objects.requireNonNull(issuedAt, "issuedAt is required");
+        this.expiresAt = Objects.requireNonNull(expiresAt, "expiresAt is required");
+        this.displayName = requireText(displayName, "displayName");
+        this.primaryDocument = primaryDocument;
+        this.status = DocumentStatus.PENDING_VERIFICATION;
+        if (!expiresAt.isAfter(issuedAt)) {
+            throw new DomainRuleViolation("document expiresAt must be after issuedAt");
+        }
+    }
+
+    public String documentId() { return documentId; }
+    public DocumentType documentType() { return documentType; }
+    public String documentNumber() { return documentNumber; }
+    public String documentNumberHash() { return documentNumberHash; }
+    public String issuingCountry() { return issuingCountry; }
+    public Instant issuedAt() { return issuedAt; }
+    public Instant expiresAt() { return expiresAt; }
+    public String displayName() { return displayName; }
+    public boolean primaryDocument() { return primaryDocument; }
+    public DocumentStatus status() { return status; }
+    public String statusReason() { return statusReason; }
+    public Instant verifiedAt() { return verifiedAt; }
+    public String verifier() { return verifier; }
+
+    public void verify(String verifierName, Instant now) {
+        if (status == DocumentStatus.VERIFIED) {
+            return;
+        }
+        if (status == DocumentStatus.EXPIRED || now.isAfter(expiresAt)) {
+            throw new DomainRuleViolation("cannot verify expired document " + documentId);
+        }
+        this.status = DocumentStatus.VERIFIED;
+        this.verifiedAt = Objects.requireNonNull(now, "now is required");
+        this.verifier = requireText(verifierName, "verifierName");
+        this.statusReason = "verified by " + verifierName;
+    }
+
+    public void expire() {
+        if (status == DocumentStatus.EXPIRED) {
+            return;
+        }
+        this.status = DocumentStatus.EXPIRED;
+        this.statusReason = "document expired at " + expiresAt;
+    }
+
+    public void revoke(String reason) {
+        if (status == DocumentStatus.REVOKED) {
+            return;
+        }
+        this.status = DocumentStatus.REVOKED;
+        this.statusReason = requireText(reason, "reason");
+    }
+
+    public boolean isActiveAt(Instant moment) {
+        return status == DocumentStatus.VERIFIED && !moment.isAfter(expiresAt);
+    }
+
+    public void requireActiveForNewBooking(Instant moment) {
+        if (status == DocumentStatus.EXPIRED || status == DocumentStatus.REVOKED) {
+            throw new DomainRuleViolation("document " + documentId + " is " + status + " and cannot be used for new bookings");
+        }
+        if (moment.isAfter(expiresAt)) {
+            throw new DomainRuleViolation("document " + documentId + " has expired at " + expiresAt);
+        }
+        if (status == DocumentStatus.PENDING_VERIFICATION) {
+            throw new DomainRuleViolation("document " + documentId + " is not yet verified and cannot be used for new bookings");
+        }
+    }
+
+    public String maskedDocumentRef() {
+        if (documentNumber.length() <= 4) {
+            return "***" + documentNumber;
+        }
+        return documentNumber.substring(0, 2) + "***" + documentNumber.substring(documentNumber.length() - 4);
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/DocumentAdded.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/DocumentAdded.java
@@ -1,0 +1,28 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record DocumentAdded(
+    String profileId,
+    String documentId,
+    DocumentType documentType,
+    String issuingCountry,
+    boolean isPrimary,
+    EventMetadata metadata
+) implements TravelerProfileEvent {
+    @Override
+    public String eventId() { return metadata.eventId(); }
+    @Override
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    @Override
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    @Override
+    public String causationId() { return metadata.causationId(); }
+    @Override
+    public String correlationId() { return metadata.correlationId(); }
+    @Override
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    @Override
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/DocumentExpired.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/DocumentExpired.java
@@ -1,0 +1,26 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record DocumentExpired(
+    String profileId,
+    String documentId,
+    DocumentType documentType,
+    EventMetadata metadata
+) implements TravelerProfileEvent {
+    @Override
+    public String eventId() { return metadata.eventId(); }
+    @Override
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    @Override
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    @Override
+    public String causationId() { return metadata.causationId(); }
+    @Override
+    public String correlationId() { return metadata.correlationId(); }
+    @Override
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    @Override
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/DocumentRevoked.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/DocumentRevoked.java
@@ -1,0 +1,27 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record DocumentRevoked(
+    String profileId,
+    String documentId,
+    DocumentType documentType,
+    String reason,
+    EventMetadata metadata
+) implements TravelerProfileEvent {
+    @Override
+    public String eventId() { return metadata.eventId(); }
+    @Override
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    @Override
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    @Override
+    public String causationId() { return metadata.causationId(); }
+    @Override
+    public String correlationId() { return metadata.correlationId(); }
+    @Override
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    @Override
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/DocumentStatus.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/DocumentStatus.java
@@ -1,0 +1,8 @@
+package com.trainticket.travelerprofile.domain;
+
+public enum DocumentStatus {
+    PENDING_VERIFICATION,
+    VERIFIED,
+    EXPIRED,
+    REVOKED
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/DocumentType.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/DocumentType.java
@@ -1,0 +1,13 @@
+package com.trainticket.travelerprofile.domain;
+
+public enum DocumentType {
+    IDENTITY_CARD,
+    PASSPORT,
+    MILITARY_ID,
+    STUDENT_ID,
+    HONGKONG_MACAU_PERMIT,
+    TAIWAN_PERMIT,
+    FOREIGNER_PERMANENT_RESIDENT_ID,
+    RESIDENCE_PERMIT,
+    OTHER
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/DocumentVerified.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/DocumentVerified.java
@@ -1,0 +1,27 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record DocumentVerified(
+    String profileId,
+    String documentId,
+    DocumentType documentType,
+    String verifier,
+    EventMetadata metadata
+) implements TravelerProfileEvent {
+    @Override
+    public String eventId() { return metadata.eventId(); }
+    @Override
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    @Override
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    @Override
+    public String causationId() { return metadata.causationId(); }
+    @Override
+    public String correlationId() { return metadata.correlationId(); }
+    @Override
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    @Override
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/DomainRuleViolation.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/DomainRuleViolation.java
@@ -1,0 +1,7 @@
+package com.trainticket.travelerprofile.domain;
+
+public class DomainRuleViolation extends RuntimeException {
+    public DomainRuleViolation(String message) {
+        super(message);
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/EligibilityExpired.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/EligibilityExpired.java
@@ -1,0 +1,26 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record EligibilityExpired(
+    String profileId,
+    String eligibilityId,
+    String eligibilityType,
+    EventMetadata metadata
+) implements TravelerProfileEvent {
+    @Override
+    public String eventId() { return metadata.eventId(); }
+    @Override
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    @Override
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    @Override
+    public String causationId() { return metadata.causationId(); }
+    @Override
+    public String correlationId() { return metadata.correlationId(); }
+    @Override
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    @Override
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/EligibilityGranted.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/EligibilityGranted.java
@@ -1,0 +1,29 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record EligibilityGranted(
+    String profileId,
+    String eligibilityId,
+    String eligibilityType,
+    String eligibilitySource,
+    Instant validFrom,
+    Instant validUntil,
+    EventMetadata metadata
+) implements TravelerProfileEvent {
+    @Override
+    public String eventId() { return metadata.eventId(); }
+    @Override
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    @Override
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    @Override
+    public String causationId() { return metadata.causationId(); }
+    @Override
+    public String correlationId() { return metadata.correlationId(); }
+    @Override
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    @Override
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/EligibilityRevoked.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/EligibilityRevoked.java
@@ -1,0 +1,27 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record EligibilityRevoked(
+    String profileId,
+    String eligibilityId,
+    String eligibilityType,
+    String reason,
+    EventMetadata metadata
+) implements TravelerProfileEvent {
+    @Override
+    public String eventId() { return metadata.eventId(); }
+    @Override
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    @Override
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    @Override
+    public String causationId() { return metadata.causationId(); }
+    @Override
+    public String correlationId() { return metadata.correlationId(); }
+    @Override
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    @Override
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/EligibilitySummary.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/EligibilitySummary.java
@@ -1,0 +1,78 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public final class EligibilitySummary {
+    private final String eligibilityId;
+    private final String eligibilityType;
+    private final String eligibilitySource;
+    private final String evidenceHash;
+    private final Instant validFrom;
+    private final Instant validUntil;
+    private boolean revoked;
+    private String revocationReason;
+
+    public EligibilitySummary(
+        String eligibilityId,
+        String eligibilityType,
+        String eligibilitySource,
+        String evidenceHash,
+        Instant validFrom,
+        Instant validUntil
+    ) {
+        this.eligibilityId = requireText(eligibilityId, "eligibilityId");
+        this.eligibilityType = requireText(eligibilityType, "eligibilityType");
+        this.eligibilitySource = requireText(eligibilitySource, "eligibilitySource");
+        this.evidenceHash = requireText(evidenceHash, "evidenceHash");
+        this.validFrom = Objects.requireNonNull(validFrom, "validFrom is required");
+        this.validUntil = Objects.requireNonNull(validUntil, "validUntil is required");
+        this.revoked = false;
+        if (!validUntil.isAfter(validFrom)) {
+            throw new DomainRuleViolation("eligibility validUntil must be after validFrom");
+        }
+    }
+
+    public String eligibilityId() { return eligibilityId; }
+    public String eligibilityType() { return eligibilityType; }
+    public String eligibilitySource() { return eligibilitySource; }
+    public String evidenceHash() { return evidenceHash; }
+    public Instant validFrom() { return validFrom; }
+    public Instant validUntil() { return validUntil; }
+    public boolean revoked() { return revoked; }
+    public String revocationReason() { return revocationReason; }
+
+    public void revoke(String reason) {
+        if (revoked) {
+            return;
+        }
+        this.revoked = true;
+        this.revocationReason = requireText(reason, "reason");
+    }
+
+    public boolean isEffectiveAt(Instant moment) {
+        if (revoked) {
+            return false;
+        }
+        return !moment.isBefore(validFrom) && !moment.isAfter(validUntil);
+    }
+
+    public void requireEffectiveForNewQuote(Instant moment) {
+        if (revoked) {
+            throw new DomainRuleViolation("eligibility " + eligibilityId + " has been revoked: " + revocationReason);
+        }
+        if (moment.isBefore(validFrom)) {
+            throw new DomainRuleViolation("eligibility " + eligibilityId + " is not yet valid until " + validFrom);
+        }
+        if (moment.isAfter(validUntil)) {
+            throw new DomainRuleViolation("eligibility " + eligibilityId + " expired at " + validUntil);
+        }
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/EventMetadata.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/EventMetadata.java
@@ -1,0 +1,39 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+public record EventMetadata(
+    String eventId,
+    Instant occurredAt,
+    String sourceCommandId,
+    String causationId,
+    String correlationId,
+    int schemaVersion,
+    Map<String, String> attributes
+) {
+    public EventMetadata {
+        eventId = requireText(eventId, "eventId");
+        Objects.requireNonNull(occurredAt, "occurredAt is required");
+        sourceCommandId = requireText(sourceCommandId, "sourceCommandId");
+        causationId = requireText(causationId, "causationId");
+        correlationId = requireText(correlationId, "correlationId");
+        if (schemaVersion < 1) {
+            throw new DomainRuleViolation("schemaVersion must be positive");
+        }
+        attributes = Map.copyOf(Objects.requireNonNull(attributes, "attributes are required"));
+    }
+
+    static EventMetadata create(Instant occurredAt, String sourceCommandId, String causationId, String correlationId, Map<String, String> attributes) {
+        return new EventMetadata(UUID.randomUUID().toString(), occurredAt, sourceCommandId, causationId, correlationId, 1, attributes);
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/PreferenceSnapshot.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/PreferenceSnapshot.java
@@ -1,0 +1,47 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public final class PreferenceSnapshot {
+    private final Map<String, String> preferences;
+    private final Map<String, String> assistanceNeeds;
+    private final int version;
+
+    public PreferenceSnapshot(Map<String, String> preferences, Map<String, String> assistanceNeeds, int version) {
+        this.preferences = Collections.unmodifiableMap(new HashMap<>(Objects.requireNonNull(preferences, "preferences are required")));
+        this.assistanceNeeds = Collections.unmodifiableMap(new HashMap<>(Objects.requireNonNull(assistanceNeeds, "assistanceNeeds are required")));
+        if (version < 1) {
+            throw new DomainRuleViolation("preference version must be positive");
+        }
+        this.version = version;
+    }
+
+    public Map<String, String> preferences() { return preferences; }
+    public Map<String, String> assistanceNeeds() { return assistanceNeeds; }
+    public int version() { return version; }
+
+    public PreferenceSnapshot withUpdatedPreference(String key, String value) {
+        requireText(key, "preferenceKey");
+        requireText(value, "preferenceValue");
+        Map<String, String> updated = new HashMap<>(preferences);
+        updated.put(key, value);
+        return new PreferenceSnapshot(updated, assistanceNeeds, version + 1);
+    }
+
+    public PreferenceSnapshot withRemovedPreference(String key) {
+        requireText(key, "preferenceKey");
+        Map<String, String> updated = new HashMap<>(preferences);
+        updated.remove(key);
+        return new PreferenceSnapshot(updated, assistanceNeeds, version + 1);
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/PreferencesUpdated.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/PreferencesUpdated.java
@@ -1,0 +1,26 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record PreferencesUpdated(
+    String profileId,
+    String preferenceType,
+    String preferenceValue,
+    EventMetadata metadata
+) implements TravelerProfileEvent {
+    @Override
+    public String eventId() { return metadata.eventId(); }
+    @Override
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    @Override
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    @Override
+    public String causationId() { return metadata.causationId(); }
+    @Override
+    public String correlationId() { return metadata.correlationId(); }
+    @Override
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    @Override
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/PrimaryDocumentChanged.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/PrimaryDocumentChanged.java
@@ -1,0 +1,26 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record PrimaryDocumentChanged(
+    String profileId,
+    String previousPrimaryDocumentId,
+    String newPrimaryDocumentId,
+    EventMetadata metadata
+) implements TravelerProfileEvent {
+    @Override
+    public String eventId() { return metadata.eventId(); }
+    @Override
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    @Override
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    @Override
+    public String causationId() { return metadata.causationId(); }
+    @Override
+    public String correlationId() { return metadata.correlationId(); }
+    @Override
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    @Override
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfile.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfile.java
@@ -1,0 +1,325 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class TravelerProfile {
+    private final String profileId;
+    private final String travelerRef;
+    private final String accountId;
+    private String displayName;
+    private String birthDate;
+    private TravelerProfileStatus status;
+    private String statusReason;
+    private final Map<String, Document> documents;
+    private String primaryDocumentId;
+    private final Map<String, EligibilitySummary> eligibilitySummaries;
+    private PreferenceSnapshot preferences;
+    private final List<TravelerProfileEvent> domainEvents;
+
+    private TravelerProfile(
+        String profileId,
+        String travelerRef,
+        String accountId,
+        String displayName,
+        String birthDate
+    ) {
+        this.profileId = requireText(profileId, "profileId");
+        this.travelerRef = requireText(travelerRef, "travelerRef");
+        this.accountId = requireText(accountId, "accountId");
+        this.displayName = requireText(displayName, "displayName");
+        this.birthDate = requireText(birthDate, "birthDate");
+        this.status = TravelerProfileStatus.DRAFT;
+        this.documents = new HashMap<>();
+        this.eligibilitySummaries = new HashMap<>();
+        this.preferences = new PreferenceSnapshot(Collections.emptyMap(), Collections.emptyMap(), 1);
+        this.domainEvents = new ArrayList<>();
+    }
+
+    public static TravelerProfile create(
+        String accountId,
+        String displayName,
+        String birthDate,
+        String clientRequestId,
+        Instant now,
+        String sourceCommandId,
+        String correlationId
+    ) {
+        String profileId = UUID.randomUUID().toString();
+        String travelerRef = "TRV-" + profileId.substring(0, 8).toUpperCase();
+        TravelerProfile profile = new TravelerProfile(profileId, travelerRef, accountId, displayName, birthDate);
+        profile.domainEvents.add(new TravelerProfileCreated(
+            profileId, travelerRef, accountId, displayName, birthDate,
+            EventMetadata.create(now, sourceCommandId, sourceCommandId, correlationId,
+                Map.of("status", profile.status.name(), "travelerRef", travelerRef))
+        ));
+        return profile;
+    }
+
+    // --- Accessors ---
+    public String profileId() { return profileId; }
+    public String travelerRef() { return travelerRef; }
+    public String accountId() { return accountId; }
+    public String displayName() { return displayName; }
+    public String birthDate() { return birthDate; }
+    public TravelerProfileStatus status() { return status; }
+    public String statusReason() { return statusReason; }
+    public List<Document> documents() { return List.copyOf(documents.values()); }
+    public Document primaryDocument() { return primaryDocumentId != null ? documents.get(primaryDocumentId) : null; }
+    public List<EligibilitySummary> eligibilitySummaries() { return List.copyOf(eligibilitySummaries.values()); }
+    public PreferenceSnapshot preferences() { return preferences; }
+    public List<TravelerProfileEvent> domainEvents() { return List.copyOf(domainEvents); }
+
+    // --- Lifecycle commands ---
+    public void activate(Instant now, String sourceCommandId, String causationId, String correlationId) {
+        requireState(TravelerProfileStatus.DRAFT);
+        if (documents.isEmpty()) {
+            throw new DomainRuleViolation("cannot activate TravelerProfile without at least one identity document");
+        }
+        if (primaryDocumentId == null) {
+            throw new DomainRuleViolation("cannot activate TravelerProfile without a primary document");
+        }
+        Document primary = documents.get(primaryDocumentId);
+        primary.requireActiveForNewBooking(now);
+        this.status = TravelerProfileStatus.ACTIVE;
+        this.statusReason = "profile activated";
+        domainEvents.add(new TravelerProfileActivated(profileId,
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId,
+                Map.of("previousStatus", TravelerProfileStatus.DRAFT.name(), "newStatus", TravelerProfileStatus.ACTIVE.name()))));
+    }
+
+    public void suspend(String reason, Instant now, String sourceCommandId, String causationId, String correlationId) {
+        requireState(TravelerProfileStatus.ACTIVE);
+        this.status = TravelerProfileStatus.SUSPENDED;
+        this.statusReason = requireText(reason, "reason");
+        domainEvents.add(new TravelerProfileSuspended(profileId, reason,
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId,
+                Map.of("previousStatus", TravelerProfileStatus.ACTIVE.name(), "newStatus", TravelerProfileStatus.SUSPENDED.name()))));
+    }
+
+    public void reactivate(Instant now, String sourceCommandId, String causationId, String correlationId) {
+        requireState(TravelerProfileStatus.SUSPENDED);
+        if (documents.isEmpty()) {
+            throw new DomainRuleViolation("cannot reactivate TravelerProfile without at least one identity document");
+        }
+        this.status = TravelerProfileStatus.ACTIVE;
+        this.statusReason = "profile reactivated";
+        domainEvents.add(new TravelerProfileActivated(profileId,
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId,
+                Map.of("previousStatus", TravelerProfileStatus.SUSPENDED.name(), "newStatus", TravelerProfileStatus.ACTIVE.name()))));
+    }
+
+    public void deactivate(String reason, Instant now, String sourceCommandId, String causationId, String correlationId) {
+        if (status == TravelerProfileStatus.DEACTIVATED) {
+            return;
+        }
+        if (status == TravelerProfileStatus.DRAFT) {
+            this.status = TravelerProfileStatus.DEACTIVATED;
+            this.statusReason = requireText(reason, "reason");
+            domainEvents.add(new TravelerProfileDeactivated(profileId, reason,
+                EventMetadata.create(now, sourceCommandId, causationId, correlationId,
+                    Map.of("previousStatus", TravelerProfileStatus.DRAFT.name(), "newStatus", TravelerProfileStatus.DEACTIVATED.name()))));
+            return;
+        }
+        requireStateIn(TravelerProfileStatus.ACTIVE, TravelerProfileStatus.SUSPENDED);
+        this.status = TravelerProfileStatus.DEACTIVATED;
+        this.statusReason = requireText(reason, "reason");
+        domainEvents.add(new TravelerProfileDeactivated(profileId, reason,
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId,
+                Map.of("previousStatus", status.name(), "newStatus", TravelerProfileStatus.DEACTIVATED.name()))));
+    }
+
+    // --- Document commands ---
+    public Document addDocument(
+        DocumentType documentType, String documentNumber, String issuingCountry,
+        Instant issuedAt, Instant expiresAt, String displayName, boolean setAsPrimary,
+        Instant now, String sourceCommandId, String causationId, String correlationId
+    ) {
+        requireNotDeactivated();
+        String documentId = UUID.randomUUID().toString();
+        String docHash = Integer.toHexString(Objects.hash(documentNumber));
+        for (Document existing : documents.values()) {
+            if (existing.documentType() == documentType && existing.documentNumberHash().equals(docHash)) {
+                throw new DomainRuleViolation("duplicate document type " + documentType + " for this profile");
+            }
+        }
+        Document doc = new Document(documentId, documentType, documentNumber, issuingCountry, issuedAt, expiresAt, displayName, setAsPrimary);
+        documents.put(documentId, doc);
+        if (setAsPrimary || documents.size() == 1) {
+            this.primaryDocumentId = documentId;
+        }
+        domainEvents.add(new DocumentAdded(profileId, documentId, documentType, issuingCountry, setAsPrimary || documents.size() == 1,
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId,
+                Map.of("documentType", documentType.name(), "isPrimary", String.valueOf(setAsPrimary || documents.size() == 1)))));
+        return doc;
+    }
+
+    public void setPrimaryDocument(String documentId, Instant now, String sourceCommandId, String causationId, String correlationId) {
+        requireNotDeactivated();
+        Document doc = documents.get(documentId);
+        if (doc == null) {
+            throw new DomainRuleViolation("unknown document " + documentId);
+        }
+        if (doc.status() == DocumentStatus.EXPIRED || doc.status() == DocumentStatus.REVOKED) {
+            throw new DomainRuleViolation("cannot set expired or revoked document as primary");
+        }
+        String previousPrimaryId = this.primaryDocumentId;
+        if (now.isAfter(doc.expiresAt())) {
+            throw new DomainRuleViolation("cannot set expired document as primary: document expired at " + doc.expiresAt());
+        }
+        this.primaryDocumentId = documentId;
+        domainEvents.add(new PrimaryDocumentChanged(profileId, previousPrimaryId, documentId,
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId,
+                Map.of("previousPrimary", previousPrimaryId != null ? previousPrimaryId : "none"))));
+    }
+
+    public void verifyDocument(String documentId, String verifierName, Instant now, String sourceCommandId, String causationId, String correlationId) {
+        requireNotDeactivated();
+        Document doc = documents.get(documentId);
+        if (doc == null) {
+            throw new DomainRuleViolation("unknown document " + documentId);
+        }
+        doc.verify(verifierName, now);
+        domainEvents.add(new DocumentVerified(profileId, documentId, doc.documentType(), verifierName,
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId,
+                Map.of("documentType", doc.documentType().name(), "verifier", verifierName))));
+    }
+
+    public void expireDocument(String documentId, Instant now, String sourceCommandId, String causationId, String correlationId) {
+        requireNotDeactivated();
+        Document doc = documents.get(documentId);
+        if (doc == null) {
+            throw new DomainRuleViolation("unknown document " + documentId);
+        }
+        doc.expire();
+        domainEvents.add(new DocumentExpired(profileId, documentId, doc.documentType(),
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId,
+                Map.of("documentType", doc.documentType().name()))));
+    }
+
+    public void revokeDocument(String documentId, String reason, Instant now, String sourceCommandId, String causationId, String correlationId) {
+        requireNotDeactivated();
+        Document doc = documents.get(documentId);
+        if (doc == null) {
+            throw new DomainRuleViolation("unknown document " + documentId);
+        }
+        doc.revoke(reason);
+        domainEvents.add(new DocumentRevoked(profileId, documentId, doc.documentType(), reason,
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId,
+                Map.of("documentType", doc.documentType().name(), "reason", reason))));
+    }
+
+    // --- Eligibility commands ---
+    public EligibilitySummary grantEligibility(
+        String eligibilityType, String eligibilitySource, String evidenceHash,
+        Instant validFrom, Instant validUntil, Instant now,
+        String sourceCommandId, String causationId, String correlationId
+    ) {
+        requireNotDeactivated();
+        String eligibilityId = UUID.randomUUID().toString();
+        EligibilitySummary summary = new EligibilitySummary(eligibilityId, eligibilityType, eligibilitySource, evidenceHash, validFrom, validUntil);
+        eligibilitySummaries.put(eligibilityId, summary);
+        domainEvents.add(new EligibilityGranted(profileId, eligibilityId, eligibilityType, eligibilitySource, validFrom, validUntil,
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId,
+                Map.of("eligibilityType", eligibilityType, "eligibilitySource", eligibilitySource))));
+        return summary;
+    }
+
+    public void revokeEligibility(String eligibilityId, String reason, Instant now, String sourceCommandId, String causationId, String correlationId) {
+        requireNotDeactivated();
+        EligibilitySummary summary = eligibilitySummaries.get(eligibilityId);
+        if (summary == null) {
+            throw new DomainRuleViolation("unknown eligibility " + eligibilityId);
+        }
+        summary.revoke(reason);
+        domainEvents.add(new EligibilityRevoked(profileId, eligibilityId, summary.eligibilityType(), reason,
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId,
+                Map.of("eligibilityType", summary.eligibilityType(), "reason", reason))));
+    }
+
+    public void expireEligibility(String eligibilityId, Instant now, String sourceCommandId, String causationId, String correlationId) {
+        requireNotDeactivated();
+        EligibilitySummary summary = eligibilitySummaries.get(eligibilityId);
+        if (summary == null) {
+            throw new DomainRuleViolation("unknown eligibility " + eligibilityId);
+        }
+        summary.revoke("expired at " + summary.validUntil());
+        domainEvents.add(new EligibilityExpired(profileId, eligibilityId, summary.eligibilityType(),
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId,
+                Map.of("eligibilityType", summary.eligibilityType()))));
+    }
+
+    // --- Preference commands ---
+    public void updatePreference(String key, String value, Instant now, String sourceCommandId, String causationId, String correlationId) {
+        requireNotDeactivated();
+        this.preferences = this.preferences.withUpdatedPreference(key, value);
+        domainEvents.add(new PreferencesUpdated(profileId, key, value,
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId,
+                Map.of("preferenceType", key, "preferenceVersion", String.valueOf(preferences.version())))));
+    }
+
+    public void removePreference(String key, Instant now, String sourceCommandId, String causationId, String correlationId) {
+        requireNotDeactivated();
+        this.preferences = this.preferences.withRemovedPreference(key);
+        domainEvents.add(new PreferencesUpdated(profileId, key, "",
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId,
+                Map.of("preferenceType", key, "preferenceVersion", String.valueOf(preferences.version()), "removed", "true"))));
+    }
+
+    // --- Validation for downstream consumers ---
+    public void requireCanReferenceForNewBooking(Instant moment) {
+        if (status == TravelerProfileStatus.DRAFT) {
+            throw new DomainRuleViolation("profile " + profileId + " is in DRAFT status and cannot be referenced for new bookings");
+        }
+        if (status == TravelerProfileStatus.DEACTIVATED) {
+            throw new DomainRuleViolation("profile " + profileId + " is DEACTIVATED and cannot be referenced for new bookings");
+        }
+        if (primaryDocumentId == null) {
+            throw new DomainRuleViolation("profile " + profileId + " has no primary document and cannot be referenced for new bookings");
+        }
+        Document primary = documents.get(primaryDocumentId);
+        if (primary == null) {
+            throw new DomainRuleViolation("profile " + profileId + " primary document not found");
+        }
+        primary.requireActiveForNewBooking(moment);
+    }
+
+    public List<EligibilitySummary> effectiveEligibilities(Instant moment) {
+        return eligibilitySummaries.values().stream()
+            .filter(e -> e.isEffectiveAt(moment))
+            .toList();
+    }
+
+    // --- Internal helpers ---
+    private void requireState(TravelerProfileStatus expected) {
+        if (status != expected) {
+            throw new DomainRuleViolation("expected profile state " + expected + " but was " + status);
+        }
+    }
+
+    private void requireStateIn(TravelerProfileStatus... allowed) {
+        for (TravelerProfileStatus s : allowed) {
+            if (status == s) return;
+        }
+        throw new DomainRuleViolation("profile state " + status + " is not allowed for this operation");
+    }
+
+    private void requireNotDeactivated() {
+        if (status == TravelerProfileStatus.DEACTIVATED) {
+            throw new DomainRuleViolation("profile " + profileId + " is DEACTIVATED and cannot be modified");
+        }
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfileActivated.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfileActivated.java
@@ -1,0 +1,24 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record TravelerProfileActivated(
+    String profileId,
+    EventMetadata metadata
+) implements TravelerProfileEvent {
+    @Override
+    public String eventId() { return metadata.eventId(); }
+    @Override
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    @Override
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    @Override
+    public String causationId() { return metadata.causationId(); }
+    @Override
+    public String correlationId() { return metadata.correlationId(); }
+    @Override
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    @Override
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfileCreated.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfileCreated.java
@@ -1,0 +1,28 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record TravelerProfileCreated(
+    String profileId,
+    String travelerRef,
+    String accountId,
+    String displayName,
+    String birthDate,
+    EventMetadata metadata
+) implements TravelerProfileEvent {
+    @Override
+    public String eventId() { return metadata.eventId(); }
+    @Override
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    @Override
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    @Override
+    public String causationId() { return metadata.causationId(); }
+    @Override
+    public String correlationId() { return metadata.correlationId(); }
+    @Override
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    @Override
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfileDeactivated.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfileDeactivated.java
@@ -1,0 +1,25 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record TravelerProfileDeactivated(
+    String profileId,
+    String reason,
+    EventMetadata metadata
+) implements TravelerProfileEvent {
+    @Override
+    public String eventId() { return metadata.eventId(); }
+    @Override
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    @Override
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    @Override
+    public String causationId() { return metadata.causationId(); }
+    @Override
+    public String correlationId() { return metadata.correlationId(); }
+    @Override
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    @Override
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfileEvent.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfileEvent.java
@@ -1,0 +1,31 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public sealed interface TravelerProfileEvent permits
+    TravelerProfileCreated,
+    TravelerProfileActivated,
+    TravelerProfileSuspended,
+    TravelerProfileDeactivated,
+    DocumentAdded,
+    DocumentVerified,
+    DocumentExpired,
+    DocumentRevoked,
+    PrimaryDocumentChanged,
+    EligibilityGranted,
+    EligibilityRevoked,
+    EligibilityExpired,
+    PreferencesUpdated {
+    String eventId();
+    Instant occurredAt();
+    String profileId();
+    String sourceCommandId();
+    String causationId();
+    String correlationId();
+    int schemaVersion();
+    Map<String, String> attributes();
+    default String eventType() {
+        return getClass().getSimpleName();
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfileStatus.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfileStatus.java
@@ -1,0 +1,8 @@
+package com.trainticket.travelerprofile.domain;
+
+public enum TravelerProfileStatus {
+    DRAFT,
+    ACTIVE,
+    SUSPENDED,
+    DEACTIVATED
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfileSuspended.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfileSuspended.java
@@ -1,0 +1,25 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record TravelerProfileSuspended(
+    String profileId,
+    String reason,
+    EventMetadata metadata
+) implements TravelerProfileEvent {
+    @Override
+    public String eventId() { return metadata.eventId(); }
+    @Override
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    @Override
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    @Override
+    public String causationId() { return metadata.causationId(); }
+    @Override
+    public String correlationId() { return metadata.correlationId(); }
+    @Override
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    @Override
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/domain/TravelerProfileTest.java
+++ b/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/domain/TravelerProfileTest.java
@@ -1,0 +1,508 @@
+package com.trainticket.travelerprofile.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TravelerProfileTest {
+    private static final Instant NOW = Instant.parse("2026-07-04T12:00:00Z");
+    private static final Instant FUTURE = Instant.parse("2027-07-04T12:00:00Z");
+    private static final Instant PAST = Instant.parse("2025-07-04T12:00:00Z");
+    private static final Instant LONG_PAST = Instant.parse("2024-01-01T00:00:00Z");
+    private static final Instant EXPIRED_DATE = Instant.parse("2025-06-01T00:00:00Z");
+
+    // ==============================
+    // TravelerProfile Creation
+    // ==============================
+
+    @Test
+    void createsTravelerProfileInDraftWithTravelerRefAndCreatedEvent() {
+        TravelerProfile profile = TravelerProfile.create(
+            "account-1", "Zhang Wei", "1990-01-15",
+            "client-req-1", NOW, "cmd-create", "corr-1"
+        );
+        assertEquals(TravelerProfileStatus.DRAFT, profile.status());
+        assertTrue(profile.travelerRef().startsWith("TRV-"));
+        assertEquals("account-1", profile.accountId());
+        assertEquals("Zhang Wei", profile.displayName());
+        assertEquals("1990-01-15", profile.birthDate());
+        assertTrue(profile.documents().isEmpty());
+        assertEquals(1, profile.domainEvents().size());
+        TravelerProfileEvent event = profile.domainEvents().getFirst();
+        assertInstanceOf(TravelerProfileCreated.class, event);
+        assertEquals(1, event.schemaVersion());
+        assertEquals(profile.profileId(), event.profileId());
+    }
+
+    @Test
+    void refusesBlankFieldsOnProfileCreation() {
+        assertThrows(DomainRuleViolation.class, () ->
+            TravelerProfile.create("", "Zhang Wei", "1990-01-15", "req-1", NOW, "cmd", "corr"));
+        assertThrows(DomainRuleViolation.class, () ->
+            TravelerProfile.create("account-1", "", "1990-01-15", "req-1", NOW, "cmd", "corr"));
+        assertThrows(DomainRuleViolation.class, () ->
+            TravelerProfile.create("account-1", "Zhang Wei", "", "req-1", NOW, "cmd", "corr"));
+    }
+
+    // ==============================
+    // Document Management
+    // ==============================
+
+    @Test
+    void addsIdentityDocumentAndEmitsDocumentAddedEvent() {
+        TravelerProfile profile = sampleDraftProfile();
+        Document doc = profile.addDocument(
+            DocumentType.IDENTITY_CARD, "110101199001151234", "CN",
+            PAST, FUTURE, "Zhang Wei", true,
+            NOW, "cmd-add-doc", "cmd-create", "corr-1"
+        );
+        assertNotNull(doc.documentId());
+        assertEquals(DocumentType.IDENTITY_CARD, doc.documentType());
+        assertEquals(DocumentStatus.PENDING_VERIFICATION, doc.status());
+        assertEquals(1, profile.documents().size());
+        assertEquals(doc.documentId(), profile.primaryDocument().documentId());
+        TravelerProfileEvent event = profile.domainEvents().getLast();
+        assertInstanceOf(DocumentAdded.class, event);
+        assertEquals(doc.documentId(), ((DocumentAdded) event).documentId());
+    }
+
+    @Test
+    void refusesDuplicateDocumentTypeAndNumber() {
+        TravelerProfile profile = sampleDraftProfile();
+        profile.addDocument(
+            DocumentType.IDENTITY_CARD, "110101199001151234", "CN",
+            PAST, FUTURE, "Zhang Wei", true,
+            NOW, "cmd-add-doc", "cmd-create", "corr-1"
+        );
+        assertThrows(DomainRuleViolation.class, () ->
+            profile.addDocument(
+                DocumentType.IDENTITY_CARD, "110101199001151234", "CN",
+                PAST, FUTURE, "Zhang Wei", false,
+                NOW, "cmd-add-doc-2", "cmd-create", "corr-1"
+            ));
+    }
+
+    @Test
+    void verifiesDocumentAndEmitsDocumentVerifiedEvent() {
+        TravelerProfile profile = sampleDraftProfile();
+        Document doc = addSampleDocument(profile, true);
+        profile.verifyDocument(doc.documentId(), "real-name-service", NOW, "cmd-verify", "cmd-add-doc", "corr-1");
+        assertEquals(DocumentStatus.VERIFIED, doc.status());
+        assertEquals("real-name-service", doc.verifier());
+        TravelerProfileEvent event = profile.domainEvents().getLast();
+        assertInstanceOf(DocumentVerified.class, event);
+        assertEquals(doc.documentId(), ((DocumentVerified) event).documentId());
+    }
+
+    @Test
+    void refusesVerificationOfDocumentPastExpiry() {
+        TravelerProfile profile = sampleDraftProfile();
+        Document doc = profile.addDocument(
+            DocumentType.PASSPORT, "E12345678", "CN",
+            LONG_PAST, EXPIRED_DATE, "Zhang Wei", true,
+            NOW, "cmd-add-doc", "cmd-create", "corr-1"
+        );
+        assertThrows(DomainRuleViolation.class, () ->
+            profile.verifyDocument(doc.documentId(), "real-name-service", NOW, "cmd-verify", "cmd-add-doc", "corr-1"));
+    }
+
+    @Test
+    void expiresDocumentAndEmitsDocumentExpiredEvent() {
+        TravelerProfile profile = sampleDraftProfile();
+        Document doc = addSampleDocument(profile, true);
+        profile.expireDocument(doc.documentId(), NOW, "cmd-expire", "cmd-add-doc", "corr-1");
+        assertEquals(DocumentStatus.EXPIRED, doc.status());
+        TravelerProfileEvent event = profile.domainEvents().getLast();
+        assertInstanceOf(DocumentExpired.class, event);
+        assertEquals(doc.documentId(), ((DocumentExpired) event).documentId());
+    }
+
+    @Test
+    void revokesDocumentAndEmitsDocumentRevokedEvent() {
+        TravelerProfile profile = sampleDraftProfile();
+        Document doc = addSampleDocument(profile, true);
+        profile.revokeDocument(doc.documentId(), "suspected forgery", NOW, "cmd-revoke", "cmd-add-doc", "corr-1");
+        assertEquals(DocumentStatus.REVOKED, doc.status());
+        TravelerProfileEvent event = profile.domainEvents().getLast();
+        assertInstanceOf(DocumentRevoked.class, event);
+        assertEquals(doc.documentId(), ((DocumentRevoked) event).documentId());
+    }
+
+    @Test
+    void changesPrimaryDocumentAndEmitsPrimaryDocumentChangedEvent() {
+        TravelerProfile profile = sampleDraftProfile();
+        Document doc1 = addSampleDocument(profile, true);
+        Document doc2 = profile.addDocument(
+            DocumentType.PASSPORT, "E98765432", "CN",
+            PAST, FUTURE, "Zhang Wei", false,
+            NOW, "cmd-add-doc-2", "cmd-create", "corr-1"
+        );
+        profile.setPrimaryDocument(doc2.documentId(), NOW, "cmd-set-primary", "cmd-add-doc-2", "corr-1");
+        assertEquals(doc2.documentId(), profile.primaryDocument().documentId());
+        TravelerProfileEvent event = profile.domainEvents().getLast();
+        assertInstanceOf(PrimaryDocumentChanged.class, event);
+        assertEquals(doc1.documentId(), ((PrimaryDocumentChanged) event).previousPrimaryDocumentId());
+        assertEquals(doc2.documentId(), ((PrimaryDocumentChanged) event).newPrimaryDocumentId());
+    }
+
+    @Test
+    void refusesExpiredDocumentAsPrimary() {
+        TravelerProfile profile = sampleDraftProfile();
+        Document doc1 = addSampleDocument(profile, true);
+        // Add a second document that will expire
+        Document doc2 = profile.addDocument(
+            DocumentType.PASSPORT, "E98765432", "CN",
+            LONG_PAST, EXPIRED_DATE, "Zhang Wei", false,
+            NOW, "cmd-add-doc-2", "cmd-create", "corr-1"
+        );
+        // Document has expired date (EXPIRED_DATE is before NOW)
+        assertThrows(DomainRuleViolation.class, () ->
+            profile.setPrimaryDocument(doc2.documentId(), NOW, "cmd-set-primary", "cmd-add-doc-2", "corr-1"));
+    }
+
+    @Test
+    void documentMaskedRefMasksNumberAppropriately() {
+        Document doc = new Document(
+            "doc-1", DocumentType.IDENTITY_CARD, "110101199001151234", "CN",
+            PAST, FUTURE, "Zhang Wei", true
+        );
+        assertEquals("11***1234", doc.maskedDocumentRef());
+        Document shortDoc = new Document(
+            "doc-2", DocumentType.OTHER, "AB12", "CN",
+            PAST, FUTURE, "Test", true
+        );
+        assertEquals("***AB12", shortDoc.maskedDocumentRef());
+    }
+
+    // ==============================
+    // Profile Lifecycle
+    // ==============================
+
+    @Test
+    void activatesProfileAfterDocumentAddedAndVerified() {
+        TravelerProfile profile = sampleDraftProfile();
+        Document doc = addSampleDocument(profile, true);
+        profile.verifyDocument(doc.documentId(), "real-name-service", NOW, "cmd-verify", "cmd-add-doc", "corr-1");
+        profile.activate(NOW, "cmd-activate", "cmd-verify", "corr-1");
+        assertEquals(TravelerProfileStatus.ACTIVE, profile.status());
+        TravelerProfileEvent event = profile.domainEvents().getLast();
+        assertInstanceOf(TravelerProfileActivated.class, event);
+    }
+
+    @Test
+    void refusesActivationWithoutDocuments() {
+        TravelerProfile profile = TravelerProfile.create(
+            "account-1", "Zhang Wei", "1990-01-15",
+            "req-1", NOW, "cmd-create", "corr-1"
+        );
+        assertThrows(DomainRuleViolation.class, () ->
+            profile.activate(NOW, "cmd-activate", "cmd-create", "corr-1"));
+    }
+
+    @Test
+    void refusesActivationWithoutPrimaryDocument() {
+        TravelerProfile profile = sampleDraftProfile();
+        profile.addDocument(
+            DocumentType.IDENTITY_CARD, "110101199001151234", "CN",
+            PAST, FUTURE, "Zhang Wei", false,
+            NOW, "cmd-add-doc", "cmd-create", "corr-1"
+        );
+        assertThrows(DomainRuleViolation.class, () ->
+            profile.activate(NOW, "cmd-activate", "cmd-add-doc", "corr-1"));
+    }
+
+    @Test
+    void suspendsAndReactivatesProfile() {
+        TravelerProfile profile = sampleActiveProfile();
+        profile.suspend("compliance hold", NOW.plusSeconds(10), "cmd-suspend", "cmd-activate", "corr-1");
+        assertEquals(TravelerProfileStatus.SUSPENDED, profile.status());
+        profile.reactivate(NOW.plusSeconds(20), "cmd-reactivate", "cmd-suspend", "corr-1");
+        assertEquals(TravelerProfileStatus.ACTIVE, profile.status());
+    }
+
+    @Test
+    void deactivatesProfileAndEmitsDeactivatedEvent() {
+        TravelerProfile profile = sampleActiveProfile();
+        profile.deactivate("account closed", NOW.plusSeconds(10), "cmd-deactivate", "cmd-activate", "corr-1");
+        assertEquals(TravelerProfileStatus.DEACTIVATED, profile.status());
+        TravelerProfileEvent event = profile.domainEvents().getLast();
+        assertInstanceOf(TravelerProfileDeactivated.class, event);
+    }
+
+    @Test
+    void refusesModificationsOnDeactivatedProfile() {
+        TravelerProfile profile = sampleActiveProfile();
+        profile.deactivate("account closed", NOW, "cmd-deactivate", "cmd-activate", "corr-1");
+        assertThrows(DomainRuleViolation.class, () ->
+            profile.addDocument(DocumentType.PASSPORT, "E12345678", "CN", PAST, FUTURE, "Zhang Wei", true, NOW, "cmd", "cmd", "corr"));
+    }
+
+    // ==============================
+    // New Booking Validation
+    // ==============================
+
+    @Test
+    void profileCanBeReferencedForNewBookingWhenActiveWithVerifiedPrimaryDocument() {
+        TravelerProfile profile = sampleActiveProfile();
+        profile.requireCanReferenceForNewBooking(NOW);
+    }
+
+    @Test
+    void refusesBookingReferenceForDraftProfile() {
+        TravelerProfile profile = sampleDraftProfile();
+        assertThrows(DomainRuleViolation.class, () ->
+            profile.requireCanReferenceForNewBooking(NOW));
+    }
+
+    @Test
+    void refusesBookingReferenceForDeactivatedProfile() {
+        TravelerProfile profile = sampleActiveProfile();
+        profile.deactivate("closed", NOW, "cmd", "cmd", "corr");
+        assertThrows(DomainRuleViolation.class, () ->
+            profile.requireCanReferenceForNewBooking(NOW));
+    }
+
+    // ==============================
+    // Eligibility Management
+    // ==============================
+
+    @Test
+    void grantsEligibilityAndEmitsEligibilityGrantedEvent() {
+        TravelerProfile profile = sampleActiveProfile();
+        EligibilitySummary eligibility = profile.grantEligibility(
+            "STUDENT", "university-verification", "hash-123",
+            NOW, FUTURE, NOW, "cmd-grant", "cmd-activate", "corr-1"
+        );
+        assertNotNull(eligibility.eligibilityId());
+        assertEquals("STUDENT", eligibility.eligibilityType());
+        assertTrue(eligibility.isEffectiveAt(NOW));
+        assertFalse(eligibility.revoked());
+        TravelerProfileEvent event = profile.domainEvents().getLast();
+        assertInstanceOf(EligibilityGranted.class, event);
+        assertEquals(eligibility.eligibilityId(), ((EligibilityGranted) event).eligibilityId());
+    }
+
+    @Test
+    void revokesEligibilityAndEmitsEligibilityRevokedEvent() {
+        TravelerProfile profile = sampleActiveProfile();
+        EligibilitySummary eligibility = sampleEligibility(profile);
+        profile.revokeEligibility(eligibility.eligibilityId(), "student status no longer valid", NOW, "cmd-revoke", "cmd-grant", "corr-1");
+        assertTrue(eligibility.revoked());
+        assertFalse(eligibility.isEffectiveAt(NOW));
+        TravelerProfileEvent event = profile.domainEvents().getLast();
+        assertInstanceOf(EligibilityRevoked.class, event);
+    }
+
+    @Test
+    void expiresEligibilityAndEmitsEligibilityExpiredEvent() {
+        TravelerProfile profile = sampleActiveProfile();
+        EligibilitySummary eligibility = sampleEligibility(profile);
+        profile.expireEligibility(eligibility.eligibilityId(), NOW, "cmd-expire", "cmd-grant", "corr-1");
+        assertTrue(eligibility.revoked());
+        assertFalse(eligibility.isEffectiveAt(NOW));
+    }
+
+    @Test
+    void refusesNewQuoteWithRevokedEligibility() {
+        TravelerProfile profile = sampleActiveProfile();
+        EligibilitySummary eligibility = sampleEligibility(profile);
+        profile.revokeEligibility(eligibility.eligibilityId(), "no longer valid", NOW, "cmd-revoke", "cmd-grant", "corr-1");
+        assertThrows(DomainRuleViolation.class, () ->
+            eligibility.requireEffectiveForNewQuote(NOW));
+    }
+
+    @Test
+    void effectiveEligibilitiesOnlyReturnsValidNonRevokedEntries() {
+        TravelerProfile profile = sampleActiveProfile();
+        EligibilitySummary e1 = sampleEligibility(profile);
+        EligibilitySummary e2 = profile.grantEligibility(
+            "SENIOR", "age-verification", "hash-456",
+            NOW, FUTURE, NOW, "cmd-grant-2", "cmd-activate", "corr-1"
+        );
+        profile.revokeEligibility(e1.eligibilityId(), "no longer valid", NOW, "cmd-revoke", "cmd-grant", "corr-1");
+        List<EligibilitySummary> effective = profile.effectiveEligibilities(NOW);
+        assertEquals(1, effective.size());
+        assertEquals(e2.eligibilityId(), effective.getFirst().eligibilityId());
+    }
+
+    @Test
+    void eligibilitySummaryValidatesDateRange() {
+        assertThrows(DomainRuleViolation.class, () ->
+            new EligibilitySummary("e-1", "STUDENT", "source", "hash", FUTURE, NOW));
+    }
+
+    // ==============================
+    // Preference Management
+    // ==============================
+
+    @Test
+    void updatesPreferenceAndEmitsPreferencesUpdatedEvent() {
+        TravelerProfile profile = sampleActiveProfile();
+        profile.updatePreference("seat-preference", "aisle", NOW, "cmd-update-pref", "cmd-activate", "corr-1");
+        assertEquals("aisle", profile.preferences().preferences().get("seat-preference"));
+        assertEquals(2, profile.preferences().version());
+        TravelerProfileEvent event = profile.domainEvents().getLast();
+        assertInstanceOf(PreferencesUpdated.class, event);
+        assertEquals("seat-preference", ((PreferencesUpdated) event).preferenceType());
+    }
+
+    @Test
+    void removesPreferenceAndUpdatesVersion() {
+        TravelerProfile profile = sampleActiveProfile();
+        profile.updatePreference("seat-preference", "aisle", NOW, "cmd-update", "cmd-activate", "corr-1");
+        profile.removePreference("seat-preference", NOW, "cmd-remove", "cmd-update", "corr-1");
+        assertFalse(profile.preferences().preferences().containsKey("seat-preference"));
+        assertEquals(3, profile.preferences().version());
+    }
+
+    @Test
+    void preferenceSnapshotImmutableAfterUpdate() {
+        TravelerProfile profile = sampleActiveProfile();
+        profile.updatePreference("seat-preference", "aisle", NOW, "cmd-update", "cmd-activate", "corr-1");
+        Map<String, String> originalPrefs = profile.preferences().preferences();
+        profile.updatePreference("meal-preference", "vegetarian", NOW, "cmd-update-2", "cmd-update", "corr-1");
+        assertEquals(1, originalPrefs.size());
+        assertEquals(2, profile.preferences().preferences().size());
+    }
+
+    // ==============================
+    // General Invariants
+    // ==============================
+
+    @Test
+    void eventMetadataGeneratesIdAndEnforcesInvariants() {
+        EventMetadata metadata = EventMetadata.create(NOW, "cmd-1", "cause-1", "corr-1", Map.of("key", "value"));
+        assertNotNull(metadata.eventId());
+        assertEquals(NOW, metadata.occurredAt());
+        assertEquals(1, metadata.schemaVersion());
+        assertFalse(metadata.attributes().isEmpty());
+        assertThrows(DomainRuleViolation.class, () ->
+            EventMetadata.create(NOW, "", "cause-1", "corr-1", Map.of()));
+    }
+
+    @Test
+    void documentTypeEnumContainsExpectedValues() {
+        assertEquals(9, DocumentType.values().length);
+    }
+
+    @Test
+    void profileHasTimelineOfEventsAfterMultipleCommands() {
+        TravelerProfile profile = sampleActiveProfile();
+        profile.updatePreference("seat-preference", "window", NOW, "cmd-pref", "cmd-activate", "corr-1");
+        profile.grantEligibility("STUDENT", "uni-verify", "hash-1", NOW, FUTURE, NOW, "cmd-elig", "cmd-pref", "corr-1");
+        List<TravelerProfileEvent> events = profile.domainEvents();
+        assertEquals(List.of(
+            "TravelerProfileCreated",
+            "DocumentAdded",
+            "DocumentVerified",
+            "TravelerProfileActivated",
+            "PreferencesUpdated",
+            "EligibilityGranted"
+        ), events.stream().map(TravelerProfileEvent::eventType).toList());
+    }
+
+    @Test
+    void eventSealedInterfaceCoversAllEventTypes() {
+        assertInstanceOf(TravelerProfileEvent.class, new TravelerProfileCreated("id", "ref", "aid", "name", "bd", null));
+        assertInstanceOf(TravelerProfileEvent.class, new TravelerProfileActivated("id", null));
+        assertInstanceOf(TravelerProfileEvent.class, new TravelerProfileSuspended("id", "reason", null));
+        assertInstanceOf(TravelerProfileEvent.class, new TravelerProfileDeactivated("id", "reason", null));
+        assertInstanceOf(TravelerProfileEvent.class, new DocumentAdded("id", "did", DocumentType.IDENTITY_CARD, "CN", true, null));
+        assertInstanceOf(TravelerProfileEvent.class, new DocumentVerified("id", "did", DocumentType.IDENTITY_CARD, "verifier", null));
+        assertInstanceOf(TravelerProfileEvent.class, new DocumentExpired("id", "did", DocumentType.IDENTITY_CARD, null));
+        assertInstanceOf(TravelerProfileEvent.class, new DocumentRevoked("id", "did", DocumentType.IDENTITY_CARD, "reason", null));
+        assertInstanceOf(TravelerProfileEvent.class, new PrimaryDocumentChanged("id", "old", "new", null));
+        assertInstanceOf(TravelerProfileEvent.class, new EligibilityGranted("id", "eid", "STUDENT", "src", NOW, FUTURE, null));
+        assertInstanceOf(TravelerProfileEvent.class, new EligibilityRevoked("id", "eid", "STUDENT", "reason", null));
+        assertInstanceOf(TravelerProfileEvent.class, new EligibilityExpired("id", "eid", "STUDENT", null));
+        assertInstanceOf(TravelerProfileEvent.class, new PreferencesUpdated("id", "type", "val", null));
+    }
+
+    // ==============================
+    // Document invariants
+    // ==============================
+
+    @Test
+    void documentRefusesExpiresAtBeforeIssuedAt() {
+        assertThrows(DomainRuleViolation.class, () ->
+            new Document("doc-1", DocumentType.IDENTITY_CARD, "110101199001151234", "CN",
+                FUTURE, PAST, "Zhang Wei", true));
+    }
+
+    @Test
+    void verifiedDocumentIsActiveAtValidMoment() {
+        Document doc = new Document("doc-1", DocumentType.IDENTITY_CARD, "110101199001151234", "CN",
+            PAST, FUTURE, "Zhang Wei", true);
+        doc.verify("real-name-service", PAST);
+        assertTrue(doc.isActiveAt(NOW));
+    }
+
+    @Test
+    void expiredDocumentIsNotActive() {
+        Document doc = new Document("doc-1", DocumentType.IDENTITY_CARD, "110101199001151234", "CN",
+            LONG_PAST, EXPIRED_DATE, "Zhang Wei", true);
+        doc.expire();
+        assertFalse(doc.isActiveAt(NOW));
+    }
+
+    // ==============================
+    // PreferenceSnapshot invariants
+    // ==============================
+
+    @Test
+    void preferenceSnapshotRefusesNegativeVersion() {
+        assertThrows(DomainRuleViolation.class, () ->
+            new PreferenceSnapshot(Map.of(), Map.of(), 0));
+    }
+
+    @Test
+    void preferenceSnapshotWithUpdatedPreferenceReturnsNewInstance() {
+        PreferenceSnapshot snapshot = new PreferenceSnapshot(Map.of("seat", "window"), Map.of(), 1);
+        PreferenceSnapshot updated = snapshot.withUpdatedPreference("meal", "vegetarian");
+        assertEquals(1, snapshot.preferences().size());
+        assertEquals(2, updated.preferences().size());
+        assertEquals(2, updated.version());
+    }
+
+    // ==============================
+    // Helpers
+    // ==============================
+
+    private TravelerProfile sampleDraftProfile() {
+        return TravelerProfile.create(
+            "account-1", "Zhang Wei", "1990-01-15",
+            "req-1", NOW, "cmd-create", "corr-1"
+        );
+    }
+
+    private TravelerProfile sampleActiveProfile() {
+        TravelerProfile profile = sampleDraftProfile();
+        Document doc = addSampleDocument(profile, true);
+        profile.verifyDocument(doc.documentId(), "real-name-service", NOW, "cmd-verify", "cmd-add-doc", "corr-1");
+        profile.activate(NOW, "cmd-activate", "cmd-verify", "corr-1");
+        return profile;
+    }
+
+    private Document addSampleDocument(TravelerProfile profile, boolean asPrimary) {
+        return profile.addDocument(
+            DocumentType.IDENTITY_CARD, "110101199001151234", "CN",
+            PAST, FUTURE, "Zhang Wei", asPrimary,
+            NOW, "cmd-add-doc", "cmd-create", "corr-1"
+        );
+    }
+
+    private EligibilitySummary sampleEligibility(TravelerProfile profile) {
+        return profile.grantEligibility(
+            "STUDENT", "university-verification", "hash-123",
+            NOW, FUTURE, NOW, "cmd-grant", "cmd-activate", "corr-1"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implement the Traveler Profile domain foundation in Java following journey-order service patterns.

## Changes

### Domain Model
- **TravelerProfile** - aggregate root with DRAFT/ACTIVE/SUSPENDED/DEACTIVATED lifecycle
- **Document** - identity document with verification, expiry, revocation lifecycle
- **EligibilitySummary** - eligibility facts with validity windows and revocation
- **PreferenceSnapshot** - immutable preference snapshots with versioning

### Commands
CreateTravelerProfile, AddDocument, VerifyDocument, ExpireDocument, SetPrimaryDocument, GrantEligibility, RevokeEligibility, ExpireEligibility, UpdatePreferences, RemovePreference

### Events (13 types)
TravelerProfileCreated/Activated/Suspended/Deactivated, DocumentAdded/Verified/Expired/Revoked, PrimaryDocumentChanged, EligibilityGranted/Revoked/Expired, PreferencesUpdated

### Key Invariants
1. Traveler must have >=1 valid document before referencing for bookings
2. Expired documents cannot be active/primary for new bookings
3. Eligibility facts are summaries with validity windows, not re-derived
4. Fare & Pricing consumes eligibility facts, never owns traveler data

### Metadata
- Updated project-index.yaml with REQ-017 entry
- Updated service-catalog.json traveler-profile status to implemented

## Validation
- `cd services/traveler-profile && mvn test` - 42 tests passing (38 domain + 4 skeleton)
- `make check` - passed