### PR TITLE
REQ-014: Post Sales domain foundation

### DIFF
--- a/docs/08-contracts/events/post-sales.md
+++ b/docs/08-contracts/events/post-sales.md
@@ -1,8 +1,27 @@
 # Post Sales — Events & Commands
 
-Last updated: 2026-06-28
+Last updated: 2026-07-04
 
 ## Published Events
+
+### PostSalesCaseOpened
+
+| Field | Description |
+|---|---|
+| **Producer** | post-sales |
+| **Consumers** | fare-pricing, journey-order |
+| **Trigger** | `OpenPostSalesCase` command processed. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | `PostSalesCaseId` | yes | Canonical case ID (`psc-<uuid>`). |
+| `journeyOrderId` | `JourneyOrderId` | yes | Parent order ID. |
+| `caseType` | enum | yes | `CANCELLATION`, `REFUND`, `CHANGE`, `REBOOK`, `COMPENSATION`. |
+| `scope` | object | yes | Affected order items, segments, travelers, entitlements. |
+| `reasonCode` | string | yes | Business reason for the case. |
+| `actorRef` | string | yes | Who requested the case. |
 
 ### PostSalesRequested
 
@@ -21,12 +40,47 @@ Last updated: 2026-06-28
 | `requestType` | enum | yes | `CANCELLATION`, `REFUND_BY_RULE`, `CHANGE`. |
 | `requestedAt` | RFC3339 UTC | yes | Request timestamp. |
 
+### PostSalesEligibilityEvaluated
+
+| Field | Description |
+|---|---|
+| **Producer** | post-sales |
+| **Consumers** | fare-pricing, notification |
+| **Trigger** | `EvaluatePostSalesEligibility` command processed. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | `PostSalesCaseId` | yes | Case ID. |
+| `eligible` | boolean | yes | Whether the request is eligible. |
+| `reasonCode` | string | yes | Eligibility reason or blocking reason. |
+| `ruleSnapshotRef` | string | no | Reference to the Fare & Pricing rule evaluation snapshot. |
+| `ruleVersion` | string | no | Rule version used for evaluation. |
+
+### PostSalesDecisionQuoted
+
+| Field | Description |
+|---|---|
+| **Producer** | post-sales |
+| **Consumers** | notification |
+| **Trigger** | `QuotePostSalesDecision` command processed. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | `PostSalesCaseId` | yes | Case ID. |
+| `decisionKind` | enum | yes | `REFUND`, `CHANGE`, `CANCELLATION`, `COMPENSATION`. |
+| `eligible` | boolean | yes | Whether the quoted decision is eligible. |
+| `ruleSnapshotRef` | string | yes | Reference to the frozen rule evaluation snapshot. |
+
 ### PostSalesApproved
 
 | Field | Description |
 |---|---|
 | **Producer** | post-sales |
-| **Consumers** | entitlement-ticketing, capacity-availability, payment |
+| **Consumers** | entitlement-ticketing, capacity-availability, payment, booking-orchestration |
 | **Trigger** | Post-sales case approved for execution. |
 
 **Payload:**
@@ -36,6 +90,22 @@ Last updated: 2026-06-28
 | `caseId` | `PostSalesCaseId` | yes | Case ID. |
 | `orderId` | `JourneyOrderId` | yes | Parent order. |
 | `approvedActions` | object | yes | Actions to execute. |
+
+### PostSalesExecutionStarted
+
+| Field | Description |
+|---|---|
+| **Producer** | post-sales |
+| **Consumers** | notification |
+| **Trigger** | `StartPostSalesExecution` command processed. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | `PostSalesCaseId` | yes | Case ID. |
+| `orderedSteps` | `PostSalesStepType[]` | yes | Ordered list of execution step types. |
+| `approvalRef` | string | yes | Reference to the approval that authorized execution. |
 
 ### PostSalesApplied
 
@@ -52,3 +122,130 @@ Last updated: 2026-06-28
 | `caseId` | `PostSalesCaseId` | yes | Case ID. |
 | `orderId` | `JourneyOrderId` | yes | Parent order. |
 | `resultSummary` | object | yes | Summary of executed actions. |
