### PR TITLE
REQ-020: Risk & Compliance domain foundation

### DIFF
--- a/docs/08-contracts/events/risk-compliance.md
+++ b/docs/08-contracts/events/risk-compliance.md
@@ -1,0 +1,180 @@
+# Risk & Compliance — Events & Commands
+
+Last updated: 2026-07-04
+
+## Published Events
+
+### RiskAssessed
+
+| Field | Description |
+|---|---|
+| **Producer** | risk-compliance |
+| **Consumers** | journey-order, payment, post-sales, account |
+| **Trigger** | `AssessRisk` command processed. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `assessmentId` | `AssessmentId` | yes | Canonical assessment ID (`asmt-<uuid>`). |
+| `subjectRef` | string | yes | Subject of the assessment (order ID, payment intent ID, account ID, etc.). |
+| `scenario` | string | yes | Risk scenario (e.g. `order_risk`, `payment_risk`, `post_sales_risk`, `account_risk`). |
+| `decision` | enum | yes | `ALLOW`, `DENY`, `CHALLENGE`, `HOLD`. |
+| `score` | integer | no | Risk score (0-1000). |
+| `level` | enum | no | `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`. |
+| `policyVersion` | string | yes | Rule/policy version that produced the decision. |
+| `evidenceRef` | string | yes | Reference to the evidence bundle. |
+| `reasonCode` | string | yes | Machine-readable reason code. |
+| `reasonExplanation` | string | no | Human-readable explanation. |
+| `assessmentSnapshotHash` | string | yes | Hash of input snapshot for explainability. |
+| `assessedAt` | RFC3339 UTC | yes | When the assessment was completed. |
+
+### ChallengeIssued
+
+| Field | Description |
+|---|---|
+| **Producer** | risk-compliance |
+| **Consumers** | account, payment |
+| **Trigger** | `IssueChallenge` command processed. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `challengeId` | `ChallengeId` | yes | Canonical challenge ID (`chg-<uuid>`). |
+| `businessRef` | string | yes | Business reference (order ID, payment intent ID, account ID). |
+| `challengeType` | enum | yes | `SMS`, `FACE_VERIFICATION`, `PAYMENT_VERIFICATION`, `MANUAL_REVIEW`. |
+| `assessmentId` | `AssessmentId` | yes | The assessment that triggered the challenge. |
+| `issuedAt` | RFC3339 UTC | yes | When the challenge was issued. |
+| `expiresAt` | RFC3339 UTC | yes | Challenge expiry time. |
+
+### ChallengeResolved
+
+| Field | Description |
+|---|---|
+| **Producer** | risk-compliance |
+| **Consumers** | account, payment, journey-order |
+| **Trigger** | `ResolveChallenge` command processed. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `challengeId` | `ChallengeId` | yes | Canonical challenge ID (`chg-<uuid>`). |
+| `outcome` | enum | yes | `PASSED`, `FAILED`, `EXPIRED`. |
+| `resolvedAt` | RFC3339 UTC | yes | When the challenge was resolved. |
+| `evidenceRef` | string | no | Reference to resolution evidence. |
+
+### SubjectBlocked
+
+| Field | Description |
+|---|---|
+| **Producer** | risk-compliance |
+| **Consumers** | journey-order, payment, account, booking-orchestration |
+| **Trigger** | `BlockSubject` command processed. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `blockId` | `BlockId` | yes | Canonical block ID (`blk-<uuid>`). |
+| `subjectRef` | string | yes | Subject reference (order ID, payment ID, account ID). |
+| `scope` | enum | yes | `ORDER`, `PAYMENT`, `ACCOUNT`. |
+| `reasonCode` | string | yes | Machine-readable reason code. |
+| `policyVersion` | string | yes | Policy version that produced the block. |
+| `evidenceRef` | string | yes | Reference to evidence bundle. |
+| `blockedAt` | RFC3339 UTC | yes | When the block was applied. |
+
+### SubjectAllowed
+
+| Field | Description |
+|---|---|
+| **Producer** | risk-compliance |
+| **Consumers** | journey-order, payment, account, booking-orchestration |
+| **Trigger** | `AllowSubject` command processed. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `allowId` | `AllowId` | yes | Canonical allow ID (`alw-<uuid>`). |
+| `subjectRef` | string | yes | Subject reference (order ID, payment ID, account ID). |
+| `scope` | enum | yes | `ORDER`, `PAYMENT`, `ACCOUNT`. |
+| `reasonCode` | string | yes | Machine-readable reason code. |
+| `policyVersion` | string | yes | Policy version that produced the allow. |
+| `evidenceRef` | string | yes | Reference to evidence bundle. |
+| `allowedAt` | RFC3339 UTC | yes | When the allow was applied. |
+
+### EvidenceRecorded
+
+| Field | Description |
+|---|---|
+| **Producer** | risk-compliance |
+| **Consumers** | reporting, admin-and-audit |
+| **Trigger** | `RecordEvidence` command processed. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `evidenceId` | `EvidenceId` | yes | Canonical evidence ID (`evid-<uuid>`). |
+| `subjectRef` | string | yes | Subject reference. |
+| `evidenceType` | string | yes | Type of evidence (e.g. `fraud_signal`, `device_fingerprint`, `rule_hit`). |
+| `evidenceSummary` | string | yes | Human-readable evidence summary. |
+| `recordedAt` | RFC3339 UTC | yes | When the evidence was recorded. |
+
+## Consumed Commands (Inbox)
+
+### AssessRisk
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `assessmentId` | `AssessmentId` | yes | Canonical assessment ID (`asmt-<uuid>`). |
+| `subjectRef` | string | yes | Subject to assess. |
+| `scenario` | string | yes | Risk scenario. |
+| `inputs` | object | yes | Input snapshot (varies by scenario). |
+| `idempotencyKey` | string | yes | Idempotency key. |
+
+### IssueChallenge
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `challengeId` | `ChallengeId` | yes | Canonical challenge ID (`chg-<uuid>`). |
+| `businessRef` | string | yes | Business reference. |
+| `challengeType` | enum | yes | `SMS`, `FACE_VERIFICATION`, `PAYMENT_VERIFICATION`, `MANUAL_REVIEW`. |
+| `assessmentId` | `AssessmentId` | yes | The assessment that triggered the challenge. |
+
+### ResolveChallenge
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `challengeId` | `ChallengeId` | yes | Canonical challenge ID (`chg-<uuid>`). |
+| `outcome` | enum | yes | `PASSED`, `FAILED`. |
+| `evidence` | string | no | Resolution evidence. |
+
+### BlockSubject
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `blockId` | `BlockId` | yes | Canonical block ID (`blk-<uuid>`). |
+| `subjectRef` | string | yes | Subject reference. |
+| `scope` | enum | yes | `ORDER`, `PAYMENT`, `ACCOUNT`. |
+| `reasonCode` | string | yes | Reason code. |
+
+### AllowSubject
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `allowId` | `AllowId` | yes | Canonical allow ID (`alw-<uuid>`). |
+| `subjectRef` | string | yes | Subject reference. |
+| `scope` | enum | yes | `ORDER`, `PAYMENT`, `ACCOUNT`. |
+| `reasonCode` | string | yes | Reason code. |
+
+### RecordEvidence
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `evidenceId` | `EvidenceId` | yes | Canonical evidence ID (`evid-<uuid>`). |
+| `subjectRef` | string | yes | Subject reference. |
+| `evidenceType` | string | yes | Type of evidence. |
+| `evidenceSummary` | string | yes | Evidence summary. |

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -281,6 +281,32 @@ requirements:
     depends_on: [REQ-003]
     confidence: confirmed
     source: "docs/02-domains/traveler-profile.md, docs/03-ddd-final/phase-1-contract.md, docs/03-ddd-final/implementation-roadmap.md"
+  - id: REQ-020
+    title: "Risk & Compliance domain foundation"
+    description: "Implement the Risk & Compliance domain foundation in Python. This domain owns risk assessments, challenges, block/allow decisions, and evidence summaries for order and payment flows."
+    priority: P1
+    status: tested
+    code:
+      - path: services/risk-compliance/src/risk_compliance/domain.py
+        description: "Domain model with RiskAssessment, Challenge, RiskDecision, EvidenceSummary aggregates and commands."
+      - path: services/risk-compliance/src/risk_compliance/__init__.py
+        description: "Public API exports for domain types, commands, and runtime."
+      - path: services/risk-compliance/src/risk_compliance/runtime.py
+        description: "Service profile with REQ-020 ownership."
+      - path: docs/08-contracts/events/risk-compliance.md
+        description: "Events and commands contract for Risk & Compliance."
+    tests:
+      - path: services/risk-compliance/tests/test_domain.py
+        description: "Unit tests for domain invariants, state machines, commands, and cross-context contracts."
+      - path: services/risk-compliance/tests/test_skeleton.py
+        description: "Application skeleton tests (health, runtime endpoints, tracing seam, domain type imports)."
+    docs:
+      - path: docs/02-domains/risk-compliance.md
+      - path: docs/03-ddd-final/phase-1-contract.md
+      - path: docs/08-contracts/events/risk-compliance.md
+    depends_on: [REQ-010, REQ-012, REQ-017, REQ-028]
+    confidence: confirmed
+    source: "docs/02-domains/risk-compliance.md, docs/03-ddd-final/phase-1-contract.md, docs/03-ddd-final/implementation-roadmap.md"
 
       - path: services/provider-integration/internal/domain/webhook_inbox_test.go
         description: "Unit tests for WebhookInbox verification, mapping, and publishing."

--- a/service-catalog.json
+++ b/service-catalog.json
@@ -57,393 +57,6 @@
   ],
   "services": [
     {
-      "id": "place-network",
-      "path": "services/place-network",
-      "domain": "Place & Network",
-      "language": "golang",
-      "runtime": "go",
-      "phase": "phase-1-core",
-      "status": "tested",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-004"
-      ],
-      "docs": [
-        "docs/02-domains/place-network.md"
-      ],
-      "owns": [
-        "Place",
-        "TransportNode",
-        "ProviderPlaceMapping"
-      ],
-      "rationale": "Go fits read-heavy master-data APIs and simple operational lookup paths."
-    },
-    {
-      "id": "service-plan",
-      "path": "services/service-plan",
-      "domain": "Service Plan",
-      "language": "golang",
-      "runtime": "go",
-      "phase": "phase-1-core",
-      "status": "tested",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-005"
-      ],
-      "docs": [
-        "docs/02-domains/service-plan.md"
-      ],
-      "owns": [
-        "Route",
-        "ServicePlan",
-        "Calendar",
-        "Timetable",
-        "PlanVersion"
-      ],
-      "rationale": "Go keeps schedule query services small, fast, and easy to operate."
-    },
-    {
-      "id": "capacity-availability",
-      "path": "services/capacity-availability",
-      "domain": "Capacity & Availability",
-      "language": "rust",
-      "runtime": "rust",
-      "phase": "phase-1-core",
-      "status": "tested",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-006"
-      ],
-      "docs": [
-        "docs/02-domains/capacity-availability.md",
-        "docs/03-ddd-final/phase-1-contract.md"
-      ],
-      "owns": [
-        "InventoryPool",
-        "StationInterval",
-        "CapacityHold",
-        "AvailabilitySnapshot"
-      ],
-      "rationale": "Rust is appropriate for interval overlap and seat-hold invariants that must fail closed."
-    },
-    {
-      "id": "fare-pricing",
-      "path": "services/fare-pricing",
-      "domain": "Fare & Pricing",
-      "language": "python",
-      "runtime": "python",
-      "phase": "phase-1-core",
-      "status": "tested",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-007"
-      ],
-      "docs": [
-        "docs/02-domains/fare-pricing.md"
-      ],
-      "owns": [
-        "FareRuleSet",
-        "FareQuote",
-        "RefundFee",
-        "ChangeFee",
-        "RuleSnapshot"
-      ],
-      "rationale": "Python keeps fare rules, explanation tooling, and later experimentation lightweight."
-    },
-    {
-      "id": "trip-planning",
-      "path": "services/trip-planning",
-      "domain": "Trip Planning",
-      "language": "python",
-      "runtime": "python",
-      "phase": "phase-1-search-foundation",
-      "status": "implemented-foundation",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-008-Trip-Planning-search-foundation"
-      ],
-      "docs": [
-        "docs/02-domains/trip-planning.md",
-        "docs/03-ddd-final/phase-1-contract.md"
-      ],
-      "owns": [
-        "TripIntent validation",
-        "Itinerary candidates",
-        "SearchResult ranking explanations",
-        "Non-authoritative PriceHint and AvailabilityHint snapshots"
-      ],
-      "rationale": "Python is a better fit for search heuristics, deterministic ranking, and auditable explanation logic."
-    },
-    {
-      "id": "offer-management",
-      "path": "services/offer-management",
-      "domain": "Offer Management",
-      "language": "typescript",
-      "runtime": "node",
-      "phase": "phase-1-offer-domain-foundation",
-      "status": "implemented-foundation",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-009-Offer-Management-domain-foundation"
-      ],
-      "docs": [
-        "docs/02-domains/offer-management.md",
-        "docs/03-ddd-final/phase-1-contract.md"
-      ],
-      "owns": [
-        "Offer identity and lifecycle",
-        "OfferItem snapshot composition",
-        "ItineraryReference",
-        "AvailabilitySnapshotReference",
-        "PriceSnapshot",
-        "FareRuleSnapshotReference",
-        "PassengerMix",
-        "RiskDisclosure",
-        "OfferQuoted",
-        "OfferExpired"
-      ],
-      "rationale": "TypeScript fits user-facing offer API composition, TTL policy, immutable snapshot enforcement, and disclosure payloads."
-    },
-    {
-      "id": "journey-order",
-      "path": "services/journey-order",
-      "domain": "Journey Order",
-      "language": "java",
-      "runtime": "jvm",
-      "phase": "phase-1-domain-foundation",
-      "status": "tested",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-010-Journey-Order-domain-foundation"
-      ],
-      "docs": [
-        "docs/02-domains/journey-order.md"
-      ],
-      "owns": [
-        "JourneyOrder aggregate root",
-        "OrderItem entity and lifecycle",
-        "MonetarySummary invariants",
-        "OrderTimeline facts",
-        "ConfirmationConditions guards",
-        "OrderLifecycleState machine",
-        "TravelerRef snapshots",
-        "SegmentOrderSnapshot references",
-        "OrderLineBinding bindings",
-        "JourneyOrderCreated, JourneyOrderPendingPayment, JourneyOrderConfirmed, JourneyOrderCancelled events"
-      ],
-      "rationale": "Java is conservative for central transactional aggregates and long-lived domain models."
-    },
-    {
-      "id": "booking-orchestration",
-      "path": "services/booking-orchestration",
-      "domain": "Booking Orchestration",
-      "language": "java",
-      "runtime": "jvm",
-      "phase": "phase-1-core",
-      "status": "status-reconciliation-needed",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-011"
-      ],
-      "docs": [
-        "docs/02-domains/booking-orchestration.md"
-      ],
-      "owns": [
-        "BookingSaga",
-        "SegmentBooking",
-        "ProviderReservation mapping"
-      ],
-      "rationale": "Java gives the saga layer explicit state transitions and stable integration testing options."
-    },
-    {
-      "id": "payment",
-      "path": "services/payment",
-      "domain": "Payment",
-      "language": "java",
-      "runtime": "jvm",
-      "phase": "phase-1-domain-foundation",
-      "status": "tested",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-012-Payment-domain-foundation"
-      ],
-      "docs": [
-        "docs/02-domains/payment.md"
-      ],
-      "owns": [
-        "PaymentIntent",
-        "Refund",
-        "CallbackRecord",
-        "IdempotencyKey"
-      ],
-      "rationale": "Java is a strong default for money state machines, idempotency, and audit-heavy flows."
-    },
-    {
-      "id": "provider-integration",
-      "path": "services/provider-integration",
-      "domain": "Provider Integration",
-      "language": "golang",
-      "runtime": "go",
-      "phase": "phase-1-acl-foundation",
-      "status": "status-reconciliation-needed",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-015"
-      ],
-      "docs": [
-        "docs/02-domains/provider-integration.md"
-      ],
-      "owns": [
-        "adapter protocol",
-        "signature verification",
-        "raw archive",
-        "external status mapping"
-      ],
-      "rationale": "Go fits protocol adapters, webhooks, retry loops, and small deployable edge services."
-    },
-    {
-      "id": "entitlement-ticketing",
-      "path": "services/entitlement-ticketing",
-      "domain": "Entitlement & Ticketing",
-      "language": "rust",
-      "runtime": "rust",
-      "phase": "phase-1-domain-foundation",
-      "status": "status-reconciliation-needed",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-013"
-      ],
-      "docs": [
-        "docs/02-domains/entitlement-ticketing.md"
-      ],
-      "owns": [
-        "Entitlement",
-        "Credential",
-        "Issue",
-        "Void",
-        "Suspend",
-        "Boarded consumption"
-      ],
-      "rationale": "Rust is appropriate for ticket entitlement lifecycle invariants and credential safety."
-    },
-    {
-      "id": "fulfillment",
-      "path": "services/fulfillment",
-      "domain": "Fulfillment",
-      "language": "golang",
-      "runtime": "go",
-      "phase": "phase-1-limited",
-      "status": "skeleton",
-      "priority": "P1",
-      "workPackages": [
-        "WP-13"
-      ],
-      "docs": [
-        "docs/02-domains/fulfillment.md"
-      ],
-      "owns": [
-        "FulfillmentRecord",
-        "BoardingVerified",
-        "NoShow",
-        "EvidenceDispute"
-      ],
-      "rationale": "Go keeps event ingestion and station-side fact normalization operationally simple."
-    },
-    {
-      "id": "post-sales",
-      "path": "services/post-sales",
-      "domain": "Post Sales",
-      "language": "java",
-      "runtime": "jvm",
-      "phase": "phase-1-core",
-      "status": "status-reconciliation-needed",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-014"
-      ],
-      "docs": [
-        "docs/02-domains/post-sales.md"
-      ],
-      "owns": [
-        "PostSalesCase",
-        "RefundDecision",
-        "ChangeExecutionPlan"
-      ],
-      "rationale": "Java keeps refund/change case workflows explicit and compatible with transaction review tooling."
-    },
-    {
-      "id": "notification",
-      "path": "services/notification",
-      "domain": "Notification",
-      "language": "typescript",
-      "runtime": "node",
-      "phase": "phase-1-domain-foundation",
-      "status": "implemented-foundation",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-019",
-        "WP-15-transaction-notification"
-      ],
-      "docs": [
-        "docs/02-domains/notification.md"
-      ],
-      "owns": [
-        "NotificationTask lifecycle (Planned, Delivering, Delivered, Failed, Cancelled)",
-        "Template versioning with variable schema and channel adaptations",
-        "RecipientPolicy with channel priority, fallback, and consent bypass",
-        "DeliveryReceipt appended facts (Delivered, Bounced, Rejected, Timeout, Expired)",
-        "NotificationScheduled, NotificationDispatched, NotificationDelivered, NotificationFailed, NotificationCancelled events",
-        "Send idempotency via idempotencyKey (triggerEventId + recipientRef + templateCode)"
-      ],
-      "rationale": "TypeScript fits template payloads, channel adapters, and product-facing notification policies. Domain foundation established with full aggregate lifecycle, idempotency, and boundary proof."
-    },
-    {
-      "id": "traveler-profile",
-      "path": "services/traveler-profile",
-      "domain": "Traveler Profile",
-      "language": "java",
-      "runtime": "jvm",
-      "phase": "phase-1-domain-foundation",
-      "status": "implemented",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-017"
-      ],
-      "docs": [
-        "docs/02-domains/traveler-profile.md"
-      ],
-      "owns": [
-        "TravelerProfile",
-        "Document",
-        "EligibilitySummary",
-        "PreferenceSnapshot"
-      ],
-      "rationale": "Java keeps PII-heavy profile aggregates and validation policies explicit."
-    },
-    {
-      "id": "risk-compliance",
-      "path": "services/risk-compliance",
-      "domain": "Risk & Compliance",
-      "language": "python",
-      "runtime": "python",
-      "phase": "phase-1-support",
-      "status": "skeleton",
-      "priority": "P1",
-      "workPackages": [
-        "WP-17"
-      ],
-      "docs": [
-        "docs/02-domains/risk-compliance.md"
-      ],
-      "owns": [
-        "RiskAssessment",
-        "Challenge",
-        "BlockDecision",
-        "EvidenceSummary"
-      ],
-      "rationale": "Python supports rule experimentation, scoring, and evidence summarization without coupling source domains."
-    },
-    {
       "id": "account",
       "path": "services/account",
       "domain": "Account",
@@ -491,6 +104,72 @@
       "rationale": "Java is a conservative fit for approvals, audit retention, and authorization boundaries."
     },
     {
+      "id": "ancillary-service",
+      "path": "services/ancillary-service",
+      "domain": "Ancillary Service",
+      "language": "typescript",
+      "runtime": "node",
+      "phase": "future-scope",
+      "status": "placeholder-skeleton",
+      "priority": "P1",
+      "workPackages": [],
+      "docs": [
+        "docs/02-domains/ancillary-service.md"
+      ],
+      "owns": [
+        "AncillaryOffer",
+        "AncillaryOrderItem",
+        "ActivationPolicy"
+      ],
+      "rationale": "TypeScript fits productized add-ons and bundle-facing API composition."
+    },
+    {
+      "id": "booking-orchestration",
+      "path": "services/booking-orchestration",
+      "domain": "Booking Orchestration",
+      "language": "java",
+      "runtime": "jvm",
+      "phase": "phase-1-core",
+      "status": "status-reconciliation-needed",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-011"
+      ],
+      "docs": [
+        "docs/02-domains/booking-orchestration.md"
+      ],
+      "owns": [
+        "BookingSaga",
+        "SegmentBooking",
+        "ProviderReservation mapping"
+      ],
+      "rationale": "Java gives the saga layer explicit state transitions and stable integration testing options."
+    },
+    {
+      "id": "capacity-availability",
+      "path": "services/capacity-availability",
+      "domain": "Capacity & Availability",
+      "language": "rust",
+      "runtime": "rust",
+      "phase": "phase-1-core",
+      "status": "tested",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-006"
+      ],
+      "docs": [
+        "docs/02-domains/capacity-availability.md",
+        "docs/03-ddd-final/phase-1-contract.md"
+      ],
+      "owns": [
+        "InventoryPool",
+        "StationInterval",
+        "CapacityHold",
+        "AvailabilitySnapshot"
+      ],
+      "rationale": "Rust is appropriate for interval overlap and seat-hold invariants that must fail closed."
+    },
+    {
       "id": "customer-service",
       "path": "services/customer-service",
       "domain": "Customer Service",
@@ -512,6 +191,96 @@
         "CaseTimeline"
       ],
       "rationale": "TypeScript fits collaborative case APIs and UI-adjacent timelines without owning target state."