+
+### PostSalesFailed
+
+| Field | Description |
+|---|---|
+| **Producer** | post-sales |
+| **Consumers** | journey-order, notification, admin-audit |
+| **Trigger** | Unrecoverable step failure or manual termination. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | `PostSalesCaseId` | yes | Case ID. |
+| `orderId` | `JourneyOrderId` | yes | Parent order. |
+| `reason` | string | yes | Failure reason. |
+| `failedStepRef` | string | no | Reference to the step that failed. |
+
+### ChangeApplied
+
+| Field | Description |
+|---|---|
+| **Producer** | post-sales |
+| **Consumers** | journey-order, entitlement-ticketing, notification |
+| **Trigger** | Change execution completed successfully. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | `PostSalesCaseId` | yes | Case ID. |
+| `orderId` | `JourneyOrderId` | yes | Parent order. |
+| `oldEntitlementRef` | string | yes | Reference to the voided old entitlement. |
+| `newEntitlementRef` | string | yes | Reference to the issued new entitlement. |
+| `changeOfferRef` | string | yes | Reference to the change offer used. |
+
+## Accepted Commands
+
+### OpenPostSalesCase
+
+| Field | Description |
+|---|---|
+| **Sender** | journey-order, customer-service |
+| **Target Aggregate** | PostSalesCase |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `journeyOrderId` | `JourneyOrderId` | yes | Parent order ID. |
+| `caseType` | enum | yes | Type of post-sales case. |
+| `scope` | object | yes | Affected scope. |
+| `reasonCode` | string | yes | Business reason. |
+| `actorRef` | string | yes | Requester reference. |
+| `idempotencyKey` | `IdempotencyKey` | yes | Idempotency key. |
+
+### EvaluatePostSalesEligibility
+
+| Field | Description |
+|---|---|
+| **Sender** | post-sales (internal) |
+| **Target Aggregate** | PostSalesCase |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | `PostSalesCaseId` | yes | Case ID. |
+| `eligible` | boolean | yes | Eligibility result. |
+| `reasonCode` | string | yes | Reason code. |
+| `ruleSnapshotRef` | string | no | Rule evaluation snapshot reference. |
+| `ruleVersion` | string | no | Rule version. |
+
+### QuotePostSalesDecision
+
+| Field | Description |
+|---|---|
+| **Sender** | post-sales (internal) |
+| **Target Aggregate** | PostSalesDecision |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | `PostSalesCaseId` | yes | Case ID. |
+| `decision` | object | yes | Decision snapshot with amounts and eligibility. |
+
+### ApprovePostSalesCase
+
+| Field | Description |
+|---|---|
+| **Sender** | customer-service, post-sales (auto) |
+| **Target Aggregate** | PostSalesCase |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | `PostSalesCaseId` | yes | Case ID. |
+| `approvalRef` | string | yes | Approval reference. |
+
+### StartPostSalesExecution
+
+| Field | Description |
+|---|---|
+| **Sender** | post-sales (internal) |
+| **Target Aggregate** | PostSalesCase / PostSalesExecutionPlan |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | `PostSalesCaseId` | yes | Case ID. |
+
+### ApplyPostSalesResult
+
+| Field | Description |
+|---|---|
+| **Sender** | post-sales (internal) |
+| **Target Aggregate** | PostSalesCase |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `caseId` | `PostSalesCaseId` | yes | Case ID. |
+| `resultSummary` | string | yes | Summary of the applied result. |

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -717,6 +717,54 @@ requirements:
     source: "docs/02-domains/supplier-catalog.md, docs/03-ddd-final/phase-1-contract.md, docs/03-ddd-final/implementation-roadmap.md"
 
   # Legacy WP-derived references below. Do not use as active backlog without