+    },
+    {
+      "id": "dispatch",
+      "path": "services/dispatch",
+      "domain": "Dispatch",
+      "language": "golang",
+      "runtime": "go",
+      "phase": "future-scope",
+      "status": "placeholder-skeleton",
+      "priority": "P1",
+      "workPackages": [],
+      "docs": [
+        "docs/02-domains/dispatch.md"
+      ],
+      "owns": [
+        "RideRequest",
+        "RideAssignment",
+        "DriverLifecycle",
+        "Eta"
+      ],
+      "rationale": "Go fits real-time dispatch APIs, adapter calls, and low-latency state updates."
+    },
+    {
+      "id": "disruption-recovery",
+      "path": "services/disruption-recovery",
+      "domain": "Disruption Recovery",
+      "language": "python",
+      "runtime": "python",
+      "phase": "future-scope",
+      "status": "placeholder-skeleton",
+      "priority": "P1",
+      "workPackages": [],
+      "docs": [
+        "docs/02-domains/disruption-recovery.md"
+      ],
+      "owns": [
+        "RecoveryCase",
+        "RecoveryOption",
+        "CompensationDecision"
+      ],
+      "rationale": "Python fits recovery optimization and policy experimentation when this future domain is enabled."
+    },
+    {
+      "id": "entitlement-ticketing",
+      "path": "services/entitlement-ticketing",
+      "domain": "Entitlement & Ticketing",
+      "language": "rust",
+      "runtime": "rust",
+      "phase": "phase-1-domain-foundation",
+      "status": "status-reconciliation-needed",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-013"
+      ],
+      "docs": [
+        "docs/02-domains/entitlement-ticketing.md"
+      ],
+      "owns": [
+        "Entitlement",
+        "Credential",
+        "Issue",
+        "Void",
+        "Suspend",
+        "Boarded consumption"
+      ],
+      "rationale": "Rust is appropriate for ticket entitlement lifecycle invariants and credential safety."
+    },
+    {
+      "id": "fare-pricing",
+      "path": "services/fare-pricing",
+      "domain": "Fare & Pricing",
+      "language": "python",
+      "runtime": "python",
+      "phase": "phase-1-core",
+      "status": "tested",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-007"
+      ],
+      "docs": [
+        "docs/02-domains/fare-pricing.md"
+      ],
+      "owns": [
+        "FareRuleSet",
+        "FareQuote",
+        "RefundFee",
+        "ChangeFee",
+        "RuleSnapshot"
+      ],
+      "rationale": "Python keeps fare rules, explanation tooling, and later experimentation lightweight."
     },
     {
       "id": "finance-settlement",
@@ -537,6 +306,204 @@
       "rationale": "Java is appropriate for financial ledgers, reconciliation workflows, and audit consistency."
     },
     {
+      "id": "fulfillment",
+      "path": "services/fulfillment",
+      "domain": "Fulfillment",
+      "language": "golang",
+      "runtime": "go",
+      "phase": "phase-1-limited",
+      "status": "skeleton",
+      "priority": "P1",
+      "workPackages": [
+        "WP-13"
+      ],
+      "docs": [
+        "docs/02-domains/fulfillment.md"
+      ],
+      "owns": [
+        "FulfillmentRecord",
+        "BoardingVerified",
+        "NoShow",
+        "EvidenceDispute"
+      ],
+      "rationale": "Go keeps event ingestion and station-side fact normalization operationally simple."
+    },
+    {
+      "id": "journey-order",
+      "path": "services/journey-order",
+      "domain": "Journey Order",
+      "language": "java",
+      "runtime": "jvm",
+      "phase": "phase-1-domain-foundation",
+      "status": "tested",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-010-Journey-Order-domain-foundation"
+      ],
+      "docs": [
+        "docs/02-domains/journey-order.md"
+      ],
+      "owns": [
+        "JourneyOrder aggregate root",
+        "OrderItem entity and lifecycle",
+        "MonetarySummary invariants",
+        "OrderTimeline facts",
+        "ConfirmationConditions guards",
+        "OrderLifecycleState machine",
+        "TravelerRef snapshots",
+        "SegmentOrderSnapshot references",
+        "OrderLineBinding bindings",
+        "JourneyOrderCreated, JourneyOrderPendingPayment, JourneyOrderConfirmed, JourneyOrderCancelled events"
+      ],
+      "rationale": "Java is conservative for central transactional aggregates and long-lived domain models."
+    },
+    {
+      "id": "notification",
+      "path": "services/notification",
+      "domain": "Notification",
+      "language": "typescript",
+      "runtime": "node",
+      "phase": "phase-1-domain-foundation",
+      "status": "implemented-foundation",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-019",
+        "WP-15-transaction-notification"
+      ],
+      "docs": [
+        "docs/02-domains/notification.md"
+      ],
+      "owns": [
+        "NotificationTask lifecycle (Planned, Delivering, Delivered, Failed, Cancelled)",
+        "Template versioning with variable schema and channel adaptations",
+        "RecipientPolicy with channel priority, fallback, and consent bypass",
+        "DeliveryReceipt appended facts (Delivered, Bounced, Rejected, Timeout, Expired)",
+        "NotificationScheduled, NotificationDispatched, NotificationDelivered, NotificationFailed, NotificationCancelled events",
+        "Send idempotency via idempotencyKey (triggerEventId + recipientRef + templateCode)"
+      ],
+      "rationale": "TypeScript fits template payloads, channel adapters, and product-facing notification policies. Domain foundation established with full aggregate lifecycle, idempotency, and boundary proof."
+    },
+    {
+      "id": "offer-management",
+      "path": "services/offer-management",
+      "domain": "Offer Management",
+      "language": "typescript",
+      "runtime": "node",
+      "phase": "phase-1-offer-domain-foundation",
+      "status": "implemented-foundation",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-009-Offer-Management-domain-foundation"
+      ],
+      "docs": [
+        "docs/02-domains/offer-management.md",
+        "docs/03-ddd-final/phase-1-contract.md"
+      ],
+      "owns": [
+        "Offer identity and lifecycle",
+        "OfferItem snapshot composition",
+        "ItineraryReference",
+        "AvailabilitySnapshotReference",
+        "PriceSnapshot",
+        "FareRuleSnapshotReference",
+        "PassengerMix",
+        "RiskDisclosure",
+        "OfferQuoted",
+        "OfferExpired"
+      ],
+      "rationale": "TypeScript fits user-facing offer API composition, TTL policy, immutable snapshot enforcement, and disclosure payloads."
+    },
+    {
+      "id": "payment",
+      "path": "services/payment",
+      "domain": "Payment",
+      "language": "java",
+      "runtime": "jvm",
+      "phase": "phase-1-domain-foundation",
+      "status": "tested",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-012-Payment-domain-foundation"
+      ],
+      "docs": [
+        "docs/02-domains/payment.md"
+      ],
+      "owns": [
+        "PaymentIntent",
+        "Refund",
+        "CallbackRecord",
+        "IdempotencyKey"
+      ],
+      "rationale": "Java is a strong default for money state machines, idempotency, and audit-heavy flows."
+    },
+    {
+      "id": "place-network",
+      "path": "services/place-network",
+      "domain": "Place & Network",
+      "language": "golang",
+      "runtime": "go",
+      "phase": "phase-1-core",
+      "status": "tested",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-004"
+      ],
+      "docs": [
+        "docs/02-domains/place-network.md"
+      ],
+      "owns": [
+        "Place",
+        "TransportNode",
+        "ProviderPlaceMapping"
+      ],
+      "rationale": "Go fits read-heavy master-data APIs and simple operational lookup paths."
+    },
+    {
+      "id": "post-sales",
+      "path": "services/post-sales",
+      "domain": "Post Sales",
+      "language": "java",
+      "runtime": "jvm",
+      "phase": "phase-1-core",
+      "status": "status-reconciliation-needed",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-014"
+      ],
+      "docs": [
+        "docs/02-domains/post-sales.md"
+      ],
+      "owns": [
+        "PostSalesCase",
+        "RefundDecision",
+        "ChangeExecutionPlan"
+      ],
+      "rationale": "Java keeps refund/change case workflows explicit and compatible with transaction review tooling."
+    },
+    {
+      "id": "provider-integration",
+      "path": "services/provider-integration",
+      "domain": "Provider Integration",
+      "language": "golang",
+      "runtime": "go",
+      "phase": "phase-1-acl-foundation",
+      "status": "status-reconciliation-needed",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-015"
+      ],
+      "docs": [
+        "docs/02-domains/provider-integration.md"
+      ],
+      "owns": [
+        "adapter protocol",
+        "signature verification",
+        "raw archive",
+        "external status mapping"
+      ],
+      "rationale": "Go fits protocol adapters, webhooks, retry loops, and small deployable edge services."
+    },
+    {
       "id": "reporting",
       "path": "services/reporting",
       "domain": "Reporting",
@@ -557,6 +524,57 @@
         "FunnelView"
       ],
       "rationale": "Python is a pragmatic fit for metric definitions, event-derived views, and analytics validation."
+    },
+    {
+      "id": "risk-compliance",
+      "path": "services/risk-compliance",
+      "domain": "Risk & Compliance",
+      "language": "python",
+      "runtime": "python",
+      "phase": "phase-1-support",
+      "status": "tested",
+      "priority": "P1",
+      "workPackages": [
+        "WP-17"
+      ],
+      "docs": [
+        "docs/02-domains/risk-compliance.md"
+      ],
+      "owns": [
+        "RiskAssessment",
+        "Challenge",
+        "RiskDecision",
+        "EvidenceSummary"
+      ],
+      "rationale": "Python supports rule experimentation, scoring, and evidence summarization without coupling source domains.",
+      "work_packages": [
+        "REQ-020",
+        "WP-17"
+      ]
+    },
+    {
+      "id": "service-plan",
+      "path": "services/service-plan",
+      "domain": "Service Plan",
+      "language": "golang",
+      "runtime": "go",
+      "phase": "phase-1-core",
+      "status": "tested",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-005"
+      ],
+      "docs": [
+        "docs/02-domains/service-plan.md"
+      ],
+      "owns": [
+        "Route",
+        "ServicePlan",
+        "Calendar",
+        "Timetable",
+        "PlanVersion"
+      ],
+      "rationale": "Go keeps schedule query services small, fast, and easy to operate."
     },
     {
       "id": "supplier-catalog",
@@ -584,26 +602,6 @@
       "rationale": "Go keeps supplier capability lookup compact and separate from provider runtime health."
     },
     {
-      "id": "disruption-recovery",
-      "path": "services/disruption-recovery",
-      "domain": "Disruption Recovery",
-      "language": "python",
-      "runtime": "python",
-      "phase": "future-scope",
-      "status": "placeholder-skeleton",
-      "priority": "P1",
-      "workPackages": [],
-      "docs": [
-        "docs/02-domains/disruption-recovery.md"
-      ],
-      "owns": [
-        "RecoveryCase",
-        "RecoveryOption",
-        "CompensationDecision"
-      ],
-      "rationale": "Python fits recovery optimization and policy experimentation when this future domain is enabled."
-    },
-    {
       "id": "transfer-management",
       "path": "services/transfer-management",
       "domain": "Transfer Management",
@@ -624,24 +622,51 @@
       "rationale": "Python fits connection-risk calculation and later protected-transfer recovery planning."
     },
     {
-      "id": "ancillary-service",
-      "path": "services/ancillary-service",
-      "domain": "Ancillary Service",
-      "language": "typescript",
-      "runtime": "node",
-      "phase": "future-scope",
-      "status": "placeholder-skeleton",
-      "priority": "P1",
-      "workPackages": [],
+      "id": "traveler-profile",
+      "path": "services/traveler-profile",
+      "domain": "Traveler Profile",
+      "language": "java",
+      "runtime": "jvm",
+      "phase": "phase-1-domain-foundation",
+      "status": "implemented",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-017"
+      ],
       "docs": [
-        "docs/02-domains/ancillary-service.md"
+        "docs/02-domains/traveler-profile.md"
       ],
       "owns": [
-        "AncillaryOffer",
-        "AncillaryOrderItem",
-        "ActivationPolicy"
+        "TravelerProfile",
+        "Document",
+        "EligibilitySummary",
+        "PreferenceSnapshot"
       ],
-      "rationale": "TypeScript fits productized add-ons and bundle-facing API composition."
+      "rationale": "Java keeps PII-heavy profile aggregates and validation policies explicit."
+    },
+    {
+      "id": "trip-planning",
+      "path": "services/trip-planning",
+      "domain": "Trip Planning",
+      "language": "python",
+      "runtime": "python",
+      "phase": "phase-1-search-foundation",
+      "status": "implemented-foundation",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-008-Trip-Planning-search-foundation"
+      ],
+      "docs": [
+        "docs/02-domains/trip-planning.md",
+        "docs/03-ddd-final/phase-1-contract.md"
+      ],
+      "owns": [
+        "TripIntent validation",
+        "Itinerary candidates",
+        "SearchResult ranking explanations",
+        "Non-authoritative PriceHint and AvailabilityHint snapshots"
+      ],
+      "rationale": "Python is a better fit for search heuristics, deterministic ranking, and auditable explanation logic."
     },
     {
       "id": "waitlist",
@@ -683,27 +708,6 @@
         "PointLedger"
       ],
       "rationale": "Java is a conservative default for stored-value and promotion ledgers."
-    },
-    {
-      "id": "dispatch",
-      "path": "services/dispatch",
-      "domain": "Dispatch",
-      "language": "golang",
-      "runtime": "go",
-      "phase": "future-scope",
-      "status": "placeholder-skeleton",
-      "priority": "P1",
-      "workPackages": [],
-      "docs": [
-        "docs/02-domains/dispatch.md"
-      ],
-      "owns": [
-        "RideRequest",
-        "RideAssignment",
-        "DriverLifecycle",
-        "Eta"
-      ],
-      "rationale": "Go fits real-time dispatch APIs, adapter calls, and low-latency state updates."
     }
   ]
 }

--- a/services/risk-compliance/src/risk_compliance/__init__.py
+++ b/services/risk-compliance/src/risk_compliance/__init__.py
@@ -1,10 +1,66 @@
 from .api import create_app
+from .domain import (
+    AssessmentInputSnapshot,
+    AssessmentStatus,
+    BlockScope,
+    BlockStatus,
+    Challenge,
+    ChallengeOutcome,
+    ChallengeStatus,
+    ChallengeType,
+    Decision,
+    EvidenceBundle,
+    EvidenceItem,
+    EvidenceSummary,
+    EvidenceType,
+    PolicyVersionRef,
+    RiskAssessment,
+    RiskComplianceError,
+    RiskDecision,
+    RiskLevel,
+    allow_subject,
+    assess_risk,
+    block_subject,
+    issue_challenge,
+    record_evidence,
+    resolve_challenge,
+)
 from .runtime import SERVICE_PROFILE, ServiceProfile, health, profile
 
 __all__ = [
-    'SERVICE_PROFILE',
-    'ServiceProfile',
-    'create_app',
-    'health',
-    'profile',
+    # Value objects
+    "AssessmentInputSnapshot",
+    "EvidenceBundle",
+    "EvidenceItem",
+    "EvidenceSummary",
+    "PolicyVersionRef",
+    # Enums
+    "AssessmentStatus",
+    "BlockScope",
+    "BlockStatus",
+    "ChallengeOutcome",
+    "ChallengeStatus",
+    "ChallengeType",
+    "Decision",
+    "EvidenceType",
+    "RiskLevel",
+    # Aggregates
+    "Challenge",
+    "RiskAssessment",
+    "RiskDecision",
+    # Errors
+    "RiskComplianceError",
+    # Commands
+    "allow_subject",
+    "assess_risk",
+    "block_subject",
+    "issue_challenge",
+    "record_evidence",
+    "resolve_challenge",
+    # Runtime
+    "SERVICE_PROFILE",
+    "ServiceProfile",
+    "create_app",
+    "health",
+    "profile",
 ]