+  - id: REQ-014
+    title: "Post Sales domain foundation"
+    description: "Implement the Post Sales domain foundation in Java. Owns the post-sales case lifecycle: eligibility evaluation, fee/refund/change decisions, execution plan orchestration, and manual exception tracking. Key invariants: Post Sales must never directly modify JourneyOrder invariants, MonetarySummary, or lifecycle state — only publish result events or send controlled commands. Every eligibility and fee decision must reference a frozen RuleSnapshot, RuleVersion, and input timestamp; confirmed execution amounts cannot be silently rewritten. Already-Used or Boarded entitlements cannot be ordinarily voided; such cases must enter Compensation or manual exception with full audit."
+    priority: P0
+    status: tested
+    code:
+      - path: services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesCase.java
+        description: "PostSalesCase aggregate root with lifecycle from OPENED through ELIGIBILITY_CHECKING, QUOTED, APPROVED, EXECUTING, APPLIED, REJECTED, FAILED, CANCELLED, and MANUAL_REVIEW_REQUIRED states."
+      - path: services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesDecision.java
+        description: "PostSalesDecision immutable decision snapshot value object with eligibility, fee, refund, extra charge, and change flow references."
+      - path: services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesExecutionPlan.java
+        description: "PostSalesExecutionPlan aggregate for ordered step execution, idempotency, retry limits, and compensation tracking."
+      - path: services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesStep.java
+        description: "PostSalesStep entity with state machine: PLANNED, EXECUTING, SUCCEEDED, FAILED, SKIPPED, MANUAL_REQUIRED."
+      - path: services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesScope.java
+        description: "PostSalesScope value object for explicit scope references (order items, segments, travelers, entitlements)."
+      - path: services/post-sales/src/main/java/com/trainticket/postsales/domain/RuleEvaluationSnapshot.java
+        description: "RuleEvaluationSnapshot value object freezing fare-pricing evaluation reference, rule snapshot, rule version, and input snapshot refs."
+      - path: services/post-sales/src/main/java/com/trainticket/postsales/domain/AmountDecisionSnapshot.java
+        description: "AmountDecisionSnapshot value object with fee, refund, extra charge amounts and explanation."
+      - path: services/post-sales/src/main/java/com/trainticket/postsales/domain/ChangeFlowSnapshot.java
+        description: "ChangeFlowSnapshot value object for conservative change execution: hold, payment, void, issue, release ordering."
+      - path: services/post-sales/src/main/java/com/trainticket/postsales/domain/Money.java
+        description: "Money value object with currency, scale, and same-currency arithmetic."
+      - path: services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesEvent.java
+        description: "Sealed event interface with 14 event types including PostSalesCaseOpened, PostSalesEligibilityEvaluated, PostSalesDecisionQuoted, PostSalesExecutionStarted, PostSalesFailed, and ChangeApplied."
+      - path: services/post-sales/src/main/java/com/trainticket/postsales/Application.java
+        description: "Spring Boot application entry point and service profile."
+      - path: services/post-sales/src/main/java/com/trainticket/postsales/ServiceProfile.java
+        description: "Service ownership and profile metadata."
+      - path: services/post-sales/src/main/java/com/trainticket/postsales/HealthController.java
+        description: "Health, liveness, readiness, and metadata endpoints."
+      - path: docs/08-contracts/events/post-sales.md
+        description: "Post Sales event and command contract specification (extended with PostSalesCaseOpened, PostSalesEligibilityEvaluated, PostSalesDecisionQuoted, PostSalesExecutionStarted, PostSalesFailed, ChangeApplied)."
+    tests:
+      - path: services/post-sales/src/test/java/com/trainticket/postsales/domain/PostSalesCaseDomainTest.java
+        description: "Unit tests for PostSalesCase lifecycle, execution plan ordering, PostSalesExecutionPlan step tracking, failure handling, eligibility evaluation, cancellation, and result application."
+      - path: services/post-sales/src/test/java/com/trainticket/postsales/ApplicationTest.java
+        description: "Unit tests for health endpoints, request context filter, runtime tracer, and service profile."
+    docs:
+      - path: services/post-sales/README.md
+      - path: docs/02-domains/post-sales.md
+      - path: docs/03-ddd-final/phase-1-contract.md
+      - path: docs/08-contracts/events/post-sales.md
+    depends_on: [REQ-012, REQ-013, REQ-028]
+    confidence: confirmed
+    source: "docs/02-domains/post-sales.md, docs/03-ddd-final/phase-1-contract.md, docs/03-ddd-final/implementation-roadmap.md"
+
   # regenerating the rewrite plan.
   - id: REQ-027
     title: "Field-level cross-domain contract specification"

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/ChangeApplied.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/ChangeApplied.java
@@ -1,0 +1,10 @@
+package com.trainticket.postsales.domain;
+
+public record ChangeApplied(
+    String caseId,
+    String journeyOrderId,
+    String oldEntitlementRef,
+    String newEntitlementRef,
+    String changeOfferRef,
+    EventMetadata metadata
+) implements PostSalesEvent { }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesCase.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesCase.java
@@ -19,6 +19,7 @@ public final class PostSalesCase {
     private final List<PostSalesEvent> domainEvents;
     private PostSalesCaseStatus status;
     private PostSalesDecision decision;
+    private PostSalesExecutionPlan executionPlanAggregate;
     private String terminalReason;
 
     private PostSalesCase(
@@ -42,7 +43,7 @@ public final class PostSalesCase {
         this.status = PostSalesCaseStatus.OPENED;
     }
 
-    public static PostSalesCase request(
+    public static PostSalesCase open(
         String journeyOrderId,
         PostSalesCaseType caseType,
         PostSalesScope scope,
@@ -54,9 +55,25 @@ public final class PostSalesCase {
         String correlationId
     ) {
         PostSalesCase postSalesCase = new PostSalesCase(UUID.randomUUID().toString(), journeyOrderId, caseType, scope, reasonCode, actorRef, idempotencyKey);
+        postSalesCase.domainEvents.add(new PostSalesCaseOpened(postSalesCase.caseId, journeyOrderId, caseType, scope, reasonCode, actorRef,
+            metadata(occurredAt, sourceCommandId, sourceCommandId, correlationId, postSalesCase.status)));
         postSalesCase.domainEvents.add(new PostSalesRequested(postSalesCase.caseId, journeyOrderId, caseType, scope, reasonCode,
             metadata(occurredAt, sourceCommandId, sourceCommandId, correlationId, postSalesCase.status)));
         return postSalesCase;
+    }
+
+    public static PostSalesCase request(
+        String journeyOrderId,
+        PostSalesCaseType caseType,
+        PostSalesScope scope,
+        String reasonCode,
+        String actorRef,
+        String idempotencyKey,
+        Instant occurredAt,
+        String sourceCommandId,
+        String correlationId
+    ) {
+        return open(journeyOrderId, caseType, scope, reasonCode, actorRef, idempotencyKey, occurredAt, sourceCommandId, correlationId);
     }
 
     public String caseId() { return caseId; }
@@ -68,13 +85,33 @@ public final class PostSalesCase {
     public String idempotencyKey() { return idempotencyKey; }
     public PostSalesCaseStatus status() { return status; }
     public PostSalesDecision decision() { return decision; }
+    public PostSalesExecutionPlan executionPlanAggregate() { return executionPlanAggregate; }
     public String terminalReason() { return terminalReason; }
     public List<PostSalesStep> executionPlan() { return executionPlan.stream().map(PostSalesStep::copy).toList(); }
     public List<PostSalesEvent> domainEvents() { return List.copyOf(domainEvents); }
 
+    public void requestCancellation(Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        requireStatus(PostSalesCaseStatus.OPENED);
+        status = PostSalesCaseStatus.ELIGIBILITY_CHECKING;
+        domainEvents.add(new PostSalesEligibilityEvaluated(caseId, true, "CANCELLATION_REQUESTED", null, null,
+            metadata(occurredAt, sourceCommandId, causationId, correlationId, status)));
+    }
+
     public void beginEvaluation(Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
         requireStatus(PostSalesCaseStatus.OPENED);
         status = PostSalesCaseStatus.ELIGIBILITY_CHECKING;
+    }
+
+    public void evaluateEligibility(boolean eligible, String reasonCode, String ruleSnapshotRef, String ruleVersion, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        if (status != PostSalesCaseStatus.ELIGIBILITY_CHECKING && status != PostSalesCaseStatus.OPENED) {
+            throw new DomainRuleViolation("eligibility can only be evaluated from ELIGIBILITY_CHECKING or OPENED status");
+        }
+        status = PostSalesCaseStatus.ELIGIBILITY_CHECKING;
+        domainEvents.add(new PostSalesEligibilityEvaluated(caseId, eligible, reasonCode, ruleSnapshotRef, ruleVersion,
+            metadata(occurredAt, sourceCommandId, causationId, correlationId, status)));
+        if (!eligible) {
+            reject(reasonCode, occurredAt, sourceCommandId, causationId, correlationId);
+        }
     }
 
     public void recordDecision(PostSalesDecision decision, boolean requireUserConfirmation, boolean requireManualApproval, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
@@ -86,6 +123,8 @@ public final class PostSalesCase {
             throw new DomainRuleViolation("decision kind must match post-sales case type");
         }
         this.decision = decision;
+        domainEvents.add(new PostSalesDecisionQuoted(caseId, decision.kind(), decision.eligible(), decision.ruleSnapshot().farePricingEvaluationRef(),
+            metadata(occurredAt, sourceCommandId, causationId, correlationId, PostSalesCaseStatus.ELIGIBILITY_CHECKING)));
         domainEvents.add(new PostSalesEvaluated(caseId, decision.kind(), decision.eligible(), decision.ruleSnapshot().farePricingEvaluationRef(),
             metadata(occurredAt, sourceCommandId, causationId, correlationId, PostSalesCaseStatus.ELIGIBILITY_CHECKING)));
         if (!decision.eligible()) {
@@ -129,9 +168,19 @@ public final class PostSalesCase {
     public void requestExecution(Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
         requireStatus(PostSalesCaseStatus.APPROVED);
         buildExecutionPlan();
+        String approvalRef = "auto";
+        List<PostSalesStep> planSteps = executionPlan.stream().map(PostSalesStep::copy).toList();
+        this.executionPlanAggregate = new PostSalesExecutionPlan(caseId, 1, planSteps);
+        this.executionPlanAggregate.start(occurredAt);
         status = PostSalesCaseStatus.EXECUTING;
         domainEvents.add(new PostSalesExecutionRequested(caseId, executionPlan.stream().map(PostSalesStep::type).toList(),
             metadata(occurredAt, sourceCommandId, causationId, correlationId, status)));
+        domainEvents.add(new PostSalesExecutionStarted(caseId, executionPlan.stream().map(PostSalesStep::type).toList(), approvalRef,
+            metadata(occurredAt, sourceCommandId, causationId, correlationId, status)));
+    }
+
+    public void startExecution(Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        requestExecution(occurredAt, sourceCommandId, causationId, correlationId);
     }
 
     public void recordStepSucceeded(PostSalesStepType stepType, String externalRef, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
@@ -139,6 +188,9 @@ public final class PostSalesCase {
         PostSalesStep step = requireStep(stepType);
         ensurePriorStepsSucceeded(stepType);
         step.succeed(externalRef, occurredAt);
+        if (executionPlanAggregate != null) {
+            executionPlanAggregate.recordStepSucceeded(stepType, externalRef, occurredAt);
+        }
         domainEvents.add(new PostSalesStepSucceeded(caseId, stepType, externalRef, metadata(occurredAt, sourceCommandId, causationId, correlationId, status)));
         if (allStepsSucceeded()) {
             apply("all post-sales execution steps succeeded", occurredAt, sourceCommandId, causationId, correlationId);
@@ -149,19 +201,49 @@ public final class PostSalesCase {
         requireStatus(PostSalesCaseStatus.EXECUTING);
         PostSalesStep step = requireStep(stepType);
         step.fail(reason, recoverable, occurredAt);
+        if (executionPlanAggregate != null) {
+            executionPlanAggregate.recordStepFailed(stepType, reason, !recoverable, occurredAt);
+        }
         domainEvents.add(new PostSalesStepFailed(caseId, stepType, reason, recoverable, metadata(occurredAt, sourceCommandId, causationId, correlationId, status)));
         if (recoverable) {
             status = PostSalesCaseStatus.MANUAL_REVIEW_REQUIRED;
             terminalReason = "manual review required after " + stepType + " failed: " + reason;
             domainEvents.add(new PostSalesManualReviewRequired(caseId, terminalReason, metadata(occurredAt, sourceCommandId, causationId, correlationId, status)));
         } else {
-            status = PostSalesCaseStatus.FAILED;
-            terminalReason = reason;
+            failCase(reason, stepType.name(), occurredAt, sourceCommandId, causationId, correlationId);
         }
+    }
+
+    public void failCase(String reason, String failedStepRef, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        if (status == PostSalesCaseStatus.APPLIED) {
+            throw new DomainRuleViolation("post-sales case cannot fail after being applied");
+        }
+        status = PostSalesCaseStatus.FAILED;
+        terminalReason = PostSalesScope.requireText(reason, "reason");
+        domainEvents.add(new PostSalesFailed(caseId, journeyOrderId, terminalReason, failedStepRef,
+            metadata(occurredAt, sourceCommandId, causationId, correlationId, status)));
+    }
+
+    public void cancelCase(String reason, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        if (status == PostSalesCaseStatus.APPLIED || status == PostSalesCaseStatus.FAILED) {
+            throw new DomainRuleViolation("post-sales case cannot be cancelled from terminal status " + status);
+        }
+        if (status == PostSalesCaseStatus.EXECUTING) {
+            throw new DomainRuleViolation("post-sales case cannot be cancelled during execution; use failCase instead");
+        }
+        status = PostSalesCaseStatus.CANCELLED;
+        terminalReason = PostSalesScope.requireText(reason, "reason");
     }
 
     public void completeManualReview(String resultSummary, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
         requireStatus(PostSalesCaseStatus.MANUAL_REVIEW_REQUIRED);
+        apply(resultSummary, occurredAt, sourceCommandId, causationId, correlationId);
+    }
+
+    public void applyResult(String resultSummary, Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        if (status != PostSalesCaseStatus.EXECUTING && status != PostSalesCaseStatus.MANUAL_REVIEW_REQUIRED) {
+            throw new DomainRuleViolation("post-sales result can only be applied from EXECUTING or MANUAL_REVIEW_REQUIRED status");
+        }
         apply(resultSummary, occurredAt, sourceCommandId, causationId, correlationId);
     }
 

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesCaseOpened.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesCaseOpened.java
@@ -1,0 +1,11 @@
+package com.trainticket.postsales.domain;
+
+public record PostSalesCaseOpened(
+    String caseId,
+    String journeyOrderId,
+    PostSalesCaseType caseType,
+    PostSalesScope scope,
+    String reasonCode,
+    String actorRef,
+    EventMetadata metadata
+) implements PostSalesEvent { }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesDecisionQuoted.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesDecisionQuoted.java
@@ -1,0 +1,9 @@
+package com.trainticket.postsales.domain;
+
+public record PostSalesDecisionQuoted(
+    String caseId,
+    DecisionKind decisionKind,
+    boolean eligible,
+    String ruleSnapshotRef,
+    EventMetadata metadata
+) implements PostSalesEvent { }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesEligibilityEvaluated.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesEligibilityEvaluated.java
@@ -1,0 +1,10 @@
+package com.trainticket.postsales.domain;
+
+public record PostSalesEligibilityEvaluated(
+    String caseId,
+    boolean eligible,
+    String reasonCode,
+    String ruleSnapshotRef,
+    String ruleVersion,
+    EventMetadata metadata
+) implements PostSalesEvent { }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesEvent.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesEvent.java
@@ -1,6 +1,6 @@
 package com.trainticket.postsales.domain;
 
-public sealed interface PostSalesEvent permits PostSalesRequested, PostSalesEvaluated, PostSalesApproved, PostSalesRejected, PostSalesExecutionRequested, PostSalesStepSucceeded, PostSalesStepFailed, PostSalesManualReviewRequired, PostSalesApplied {
+public sealed interface PostSalesEvent permits PostSalesRequested, PostSalesCaseOpened, PostSalesEvaluated, PostSalesEligibilityEvaluated, PostSalesDecisionQuoted, PostSalesApproved, PostSalesRejected, PostSalesExecutionRequested, PostSalesExecutionStarted, PostSalesStepSucceeded, PostSalesStepFailed, PostSalesManualReviewRequired, PostSalesApplied, PostSalesFailed, ChangeApplied {
     String caseId();
     EventMetadata metadata();
 }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesExecutionPlan.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesExecutionPlan.java
@@ -1,0 +1,97 @@
+package com.trainticket.postsales.domain;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public final class PostSalesExecutionPlan {
+    private final String caseId;
+    private final int version;
+    private final List<PostSalesStep> steps;
+    private PostSalesStepStatus status;
+
+    public PostSalesExecutionPlan(String caseId, int version, List<PostSalesStep> steps) {
+        this.caseId = PostSalesScope.requireText(caseId, "caseId");
+        if (version < 1) {
+            throw new DomainRuleViolation("execution plan version must be positive");
+        }
+        this.version = version;
+        this.steps = new ArrayList<>(Objects.requireNonNull(steps, "steps are required"));
+        if (this.steps.isEmpty()) {
+            throw new DomainRuleViolation("execution plan must have at least one step");
+        }
+        this.status = PostSalesStepStatus.PLANNED;
+    }
+
+    public String caseId() { return caseId; }
+    public int version() { return version; }
+    public List<PostSalesStep> steps() { return Collections.unmodifiableList(steps); }
+    public PostSalesStepStatus status() { return status; }
+
+    public void start(Instant occurredAt) {
+        if (status != PostSalesStepStatus.PLANNED) {
+            throw new DomainRuleViolation("execution plan can only start from PLANNED status");
+        }
+        status = PostSalesStepStatus.EXECUTING;
+        for (PostSalesStep step : steps) {
+            if (step.status() == PostSalesStepStatus.PLANNED) {
+                step.markExecuting();
+                break;
+            }
+        }
+    }
+
+    public void recordStepSucceeded(PostSalesStepType stepType, String externalRef, Instant occurredAt) {
+        requireStatus(PostSalesStepStatus.EXECUTING);
+        PostSalesStep step = requireStep(stepType);
+        ensurePriorStepsSucceeded(stepType);
+        step.succeed(externalRef, occurredAt);
+        if (allStepsSucceeded()) {
+            status = PostSalesStepStatus.SUCCEEDED;
+        }
+    }
+
+    public void recordStepFailed(PostSalesStepType stepType, String reason, boolean manualRequired, Instant occurredAt) {
+        requireStatus(PostSalesStepStatus.EXECUTING);
+        PostSalesStep step = requireStep(stepType);
+        step.fail(reason, manualRequired, occurredAt);
+        if (!manualRequired) {
+            status = PostSalesStepStatus.FAILED;
+        }
+    }
+
+    public void compensate() {
+        if (status != PostSalesStepStatus.FAILED && status != PostSalesStepStatus.MANUAL_REQUIRED) {
+            throw new DomainRuleViolation("only failed or manual-required plan can be compensated");
+        }
+        status = PostSalesStepStatus.SKIPPED;
+    }
+
+    private void ensurePriorStepsSucceeded(PostSalesStepType stepType) {
+        for (PostSalesStep step : steps) {
+            if (step.type() == stepType) {
+                return;
+            }
+            if (step.status() != PostSalesStepStatus.SUCCEEDED) {
+                throw new DomainRuleViolation("execution plan must complete " + step.type() + " before " + stepType);
+            }
+        }
+    }
+
+    private boolean allStepsSucceeded() {
+        return steps.stream().allMatch(step -> step.status() == PostSalesStepStatus.SUCCEEDED);
+    }
+
+    private PostSalesStep requireStep(PostSalesStepType stepType) {
+        return steps.stream().filter(step -> step.type() == stepType).findFirst()
+            .orElseThrow(() -> new DomainRuleViolation("unknown execution step " + stepType));
+    }
+
+    private void requireStatus(PostSalesStepStatus expected) {
+        if (status != expected) {
+            throw new DomainRuleViolation("expected execution plan status " + expected + " but was " + status);
+        }
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesExecutionStarted.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesExecutionStarted.java
@@ -1,0 +1,10 @@
+package com.trainticket.postsales.domain;
+
+import java.util.List;
+
+public record PostSalesExecutionStarted(
+    String caseId,
+    List<PostSalesStepType> orderedSteps,
+    String approvalRef,
+    EventMetadata metadata
+) implements PostSalesEvent { }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesFailed.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesFailed.java
@@ -1,0 +1,9 @@
+package com.trainticket.postsales.domain;
+
+public record PostSalesFailed(
+    String caseId,
+    String journeyOrderId,
+    String reason,
+    String failedStepRef,
+    EventMetadata metadata
+) implements PostSalesEvent { }

--- a/services/post-sales/src/test/java/com/trainticket/postsales/domain/PostSalesCaseDomainTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/domain/PostSalesCaseDomainTest.java
@@ -2,6 +2,7 @@ package com.trainticket.postsales.domain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -45,7 +46,8 @@ class PostSalesCaseDomainTest {
         }
 
         assertEquals(PostSalesCaseStatus.APPLIED, postSalesCase.status());
-        assertInstanceOf(PostSalesRequested.class, postSalesCase.domainEvents().get(0));
+        assertInstanceOf(PostSalesCaseOpened.class, postSalesCase.domainEvents().get(0));
+        assertInstanceOf(PostSalesRequested.class, postSalesCase.domainEvents().get(1));
         assertTrue(postSalesCase.domainEvents().stream().anyMatch(PostSalesEvaluated.class::isInstance));
         assertTrue(postSalesCase.domainEvents().stream().anyMatch(PostSalesApproved.class::isInstance));
         assertTrue(postSalesCase.domainEvents().stream().anyMatch(PostSalesApplied.class::isInstance));
@@ -110,6 +112,109 @@ class PostSalesCaseDomainTest {
 
         assertEquals(PostSalesCaseStatus.REJECTED, postSalesCase.status());
         assertThrows(DomainRuleViolation.class, () -> postSalesCase.requestExecution(NOW.plusSeconds(3), "execute", "quote", "corr"));
+    }
+
+    @Test
+    void postSalesExecutionPlanCreatedAndTracksStepsIndependently() {
+        List<PostSalesStep> steps = List.of(
+            new PostSalesStep(PostSalesStepType.VOID_ENTITLEMENT, "ent-1", "idem-void", 2),
+            new PostSalesStep(PostSalesStepType.REQUEST_REFUND, "payment:refund", "idem-refund", 1),
+            new PostSalesStep(PostSalesStepType.APPLY_RESULT, "order-1", "idem-apply", 0)
+        );
+        PostSalesExecutionPlan plan = new PostSalesExecutionPlan("case-1", 1, steps);
+
+        assertEquals("case-1", plan.caseId());
+        assertEquals(1, plan.version());
+        assertEquals(3, plan.steps().size());
+        assertEquals(PostSalesStepStatus.PLANNED, plan.status());
+
+        plan.start(NOW);
+        assertEquals(PostSalesStepStatus.EXECUTING, plan.status());
+
+        plan.recordStepSucceeded(PostSalesStepType.VOID_ENTITLEMENT, "voided", NOW.plusSeconds(1));
+        assertEquals(PostSalesStepStatus.EXECUTING, plan.status());
+
+        plan.recordStepSucceeded(PostSalesStepType.REQUEST_REFUND, "refunded", NOW.plusSeconds(2));
+        assertEquals(PostSalesStepStatus.EXECUTING, plan.status());
+
+        plan.recordStepSucceeded(PostSalesStepType.APPLY_RESULT, "applied", NOW.plusSeconds(3));
+        assertEquals(PostSalesStepStatus.SUCCEEDED, plan.status());
+    }
+
+    @Test
+    void postSalesExecutionPlanRejectsOutOfOrderSteps() {
+        List<PostSalesStep> steps = List.of(
+            new PostSalesStep(PostSalesStepType.VOID_ENTITLEMENT, "ent-1", "idem-void", 2),
+            new PostSalesStep(PostSalesStepType.REQUEST_REFUND, "payment:refund", "idem-refund", 1)
+        );
+        PostSalesExecutionPlan plan = new PostSalesExecutionPlan("case-1", 1, steps);
+        plan.start(NOW);
+
+        assertThrows(DomainRuleViolation.class, () ->
+            plan.recordStepSucceeded(PostSalesStepType.REQUEST_REFUND, "refund", NOW.plusSeconds(1)));
+    }
+
+    @Test
+    void postSalesExecutionPlanStepFailureMarksPlanFailed() {
+        List<PostSalesStep> steps = List.of(
+            new PostSalesStep(PostSalesStepType.VOID_ENTITLEMENT, "ent-1", "idem-void", 2),
+            new PostSalesStep(PostSalesStepType.REQUEST_REFUND, "payment:refund", "idem-refund", 1)
+        );
+        PostSalesExecutionPlan plan = new PostSalesExecutionPlan("case-1", 1, steps);
+        plan.start(NOW);
+        plan.recordStepSucceeded(PostSalesStepType.VOID_ENTITLEMENT, "voided", NOW.plusSeconds(1));
+        plan.recordStepFailed(PostSalesStepType.REQUEST_REFUND, "channel declined", false, NOW.plusSeconds(2));
+
+        assertEquals(PostSalesStepStatus.FAILED, plan.status());
+    }
+
+    @Test
+    void postSalesCaseOpenedEmitsCaseOpenedAndRequestedEvents() {
+        PostSalesCase postSalesCase = PostSalesCase.open("order-1", PostSalesCaseType.REFUND, scope(), "CUSTOMER_REQUEST", "traveler-1", "idem-open", NOW, "request", "corr");
+
+        assertEquals(PostSalesCaseStatus.OPENED, postSalesCase.status());
+        assertInstanceOf(PostSalesCaseOpened.class, postSalesCase.domainEvents().get(0));
+        assertInstanceOf(PostSalesRequested.class, postSalesCase.domainEvents().get(1));
+    }
+
+    @Test
+    void eligibilityEvaluationEmitsEventAndCanRejectDirectly() {
+        PostSalesCase postSalesCase = refundCase();
+        postSalesCase.evaluateEligibility(false, "RULE_BLOCKED", "eval-1", "v1", NOW.plusSeconds(1), "evaluate", "request", "corr");
+
+        assertEquals(PostSalesCaseStatus.REJECTED, postSalesCase.status());
+        assertTrue(postSalesCase.domainEvents().stream().anyMatch(PostSalesEligibilityEvaluated.class::isInstance));
+    }
+
+    @Test
+    void executionStartedEventIsEmitted() {
+        PostSalesCase postSalesCase = approvedExecutingRefundCase();
+        assertTrue(postSalesCase.domainEvents().stream().anyMatch(PostSalesExecutionStarted.class::isInstance));
+    }
+
+    @Test
+    void failCaseEmitsPostSalesFailedEvent() {
+        PostSalesCase postSalesCase = approvedExecutingRefundCase();
+        postSalesCase.recordStepFailed(PostSalesStepType.VOID_ENTITLEMENT, "entitlement void failed", false, NOW.plusSeconds(10), "step", "execute", "corr");
+
+        assertEquals(PostSalesCaseStatus.FAILED, postSalesCase.status());
+        assertTrue(postSalesCase.domainEvents().stream().anyMatch(PostSalesFailed.class::isInstance));
+    }
+
+    @Test
+    void cancelCaseFromOpenStatusWorks() {
+        PostSalesCase postSalesCase = refundCase();
+        postSalesCase.cancelCase("user cancelled", NOW.plusSeconds(1), "cancel", "request", "corr");
+
+        assertEquals(PostSalesCaseStatus.CANCELLED, postSalesCase.status());
+    }
+
+    @Test
+    void applyResultFromExecutingWorks() {
+        PostSalesCase postSalesCase = approvedExecutingRefundCase();
+        postSalesCase.applyResult("manual override applied", NOW.plusSeconds(10), "apply", "execute", "corr");
+
+        assertEquals(PostSalesCaseStatus.APPLIED, postSalesCase.status());
     }
 
     private static PostSalesCase approvedExecutingRefundCase() {


### PR DESCRIPTION
Implement the Post Sales domain foundation in Java.

Key additions:
- PostSalesExecutionPlan aggregate with ordered step execution
- New domain events: PostSalesCaseOpened, PostSalesEligibilityEvaluated,
  PostSalesDecisionQuoted, PostSalesExecutionStarted, PostSalesFailed, ChangeApplied
- open() factory method emitting PostSalesCaseOpened event
- Additional commands: evaluateEligibility, startExecution, failCase, cancelCase, applyResult
- Extended PostSalesEvent sealed interface
- Updated contract document
- Comprehensive unit tests
- Updated project-index.yaml