--- a/services/risk-compliance/src/risk_compliance/domain.py
+++ b/services/risk-compliance/src/risk_compliance/domain.py
@@ -1,0 +1,712 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from enum import Enum
+from hashlib import sha256
+from typing import Mapping, Self
+
+
+class RiskComplianceError(ValueError):
+    """Raised when risk-compliance invariants are violated."""
+
+
+# ── Enums ───────────────────────────────────────────────────────────────────
+
+
+class Decision(str, Enum):
+    ALLOW = "ALLOW"
+    DENY = "DENY"
+    CHALLENGE = "CHALLENGE"
+    HOLD = "HOLD"
+
+
+class RiskLevel(str, Enum):
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"
+    CRITICAL = "CRITICAL"
+
+
+class AssessmentStatus(str, Enum):
+    REQUESTED = "REQUESTED"
+    EVALUATING = "EVALUATING"
+    ALLOWED = "ALLOWED"
+    DENIED = "DENIED"
+    CHALLENGED = "CHALLENGED"
+    HELD = "HELD"
+    MANUAL_REVIEW = "MANUAL_REVIEW"
+    FAILED = "FAILED"
+    SUPERSEDED = "SUPERSEDED"
+
+
+class ChallengeType(str, Enum):
+    SMS = "SMS"
+    FACE_VERIFICATION = "FACE_VERIFICATION"
+    PAYMENT_VERIFICATION = "PAYMENT_VERIFICATION"
+    MANUAL_REVIEW = "MANUAL_REVIEW"
+
+
+class ChallengeStatus(str, Enum):
+    CREATED = "CREATED"
+    PENDING_USER_ACTION = "PENDING_USER_ACTION"
+    PASSED = "PASSED"
+    FAILED = "FAILED"
+    EXPIRED = "EXPIRED"
+    CANCELLED = "CANCELLED"
+
+
+class ChallengeOutcome(str, Enum):
+    PASSED = "PASSED"
+    FAILED = "FAILED"
+    EXPIRED = "EXPIRED"
+
+
+class BlockScope(str, Enum):
+    ORDER = "ORDER"
+    PAYMENT = "PAYMENT"
+    ACCOUNT = "ACCOUNT"
+
+
+class BlockStatus(str, Enum):
+    ACTIVE = "ACTIVE"
+    RELEASED = "RELEASED"
+    EXPIRED = "EXPIRED"
+
+
+class EvidenceType(str, Enum):
+    FRAUD_SIGNAL = "fraud_signal"
+    DEVICE_FINGERPRINT = "device_fingerprint"
+    RULE_HIT = "rule_hit"
+    EXTERNAL_LIST_MATCH = "external_list_match"
+    MANUAL_REVIEW = "manual_review"
+    CHALLENGE_RESULT = "challenge_result"
+
+
+# ── Value Objects ────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class AssessmentInputSnapshot:
+    """Immutable snapshot of the inputs used for a risk assessment."""
+
+    subject_ref: str
+    scenario: str
+    input_data: Mapping[str, object] = field(default_factory=dict)
+    captured_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def __post_init__(self) -> None:
+        if not self.subject_ref.strip():
+            raise RiskComplianceError("subject_ref is required")
+        if not self.scenario.strip():
+            raise RiskComplianceError("scenario is required")
+
+    @property
+    def digest(self) -> str:
+        payload = f"{self.subject_ref}:{self.scenario}:{sorted(str(k)+str(v) for k, v in self.input_data.items())}"
+        return sha256(payload.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyVersionRef:
+    """Reference to the policy/rule version that produced a decision."""
+
+    policy_set_id: str
+    version: str
+
+    def __post_init__(self) -> None:
+        if not self.policy_set_id.strip():
+            raise RiskComplianceError("policy_set_id is required")
+        if not self.version.strip():
+            raise RiskComplianceError("version is required")
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceBundle:
+    """Evidence bundle summarizing the signals and rules that led to a decision."""
+
+    bundle_id: str
+    evidence_items: tuple[EvidenceItem, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if not self.bundle_id.strip():
+            raise RiskComplianceError("bundle_id is required")
+
+    def add_item(self, item: EvidenceItem) -> Self:
+        return EvidenceBundle(
+            self.bundle_id,
+            self.evidence_items + (item,),
+        )
+
+    @property
+    def digest(self) -> str:
+        payload = "|".join(f"{e.evidence_id}:{e.evidence_type}:{e.summary}" for e in self.evidence_items)
+        return sha256(payload.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceItem:
+    evidence_id: str
+    evidence_type: str
+    summary: str
+    recorded_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def __post_init__(self) -> None:
+        if not self.evidence_id.strip():
+            raise RiskComplianceError("evidence_id is required")
+        if not self.evidence_type.strip():
+            raise RiskComplianceError("evidence_type is required")
+        if not self.summary.strip():
+            raise RiskComplianceError("summary is required")
+
+
+# ── Aggregate: RiskAssessment ───────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class RiskAssessment:
+    """A risk assessment for a business action.
+
+    Invariants:
+    - Same subject + scenario + policyVersion + idempotencyKey produces
+      semantically equivalent results.
+    - Decision must reference the input snapshot and rule version.
+    - Terminal states (ALLOWED, DENIED, SUPERSEDED) are immutable.
+    """
+
+    assessment_id: str
+    subject_ref: str
+    scenario: str
+    status: AssessmentStatus
+    decision: Decision | None
+    score: int | None
+    level: RiskLevel | None
+    policy_version: PolicyVersionRef | None
+    input_snapshot: AssessmentInputSnapshot
+    evidence_bundle: EvidenceBundle | None
+    reason_code: str | None
+    reason_explanation: str | None
+    assessed_at: datetime | None
+    superseded_by: str | None = None
+    idempotency_key: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.assessment_id.strip():
+            raise RiskComplianceError("assessment_id is required")
+        if not self.subject_ref.strip():
+            raise RiskComplianceError("subject_ref is required")
+        if not self.scenario.strip():
+            raise RiskComplianceError("scenario is required")
+
+        # Validate score range
+        if self.score is not None and not (0 <= self.score <= 1000):
+            raise RiskComplianceError("score must be between 0 and 1000")
+
+        # Terminal states must have decision
+        if self.status in (AssessmentStatus.ALLOWED, AssessmentStatus.DENIED):
+            if self.decision is None:
+                raise RiskComplianceError("terminal states require a decision")
+            if self.policy_version is None:
+                raise RiskComplianceError("terminal states require a policy version")
+            if self.assessed_at is None:
+                raise RiskComplianceError("terminal states require assessed_at")
+            if self.reason_code is None:
+                raise RiskComplianceError("terminal states require a reason_code")
+
+    def is_terminal(self) -> bool:
+        return self.status in (
+            AssessmentStatus.ALLOWED,
+            AssessmentStatus.DENIED,
+            AssessmentStatus.SUPERSEDED,
+        )
+
+    def allow(self, *, decision: Decision, score: int | None = None,
+              level: RiskLevel | None = None,
+              policy_version: PolicyVersionRef,
+              reason_code: str, reason_explanation: str | None = None,
+              evidence_bundle: EvidenceBundle | None = None,
+              assessed_at: datetime | None = None) -> RiskAssessment:
+        if self.is_terminal():
+            raise RiskComplianceError("cannot transition from terminal state")
+        if decision is not Decision.ALLOW and decision is not Decision.HOLD:
+            raise RiskComplianceError("allow transition requires ALLOW or HOLD decision")
+        return RiskAssessment(
+            assessment_id=self.assessment_id,
+            subject_ref=self.subject_ref,
+            scenario=self.scenario,
+            status=AssessmentStatus.ALLOWED if decision is Decision.ALLOW else AssessmentStatus.HELD,
+            decision=decision,
+            score=score,
+            level=level,
+            policy_version=policy_version,
+            input_snapshot=self.input_snapshot,
+            evidence_bundle=evidence_bundle or self.evidence_bundle,
+            reason_code=reason_code,
+            reason_explanation=reason_explanation,
+            assessed_at=assessed_at or datetime.now(UTC),
+            idempotency_key=self.idempotency_key,
+        )
+
+    def deny(self, *, policy_version: PolicyVersionRef,
+             reason_code: str, reason_explanation: str | None = None,
+             score: int | None = None, level: RiskLevel | None = None,
+             evidence_bundle: EvidenceBundle | None = None,
+             assessed_at: datetime | None = None) -> RiskAssessment:
+        if self.is_terminal():
+            raise RiskComplianceError("cannot transition from terminal state")
+        return RiskAssessment(
+            assessment_id=self.assessment_id,
+            subject_ref=self.subject_ref,
+            scenario=self.scenario,
+            status=AssessmentStatus.DENIED,
+            decision=Decision.DENY,
+            score=score,
+            level=level or RiskLevel.HIGH,
+            policy_version=policy_version,
+            input_snapshot=self.input_snapshot,
+            evidence_bundle=evidence_bundle or self.evidence_bundle,
+            reason_code=reason_code,
+            reason_explanation=reason_explanation,
+            assessed_at=assessed_at or datetime.now(UTC),
+            idempotency_key=self.idempotency_key,
+        )
+
+    def challenge(self, *, policy_version: PolicyVersionRef,
+                  reason_code: str, reason_explanation: str | None = None,
+                  score: int | None = None, level: RiskLevel | None = None,
+                  evidence_bundle: EvidenceBundle | None = None,
+                  assessed_at: datetime | None = None) -> RiskAssessment:
+        if self.is_terminal():
+            raise RiskComplianceError("cannot transition from terminal state")
+        return RiskAssessment(
+            assessment_id=self.assessment_id,
+            subject_ref=self.subject_ref,
+            scenario=self.scenario,
+            status=AssessmentStatus.CHALLENGED,
+            decision=Decision.CHALLENGE,
+            score=score,
+            level=level or RiskLevel.MEDIUM,
+            policy_version=policy_version,
+            input_snapshot=self.input_snapshot,
+            evidence_bundle=evidence_bundle or self.evidence_bundle,
+            reason_code=reason_code,
+            reason_explanation=reason_explanation,
+            assessed_at=assessed_at or datetime.now(UTC),
+            idempotency_key=self.idempotency_key,
+        )
+
+    def supersede(self, superseded_by: str) -> RiskAssessment:
+        if not superseded_by.strip():
+            raise RiskComplianceError("superseded_by is required")
+        return RiskAssessment(
+            assessment_id=self.assessment_id,
+            subject_ref=self.subject_ref,
+            scenario=self.scenario,
+            status=AssessmentStatus.SUPERSEDED,
+            decision=self.decision,
+            score=self.score,
+            level=self.level,
+            policy_version=self.policy_version,
+            input_snapshot=self.input_snapshot,
+            evidence_bundle=self.evidence_bundle,
+            reason_code=self.reason_code,
+            reason_explanation=self.reason_explanation,
+            assessed_at=self.assessed_at,
+            superseded_by=superseded_by,
+            idempotency_key=self.idempotency_key,
+        )
+
+
+# ── Aggregate: Challenge ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class Challenge:
+    """A challenge that must be resolved before a business action can proceed.
+
+    Invariants:
+    - Only one active challenge per business ref + challenge type at a time.
+    - Challenge outcomes (PASSED/FAILED/EXPIRED) are terminal states.
+    """
+
+    challenge_id: str
+    business_ref: str
+    challenge_type: ChallengeType
+    assessment_id: str
+    status: ChallengeStatus
+    issued_at: datetime
+    expires_at: datetime
+    resolved_at: datetime | None = None
+    outcome: ChallengeOutcome | None = None
+    outcome_evidence: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.challenge_id.strip():
+            raise RiskComplianceError("challenge_id is required")
+        if not self.business_ref.strip():
+            raise RiskComplianceError("business_ref is required")
+        if not self.assessment_id.strip():
+            raise RiskComplianceError("assessment_id is required")
+        if self.expires_at <= self.issued_at:
+            raise RiskComplianceError("expires_at must be after issued_at")
+
+    def is_active(self) -> bool:
+        return self.status in (ChallengeStatus.CREATED, ChallengeStatus.PENDING_USER_ACTION)
+
+    def is_terminal(self) -> bool:
+        return self.status in (
+            ChallengeStatus.PASSED,
+            ChallengeStatus.FAILED,
+            ChallengeStatus.EXPIRED,
+            ChallengeStatus.CANCELLED,
+        )
+
+    def start(self) -> Challenge:
+        if self.status is not ChallengeStatus.CREATED:
+            raise RiskComplianceError("can only start a CREATED challenge")
+        return Challenge(
+            challenge_id=self.challenge_id,
+            business_ref=self.business_ref,
+            challenge_type=self.challenge_type,
+            assessment_id=self.assessment_id,
+            status=ChallengeStatus.PENDING_USER_ACTION,
+            issued_at=self.issued_at,
+            expires_at=self.expires_at,
+        )
+
+    def pass_challenge(self, *, resolved_at: datetime | None = None,
+                       evidence: str | None = None) -> Challenge:
+        if not self.is_active():
+            raise RiskComplianceError("can only pass an active challenge")
+        if self._is_expired(resolved_at or datetime.now(UTC)):
+            raise RiskComplianceError("cannot pass an expired challenge")
+        return Challenge(
+            challenge_id=self.challenge_id,
+            business_ref=self.business_ref,
+            challenge_type=self.challenge_type,
+            assessment_id=self.assessment_id,
+            status=ChallengeStatus.PASSED,
+            issued_at=self.issued_at,
+            expires_at=self.expires_at,
+            resolved_at=resolved_at or datetime.now(UTC),
+            outcome=ChallengeOutcome.PASSED,
+            outcome_evidence=evidence,
+        )
+
+    def fail_challenge(self, *, resolved_at: datetime | None = None,
+                       evidence: str | None = None) -> Challenge:
+        if not self.is_active():
+            raise RiskComplianceError("can only fail an active challenge")
+        return Challenge(
+            challenge_id=self.challenge_id,
+            business_ref=self.business_ref,
+            challenge_type=self.challenge_type,
+            assessment_id=self.assessment_id,
+            status=ChallengeStatus.FAILED,
+            issued_at=self.issued_at,
+            expires_at=self.expires_at,
+            resolved_at=resolved_at or datetime.now(UTC),
+            outcome=ChallengeOutcome.FAILED,
+            outcome_evidence=evidence,
+        )
+
+    def expire(self, *, at: datetime | None = None) -> Challenge:
+        if not self.is_active():
+            raise RiskComplianceError("can only expire an active challenge")
+        return Challenge(
+            challenge_id=self.challenge_id,
+            business_ref=self.business_ref,
+            challenge_type=self.challenge_type,
+            assessment_id=self.assessment_id,
+            status=ChallengeStatus.EXPIRED,
+            issued_at=self.issued_at,
+            expires_at=self.expires_at,
+            resolved_at=at or datetime.now(UTC),
+            outcome=ChallengeOutcome.EXPIRED,
+        )
+
+    def cancel(self) -> Challenge:
+        if not self.is_active():
+            raise RiskComplianceError("can only cancel an active challenge")
+        return Challenge(
+            challenge_id=self.challenge_id,
+            business_ref=self.business_ref,
+            challenge_type=self.challenge_type,
+            assessment_id=self.assessment_id,
+            status=ChallengeStatus.CANCELLED,
+            issued_at=self.issued_at,
+            expires_at=self.expires_at,
+            resolved_at=datetime.now(UTC),
+        )
+
+    def _is_expired(self, at: datetime) -> bool:
+        return at >= self.expires_at
+
+    @classmethod
+    def create(cls, *, challenge_id: str, business_ref: str,
+               challenge_type: ChallengeType, assessment_id: str,
+               ttl: timedelta,
+               issued_at: datetime | None = None) -> Challenge:
+        now = issued_at or datetime.now(UTC)
+        return cls(
+            challenge_id=challenge_id,
+            business_ref=business_ref,
+            challenge_type=challenge_type,
+            assessment_id=assessment_id,
+            status=ChallengeStatus.CREATED,
+            issued_at=now,
+            expires_at=now + ttl,
+        )
+
+
+# ── Aggregate: RiskDecision ──────────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class RiskDecision:
+    """A block/allow decision on a subject scope.
+
+    Invariants:
+    - A Block decision prevents new transactions in the scope but never
+      cancels in-flight refunds or notifications.
+    - Every decision references the assessment inputs snapshot and rule version.
+    """
+
+    decision_id: str
+    subject_ref: str
+    scope: BlockScope
+    is_block: bool
+    reason_code: str
+    policy_version: PolicyVersionRef
+    assessment_id: str
+    input_snapshot_digest: str
+    evidence_bundle: EvidenceBundle | None
+    decided_at: datetime
+    status: BlockStatus = BlockStatus.ACTIVE
+
+    def __post_init__(self) -> None:
+        if not self.decision_id.strip():
+            raise RiskComplianceError("decision_id is required")
+        if not self.subject_ref.strip():
+            raise RiskComplianceError("subject_ref is required")
+        if not self.reason_code.strip():
+            raise RiskComplianceError("reason_code is required")
+        if not self.input_snapshot_digest.strip():
+            raise RiskComplianceError("input_snapshot_digest is required")
+
+    @classmethod
+    def block(cls, *, decision_id: str, subject_ref: str, scope: BlockScope,
+              reason_code: str, policy_version: PolicyVersionRef,
+              assessment_id: str, input_snapshot_digest: str,
+              evidence_bundle: EvidenceBundle | None = None,
+              decided_at: datetime | None = None) -> RiskDecision:
+        return cls(
+            decision_id=decision_id,
+            subject_ref=subject_ref,
+            scope=scope,
+            is_block=True,
+            reason_code=reason_code,
+            policy_version=policy_version,
+            assessment_id=assessment_id,
+            input_snapshot_digest=input_snapshot_digest,
+            evidence_bundle=evidence_bundle,
+            decided_at=decided_at or datetime.now(UTC),
+        )
+
+    @classmethod
+    def allow(cls, *, decision_id: str, subject_ref: str, scope: BlockScope,
+              reason_code: str, policy_version: PolicyVersionRef,
+              assessment_id: str, input_snapshot_digest: str,
+              evidence_bundle: EvidenceBundle | None = None,
+              decided_at: datetime | None = None) -> RiskDecision:
+        return cls(
+            decision_id=decision_id,
+            subject_ref=subject_ref,
+            scope=scope,
+            is_block=False,
+            reason_code=reason_code,
+            policy_version=policy_version,
+            assessment_id=assessment_id,
+            input_snapshot_digest=input_snapshot_digest,
+            evidence_bundle=evidence_bundle,
+            decided_at=decided_at or datetime.now(UTC),
+        )
+
+    def release(self) -> RiskDecision:
+        if self.status is not BlockStatus.ACTIVE:
+            raise RiskComplianceError("can only release an ACTIVE decision")
+        return RiskDecision(
+            decision_id=self.decision_id,
+            subject_ref=self.subject_ref,
+            scope=self.scope,
+            is_block=self.is_block,
+            reason_code=self.reason_code,
+            policy_version=self.policy_version,
+            assessment_id=self.assessment_id,
+            input_snapshot_digest=self.input_snapshot_digest,
+            evidence_bundle=self.evidence_bundle,
+            decided_at=self.decided_at,
+            status=BlockStatus.RELEASED,
+        )
+
+
+# ── Aggregate: EvidenceSummary ────────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceSummary:
+    """A recorded evidence fact for audit and explainability."""
+
+    evidence_id: str
+    subject_ref: str
+    evidence_type: str
+    summary: str
+    detail: str | None = None
+    recorded_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def __post_init__(self) -> None:
+        if not self.evidence_id.strip():
+            raise RiskComplianceError("evidence_id is required")
+        if not self.subject_ref.strip():
+            raise RiskComplianceError("subject_ref is required")
+        if not self.evidence_type.strip():
+            raise RiskComplianceError("evidence_type is required")
+        if not self.summary.strip():
+            raise RiskComplianceError("summary is required")
+
+
+# ── Domain Commands ──────────────────────────────────────────────────────────
+
+
+def assess_risk(
+    *,
+    assessment_id: str,
+    subject_ref: str,
+    scenario: str,
+    input_data: Mapping[str, object] | None = None,
+    idempotency_key: str | None = None,
+) -> RiskAssessment:
+    """Create a new risk assessment in REQUESTED state."""
+    snapshot = AssessmentInputSnapshot(
+        subject_ref=subject_ref,
+        scenario=scenario,
+        input_data=input_data or {},
+    )
+    return RiskAssessment(
+        assessment_id=assessment_id,
+        subject_ref=subject_ref,
+        scenario=scenario,
+        status=AssessmentStatus.REQUESTED,
+        decision=None,
+        score=None,
+        level=None,
+        policy_version=None,
+        input_snapshot=snapshot,
+        evidence_bundle=None,
+        reason_code=None,
+        reason_explanation=None,
+        assessed_at=None,
+        idempotency_key=idempotency_key,
+    )
+
+
+def issue_challenge(
+    *,
+    challenge_id: str,
+    business_ref: str,
+    challenge_type: ChallengeType,
+    assessment_id: str,
+    ttl: timedelta,
+    issued_at: datetime | None = None,
+) -> Challenge:
+    """Issue a new challenge."""
+    return Challenge.create(
+        challenge_id=challenge_id,
+        business_ref=business_ref,
+        challenge_type=challenge_type,
+        assessment_id=assessment_id,
+        ttl=ttl,
+        issued_at=issued_at,
+    )
+
+
+def resolve_challenge(
+    challenge: Challenge,
+    *,
+    outcome: ChallengeOutcome,
+    evidence: str | None = None,
+    resolved_at: datetime | None = None,
+) -> Challenge:
+    """Resolve an active challenge with the given outcome."""
+    if outcome is ChallengeOutcome.PASSED:
+        return challenge.pass_challenge(resolved_at=resolved_at, evidence=evidence)
+    elif outcome is ChallengeOutcome.FAILED:
+        return challenge.fail_challenge(resolved_at=resolved_at, evidence=evidence)
+    else:
+        return challenge.expire(at=resolved_at)
+
+
+def block_subject(
+    *,
+    decision_id: str,
+    subject_ref: str,
+    scope: BlockScope,
+    reason_code: str,
+    policy_version: PolicyVersionRef,
+    assessment_id: str,
+    input_snapshot_digest: str,
+    evidence_bundle: EvidenceBundle | None = None,
+) -> RiskDecision:
+    """Block a subject scope."""
+    return RiskDecision.block(
+        decision_id=decision_id,
+        subject_ref=subject_ref,
+        scope=scope,
+        reason_code=reason_code,
+        policy_version=policy_version,
+        assessment_id=assessment_id,
+        input_snapshot_digest=input_snapshot_digest,
+        evidence_bundle=evidence_bundle,
+    )
+
+
+def allow_subject(
+    *,
+    decision_id: str,
+    subject_ref: str,
+    scope: BlockScope,
+    reason_code: str,
+    policy_version: PolicyVersionRef,
+    assessment_id: str,
+    input_snapshot_digest: str,
+    evidence_bundle: EvidenceBundle | None = None,
+) -> RiskDecision:
+    """Allow a subject scope."""
+    return RiskDecision.allow(
+        decision_id=decision_id,
+        subject_ref=subject_ref,
+        scope=scope,
+        reason_code=reason_code,
+        policy_version=policy_version,
+        assessment_id=assessment_id,
+        input_snapshot_digest=input_snapshot_digest,
+        evidence_bundle=evidence_bundle,
+    )
+
+
+def record_evidence(
+    *,
+    evidence_id: str,
+    subject_ref: str,
+    evidence_type: str,
+    summary: str,
+    detail: str | None = None,
+) -> EvidenceSummary:
+    """Record an evidence fact."""
+    return EvidenceSummary(
+        evidence_id=evidence_id,
+        subject_ref=subject_ref,
+        evidence_type=evidence_type,
+        summary=summary,
+        detail=detail,
+    )

--- a/services/risk-compliance/src/risk_compliance/runtime.py
+++ b/services/risk-compliance/src/risk_compliance/runtime.py
@@ -11,7 +11,7 @@ class ServiceProfile(TypedDict):
     boundary: NotRequired[str]
 
 
-SERVICE_PROFILE: ServiceProfile = {'service_id': 'risk-compliance', 'domain': 'Risk & Compliance', 'language': 'python', 'phase': 'phase-1-support', 'work_packages': ['WP-17'], 'owns': ['RiskAssessment', 'Challenge', 'BlockDecision', 'EvidenceSummary']}
+SERVICE_PROFILE: ServiceProfile = {'service_id': 'risk-compliance', 'domain': 'Risk & Compliance', 'language': 'python', 'phase': 'phase-1-support', 'work_packages': ['REQ-020', 'WP-17'], 'owns': ['RiskAssessment', 'Challenge', 'RiskDecision', 'EvidenceSummary']}
 
 
 def health() -> str:

--- a/services/risk-compliance/tests/test_domain.py
+++ b/services/risk-compliance/tests/test_domain.py
@@ -1,0 +1,614 @@
+from __future__ import annotations
+
+import unittest
+from datetime import UTC, datetime, timedelta
+from dataclasses import FrozenInstanceError
+
+from risk_compliance import (
+    AssessmentInputSnapshot,
+    AssessmentStatus,
+    BlockScope,
+    BlockStatus,
+    Challenge,
+    ChallengeOutcome,
+    ChallengeStatus,
+    ChallengeType,
+    Decision,
+    EvidenceBundle,
+    EvidenceItem,
+    EvidenceSummary,
+    PolicyVersionRef,
+    RiskAssessment,
+    RiskComplianceError,
+    RiskDecision,
+    RiskLevel,
+    allow_subject,
+    assess_risk,
+    block_subject,
+    issue_challenge,
+    record_evidence,
+    resolve_challenge,
+)
+
+
+NOW = datetime(2026, 7, 4, 12, 0, tzinfo=UTC)
+POLICY_V1 = PolicyVersionRef(policy_set_id="risk-rules-v1", version="1.0.0")
+
+
+def sample_input() -> AssessmentInputSnapshot:
+    return AssessmentInputSnapshot(
+        subject_ref="ord-abc123",
+        scenario="order_risk",
+        input_data={"amount": 50000, "traveler_ref": "tvl-xyz789"},
+        captured_at=NOW,
+    )
+
+
+def sample_evidence_bundle() -> EvidenceBundle:
+    return EvidenceBundle(
+        bundle_id="eb-001",
+        evidence_items=(
+            EvidenceItem("evid-001", "fraud_signal", "Suspicious device fingerprint"),
+            EvidenceItem("evid-002", "rule_hit", "Velocity check exceeded threshold"),
+        ),
+    )
+
+
+class RiskAssessmentTest(unittest.TestCase):
+    def test_assess_risk_creates_requested_state(self) -> None:
+        assessment = assess_risk(
+            assessment_id="asmt-001",
+            subject_ref="ord-abc123",
+            scenario="order_risk",
+            input_data={"amount": 50000},
+        )
+        self.assertEqual(assessment.assessment_id, "asmt-001")
+        self.assertEqual(assessment.status, AssessmentStatus.REQUESTED)
+        self.assertIsNone(assessment.decision)
+        self.assertIsNone(assessment.assessed_at)
+        self.assertEqual(assessment.input_snapshot.subject_ref, "ord-abc123")
+
+    def test_assess_risk_rejects_empty_id(self) -> None:
+        with self.assertRaises(RiskComplianceError):
+            assess_risk(assessment_id="", subject_ref="ord-001", scenario="order_risk")
+
+    def test_allow_transition_from_requested(self) -> None:
+        assessment = assess_risk(
+            assessment_id="asmt-002",
+            subject_ref="ord-002",
+            scenario="order_risk",
+        )
+        allowed = assessment.allow(
+            decision=Decision.ALLOW,
+            score=150,
+            level=RiskLevel.LOW,
+            policy_version=POLICY_V1,
+            reason_code="PASSED_ALL_CHECKS",
+            reason_explanation="All risk checks passed",
+            assessed_at=NOW,
+        )
+        self.assertEqual(allowed.status, AssessmentStatus.ALLOWED)
+        self.assertEqual(allowed.decision, Decision.ALLOW)
+        self.assertEqual(allowed.score, 150)
+        self.assertEqual(allowed.level, RiskLevel.LOW)
+        self.assertEqual(allowed.reason_code, "PASSED_ALL_CHECKS")
+        self.assertEqual(allowed.assessed_at, NOW)
+
+    def test_deny_transition_from_requested(self) -> None:
+        assessment = assess_risk(
+            assessment_id="asmt-003",
+            subject_ref="ord-003",
+            scenario="order_risk",
+        )
+        denied = assessment.deny(
+            policy_version=POLICY_V1,
+            reason_code="BLACKLIST_MATCH",
+            reason_explanation="Subject matched blacklist",
+            score=950,
+            level=RiskLevel.CRITICAL,
+            assessed_at=NOW,
+        )
+        self.assertEqual(denied.status, AssessmentStatus.DENIED)
+        self.assertEqual(denied.decision, Decision.DENY)
+        self.assertEqual(denied.reason_code, "BLACKLIST_MATCH")
+
+    def test_challenge_transition_from_requested(self) -> None:
+        assessment = assess_risk(
+            assessment_id="asmt-004",
+            subject_ref="ord-004",
+            scenario="payment_risk",
+        )
+        challenged = assessment.challenge(
+            policy_version=POLICY_V1,
+            reason_code="CHALLENGE_REQUIRED",
+            score=500,
+            level=RiskLevel.MEDIUM,
+            assessed_at=NOW,
+        )
+        self.assertEqual(challenged.status, AssessmentStatus.CHALLENGED)
+        self.assertEqual(challenged.decision, Decision.CHALLENGE)
+
+    def test_supersede_from_terminal_state(self) -> None:
+        assessment = assess_risk(
+            assessment_id="asmt-005",
+            subject_ref="ord-005",
+            scenario="order_risk",
+        )
+        allowed = assessment.allow(
+            decision=Decision.ALLOW,
+            policy_version=POLICY_V1,
+            reason_code="ALLOWED",
+            assessed_at=NOW,
+        )
+        superseded = allowed.supersede("asmt-005-v2")
+        self.assertEqual(superseded.status, AssessmentStatus.SUPERSEDED)
+        self.assertEqual(superseded.superseded_by, "asmt-005-v2")
+
+    def test_cannot_transition_from_terminal_state(self) -> None:
+        assessment = assess_risk(
+            assessment_id="asmt-006",
+            subject_ref="ord-006",
+            scenario="order_risk",
+        )
+        allowed = assessment.allow(
+            decision=Decision.ALLOW,
+            policy_version=POLICY_V1,
+            reason_code="ALLOWED",
+            assessed_at=NOW,
+        )
+        with self.assertRaises(RiskComplianceError):
+            allowed.deny(
+                policy_version=POLICY_V1,
+                reason_code="SHOULD_NOT_HAPPEN",
+            )
+
+    def test_terminal_state_requires_decision_and_policy_version(self) -> None:
+        snapshot = sample_input()
+        with self.assertRaises(RiskComplianceError):
+            RiskAssessment(
+                assessment_id="asmt-bad",
+                subject_ref="ord-bad",
+                scenario="order_risk",
+                status=AssessmentStatus.ALLOWED,
+                decision=None,
+                score=None,
+                level=None,
+                policy_version=None,
+                input_snapshot=snapshot,
+                evidence_bundle=None,
+                reason_code=None,
+                reason_explanation=None,
+                assessed_at=None,
+            )
+
+    def test_score_range_enforced(self) -> None:
+        snapshot = sample_input()
+        with self.assertRaises(RiskComplianceError):
+            RiskAssessment(
+                assessment_id="asmt-bad-score",
+                subject_ref="ord-bad",
+                scenario="order_risk",
+                status=AssessmentStatus.REQUESTED,
+                decision=None,
+                score=1001,
+                level=None,
+                policy_version=None,
+                input_snapshot=snapshot,
+                evidence_bundle=None,
+                reason_code=None,
+                reason_explanation=None,
+                assessed_at=None,
+            )
+
+    def test_assessment_immutability(self) -> None:
+        assessment = assess_risk(
+            assessment_id="asmt-immutable",
+            subject_ref="ord-imm",
+            scenario="order_risk",
+        )
+        with self.assertRaises(FrozenInstanceError):
+            assessment.status = AssessmentStatus.ALLOWED  # type: ignore[misc]
+
+    def test_input_snapshot_digest_stable(self) -> None:
+        snap1 = AssessmentInputSnapshot(
+            subject_ref="ord-abc",
+            scenario="order_risk",
+            input_data={"a": 1, "b": 2},
+        )
+        snap2 = AssessmentInputSnapshot(
+            subject_ref="ord-abc",
+            scenario="order_risk",
+            input_data={"b": 2, "a": 1},  # same keys, different order
+        )
+        self.assertEqual(snap1.digest, snap2.digest)
+
+    def test_hold_transition(self) -> None:
+        assessment = assess_risk(
+            assessment_id="asmt-hold",
+            subject_ref="ord-hold",
+            scenario="order_risk",
+        )
+        held = assessment.allow(
+            decision=Decision.HOLD,
+            policy_version=POLICY_V1,
+            reason_code="HOLD_FOR_REVIEW",
+            assessed_at=NOW,
+        )
+        self.assertEqual(held.status, AssessmentStatus.HELD)
+        self.assertEqual(held.decision, Decision.HOLD)
+
+    def test_allow_transition_rejects_deny(self) -> None:
+        assessment = assess_risk(
+            assessment_id="asmt-allow-bad",
+            subject_ref="ord-bad",
+            scenario="order_risk",
+        )
+        with self.assertRaises(RiskComplianceError):
+            assessment.allow(
+                decision=Decision.DENY,
+                policy_version=POLICY_V1,
+                reason_code="SHOULD_NOT",
+                assessed_at=NOW,
+            )
+
+
+class ChallengeTest(unittest.TestCase):
+    def test_create_challenge(self) -> None:
+        challenge = issue_challenge(
+            challenge_id="chg-001",
+            business_ref="ord-001",
+            challenge_type=ChallengeType.SMS,
+            assessment_id="asmt-001",
+            ttl=timedelta(minutes=15),
+            issued_at=NOW,
+        )
+        self.assertEqual(challenge.challenge_id, "chg-001")
+        self.assertEqual(challenge.status, ChallengeStatus.CREATED)
+        self.assertEqual(challenge.expires_at, NOW + timedelta(minutes=15))
+
+    def test_challenge_lifecycle(self) -> None:
+        challenge = issue_challenge(
+            challenge_id="chg-002",
+            business_ref="ord-002",
+            challenge_type=ChallengeType.SMS,
+            assessment_id="asmt-002",
+            ttl=timedelta(minutes=15),
+            issued_at=NOW,
+        )
+
+        # Start
+        started = challenge.start()
+        self.assertEqual(started.status, ChallengeStatus.PENDING_USER_ACTION)
+
+        # Pass
+        passed = started.pass_challenge(resolved_at=NOW + timedelta(minutes=5))
+        self.assertEqual(passed.status, ChallengeStatus.PASSED)
+        self.assertEqual(passed.outcome, ChallengeOutcome.PASSED)
+        self.assertIsNotNone(passed.resolved_at)
+
+    def test_challenge_fail(self) -> None:
+        challenge = issue_challenge(
+            challenge_id="chg-003",
+            business_ref="ord-003",
+            challenge_type=ChallengeType.FACE_VERIFICATION,
+            assessment_id="asmt-003",
+            ttl=timedelta(minutes=10),
+            issued_at=NOW,
+        )
+        started = challenge.start()
+        failed = started.fail_challenge(resolved_at=NOW + timedelta(minutes=3))
+        self.assertEqual(failed.status, ChallengeStatus.FAILED)
+        self.assertEqual(failed.outcome, ChallengeOutcome.FAILED)
+
+    def test_challenge_expire(self) -> None:
+        challenge = issue_challenge(
+            challenge_id="chg-004",
+            business_ref="ord-004",
+            challenge_type=ChallengeType.SMS,
+            assessment_id="asmt-004",
+            ttl=timedelta(seconds=1),
+            issued_at=NOW,
+        )
+        started = challenge.start()
+        expired = started.expire(at=NOW + timedelta(seconds=2))
+        self.assertEqual(expired.status, ChallengeStatus.EXPIRED)
+        self.assertEqual(expired.outcome, ChallengeOutcome.EXPIRED)
+
+    def test_challenge_cancel(self) -> None:
+        challenge = issue_challenge(
+            challenge_id="chg-005",
+            business_ref="ord-005",
+            challenge_type=ChallengeType.MANUAL_REVIEW,
+            assessment_id="asmt-005",
+            ttl=timedelta(hours=24),
+            issued_at=NOW,
+        )
+        started = challenge.start()
+        cancelled = started.cancel()
+        self.assertEqual(cancelled.status, ChallengeStatus.CANCELLED)
+
+    def test_cannot_pass_unstarted_challenge(self) -> None:
+        challenge = issue_challenge(
+            challenge_id="chg-006",
+            business_ref="ord-006",
+            challenge_type=ChallengeType.SMS,
+            assessment_id="asmt-006",
+            ttl=timedelta(minutes=15),
+            issued_at=NOW,
+        )
+        with self.assertRaises(RiskComplianceError):
+            challenge.pass_challenge()
+
+    def test_cannot_pass_expired_challenge(self) -> None:
+        challenge = issue_challenge(
+            challenge_id="chg-007",
+            business_ref="ord-007",
+            challenge_type=ChallengeType.SMS,
+            assessment_id="asmt-007",
+            ttl=timedelta(minutes=1),
+            issued_at=NOW - timedelta(minutes=10),  # already expired
+        )
+        started = challenge.start()
+        with self.assertRaises(RiskComplianceError):
+            started.pass_challenge(resolved_at=NOW)
+
+    def test_cannot_pass_terminal_challenge(self) -> None:
+        challenge = issue_challenge(
+            challenge_id="chg-008",
+            business_ref="ord-008",
+            challenge_type=ChallengeType.SMS,
+            assessment_id="asmt-008",
+            ttl=timedelta(minutes=15),
+            issued_at=NOW,
+        )
+        started = challenge.start()
+        passed = started.pass_challenge(resolved_at=NOW + timedelta(minutes=5))
+        with self.assertRaises(RiskComplianceError):
+            passed.fail_challenge()
+
+    def test_resolve_challenge_command(self) -> None:
+        challenge = issue_challenge(
+            challenge_id="chg-009",
+            business_ref="ord-009",
+            challenge_type=ChallengeType.SMS,
+            assessment_id="asmt-009",
+            ttl=timedelta(minutes=15),
+            issued_at=NOW,
+        ).start()
+
+        resolved = resolve_challenge(
+            challenge,
+            outcome=ChallengeOutcome.PASSED,
+            evidence="User verified via SMS code",
+            resolved_at=NOW + timedelta(minutes=3),
+        )
+        self.assertEqual(resolved.status, ChallengeStatus.PASSED)
+        self.assertEqual(resolved.outcome_evidence, "User verified via SMS code")
+
+
+class RiskDecisionTest(unittest.TestCase):
+    def test_block_decision(self) -> None:
+        decision = block_subject(
+            decision_id="blk-001",
+            subject_ref="ord-001",
+            scope=BlockScope.ORDER,
+            reason_code="FRAUD_SUSPECTED",
+            policy_version=POLICY_V1,
+            assessment_id="asmt-001",
+            input_snapshot_digest=sample_input().digest,
+        )
+        self.assertTrue(decision.is_block)
+        self.assertEqual(decision.scope, BlockScope.ORDER)
+        self.assertEqual(decision.status, BlockStatus.ACTIVE)
+
+    def test_allow_decision(self) -> None:
+        decision = allow_subject(
+            decision_id="alw-001",
+            subject_ref="ord-002",
+            scope=BlockScope.ORDER,
+            reason_code="CLEARED",
+            policy_version=POLICY_V1,
+            assessment_id="asmt-002",
+            input_snapshot_digest=sample_input().digest,
+        )
+        self.assertFalse(decision.is_block)
+        self.assertEqual(decision.status, BlockStatus.ACTIVE)
+
+    def test_release_block_decision(self) -> None:
+        decision = block_subject(
+            decision_id="blk-002",
+            subject_ref="ord-003",
+            scope=BlockScope.ORDER,
+            reason_code="BLOCKED",
+            policy_version=POLICY_V1,
+            assessment_id="asmt-003",
+            input_snapshot_digest=sample_input().digest,
+        )
+        released = decision.release()
+        self.assertEqual(released.status, BlockStatus.RELEASED)
+
+    def test_cannot_release_non_active(self) -> None:
+        decision = block_subject(
+            decision_id="blk-003",
+            subject_ref="ord-004",
+            scope=BlockScope.ORDER,
+            reason_code="BLOCKED",
+            policy_version=POLICY_V1,
+            assessment_id="asmt-004",
+            input_snapshot_digest=sample_input().digest,
+        )
+        released = decision.release()
+        with self.assertRaises(RiskComplianceError):
+            released.release()
+
+    def test_block_subject_requires_valid_id(self) -> None:
+        with self.assertRaises(RiskComplianceError):
+            block_subject(
+                decision_id="",
+                subject_ref="ord-001",
+                scope=BlockScope.ORDER,
+                reason_code="TEST",
+                policy_version=POLICY_V1,
+                assessment_id="asmt-001",
+                input_snapshot_digest="digest",
+            )
+
+    def test_block_scope_enforcement(self) -> None:
+        for scope in BlockScope:
+            decision = block_subject(
+                decision_id=f"blk-scope-{scope.value}",
+                subject_ref=f"ref-{scope.value}",
+                scope=scope,
+                reason_code="TEST",
+                policy_version=POLICY_V1,
+                assessment_id="asmt-scope",
+                input_snapshot_digest="digest",
+            )
+            self.assertEqual(decision.scope, scope)
+
+
+class EvidenceSummaryTest(unittest.TestCase):
+    def test_record_evidence(self) -> None:
+        evidence = record_evidence(
+            evidence_id="evid-001",
+            subject_ref="ord-001",
+            evidence_type="fraud_signal",
+            summary="Suspicious device fingerprint detected",
+            detail="Device ID: abc-123, Risk Score: 850",
+        )
+        self.assertEqual(evidence.evidence_id, "evid-001")
+        self.assertEqual(evidence.subject_ref, "ord-001")
+        self.assertEqual(evidence.evidence_type, "fraud_signal")
+
+    def test_record_evidence_rejects_empty_id(self) -> None:
+        with self.assertRaises(RiskComplianceError):
+            record_evidence(
+                evidence_id="",
+                subject_ref="ord-001",
+                evidence_type="fraud_signal",
+                summary="test",
+            )
+
+    def test_record_evidence_rejects_empty_summary(self) -> None:
+        with self.assertRaises(RiskComplianceError):
+            record_evidence(
+                evidence_id="evid-002",
+                subject_ref="ord-001",
+                evidence_type="fraud_signal",
+                summary="",
+            )
+
+
+class EvidenceBundleTest(unittest.TestCase):
+    def test_evidence_bundle_digest(self) -> None:
+        bundle = EvidenceBundle(
+            bundle_id="eb-001",
+            evidence_items=(
+                EvidenceItem("evid-001", "fraud_signal", "Signal A"),
+                EvidenceItem("evid-002", "rule_hit", "Rule B"),
+            ),
+        )
+        self.assertTrue(bundle.digest)
+
+    def test_evidence_bundle_add_item(self) -> None:
+        bundle = EvidenceBundle(bundle_id="eb-002")
+        self.assertEqual(len(bundle.evidence_items), 0)
+        bundle2 = bundle.add_item(
+            EvidenceItem("evid-003", "manual_review", "Reviewed by operator")
+        )
+        self.assertEqual(len(bundle2.evidence_items), 1)
+        self.assertEqual(len(bundle.evidence_items), 0)  # immutable
+
+
+class PolicyVersionRefTest(unittest.TestCase):
+    def test_valid_policy_version(self) -> None:
+        ref = PolicyVersionRef(policy_set_id="rules-v1", version="1.0.0")
+        self.assertEqual(ref.policy_set_id, "rules-v1")
+        self.assertEqual(ref.version, "1.0.0")
+
+    def test_empty_policy_set_id(self) -> None:
+        with self.assertRaises(RiskComplianceError):
+            PolicyVersionRef(policy_set_id="", version="1.0.0")
+
+    def test_empty_version(self) -> None:
+        with self.assertRaises(RiskComplianceError):
+            PolicyVersionRef(policy_set_id="rules-v1", version="")
+
+
+class AssessmentInputSnapshotTest(unittest.TestCase):
+    def test_empty_subject_ref(self) -> None:
+        with self.assertRaises(RiskComplianceError):
+            AssessmentInputSnapshot(subject_ref="", scenario="order_risk")
+
+    def test_empty_scenario(self) -> None:
+        with self.assertRaises(RiskComplianceError):
+            AssessmentInputSnapshot(subject_ref="ord-001", scenario="")
+
+
+class DomainInvariantsTest(unittest.TestCase):
+    def test_block_decision_never_cancels_in_flight(self) -> None:
+        """A Block decision should be scoped and not cancel in-flight refunds/notifications.
+
+        This is a domain invariant test: the RiskDecision only records the block fact.
+        It doesn't have side effects on refunds or notifications.
+        """
+        decision = block_subject(
+            decision_id="blk-invariant",
+            subject_ref="ord-inflight",
+            scope=BlockScope.ORDER,
+            reason_code="FRAUD_SUSPECTED",
+            policy_version=POLICY_V1,
+            assessment_id="asmt-inflight",
+            input_snapshot_digest=sample_input().digest,
+        )
+        self.assertTrue(decision.is_block)
+        self.assertEqual(decision.scope, BlockScope.ORDER)
+        # The decision itself does NOT cancel refunds or notifications
+        # It's a fact that other domains consume and act upon
+        self.assertEqual(decision.status, BlockStatus.ACTIVE)
+
+    def test_decision_references_assessment_input_and_rule_version(self) -> None:
+        """Every decision must reference assessment input snapshot and policy version."""
+        decision = allow_subject(
+            decision_id="alw-ref",
+            subject_ref="ord-ref",
+            scope=BlockScope.ORDER,
+            reason_code="CLEARED",
+            policy_version=POLICY_V1,
+            assessment_id="asmt-ref",
+            input_snapshot_digest=sample_input().digest,
+        )
+        self.assertEqual(decision.policy_version, POLICY_V1)
+        self.assertEqual(decision.assessment_id, "asmt-ref")
+        self.assertTrue(decision.input_snapshot_digest)
+
+    def test_challenge_outcomes_appended_as_facts(self) -> None:
+        """Challenge outcomes are recorded as evidence facts."""
+        # Create and resolve a challenge
+        challenge = issue_challenge(
+            challenge_id="chg-fact",
+            business_ref="ord-fact",
+            challenge_type=ChallengeType.SMS,
+            assessment_id="asmt-fact",
+            ttl=timedelta(minutes=15),
+            issued_at=NOW,
+        ).start()
+
+        passed = challenge.pass_challenge(resolved_at=NOW + timedelta(minutes=3), evidence="SMS code verified")
+        self.assertEqual(passed.outcome, ChallengeOutcome.PASSED)
+        self.assertEqual(passed.outcome_evidence, "SMS code verified")
+
+        # The outcome is a fact recorded on the challenge
+        # This can be used to create an EvidenceSummary for audit
+        evidence = record_evidence(
+            evidence_id="evid-challenge-result",
+            subject_ref="ord-fact",
+            evidence_type="challenge_result",
+            summary=f"Challenge {passed.challenge_id} outcome: {passed.outcome.value}",
+            detail=passed.outcome_evidence,
+        )
+        self.assertEqual(evidence.evidence_type, "challenge_result")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/risk-compliance/tests/test_skeleton.py
+++ b/services/risk-compliance/tests/test_skeleton.py
@@ -2,7 +2,26 @@ import unittest
 
 from fastapi.testclient import TestClient
 
-from risk_compliance import create_app, health, profile
+from risk_compliance import (
+    Challenge,
+    ChallengeOutcome,
+    ChallengeType,
+    Decision,
+    EvidenceSummary,
+    RiskAssessment,
+    RiskComplianceError,
+    RiskDecision,
+    RiskLevel,
+    allow_subject,
+    assess_risk,
+    block_subject,
+    create_app,
+    health,
+    issue_challenge,
+    profile,
+    record_evidence,
+    resolve_challenge,
+)
 
 
 class SkeletonTest(unittest.TestCase):
@@ -10,7 +29,31 @@ class SkeletonTest(unittest.TestCase):
         service_profile = profile()
         self.assertEqual(service_profile["service_id"], 'risk-compliance')
         self.assertEqual(service_profile["domain"], 'Risk & Compliance')
+        self.assertIn('REQ-020', service_profile["work_packages"])
+        self.assertIn('RiskAssessment', service_profile["owns"])
+        self.assertIn('Challenge', service_profile["owns"])
+        self.assertIn('RiskDecision', service_profile["owns"])
+        self.assertIn('EvidenceSummary', service_profile["owns"])
         self.assertEqual(health(), "ok")
+
+    def test_domain_types_are_importable(self) -> None:
+        self.assertIsNotNone(RiskAssessment)
+        self.assertIsNotNone(Challenge)
+        self.assertIsNotNone(RiskDecision)
+        self.assertIsNotNone(EvidenceSummary)
+        self.assertIsNotNone(RiskComplianceError)
+        self.assertIsNotNone(Decision)
+        self.assertIsNotNone(RiskLevel)
+        self.assertIsNotNone(ChallengeType)
+        self.assertIsNotNone(ChallengeOutcome)
+
+    def test_domain_commands_are_importable(self) -> None:
+        self.assertIsNotNone(assess_risk)
+        self.assertIsNotNone(issue_challenge)
+        self.assertIsNotNone(resolve_challenge)
+        self.assertIsNotNone(block_subject)
+        self.assertIsNotNone(allow_subject)
+        self.assertIsNotNone(record_evidence)
 
     def test_fastapi_runtime_routes_are_registered(self) -> None:
         app = create_app()


### PR DESCRIPTION
Implements REQ-020 Risk & Compliance domain foundation in Python.

## Changes
- **Domain model**: RiskAssessment, Challenge, RiskDecision, EvidenceSummary aggregates with full state machines
- **Commands**: assess_risk, issue_challenge, resolve_challenge, block_subject, allow_subject, record_evidence
- **Contract**: docs/08-contracts/events/risk-compliance.md defining RiskAssessed, ChallengeIssued, ChallengeResolved, SubjectBlocked, SubjectAllowed, EvidenceRecorded events
- **48 unit tests** covering domain invariants, state machines, immutability, and cross-context contract invariants
- Updated service-catalog.json and project-index.yaml with REQ-020 status

## Key invariants implemented
- Risk never directly modifies Account, Traveler, or Payment state
- Every decision references assessment inputs snapshot and rule version
- Block decisions are scoped and never cancel in-flight refunds/notifications
- Challenge outcomes (passed/failed/expired) are appended as facts

Depends on: REQ-010, REQ-012, REQ-017, REQ-028