### PR TITLE
REQ-018: Fulfillment facts domain foundation

### DIFF
--- a/docs/08-contracts/events/fulfillment.md
+++ b/docs/08-contracts/events/fulfillment.md
@@ -1,0 +1,193 @@
+# Fulfillment — Events & Commands
+
+Last updated: 2026-07-05
+
+## Published Events
+
+### BoardingVerified
+
+| Field | Description |
+|---|---|
+| **Producer** | fulfillment |
+| **Consumers** | entitlement-ticketing, journey-order, notification |
+| **Trigger** | `VerifyBoarding` command processed; passenger boarding verified at gate/station. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `fulfillmentRecordId` | string | yes | Fulfillment record identifier. Format: `fr-<uuid>`. |
+| `entitlementId` | `EntitlementId` | yes | Reference to the entitlement (`ent-<uuid>`). |
+| `segmentBookingId` | `SegmentBookingId` | yes | Reference to the segment booking (`sb-<uuid>`). |
+| `journeyOrderId` | `OrderId` | yes | Reference to the journey order (`ord-<uuid>`). |
+| `travelerId` | `TravelerId` | yes | Traveler reference (`tvl-<uuid>`). |
+| `segmentRef` | `SegmentRef` | yes | Segment reference (`seg-<uuid>`). |
+| `source` | string | yes | Source of the boarding verification: `GATE`, `STATION`, `PROVIDER`, `CONDUCTOR`, `ADMIN`. |
+| `sourceEventId` | string | yes | Source event identifier for idempotency. |
+| `occurredAt` | RFC3339 UTC | yes | When the boarding event physically occurred. |
+| `receivedAt` | RFC3339 UTC | yes | When the boarding event was received by the system. |
+| `locationSnapshot` | object | no | Location snapshot: `{ "placeId": "plc-<uuid>", "nodeId": "tnd-<uuid>", "displayName": "..." }`. |
+
+### NoShowRecorded
+
+| Field | Description |
+|---|---|
+| **Producer** | fulfillment |
+| **Consumers** | entitlement-ticketing, journey-order, post-sales, notification |
+| **Trigger** | `RecordNoShow` command processed; passenger did not board within the boarding window. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `fulfillmentRecordId` | string | yes | Fulfillment record identifier (`fr-<uuid>`). |
+| `entitlementId` | `EntitlementId` | yes | Reference to the entitlement (`ent-<uuid>`). |
+| `segmentBookingId` | `SegmentBookingId` | yes | Reference to the segment booking (`sb-<uuid>`). |
+| `journeyOrderId` | `OrderId` | yes | Reference to the journey order (`ord-<uuid>`). |
+| `travelerId` | `TravelerId` | yes | Traveler reference (`tvl-<uuid>`). |
+| `segmentRef` | `SegmentRef` | yes | Segment reference (`seg-<uuid>`). |
+| `reason` | string | yes | No-show reason: `BOARDING_WINDOW_EXPIRED`, `VERIFICATION_FAILED`, `MANUAL_RECORD`. |
+| `assessedAt` | RFC3339 UTC | yes | When the no-show was assessed. |
+
+### FulfillmentCompleted
+
+| Field | Description |
+|---|---|
+| **Producer** | fulfillment |
+| **Consumers** | entitlement-ticketing, journey-order, notification, finance-settlement |
+| **Trigger** | Segment fulfillment completed (arrival confirmed or segment finished). |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `fulfillmentRecordId` | string | yes | Fulfillment record identifier (`fr-<uuid>`). |
+| `entitlementId` | `EntitlementId` | yes | Reference to the entitlement (`ent-<uuid>`). |
+| `segmentBookingId` | `SegmentBookingId` | yes | Reference to the segment booking (`sb-<uuid>`). |
+| `journeyOrderId` | `OrderId` | yes | Reference to the journey order (`ord-<uuid>`). |
+| `travelerId` | `TravelerId` | yes | Traveler reference (`tvl-<uuid>`). |
+| `completedAt` | RFC3339 UTC | yes | When the fulfillment was completed. |
+| `completionSource` | string | yes | Source of completion: `ARRIVAL`, `PROVIDER`, `ADMIN`, `SYSTEM`. |
+
+### EvidenceDisputeOpened
+
+| Field | Description |
+|---|---|
+| **Producer** | fulfillment |
+| **Consumers** | customer-service, admin-audit |
+| **Trigger** | `OpenEvidenceDispute` command processed; offline evidence conflict detected. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `disputeId` | string | yes | Dispute identifier. Format: `disp-<uuid>`. |
+| `fulfillmentRecordId` | string | yes | Fulfillment record identifier (`fr-<uuid>`). |
+| `entitlementId` | `EntitlementId` | yes | Reference to the entitlement (`ent-<uuid>`). |
+| `disputeType` | string | yes | Type of dispute: `OFFLINE_EVIDENCE_CONFLICT`, `DUPLICATE_BOARDING`, `UNRECOGNIZED_CHECK_IN`. |
+| `evidenceSummary` | string | yes | Summary of the conflicting evidence. |
+| `openedAt` | RFC3339 UTC | yes | When the dispute was opened. |
+| `openedBy` | string | yes | Who opened the dispute: `SYSTEM`, `ADMIN`, `PROVIDER`. |
+
+### EvidenceDisputeResolved
+
+| Field | Description |
+|---|---|
+| **Producer** | fulfillment |
+| **Consumers** | customer-service, admin-audit |
+| **Trigger** | `ResolveEvidenceDispute` command processed. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `disputeId` | string | yes | Dispute identifier (`disp-<uuid>`). |
+| `fulfillmentRecordId` | string | yes | Fulfillment record identifier (`fr-<uuid>`). |
+| `resolution` | string | yes | Resolution: `UPHELD`, `REJECTED`, `INCONCLUSIVE`. |
+| `reason` | string | yes | Reason for the resolution. |
+| `resolvedAt` | RFC3339 UTC | yes | When the dispute was resolved. |
+| `resolvedBy` | string | yes | Who resolved the dispute. |
+
+## Accepted Commands
+
+### RecordCheckIn
+
+| Field | Description |
+|---|---|
+| **Sender** | station-device, provider-integration, admin-audit |
+| **Trigger** | Passenger checks in at station or gate. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `fulfillmentRecordId` | string | yes | Fulfillment record identifier (`fr-<uuid>`). |
+| `entitlementId` | `EntitlementId` | yes | Reference to the entitlement (`ent-<uuid>`). |
+| `source` | string | yes | Source: `GATE`, `STATION`, `PROVIDER`, `CONDUCTOR`, `ADMIN`. |
+| `sourceEventId` | string | yes | Source event identifier for idempotency. |
+| `occurredAt` | RFC3339 UTC | yes | When the check-in physically occurred. |
+
+### VerifyBoarding
+
+| Field | Description |
+|---|---|
+| **Sender** | gate-device, provider-integration, conductor-app |
+| **Trigger** | Passenger boarding verified at gate or by conductor. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `fulfillmentRecordId` | string | yes | Fulfillment record identifier (`fr-<uuid>`). |
+| `entitlementId` | `EntitlementId` | yes | Reference to the entitlement (`ent-<uuid>`). |
+| `source` | string | yes | Source: `GATE`, `STATION`, `PROVIDER`, `CONDUCTOR`, `ADMIN`. |
+| `sourceEventId` | string | yes | Source event identifier for idempotency. |
+| `occurredAt` | RFC3339 UTC | yes | When the boarding physically occurred. |
+
+### RecordNoShow
+
+| Field | Description |
+|---|---|
+| **Sender** | system, admin-audit |
+| **Trigger** | Boarding window expired or manual no-show assessment. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `fulfillmentRecordId` | string | yes | Fulfillment record identifier (`fr-<uuid>`). |
+| `reason` | string | yes | No-show reason: `BOARDING_WINDOW_EXPIRED`, `VERIFICATION_FAILED`, `MANUAL_RECORD`. |
+| `assessedAt` | RFC3339 UTC | yes | When the no-show was assessed. |
+
+### OpenEvidenceDispute
+
+| Field | Description |
+|---|---|
+| **Sender** | system, admin-audit, customer-service |
+| **Trigger** | Offline evidence conflict or duplicate boarding detected. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `fulfillmentRecordId` | string | yes | Fulfillment record identifier (`fr-<uuid>`). |
+| `entitlementId` | `EntitlementId` | yes | Reference to the entitlement (`ent-<uuid>`). |
+| `disputeType` | string | yes | Type of dispute. |
+| `evidenceSummary` | string | yes | Summary of the conflicting evidence. |
+| `openedBy` | string | yes | Who opened the dispute. |
+
+### ResolveEvidenceDispute
+
+| Field | Description |
+|---|---|
+| **Sender** | admin-audit, customer-service |
+| **Trigger** | Dispute investigation completed. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `disputeId` | string | yes | Dispute identifier (`disp-<uuid>`). |
+| `resolution` | string | yes | `UPHELD`, `REJECTED`, `INCONCLUSIVE`. |
+| `reason` | string | yes | Reason for the resolution. |
+| `resolvedBy` | string | yes | Who resolved the dispute. |

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -397,6 +397,36 @@ requirements:
     confidence: confirmed
     source: "docs/02-domains/admin-audit.md, docs/03-ddd-final/phase-1-contract.md, docs/03-ddd-final/implementation-roadmap.md"
 
+  - id: REQ-018
+    title: "Fulfillment facts domain foundation"
+    description: "Implement the Fulfillment domain foundation in Go. Records physical travel facts: check-in, boarding verification, no-show, and offline evidence disputes."
+    priority: P0
+    status: implemented
+    code:
+      - path: services/fulfillment/internal/domain/fulfillment_record.go
+        description: "FulfillmentRecord aggregate with check-in, boarding, no-show, and completion lifecycle."
+      - path: services/fulfillment/internal/domain/evidence_dispute.go
+        description: "EvidenceDispute aggregate for offline evidence conflicts with open/resolve lifecycle."
+      - path: services/fulfillment/internal/domain/types.go
+        description: "Shared types, canonical IDs, enums, value objects, and domain events."
+      - path: services/fulfillment/internal/domain/profile.go
+        description: "Service profile updated to REQ-018 ownership set."
+    tests:
+      - path: services/fulfillment/internal/domain/fulfillment_record_test.go
+        description: "Unit tests for FulfillmentRecord lifecycle, idempotency, and invariants."
+      - path: services/fulfillment/internal/domain/evidence_dispute_test.go
+        description: "Unit tests for EvidenceDispute lifecycle, validation, and domain events."
+    docs:
+      - path: docs/02-domains/fulfillment.md
+      - path: docs/03-ddd-final/phase-1-contract.md
+      - path: docs/08-contracts/events/fulfillment.md
+    depends_on:
+      - REQ-013
+      - REQ-028
+    confidence: confirmed
+    source: "docs/02-domains/fulfillment.md, docs/03-ddd-final/phase-1-contract.md, docs/03-ddd-final/implementation-roadmap.md"
+
+
 
   - id: REQ-019
     title: Notification domain foundation

--- a/service-catalog.json
+++ b/service-catalog.json
@@ -57,6 +57,398 @@
   ],
   "services": [
     {
+      "id": "place-network",
+      "path": "services/place-network",
+      "domain": "Place & Network",
+      "language": "golang",
+      "runtime": "go",
+      "phase": "phase-1-core",
+      "status": "tested",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-004"
+      ],
+      "docs": [
+        "docs/02-domains/place-network.md"
+      ],
+      "owns": [
+        "Place",
+        "TransportNode",
+        "ProviderPlaceMapping"
+      ],
+      "rationale": "Go fits read-heavy master-data APIs and simple operational lookup paths."
+    },
+    {
+      "id": "service-plan",
+      "path": "services/service-plan",
+      "domain": "Service Plan",
+      "language": "golang",
+      "runtime": "go",
+      "phase": "phase-1-core",
+      "status": "tested",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-005"
+      ],
+      "docs": [
+        "docs/02-domains/service-plan.md"
+      ],
+      "owns": [
+        "Route",
+        "ServicePlan",
+        "Calendar",
+        "Timetable",
+        "PlanVersion"
+      ],
+      "rationale": "Go keeps schedule query services small, fast, and easy to operate."
+    },
+    {
+      "id": "capacity-availability",
+      "path": "services/capacity-availability",
+      "domain": "Capacity & Availability",
+      "language": "rust",
+      "runtime": "rust",
+      "phase": "phase-1-core",
+      "status": "tested",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-006"
+      ],
+      "docs": [
+        "docs/02-domains/capacity-availability.md",
+        "docs/03-ddd-final/phase-1-contract.md"
+      ],
+      "owns": [
+        "InventoryPool",
+        "StationInterval",
+        "CapacityHold",
+        "AvailabilitySnapshot"
+      ],
+      "rationale": "Rust is appropriate for interval overlap and seat-hold invariants that must fail closed."
+    },
+    {
+      "id": "fare-pricing",
+      "path": "services/fare-pricing",
+      "domain": "Fare & Pricing",
+      "language": "python",
+      "runtime": "python",
+      "phase": "phase-1-core",
+      "status": "tested",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-007"
+      ],
+      "docs": [
+        "docs/02-domains/fare-pricing.md"
+      ],
+      "owns": [
+        "FareRuleSet",
+        "FareQuote",
+        "RefundFee",
+        "ChangeFee",
+        "RuleSnapshot"
+      ],
+      "rationale": "Python keeps fare rules, explanation tooling, and later experimentation lightweight."
+    },
+    {
+      "id": "trip-planning",
+      "path": "services/trip-planning",
+      "domain": "Trip Planning",
+      "language": "python",
+      "runtime": "python",
+      "phase": "phase-1-search-foundation",
+      "status": "implemented-foundation",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-008-Trip-Planning-search-foundation"
+      ],
+      "docs": [
+        "docs/02-domains/trip-planning.md",
+        "docs/03-ddd-final/phase-1-contract.md"
+      ],
+      "owns": [
+        "TripIntent validation",
+        "Itinerary candidates",
+        "SearchResult ranking explanations",
+        "Non-authoritative PriceHint and AvailabilityHint snapshots"
+      ],
+      "rationale": "Python is a better fit for search heuristics, deterministic ranking, and auditable explanation logic."
+    },
+    {
+      "id": "offer-management",
+      "path": "services/offer-management",
+      "domain": "Offer Management",
+      "language": "typescript",
+      "runtime": "node",
+      "phase": "phase-1-offer-domain-foundation",
+      "status": "implemented-foundation",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-009-Offer-Management-domain-foundation"
+      ],
+      "docs": [
+        "docs/02-domains/offer-management.md",
+        "docs/03-ddd-final/phase-1-contract.md"
+      ],
+      "owns": [
+        "Offer identity and lifecycle",
+        "OfferItem snapshot composition",
+        "ItineraryReference",
+        "AvailabilitySnapshotReference",
+        "PriceSnapshot",
+        "FareRuleSnapshotReference",
+        "PassengerMix",
+        "RiskDisclosure",
+        "OfferQuoted",
+        "OfferExpired"
+      ],
+      "rationale": "TypeScript fits user-facing offer API composition, TTL policy, immutable snapshot enforcement, and disclosure payloads."
+    },
+    {
+      "id": "journey-order",
+      "path": "services/journey-order",
+      "domain": "Journey Order",
+      "language": "java",
+      "runtime": "jvm",
+      "phase": "phase-1-domain-foundation",
+      "status": "tested",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-010-Journey-Order-domain-foundation"
+      ],
+      "docs": [
+        "docs/02-domains/journey-order.md"
+      ],
+      "owns": [
+        "JourneyOrder aggregate root",
+        "OrderItem entity and lifecycle",
+        "MonetarySummary invariants",
+        "OrderTimeline facts",
+        "ConfirmationConditions guards",
+        "OrderLifecycleState machine",
+        "TravelerRef snapshots",
+        "SegmentOrderSnapshot references",
+        "OrderLineBinding bindings",
+        "JourneyOrderCreated, JourneyOrderPendingPayment, JourneyOrderConfirmed, JourneyOrderCancelled events"
+      ],
+      "rationale": "Java is conservative for central transactional aggregates and long-lived domain models."
+    },
+    {
+      "id": "booking-orchestration",
+      "path": "services/booking-orchestration",
+      "domain": "Booking Orchestration",
+      "language": "java",
+      "runtime": "jvm",
+      "phase": "phase-1-core",
+      "status": "status-reconciliation-needed",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-011"
+      ],
+      "docs": [
+        "docs/02-domains/booking-orchestration.md"
+      ],
+      "owns": [
+        "BookingSaga",
+        "SegmentBooking",
+        "ProviderReservation mapping"
+      ],
+      "rationale": "Java gives the saga layer explicit state transitions and stable integration testing options."
+    },
+    {
+      "id": "payment",
+      "path": "services/payment",
+      "domain": "Payment",
+      "language": "java",
+      "runtime": "jvm",
+      "phase": "phase-1-domain-foundation",
+      "status": "tested",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-012-Payment-domain-foundation"
+      ],
+      "docs": [
+        "docs/02-domains/payment.md"
+      ],
+      "owns": [
+        "PaymentIntent",
+        "Refund",
+        "CallbackRecord",
+        "IdempotencyKey"
+      ],
+      "rationale": "Java is a strong default for money state machines, idempotency, and audit-heavy flows."
+    },
+    {
+      "id": "provider-integration",
+      "path": "services/provider-integration",
+      "domain": "Provider Integration",
+      "language": "golang",
+      "runtime": "go",
+      "phase": "phase-1-acl-foundation",
+      "status": "status-reconciliation-needed",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-015"
+      ],
+      "docs": [
+        "docs/02-domains/provider-integration.md"
+      ],
+      "owns": [
+        "adapter protocol",
+        "signature verification",
+        "raw archive",
+        "external status mapping"
+      ],
+      "rationale": "Go fits protocol adapters, webhooks, retry loops, and small deployable edge services."
+    },
+    {
+      "id": "entitlement-ticketing",
+      "path": "services/entitlement-ticketing",
+      "domain": "Entitlement & Ticketing",
+      "language": "rust",
+      "runtime": "rust",
+      "phase": "phase-1-domain-foundation",
+      "status": "status-reconciliation-needed",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-013"
+      ],
+      "docs": [
+        "docs/02-domains/entitlement-ticketing.md"
+      ],
+      "owns": [
+        "Entitlement",
+        "Credential",
+        "Issue",
+        "Void",
+        "Suspend",
+        "Boarded consumption"
+      ],
+      "rationale": "Rust is appropriate for ticket entitlement lifecycle invariants and credential safety."
+    },
+    {
+      "id": "fulfillment",
+      "path": "services/fulfillment",
+      "domain": "Fulfillment",
+      "language": "golang",
+      "runtime": "go",
+      "phase": "phase-1-limited",
+      "status": "implemented",
+      "priority": "P1",
+      "workPackages": [
+        "REQ-018"
+      ],
+      "docs": [
+        "docs/02-domains/fulfillment.md",
+        "docs/03-ddd-final/phase-1-contract.md",
+        "docs/08-contracts/events/fulfillment.md"
+      ],
+      "owns": [
+        "FulfillmentRecord aggregate",
+        "EvidenceDispute aggregate",
+        "BoardingVerified event",
+        "NoShowRecorded event",
+        "FulfillmentCompleted event",
+        "EvidenceDisputeOpened event",
+        "EvidenceDisputeResolved event"
+      ],
+      "rationale": "Go keeps event ingestion and station-side fact normalization operationally simple."
+    },
+    {
+      "id": "post-sales",
+      "path": "services/post-sales",
+      "domain": "Post Sales",
+      "language": "java",
+      "runtime": "jvm",
+      "phase": "phase-1-core",
+      "status": "status-reconciliation-needed",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-014"
+      ],
+      "docs": [
+        "docs/02-domains/post-sales.md"
+      ],
+      "owns": [
+        "PostSalesCase",
+        "RefundDecision",
+        "ChangeExecutionPlan"
+      ],
+      "rationale": "Java keeps refund/change case workflows explicit and compatible with transaction review tooling."
+    },
+    {
+      "id": "notification",
+      "path": "services/notification",
+      "domain": "Notification",
+      "language": "typescript",
+      "runtime": "node",
+      "phase": "phase-1-domain-foundation",
+      "status": "implemented-foundation",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-019",
+        "WP-15-transaction-notification"
+      ],
+      "docs": [
+        "docs/02-domains/notification.md"
+      ],
+      "owns": [
+        "NotificationTask lifecycle (Planned, Delivering, Delivered, Failed, Cancelled)",
+        "Template versioning with variable schema and channel adaptations",
+        "RecipientPolicy with channel priority, fallback, and consent bypass",
+        "DeliveryReceipt appended facts (Delivered, Bounced, Rejected, Timeout, Expired)",
+        "NotificationScheduled, NotificationDispatched, NotificationDelivered, NotificationFailed, NotificationCancelled events",
+        "Send idempotency via idempotencyKey (triggerEventId + recipientRef + templateCode)"
+      ],
+      "rationale": "TypeScript fits template payloads, channel adapters, and product-facing notification policies. Domain foundation established with full aggregate lifecycle, idempotency, and boundary proof."
+    },
+    {
+      "id": "traveler-profile",
+      "path": "services/traveler-profile",
+      "domain": "Traveler Profile",
+      "language": "java",
+      "runtime": "jvm",
+      "phase": "phase-1-domain-foundation",
+      "status": "implemented",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-017"
+      ],
+      "docs": [
+        "docs/02-domains/traveler-profile.md"
+      ],
+      "owns": [
+        "TravelerProfile",
+        "Document",
+        "EligibilitySummary",
+        "PreferenceSnapshot"
+      ],
+      "rationale": "Java keeps PII-heavy profile aggregates and validation policies explicit."
+    },
+    {
+      "id": "risk-compliance",
+      "path": "services/risk-compliance",
+      "domain": "Risk & Compliance",
+      "language": "python",
+      "runtime": "python",
+      "phase": "phase-1-support",
+      "status": "skeleton",
+      "priority": "P1",
+      "workPackages": [
+        "WP-17"
+      ],
+      "docs": [
+        "docs/02-domains/risk-compliance.md"
+      ],
+      "owns": [
+        "RiskAssessment",
+        "Challenge",
+        "BlockDecision",
+        "EvidenceSummary"
+      ],
+      "rationale": "Python supports rule experimentation, scoring, and evidence summarization without coupling source domains."
+    },
+    {
       "id": "account",
       "path": "services/account",
       "domain": "Account",
@@ -104,72 +496,6 @@
       "rationale": "Java is a conservative fit for approvals, audit retention, and authorization boundaries."
     },
     {
-      "id": "ancillary-service",
-      "path": "services/ancillary-service",
-      "domain": "Ancillary Service",
-      "language": "typescript",
-      "runtime": "node",
-      "phase": "future-scope",
-      "status": "placeholder-skeleton",
-      "priority": "P1",
-      "workPackages": [],
-      "docs": [
-        "docs/02-domains/ancillary-service.md"
-      ],
-      "owns": [
-        "AncillaryOffer",
-        "AncillaryOrderItem",
-        "ActivationPolicy"
-      ],
-      "rationale": "TypeScript fits productized add-ons and bundle-facing API composition."
-    },
-    {
-      "id": "booking-orchestration",
-      "path": "services/booking-orchestration",
-      "domain": "Booking Orchestration",
-      "language": "java",
-      "runtime": "jvm",
-      "phase": "phase-1-core",
-      "status": "status-reconciliation-needed",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-011"
-      ],
-      "docs": [
-        "docs/02-domains/booking-orchestration.md"
-      ],
-      "owns": [
-        "BookingSaga",
-        "SegmentBooking",
-        "ProviderReservation mapping"
-      ],
-      "rationale": "Java gives the saga layer explicit state transitions and stable integration testing options."
-    },
-    {
-      "id": "capacity-availability",
-      "path": "services/capacity-availability",
-      "domain": "Capacity & Availability",
-      "language": "rust",
-      "runtime": "rust",
-      "phase": "phase-1-core",
-      "status": "tested",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-006"
-      ],
-      "docs": [
-        "docs/02-domains/capacity-availability.md",
-        "docs/03-ddd-final/phase-1-contract.md"
-      ],
-      "owns": [
-        "InventoryPool",
-        "StationInterval",
-        "CapacityHold",
-        "AvailabilitySnapshot"
-      ],
-      "rationale": "Rust is appropriate for interval overlap and seat-hold invariants that must fail closed."
-    },
-    {
       "id": "customer-service",
       "path": "services/customer-service",
       "domain": "Customer Service",
@@ -191,96 +517,6 @@
         "CaseTimeline"
       ],
       "rationale": "TypeScript fits collaborative case APIs and UI-adjacent timelines without owning target state."
-    },
-    {
-      "id": "dispatch",
-      "path": "services/dispatch",
-      "domain": "Dispatch",
-      "language": "golang",
-      "runtime": "go",
-      "phase": "future-scope",
-      "status": "placeholder-skeleton",
-      "priority": "P1",
-      "workPackages": [],
-      "docs": [
-        "docs/02-domains/dispatch.md"
-      ],
-      "owns": [
-        "RideRequest",
-        "RideAssignment",
-        "DriverLifecycle",
-        "Eta"
-      ],
-      "rationale": "Go fits real-time dispatch APIs, adapter calls, and low-latency state updates."
-    },
-    {
-      "id": "disruption-recovery",
-      "path": "services/disruption-recovery",
-      "domain": "Disruption Recovery",
-      "language": "python",
-      "runtime": "python",
-      "phase": "future-scope",
-      "status": "placeholder-skeleton",
-      "priority": "P1",
-      "workPackages": [],
-      "docs": [
-        "docs/02-domains/disruption-recovery.md"
-      ],
-      "owns": [
-        "RecoveryCase",
-        "RecoveryOption",
-        "CompensationDecision"
-      ],
-      "rationale": "Python fits recovery optimization and policy experimentation when this future domain is enabled."
-    },
-    {
-      "id": "entitlement-ticketing",
-      "path": "services/entitlement-ticketing",
-      "domain": "Entitlement & Ticketing",
-      "language": "rust",
-      "runtime": "rust",
-      "phase": "phase-1-domain-foundation",
-      "status": "status-reconciliation-needed",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-013"
-      ],
-      "docs": [
-        "docs/02-domains/entitlement-ticketing.md"
-      ],
-      "owns": [
-        "Entitlement",
-        "Credential",
-        "Issue",
-        "Void",
-        "Suspend",
-        "Boarded consumption"
-      ],
-      "rationale": "Rust is appropriate for ticket entitlement lifecycle invariants and credential safety."
-    },
-    {
-      "id": "fare-pricing",
-      "path": "services/fare-pricing",
-      "domain": "Fare & Pricing",
-      "language": "python",
-      "runtime": "python",
-      "phase": "phase-1-core",
-      "status": "tested",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-007"
-      ],
-      "docs": [
-        "docs/02-domains/fare-pricing.md"
-      ],
-      "owns": [
-        "FareRuleSet",
-        "FareQuote",
-        "RefundFee",
-        "ChangeFee",
-        "RuleSnapshot"
-      ],
-      "rationale": "Python keeps fare rules, explanation tooling, and later experimentation lightweight."
     },
     {
       "id": "finance-settlement",
@@ -306,204 +542,6 @@
       "rationale": "Java is appropriate for financial ledgers, reconciliation workflows, and audit consistency."
     },
     {
-      "id": "fulfillment",
-      "path": "services/fulfillment",
-      "domain": "Fulfillment",
-      "language": "golang",
-      "runtime": "go",
-      "phase": "phase-1-limited",
-      "status": "skeleton",
-      "priority": "P1",
-      "workPackages": [
-        "WP-13"
-      ],
-      "docs": [
-        "docs/02-domains/fulfillment.md"
-      ],
-      "owns": [
-        "FulfillmentRecord",
-        "BoardingVerified",
-        "NoShow",
-        "EvidenceDispute"
-      ],
-      "rationale": "Go keeps event ingestion and station-side fact normalization operationally simple."
-    },
-    {
-      "id": "journey-order",
-      "path": "services/journey-order",
-      "domain": "Journey Order",
-      "language": "java",
-      "runtime": "jvm",
-      "phase": "phase-1-domain-foundation",
-      "status": "tested",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-010-Journey-Order-domain-foundation"
-      ],
-      "docs": [
-        "docs/02-domains/journey-order.md"
-      ],
-      "owns": [
-        "JourneyOrder aggregate root",
-        "OrderItem entity and lifecycle",
-        "MonetarySummary invariants",
-        "OrderTimeline facts",
-        "ConfirmationConditions guards",
-        "OrderLifecycleState machine",
-        "TravelerRef snapshots",
-        "SegmentOrderSnapshot references",
-        "OrderLineBinding bindings",
-        "JourneyOrderCreated, JourneyOrderPendingPayment, JourneyOrderConfirmed, JourneyOrderCancelled events"
-      ],
-      "rationale": "Java is conservative for central transactional aggregates and long-lived domain models."
-    },
-    {
-      "id": "notification",
-      "path": "services/notification",
-      "domain": "Notification",
-      "language": "typescript",
-      "runtime": "node",
-      "phase": "phase-1-domain-foundation",
-      "status": "implemented-foundation",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-019",
-        "WP-15-transaction-notification"
-      ],
-      "docs": [
-        "docs/02-domains/notification.md"
-      ],
-      "owns": [
-        "NotificationTask lifecycle (Planned, Delivering, Delivered, Failed, Cancelled)",
-        "Template versioning with variable schema and channel adaptations",
-        "RecipientPolicy with channel priority, fallback, and consent bypass",
-        "DeliveryReceipt appended facts (Delivered, Bounced, Rejected, Timeout, Expired)",
-        "NotificationScheduled, NotificationDispatched, NotificationDelivered, NotificationFailed, NotificationCancelled events",
-        "Send idempotency via idempotencyKey (triggerEventId + recipientRef + templateCode)"
-      ],
-      "rationale": "TypeScript fits template payloads, channel adapters, and product-facing notification policies. Domain foundation established with full aggregate lifecycle, idempotency, and boundary proof."
-    },
-    {
-      "id": "offer-management",
-      "path": "services/offer-management",
-      "domain": "Offer Management",
-      "language": "typescript",
-      "runtime": "node",
-      "phase": "phase-1-offer-domain-foundation",
-      "status": "implemented-foundation",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-009-Offer-Management-domain-foundation"
-      ],
-      "docs": [
-        "docs/02-domains/offer-management.md",
-        "docs/03-ddd-final/phase-1-contract.md"
-      ],
-      "owns": [
-        "Offer identity and lifecycle",
-        "OfferItem snapshot composition",
-        "ItineraryReference",
-        "AvailabilitySnapshotReference",
-        "PriceSnapshot",
-        "FareRuleSnapshotReference",
-        "PassengerMix",
-        "RiskDisclosure",
-        "OfferQuoted",
-        "OfferExpired"
-      ],
-      "rationale": "TypeScript fits user-facing offer API composition, TTL policy, immutable snapshot enforcement, and disclosure payloads."
-    },
-    {
-      "id": "payment",
-      "path": "services/payment",
-      "domain": "Payment",
-      "language": "java",
-      "runtime": "jvm",
-      "phase": "phase-1-domain-foundation",
-      "status": "tested",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-012-Payment-domain-foundation"
-      ],
-      "docs": [
-        "docs/02-domains/payment.md"
-      ],
-      "owns": [
-        "PaymentIntent",
-        "Refund",
-        "CallbackRecord",
-        "IdempotencyKey"
-      ],
-      "rationale": "Java is a strong default for money state machines, idempotency, and audit-heavy flows."
-    },
-    {
-      "id": "place-network",
-      "path": "services/place-network",
-      "domain": "Place & Network",
-      "language": "golang",
-      "runtime": "go",
-      "phase": "phase-1-core",
-      "status": "tested",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-004"
-      ],
-      "docs": [
-        "docs/02-domains/place-network.md"
-      ],
-      "owns": [
-        "Place",
-        "TransportNode",
-        "ProviderPlaceMapping"
-      ],
-      "rationale": "Go fits read-heavy master-data APIs and simple operational lookup paths."
-    },
-    {
-      "id": "post-sales",
-      "path": "services/post-sales",
-      "domain": "Post Sales",
-      "language": "java",
-      "runtime": "jvm",
-      "phase": "phase-1-core",
-      "status": "status-reconciliation-needed",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-014"
-      ],
-      "docs": [
-        "docs/02-domains/post-sales.md"
-      ],
-      "owns": [
-        "PostSalesCase",
-        "RefundDecision",
-        "ChangeExecutionPlan"
-      ],
-      "rationale": "Java keeps refund/change case workflows explicit and compatible with transaction review tooling."
-    },
-    {
-      "id": "provider-integration",
-      "path": "services/provider-integration",
-      "domain": "Provider Integration",
-      "language": "golang",
-      "runtime": "go",
-      "phase": "phase-1-acl-foundation",
-      "status": "status-reconciliation-needed",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-015"
-      ],
-      "docs": [
-        "docs/02-domains/provider-integration.md"
-      ],
-      "owns": [
-        "adapter protocol",
-        "signature verification",
-        "raw archive",
-        "external status mapping"
-      ],
-      "rationale": "Go fits protocol adapters, webhooks, retry loops, and small deployable edge services."
-    },
-    {
       "id": "reporting",
       "path": "services/reporting",
       "domain": "Reporting",
@@ -526,71 +564,20 @@
       "rationale": "Python is a pragmatic fit for metric definitions, event-derived views, and analytics validation."
     },
     {
-      "id": "risk-compliance",
-      "path": "services/risk-compliance",
-      "domain": "Risk & Compliance",
-      "language": "python",
-      "runtime": "python",
-      "phase": "phase-1-support",
-      "status": "tested",
-      "priority": "P1",
-      "workPackages": [
-        "WP-17"
-      ],
-      "docs": [
-        "docs/02-domains/risk-compliance.md"
-      ],
-      "owns": [
-        "RiskAssessment",
-        "Challenge",
-        "RiskDecision",
-        "EvidenceSummary"
-      ],
-      "rationale": "Python supports rule experimentation, scoring, and evidence summarization without coupling source domains.",
-      "work_packages": [
-        "REQ-020",
-        "WP-17"
-      ]
-    },
-    {
-      "id": "service-plan",
-      "path": "services/service-plan",
-      "domain": "Service Plan",
-      "language": "golang",
-      "runtime": "go",
-      "phase": "phase-1-core",
-      "status": "tested",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-005"
-      ],
-      "docs": [
-        "docs/02-domains/service-plan.md"
-      ],
-      "owns": [
-        "Route",
-        "ServicePlan",
-        "Calendar",
-        "Timetable",
-        "PlanVersion"
-      ],
-      "rationale": "Go keeps schedule query services small, fast, and easy to operate."
-    },
-    {
       "id": "supplier-catalog",
       "path": "services/supplier-catalog",
       "domain": "Supplier Catalog",
       "language": "golang",
       "runtime": "go",
       "phase": "phase-1-support",
-      "status": "tested",
+      "status": "skeleton",
       "priority": "P1",
       "workPackages": [
-        "REQ-026"
+        "WP-02",
+        "WP-11"
       ],
       "docs": [
-        "docs/02-domains/supplier-catalog.md",
-        "docs/08-contracts/events/supplier-catalog.md"
+        "docs/02-domains/supplier-catalog.md"
       ],
       "owns": [
         "Supplier",
@@ -600,6 +587,26 @@
         "ExternalCode"
       ],
       "rationale": "Go keeps supplier capability lookup compact and separate from provider runtime health."
+    },
+    {
+      "id": "disruption-recovery",
+      "path": "services/disruption-recovery",
+      "domain": "Disruption Recovery",
+      "language": "python",
+      "runtime": "python",
+      "phase": "future-scope",
+      "status": "placeholder-skeleton",
+      "priority": "P1",
+      "workPackages": [],
+      "docs": [
+        "docs/02-domains/disruption-recovery.md"
+      ],
+      "owns": [
+        "RecoveryCase",
+        "RecoveryOption",
+        "CompensationDecision"
+      ],
+      "rationale": "Python fits recovery optimization and policy experimentation when this future domain is enabled."
     },
     {
       "id": "transfer-management",
@@ -622,51 +629,24 @@
       "rationale": "Python fits connection-risk calculation and later protected-transfer recovery planning."
     },
     {
-      "id": "traveler-profile",
-      "path": "services/traveler-profile",
-      "domain": "Traveler Profile",
-      "language": "java",
-      "runtime": "jvm",
-      "phase": "phase-1-domain-foundation",
-      "status": "implemented",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-017"
-      ],
+      "id": "ancillary-service",
+      "path": "services/ancillary-service",
+      "domain": "Ancillary Service",
+      "language": "typescript",
+      "runtime": "node",
+      "phase": "future-scope",
+      "status": "placeholder-skeleton",
+      "priority": "P1",
+      "workPackages": [],
       "docs": [
-        "docs/02-domains/traveler-profile.md"
+        "docs/02-domains/ancillary-service.md"
       ],
       "owns": [
-        "TravelerProfile",
-        "Document",
-        "EligibilitySummary",
-        "PreferenceSnapshot"
+        "AncillaryOffer",
+        "AncillaryOrderItem",
+        "ActivationPolicy"
       ],
-      "rationale": "Java keeps PII-heavy profile aggregates and validation policies explicit."
-    },
-    {
-      "id": "trip-planning",
-      "path": "services/trip-planning",
-      "domain": "Trip Planning",
-      "language": "python",
-      "runtime": "python",
-      "phase": "phase-1-search-foundation",
-      "status": "implemented-foundation",
-      "priority": "P0",
-      "workPackages": [
-        "REQ-008-Trip-Planning-search-foundation"
-      ],
-      "docs": [
-        "docs/02-domains/trip-planning.md",
-        "docs/03-ddd-final/phase-1-contract.md"
-      ],
-      "owns": [
-        "TripIntent validation",
-        "Itinerary candidates",
-        "SearchResult ranking explanations",
-        "Non-authoritative PriceHint and AvailabilityHint snapshots"
-      ],
-      "rationale": "Python is a better fit for search heuristics, deterministic ranking, and auditable explanation logic."
+      "rationale": "TypeScript fits productized add-ons and bundle-facing API composition."
     },
     {
       "id": "waitlist",
@@ -708,6 +688,27 @@
         "PointLedger"
       ],
       "rationale": "Java is a conservative default for stored-value and promotion ledgers."
+    },
+    {
+      "id": "dispatch",
+      "path": "services/dispatch",
+      "domain": "Dispatch",
+      "language": "golang",
+      "runtime": "go",
+      "phase": "future-scope",
+      "status": "placeholder-skeleton",
+      "priority": "P1",
+      "workPackages": [],
+      "docs": [
+        "docs/02-domains/dispatch.md"
+      ],
+      "owns": [
+        "RideRequest",
+        "RideAssignment",
+        "DriverLifecycle",
+        "Eta"
+      ],
+      "rationale": "Go fits real-time dispatch APIs, adapter calls, and low-latency state updates."
     }
   ]
 }

--- a/services/fulfillment/internal/domain/clock.go
+++ b/services/fulfillment/internal/domain/clock.go
@@ -1,0 +1,6 @@
+package domain
+
+import "time"
+
+// timeNow is a package-level clock variable that can be overridden in tests.
+var timeNow = time.Now

--- a/services/fulfillment/internal/domain/evidence_dispute.go
+++ b/services/fulfillment/internal/domain/evidence_dispute.go
@@ -1,0 +1,121 @@
+package domain
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// EvidenceDispute is an aggregate representing a dispute over offline evidence
+// or conflicting fulfillment facts. It has its own lifecycle and never mutates
+// the original fulfillment fact.
+type EvidenceDispute struct {
+	DisputeID           EvidenceDisputeID
+	FulfillmentRecordID FulfillmentRecordID
+	EntitlementID       EntitlementRef
+	DisputeType         DisputeType
+	Status              DisputeStatus
+	EvidenceSummary     string
+	Resolution          *DisputeResolution
+	ResolutionReason    string
+	OpenedAt            time.Time
+	OpenedBy            string
+	ResolvedAt          *time.Time
+	ResolvedBy          string
+	UpdatedAt           time.Time
+
+	events []DomainEvent
+}
+
+// NewEvidenceDispute creates a new EvidenceDispute aggregate.
+func NewEvidenceDispute(
+	disputeID EvidenceDisputeID,
+	fulfillmentRecordID FulfillmentRecordID,
+	entitlementID EntitlementRef,
+	disputeType DisputeType,
+	evidenceSummary string,
+	openedBy string,
+) (*EvidenceDispute, error) {
+	if err := disputeID.Validate(); err != nil {
+		return nil, fmt.Errorf("new evidence dispute: %w", err)
+	}
+	if err := fulfillmentRecordID.Validate(); err != nil {
+		return nil, fmt.Errorf("new evidence dispute: %w", err)
+	}
+	if err := entitlementID.Validate(); err != nil {
+		return nil, fmt.Errorf("new evidence dispute: %w", err)
+	}
+	if strings.TrimSpace(evidenceSummary) == "" {
+		return nil, fmt.Errorf("new evidence dispute: evidence summary is required")
+	}
+	if strings.TrimSpace(openedBy) == "" {
+		return nil, fmt.Errorf("new evidence dispute: openedBy is required")
+	}
+
+	now := timeNow().UTC()
+	dispute := &EvidenceDispute{
+		DisputeID:           disputeID,
+		FulfillmentRecordID: fulfillmentRecordID,
+		EntitlementID:       entitlementID,
+		DisputeType:         disputeType,
+		Status:              DisputeStatusOpen,
+		EvidenceSummary:     evidenceSummary,
+		OpenedAt:            now,
+		OpenedBy:            openedBy,
+		UpdatedAt:           now,
+		events:              []DomainEvent{},
+	}
+
+	dispute.emit(EvidenceDisputeOpenedEvent{
+		DisputeID:           disputeID,
+		FulfillmentRecordID: fulfillmentRecordID,
+		EntitlementID:       entitlementID,
+		DisputeType:         disputeType,
+		EvidenceSummary:     evidenceSummary,
+		openedAt:            now,
+		OpenedBy:            openedBy,
+	})
+	return dispute, nil
+}
+
+// Resolve resolves an open evidence dispute with the given resolution.
+func (d *EvidenceDispute) Resolve(resolution DisputeResolution, reason string, resolvedBy string) error {
+	if d.Status != DisputeStatusOpen {
+		return fmt.Errorf("cannot resolve dispute %q: already %s", d.DisputeID, d.Status)
+	}
+	if strings.TrimSpace(reason) == "" {
+		return fmt.Errorf("resolve dispute: reason is required")
+	}
+	if strings.TrimSpace(resolvedBy) == "" {
+		return fmt.Errorf("resolve dispute: resolvedBy is required")
+	}
+
+	now := timeNow().UTC()
+	d.Status = DisputeStatusResolved
+	d.Resolution = &resolution
+	d.ResolutionReason = reason
+	d.ResolvedAt = &now
+	d.ResolvedBy = resolvedBy
+	d.UpdatedAt = now
+
+	d.emit(EvidenceDisputeResolvedEvent{
+		DisputeID:           d.DisputeID,
+		FulfillmentRecordID: d.FulfillmentRecordID,
+		Resolution:          resolution,
+		Reason:              reason,
+		resolvedAt:          now,
+		ResolvedBy:          resolvedBy,
+	})
+	return nil
+}
+
+// Events returns the pending domain events and clears the event log.
+func (d *EvidenceDispute) Events() []DomainEvent {
+	events := d.events
+	d.events = nil
+	return events
+}
+
+func (d *EvidenceDispute) emit(event DomainEvent) {
+	d.events = append(d.events, event)
+}

--- a/services/fulfillment/internal/domain/evidence_dispute_test.go
+++ b/services/fulfillment/internal/domain/evidence_dispute_test.go
@@ -1,0 +1,305 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewEvidenceDispute(t *testing.T) {
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+	defer resetClock()
+
+	dispute, err := NewEvidenceDispute(
+		"disp-abc123",
+		"fr-def456",
+		"ent-ghi789",
+		DisputeTypeOfflineConflict,
+		"Gate scan at 10:05 UTC but station check-in at 10:02 UTC shows different location",
+		"SYSTEM",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dispute.DisputeID != "disp-abc123" {
+		t.Fatalf("unexpected id: %s", dispute.DisputeID)
+	}
+	if dispute.Status != DisputeStatusOpen {
+		t.Fatalf("expected OPEN, got %s", dispute.Status)
+	}
+	if dispute.FulfillmentRecordID != "fr-def456" {
+		t.Fatalf("unexpected fulfillment record id: %s", dispute.FulfillmentRecordID)
+	}
+	if dispute.EntitlementID != "ent-ghi789" {
+		t.Fatalf("unexpected entitlement id: %s", dispute.EntitlementID)
+	}
+	if dispute.DisputeType != DisputeTypeOfflineConflict {
+		t.Fatalf("unexpected dispute type: %s", dispute.DisputeType)
+	}
+
+	// Verify event was emitted.
+	events := dispute.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].EventType() != "EvidenceDisputeOpened" {
+		t.Fatalf("expected EvidenceDisputeOpened, got %s", events[0].EventType())
+	}
+	openedEvt, ok := events[0].(EvidenceDisputeOpenedEvent)
+	if !ok {
+		t.Fatalf("expected EvidenceDisputeOpenedEvent type")
+	}
+	if openedEvt.DisputeID != "disp-abc123" {
+		t.Fatalf("unexpected dispute id in event: %s", openedEvt.DisputeID)
+	}
+	if openedEvt.DisputeType != DisputeTypeOfflineConflict {
+		t.Fatalf("unexpected dispute type in event: %s", openedEvt.DisputeType)
+	}
+}
+
+func TestNewEvidenceDisputeRejectsInvalidID(t *testing.T) {
+	_, err := NewEvidenceDispute(
+		"invalid",
+		"fr-def456",
+		"ent-ghi789",
+		DisputeTypeOfflineConflict,
+		"Evidence summary",
+		"SYSTEM",
+	)
+	if err == nil || !strings.Contains(err.Error(), "invalid EvidenceDisputeID") {
+		t.Fatalf("expected id error, got %v", err)
+	}
+}
+
+func TestNewEvidenceDisputeRejectsInvalidFulfillmentRecordID(t *testing.T) {
+	_, err := NewEvidenceDispute(
+		"disp-abc123",
+		"invalid",
+		"ent-ghi789",
+		DisputeTypeOfflineConflict,
+		"Evidence summary",
+		"SYSTEM",
+	)
+	if err == nil || !strings.Contains(err.Error(), "invalid FulfillmentRecordID") {
+		t.Fatalf("expected fulfillment record id error, got %v", err)
+	}
+}
+
+func TestNewEvidenceDisputeRejectsInvalidEntitlement(t *testing.T) {
+	_, err := NewEvidenceDispute(
+		"disp-abc123",
+		"fr-def456",
+		"invalid",
+		DisputeTypeOfflineConflict,
+		"Evidence summary",
+		"SYSTEM",
+	)
+	if err == nil || !strings.Contains(err.Error(), "invalid EntitlementRef") {
+		t.Fatalf("expected entitlement error, got %v", err)
+	}
+}
+
+func TestNewEvidenceDisputeRejectsEmptyEvidence(t *testing.T) {
+	_, err := NewEvidenceDispute(
+		"disp-abc123",
+		"fr-def456",
+		"ent-ghi789",
+		DisputeTypeOfflineConflict,
+		"",
+		"SYSTEM",
+	)
+	if err == nil || !strings.Contains(err.Error(), "evidence summary is required") {
+		t.Fatalf("expected evidence error, got %v", err)
+	}
+}
+
+func TestNewEvidenceDisputeRejectsEmptyOpenedBy(t *testing.T) {
+	_, err := NewEvidenceDispute(
+		"disp-abc123",
+		"fr-def456",
+		"ent-ghi789",
+		DisputeTypeOfflineConflict,
+		"Evidence summary",
+		"",
+	)
+	if err == nil || !strings.Contains(err.Error(), "openedBy is required") {
+		t.Fatalf("expected openedBy error, got %v", err)
+	}
+}
+
+func TestResolveEvidenceDispute(t *testing.T) {
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+	defer resetClock()
+
+	dispute, _ := NewEvidenceDispute(
+		"disp-abc123",
+		"fr-def456",
+		"ent-ghi789",
+		DisputeTypeOfflineConflict,
+		"Evidence summary",
+		"SYSTEM",
+	)
+	// Clear the open event.
+	dispute.Events()
+
+	err := dispute.Resolve(DisputeResolutionUpheld, "Gate scan confirmed as primary evidence", "ADMIN-001")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dispute.Status != DisputeStatusResolved {
+		t.Fatalf("expected RESOLVED, got %s", dispute.Status)
+	}
+	if dispute.Resolution == nil || *dispute.Resolution != DisputeResolutionUpheld {
+		t.Fatalf("expected UPHELD resolution")
+	}
+	if dispute.ResolutionReason != "Gate scan confirmed as primary evidence" {
+		t.Fatalf("unexpected resolution reason: %s", dispute.ResolutionReason)
+	}
+	if dispute.ResolvedBy != "ADMIN-001" {
+		t.Fatalf("unexpected resolved by: %s", dispute.ResolvedBy)
+	}
+
+	events := dispute.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].EventType() != "EvidenceDisputeResolved" {
+		t.Fatalf("expected EvidenceDisputeResolved, got %s", events[0].EventType())
+	}
+	resolvedEvt, ok := events[0].(EvidenceDisputeResolvedEvent)
+	if !ok {
+		t.Fatalf("expected EvidenceDisputeResolvedEvent type")
+	}
+	if resolvedEvt.DisputeID != "disp-abc123" {
+		t.Fatalf("unexpected dispute id in event: %s", resolvedEvt.DisputeID)
+	}
+	if resolvedEvt.Resolution != DisputeResolutionUpheld {
+		t.Fatalf("unexpected resolution in event: %s", resolvedEvt.Resolution)
+	}
+}
+
+func TestResolveEvidenceDisputeRejectsAlreadyResolved(t *testing.T) {
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+	defer resetClock()
+
+	dispute, _ := NewEvidenceDispute(
+		"disp-abc123",
+		"fr-def456",
+		"ent-ghi789",
+		DisputeTypeOfflineConflict,
+		"Evidence summary",
+		"SYSTEM",
+	)
+	dispute.Events()
+
+	_ = dispute.Resolve(DisputeResolutionUpheld, "Gate scan confirmed", "ADMIN-001")
+
+	err := dispute.Resolve(DisputeResolutionRejected, "Re-evaluated", "ADMIN-002")
+	if err == nil || !strings.Contains(err.Error(), "already RESOLVED") {
+		t.Fatalf("expected error for already resolved, got %v", err)
+	}
+}
+
+func TestResolveEvidenceDisputeRejectsEmptyReason(t *testing.T) {
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+	defer resetClock()
+
+	dispute, _ := NewEvidenceDispute(
+		"disp-abc123",
+		"fr-def456",
+		"ent-ghi789",
+		DisputeTypeOfflineConflict,
+		"Evidence summary",
+		"SYSTEM",
+	)
+	dispute.Events()
+
+	err := dispute.Resolve(DisputeResolutionUpheld, "", "ADMIN-001")
+	if err == nil || !strings.Contains(err.Error(), "reason is required") {
+		t.Fatalf("expected reason error, got %v", err)
+	}
+}
+
+func TestResolveEvidenceDisputeRejectsEmptyResolvedBy(t *testing.T) {
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+	defer resetClock()
+
+	dispute, _ := NewEvidenceDispute(
+		"disp-abc123",
+		"fr-def456",
+		"ent-ghi789",
+		DisputeTypeOfflineConflict,
+		"Evidence summary",
+		"SYSTEM",
+	)
+	dispute.Events()
+
+	err := dispute.Resolve(DisputeResolutionUpheld, "Reason", "")
+	if err == nil || !strings.Contains(err.Error(), "resolvedBy is required") {
+		t.Fatalf("expected resolvedBy error, got %v", err)
+	}
+}
+
+func TestEvidenceDisputeEventsClearedAfterRead(t *testing.T) {
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+	defer resetClock()
+
+	dispute, _ := NewEvidenceDispute(
+		"disp-abc123",
+		"fr-def456",
+		"ent-ghi789",
+		DisputeTypeDuplicateBoarding,
+		"Duplicate gate scan at 10:05",
+		"SYSTEM",
+	)
+
+	events1 := dispute.Events()
+	if len(events1) != 1 {
+		t.Fatalf("expected 1 event on first read, got %d", len(events1))
+	}
+
+	events2 := dispute.Events()
+	if len(events2) != 0 {
+		t.Fatalf("expected 0 events after clearing, got %d", len(events2))
+	}
+}
+
+func TestEvidenceDisputeMultipleTypes(t *testing.T) {
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+	defer resetClock()
+
+	testCases := []struct {
+		name string
+		typ  DisputeType
+	}{
+		{"OfflineConflict", DisputeTypeOfflineConflict},
+		{"DuplicateBoarding", DisputeTypeDuplicateBoarding},
+		{"UnrecognizedCheckIn", DisputeTypeUnrecognizedCheckIn},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dispute, err := NewEvidenceDispute(
+				"disp-abc123",
+				"fr-def456",
+				"ent-ghi789",
+				tc.typ,
+				"Evidence: "+tc.name,
+				"SYSTEM",
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if dispute.DisputeType != tc.typ {
+				t.Fatalf("expected %s, got %s", tc.typ, dispute.DisputeType)
+			}
+		})
+	}
+}

--- a/services/fulfillment/internal/domain/fulfillment_record.go
+++ b/services/fulfillment/internal/domain/fulfillment_record.go
@@ -1,0 +1,273 @@
+package domain
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// FulfillmentRecord is the aggregate root for a traveler's fulfillment on a segment.
+// It records physical travel facts: check-in, boarding, no-show, and completion.
+// It never issues or voids entitlements itself.
+type FulfillmentRecord struct {
+	FulfillmentRecordID FulfillmentRecordID
+	EntitlementID       EntitlementRef
+	SegmentBookingID    SegmentBookingRef
+	JourneyOrderID      OrderRef
+	TravelerID          TravelerRef
+	SegmentRef          SegmentRef
+	Status              FulfillmentStatus
+
+	// Boarding fact recorded (value object).
+	BoardingFact *BoardingFact
+
+	// No-show details.
+	NoShowReason    *NoShowReason
+	NoShowAssessedAt *time.Time
+
+	// Completion details.
+	CompletedAt      *time.Time
+	CompletionSource *CompletionSource
+
+	// Audit trail.
+	AuditTrail []AuditEntry
+
+	// Event log - events pending publication.
+	events []DomainEvent
+
+	// Tracking fields.
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// NewFulfillmentRecord creates a new FulfillmentRecord aggregate.
+func NewFulfillmentRecord(
+	id FulfillmentRecordID,
+	entitlementID EntitlementRef,
+	segmentBookingID SegmentBookingRef,
+	journeyOrderID OrderRef,
+	travelerID TravelerRef,
+	segmentRef SegmentRef,
+) (*FulfillmentRecord, error) {
+	if err := id.Validate(); err != nil {
+		return nil, fmt.Errorf("new fulfillment record: %w", err)
+	}
+	if err := entitlementID.Validate(); err != nil {
+		return nil, fmt.Errorf("new fulfillment record: %w", err)
+	}
+	if err := segmentBookingID.Validate(); err != nil {
+		return nil, fmt.Errorf("new fulfillment record: %w", err)
+	}
+	if err := travelerID.Validate(); err != nil {
+		return nil, fmt.Errorf("new fulfillment record: %w", err)
+	}
+
+	now := timeNow().UTC()
+	return &FulfillmentRecord{
+		FulfillmentRecordID: id,
+		EntitlementID:       entitlementID,
+		SegmentBookingID:    segmentBookingID,
+		JourneyOrderID:      journeyOrderID,
+		TravelerID:          travelerID,
+		SegmentRef:          segmentRef,
+		Status:              FulfillmentStatusReady,
+		AuditTrail:          []AuditEntry{},
+		events:              []DomainEvent{},
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}, nil
+}
+
+// ============================================================
+// Command: RecordCheckIn
+// ============================================================
+
+// RecordCheckIn processes a check-in event. Idempotent if already checked in.
+func (r *FulfillmentRecord) RecordCheckIn(source FulfillmentSource, sourceEventID string, occurredAt time.Time) error {
+	if r.Status == FulfillmentStatusCompleted || r.Status == FulfillmentStatusCancelled {
+		return fmt.Errorf("cannot check in fulfillment record %q in status %s", r.FulfillmentRecordID, r.Status)
+	}
+	if r.Status == FulfillmentStatusNoShow {
+		return fmt.Errorf("cannot check in fulfillment record %q in status NO_SHOW", r.FulfillmentRecordID)
+	}
+	if r.Status == FulfillmentStatusCheckedIn {
+		// Idempotent: already checked in.
+		return nil
+	}
+	if strings.TrimSpace(sourceEventID) == "" {
+		return fmt.Errorf("sourceEventId is required for check-in")
+	}
+
+	prev := r.Status
+	r.Status = FulfillmentStatusCheckedIn
+	r.UpdatedAt = timeNow().UTC()
+	r.appendAuditEntry("RecordCheckIn", string(source), "check-in recorded", prev, r.Status)
+	return nil
+}
+
+// ============================================================
+// Command: VerifyBoarding
+// ============================================================
+
+// VerifyBoarding processes a boarding verification. Idempotent for the same
+// entitlement + segment (duplicate boarding events are ignored).
+func (r *FulfillmentRecord) VerifyBoarding(
+	entitlementID EntitlementRef,
+	source FulfillmentSource,
+	sourceEventID string,
+	occurredAt time.Time,
+	receivedAt time.Time,
+	location *LocationSnapshot,
+) error {
+	if err := entitlementID.Validate(); err != nil {
+		return fmt.Errorf("verify boarding: %w", err)
+	}
+	if r.EntitlementID != entitlementID {
+		return fmt.Errorf("verify boarding: entitlement mismatch: record has %q, got %q", r.EntitlementID, entitlementID)
+	}
+	if strings.TrimSpace(sourceEventID) == "" {
+		return fmt.Errorf("verify boarding: sourceEventId is required")
+	}
+
+	// Check terminal states.
+	switch r.Status {
+	case FulfillmentStatusCompleted, FulfillmentStatusCancelled, FulfillmentStatusNoShow:
+		return fmt.Errorf("cannot verify boarding in status %s", r.Status)
+	}
+
+	// Idempotency: same source + sourceEventID already recorded.
+	if r.BoardingFact != nil && r.BoardingFact.SourceEventID == sourceEventID && r.BoardingFact.Source == source {
+		return nil
+	}
+
+	// Duplicate boarding for same entitlement + segment: if already boarded, silently idempotent.
+	if r.Status == FulfillmentStatusBoarded {
+		return nil
+	}
+
+	prev := r.Status
+	r.BoardingFact = &BoardingFact{
+		EntitlementID:    entitlementID,
+		SegmentBookingID: r.SegmentBookingID,
+		SegmentRef:       r.SegmentRef,
+		Source:           source,
+		SourceEventID:    sourceEventID,
+		OccurredAt:       occurredAt,
+		ReceivedAt:       receivedAt,
+	}
+	r.Status = FulfillmentStatusBoarded
+	r.UpdatedAt = timeNow().UTC()
+	r.appendAuditEntry("VerifyBoarding", string(source), "boarding verified", prev, r.Status)
+
+	r.emit(BoardingVerifiedEvent{
+		FulfillmentRecordID: r.FulfillmentRecordID,
+		EntitlementID:       entitlementID,
+		SegmentBookingID:    r.SegmentBookingID,
+		JourneyOrderID:      r.JourneyOrderID,
+		TravelerID:          r.TravelerID,
+		SegmentRef:          r.SegmentRef,
+		Source:              source,
+		SourceEventID:       sourceEventID,
+		eventTime:           occurredAt,
+		ReceivedAt:          receivedAt,
+		LocationSnapshot:    location,
+	})
+	return nil
+}
+
+// ============================================================
+// Command: RecordNoShow
+// ============================================================
+
+// RecordNoShow records a no-show fact for this fulfillment record.
+func (r *FulfillmentRecord) RecordNoShow(reason NoShowReason, assessedAt time.Time) error {
+	switch r.Status {
+	case FulfillmentStatusCompleted, FulfillmentStatusCancelled:
+		return fmt.Errorf("cannot record no-show in status %s", r.Status)
+	case FulfillmentStatusBoarded:
+		return fmt.Errorf("cannot record no-show: already boarded")
+	case FulfillmentStatusNoShow:
+		// Idempotent: already recorded as no-show.
+		return nil
+	}
+
+	prev := r.Status
+	r.Status = FulfillmentStatusNoShow
+	r.NoShowReason = &reason
+	r.NoShowAssessedAt = &assessedAt
+	r.UpdatedAt = timeNow().UTC()
+	r.appendAuditEntry("RecordNoShow", "SYSTEM", string(reason), prev, r.Status)
+
+	r.emit(NoShowRecordedEvent{
+		FulfillmentRecordID: r.FulfillmentRecordID,
+		EntitlementID:       r.EntitlementID,
+		SegmentBookingID:    r.SegmentBookingID,
+		JourneyOrderID:      r.JourneyOrderID,
+		TravelerID:          r.TravelerID,
+		SegmentRef:          r.SegmentRef,
+		Reason:              reason,
+		assessedAt:          assessedAt,
+	})
+	return nil
+}
+
+// ============================================================
+// Command: CompleteFulfillment
+// ============================================================
+
+// CompleteFulfillment marks the fulfillment as completed.
+func (r *FulfillmentRecord) CompleteFulfillment(source CompletionSource, completedAt time.Time) error {
+	if r.Status == FulfillmentStatusCancelled {
+		return fmt.Errorf("cannot complete cancelled fulfillment")
+	}
+	if r.Status == FulfillmentStatusCompleted {
+		return nil // idempotent
+	}
+	if r.Status != FulfillmentStatusBoarded && r.Status != FulfillmentStatusCheckedIn && r.Status != FulfillmentStatusReady {
+		return fmt.Errorf("cannot complete fulfillment in status %s (must be boarded, checked-in, or ready)", r.Status)
+	}
+
+	prev := r.Status
+	r.Status = FulfillmentStatusCompleted
+	r.CompletedAt = &completedAt
+	r.CompletionSource = &source
+	r.UpdatedAt = timeNow().UTC()
+	r.appendAuditEntry("CompleteFulfillment", string(source), "fulfillment completed", prev, r.Status)
+
+	r.emit(FulfillmentCompletedEvent{
+		FulfillmentRecordID: r.FulfillmentRecordID,
+		EntitlementID:       r.EntitlementID,
+		SegmentBookingID:    r.SegmentBookingID,
+		JourneyOrderID:      r.JourneyOrderID,
+		TravelerID:          r.TravelerID,
+		completedAt:         completedAt,
+		CompletionSource:    source,
+	})
+	return nil
+}
+
+// ============================================================
+// Event Sink
+// ============================================================
+
+// Events returns the pending domain events and clears the event log.
+func (r *FulfillmentRecord) Events() []DomainEvent {
+	events := r.events
+	r.events = nil
+	return events
+}
+
+func (r *FulfillmentRecord) emit(event DomainEvent) {
+	r.events = append(r.events, event)
+}
+
+func (r *FulfillmentRecord) appendAuditEntry(commandID, actor, reason string, prev, new FulfillmentStatus) {
+	r.AuditTrail = append(r.AuditTrail, AuditEntry{
+		CommandID:     commandID,
+		Actor:         actor,
+		Reason:        reason,
+		PreviousState: prev,
+		NewState:      new,
+		OccurredAt:    timeNow().UTC(),
+	})
+}

--- a/services/fulfillment/internal/domain/fulfillment_record_test.go
+++ b/services/fulfillment/internal/domain/fulfillment_record_test.go
@@ -1,0 +1,520 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func resetClock() {
+	timeNow = time.Now
+}
+
+func fixedClock(t *testing.T, now time.Time) {
+	t.Helper()
+	timeNow = func() time.Time { return now }
+}
+
+func TestNewFulfillmentRecord(t *testing.T) {
+	rec, err := NewFulfillmentRecord(
+		"fr-abc123",
+		"ent-def456",
+		"sb-ghi789",
+		"ord-jkl012",
+		"tvl-mno345",
+		"seg-pqr678",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.FulfillmentRecordID != "fr-abc123" {
+		t.Fatalf("unexpected id: %s", rec.FulfillmentRecordID)
+	}
+	if rec.Status != FulfillmentStatusReady {
+		t.Fatalf("expected READY, got %s", rec.Status)
+	}
+	if rec.EntitlementID != "ent-def456" {
+		t.Fatalf("unexpected entitlement: %s", rec.EntitlementID)
+	}
+}
+
+func TestNewFulfillmentRecordRejectsInvalidID(t *testing.T) {
+	_, err := NewFulfillmentRecord(
+		"invalid",
+		"ent-def456",
+		"sb-ghi789",
+		"ord-jkl012",
+		"tvl-mno345",
+		"seg-pqr678",
+	)
+	if err == nil || !strings.Contains(err.Error(), "invalid FulfillmentRecordID") {
+		t.Fatalf("expected id error, got %v", err)
+	}
+}
+
+func TestNewFulfillmentRecordRejectsInvalidEntitlement(t *testing.T) {
+	_, err := NewFulfillmentRecord(
+		"fr-abc123",
+		"invalid-ent",
+		"sb-ghi789",
+		"ord-jkl012",
+		"tvl-mno345",
+		"seg-pqr678",
+	)
+	if err == nil || !strings.Contains(err.Error(), "invalid EntitlementRef") {
+		t.Fatalf("expected entitlement error, got %v", err)
+	}
+}
+
+func TestRecordCheckIn(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	err := rec.RecordCheckIn(FulfillmentSourceStation, "evt-checkin-001", now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Status != FulfillmentStatusCheckedIn {
+		t.Fatalf("expected CHECKED_IN, got %s", rec.Status)
+	}
+	if len(rec.AuditTrail) != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", len(rec.AuditTrail))
+	}
+}
+
+func TestRecordCheckInIdempotent(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	_ = rec.RecordCheckIn(FulfillmentSourceStation, "evt-checkin-001", now)
+	// Second check-in should be idempotent.
+	err := rec.RecordCheckIn(FulfillmentSourceStation, "evt-checkin-001", now)
+	if err != nil {
+		t.Fatalf("expected idempotent check-in, got error: %v", err)
+	}
+	if rec.Status != FulfillmentStatusCheckedIn {
+		t.Fatalf("expected CHECKED_IN, got %s", rec.Status)
+	}
+}
+
+func TestRecordCheckInRejectsAfterCompleted(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	_ = rec.VerifyBoarding(rec.EntitlementID, FulfillmentSourceGate, "evt-board-001", now, now, nil)
+	_ = rec.CompleteFulfillment(CompletionSourceArrival, now.Add(2*time.Hour))
+
+	err := rec.RecordCheckIn(FulfillmentSourceStation, "evt-checkin-late", now)
+	if err == nil || !strings.Contains(err.Error(), "cannot check in") {
+		t.Fatalf("expected error for completed check-in, got %v", err)
+	}
+}
+
+func TestRecordCheckInRejectsAfterNoShow(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	_ = rec.RecordNoShow(NoShowReasonWindowExpired, now)
+
+	err := rec.RecordCheckIn(FulfillmentSourceStation, "evt-checkin-late", now)
+	if err == nil || !strings.Contains(err.Error(), "NO_SHOW") {
+		t.Fatalf("expected error for no-show check-in, got %v", err)
+	}
+}
+
+func TestVerifyBoarding(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	err := rec.VerifyBoarding(rec.EntitlementID, FulfillmentSourceGate, "evt-board-001", now, now, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Status != FulfillmentStatusBoarded {
+		t.Fatalf("expected BOARDED, got %s", rec.Status)
+	}
+	if rec.BoardingFact == nil {
+		t.Fatalf("expected boarding fact")
+	}
+	if rec.BoardingFact.SourceEventID != "evt-board-001" {
+		t.Fatalf("unexpected source event id: %s", rec.BoardingFact.SourceEventID)
+	}
+
+	// Verify event was emitted.
+	events := rec.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].EventType() != "BoardingVerified" {
+		t.Fatalf("expected BoardingVerified, got %s", events[0].EventType())
+	}
+}
+
+func TestVerifyBoardingEntitlementMismatch(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+
+	err := rec.VerifyBoarding("ent-wrong", FulfillmentSourceGate, "evt-board-001", now, now, nil)
+	if err == nil || !strings.Contains(err.Error(), "entitlement mismatch") {
+		t.Fatalf("expected entitlement mismatch error, got %v", err)
+	}
+}
+
+func TestVerifyBoardingDuplicateIdempotent(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	_ = rec.VerifyBoarding(rec.EntitlementID, FulfillmentSourceGate, "evt-board-001", now, now, nil)
+	// Clear events from first boarding.
+	rec.Events()
+
+	// Same source + sourceEventID => idempotent, no event emitted.
+	err := rec.VerifyBoarding(rec.EntitlementID, FulfillmentSourceGate, "evt-board-001", now, now, nil)
+	if err != nil {
+		t.Fatalf("expected idempotent boarding, got error: %v", err)
+	}
+	if rec.Status != FulfillmentStatusBoarded {
+		t.Fatalf("expected BOARDED, got %s", rec.Status)
+	}
+	// No new events.
+	events := rec.Events()
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events for idempotent boarding, got %d", len(events))
+	}
+}
+
+func TestVerifyBoardingDuplicateForSameEntitlementSegment(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	_ = rec.VerifyBoarding(rec.EntitlementID, FulfillmentSourceGate, "evt-board-001", now, now, nil)
+	rec.Events()
+
+	// Different sourceEventID but already boarded => idempotent (no event, no state change).
+	err := rec.VerifyBoarding(rec.EntitlementID, FulfillmentSourceConductor, "evt-board-002", now, now, nil)
+	if err != nil {
+		t.Fatalf("expected idempotent duplicate boarding, got error: %v", err)
+	}
+	if rec.Status != FulfillmentStatusBoarded {
+		t.Fatalf("expected BOARDED, got %s", rec.Status)
+	}
+	events := rec.Events()
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events for duplicate boarding, got %d", len(events))
+	}
+}
+
+func TestVerifyBoardingRejectsAfterCompleted(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	_ = rec.VerifyBoarding(rec.EntitlementID, FulfillmentSourceGate, "evt-board-001", now, now, nil)
+	_ = rec.CompleteFulfillment(CompletionSourceArrival, now.Add(2*time.Hour))
+
+	err := rec.VerifyBoarding(rec.EntitlementID, FulfillmentSourceGate, "evt-board-002", now, now, nil)
+	if err == nil || !strings.Contains(err.Error(), "cannot verify boarding") {
+		t.Fatalf("expected error for completed boarding, got %v", err)
+	}
+}
+
+func TestVerifyBoardingRejectsAfterNoShow(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	_ = rec.RecordNoShow(NoShowReasonWindowExpired, now)
+
+	err := rec.VerifyBoarding(rec.EntitlementID, FulfillmentSourceGate, "evt-board-001", now, now, nil)
+	if err == nil || !strings.Contains(err.Error(), "cannot verify boarding") {
+		t.Fatalf("expected error for no-show boarding, got %v", err)
+	}
+}
+
+func TestRecordNoShow(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	err := rec.RecordNoShow(NoShowReasonWindowExpired, now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Status != FulfillmentStatusNoShow {
+		t.Fatalf("expected NO_SHOW, got %s", rec.Status)
+	}
+	if rec.NoShowReason == nil || *rec.NoShowReason != NoShowReasonWindowExpired {
+		t.Fatalf("expected window expired reason")
+	}
+
+	events := rec.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].EventType() != "NoShowRecorded" {
+		t.Fatalf("expected NoShowRecorded, got %s", events[0].EventType())
+	}
+}
+
+func TestRecordNoShowIdempotent(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	_ = rec.RecordNoShow(NoShowReasonWindowExpired, now)
+	rec.Events()
+
+	err := rec.RecordNoShow(NoShowReasonManualRecord, now)
+	if err != nil {
+		t.Fatalf("expected idempotent no-show, got error: %v", err)
+	}
+	// No new events for idempotent no-show.
+	events := rec.Events()
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events, got %d", len(events))
+	}
+}
+
+func TestRecordNoShowRejectsAfterBoarded(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	_ = rec.VerifyBoarding(rec.EntitlementID, FulfillmentSourceGate, "evt-board-001", now, now, nil)
+
+	err := rec.RecordNoShow(NoShowReasonWindowExpired, now)
+	if err == nil || !strings.Contains(err.Error(), "already boarded") {
+		t.Fatalf("expected error for boarded no-show, got %v", err)
+	}
+}
+
+func TestRecordNoShowRejectsAfterCompleted(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	_ = rec.VerifyBoarding(rec.EntitlementID, FulfillmentSourceGate, "evt-board-001", now, now, nil)
+	_ = rec.CompleteFulfillment(CompletionSourceArrival, now.Add(2*time.Hour))
+
+	err := rec.RecordNoShow(NoShowReasonWindowExpired, now)
+	if err == nil || !strings.Contains(err.Error(), "cannot record no-show") {
+		t.Fatalf("expected error for completed no-show, got %v", err)
+	}
+}
+
+func TestCompleteFulfillment(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	_ = rec.VerifyBoarding(rec.EntitlementID, FulfillmentSourceGate, "evt-board-001", now, now, nil)
+	rec.Events()
+
+	completedAt := now.Add(2 * time.Hour)
+	err := rec.CompleteFulfillment(CompletionSourceArrival, completedAt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Status != FulfillmentStatusCompleted {
+		t.Fatalf("expected COMPLETED, got %s", rec.Status)
+	}
+	if rec.CompletedAt == nil || !rec.CompletedAt.Equal(completedAt) {
+		t.Fatalf("unexpected completed at")
+	}
+	if rec.CompletionSource == nil || *rec.CompletionSource != CompletionSourceArrival {
+		t.Fatalf("unexpected completion source")
+	}
+
+	events := rec.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].EventType() != "FulfillmentCompleted" {
+		t.Fatalf("expected FulfillmentCompleted, got %s", events[0].EventType())
+	}
+}
+
+func TestCompleteFulfillmentFromCheckedIn(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	_ = rec.RecordCheckIn(FulfillmentSourceStation, "evt-checkin-001", now)
+	rec.Events()
+
+	err := rec.CompleteFulfillment(CompletionSourceProvider, now.Add(3*time.Hour))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Status != FulfillmentStatusCompleted {
+		t.Fatalf("expected COMPLETED, got %s", rec.Status)
+	}
+}
+
+func TestCompleteFulfillmentIdempotent(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	_ = rec.VerifyBoarding(rec.EntitlementID, FulfillmentSourceGate, "evt-board-001", now, now, nil)
+	_ = rec.CompleteFulfillment(CompletionSourceArrival, now.Add(2*time.Hour))
+	rec.Events()
+
+	err := rec.CompleteFulfillment(CompletionSourceSystem, now.Add(3*time.Hour))
+	if err != nil {
+		t.Fatalf("expected idempotent completion, got error: %v", err)
+	}
+	events := rec.Events()
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events, got %d", len(events))
+	}
+}
+
+func TestCompleteFulfillmentRejectsCancelled(t *testing.T) {
+	// We don't have a Cancel command yet, but we can test the guard for
+	// the pre-completion states. This test just validates that cancelled
+	// status prevents completion.
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	// Force status to cancelled (no cancel command in foundation phase).
+	rec.Status = FulfillmentStatusCancelled
+
+	err := rec.CompleteFulfillment(CompletionSourceSystem, now)
+	if err == nil || !strings.Contains(err.Error(), "cannot complete cancelled") {
+		t.Fatalf("expected error for cancelled, got %v", err)
+	}
+}
+
+func TestVerifyBoardingWithLocationSnapshot(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	loc := &LocationSnapshot{
+		PlaceID:     "plc-abc",
+		NodeID:      "tnd-def",
+		DisplayName: "Gate A1",
+	}
+	err := rec.VerifyBoarding(rec.EntitlementID, FulfillmentSourceGate, "evt-board-001", now, now, loc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Status != FulfillmentStatusBoarded {
+		t.Fatalf("expected BOARDED, got %s", rec.Status)
+	}
+
+	events := rec.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	evt, ok := events[0].(BoardingVerifiedEvent)
+	if !ok {
+		t.Fatalf("expected BoardingVerifiedEvent")
+	}
+	if evt.LocationSnapshot == nil {
+		t.Fatalf("expected location snapshot")
+	}
+	if evt.LocationSnapshot.PlaceID != "plc-abc" {
+		t.Fatalf("unexpected place id: %s", evt.LocationSnapshot.PlaceID)
+	}
+}
+
+func TestFulfillmentRecordEventsClearedAfterRead(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	_ = rec.VerifyBoarding(rec.EntitlementID, FulfillmentSourceGate, "evt-board-001", now, now, nil)
+
+	events1 := rec.Events()
+	if len(events1) != 1 {
+		t.Fatalf("expected 1 event on first read, got %d", len(events1))
+	}
+
+	events2 := rec.Events()
+	if len(events2) != 0 {
+		t.Fatalf("expected 0 events after clearing, got %d", len(events2))
+	}
+}
+
+func TestAuditTrailRecording(t *testing.T) {
+	rec, _ := NewFulfillmentRecord(
+		"fr-abc123", "ent-def456", "sb-ghi789", "ord-jkl012", "tvl-mno345", "seg-pqr678",
+	)
+	now := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
+	fixedClock(t, now)
+
+	_ = rec.RecordCheckIn(FulfillmentSourceStation, "evt-checkin-001", now)
+	_ = rec.VerifyBoarding(rec.EntitlementID, FulfillmentSourceGate, "evt-board-001", now, now, nil)
+
+	if len(rec.AuditTrail) != 2 {
+		t.Fatalf("expected 2 audit entries, got %d", len(rec.AuditTrail))
+	}
+	if rec.AuditTrail[0].CommandID != "RecordCheckIn" {
+		t.Fatalf("expected first entry to be RecordCheckIn")
+	}
+	if rec.AuditTrail[0].PreviousState != FulfillmentStatusReady {
+		t.Fatalf("expected previous state READY, got %s", rec.AuditTrail[0].PreviousState)
+	}
+	if rec.AuditTrail[0].NewState != FulfillmentStatusCheckedIn {
+		t.Fatalf("expected new state CHECKED_IN, got %s", rec.AuditTrail[0].NewState)
+	}
+	if rec.AuditTrail[1].CommandID != "VerifyBoarding" {
+		t.Fatalf("expected second entry to be VerifyBoarding")
+	}
+	if rec.AuditTrail[1].PreviousState != FulfillmentStatusCheckedIn {
+		t.Fatalf("expected previous state CHECKED_IN, got %s", rec.AuditTrail[1].PreviousState)
+	}
+	if rec.AuditTrail[1].NewState != FulfillmentStatusBoarded {
+		t.Fatalf("expected new state BOARDED, got %s", rec.AuditTrail[1].NewState)
+	}
+}

--- a/services/fulfillment/internal/domain/profile.go
+++ b/services/fulfillment/internal/domain/profile.go
@@ -15,8 +15,16 @@ func Profile() ServiceProfile {
 		Domain:       "Fulfillment",
 		Language:     "golang",
 		Phase:        "phase-1-limited",
-		WorkPackages: []string{"WP-13"},
-		Owns:         []string{"FulfillmentRecord", "BoardingVerified", "NoShow", "EvidenceDispute"},
+		WorkPackages: []string{"REQ-018"},
+		Owns: []string{
+			"FulfillmentRecord aggregate",
+			"EvidenceDispute aggregate",
+			"BoardingVerified event",
+			"NoShowRecorded event",
+			"FulfillmentCompleted event",
+			"EvidenceDisputeOpened event",
+			"EvidenceDisputeResolved event",
+		},
 	}
 }
 
@@ -24,5 +32,5 @@ func Health() string {
 	return "ok"
 }
 
-const WorkPackageSummary = "WP-13"
-const OwnershipSummary = "FulfillmentRecord, BoardingVerified, NoShow, EvidenceDispute"
+const WorkPackageSummary = "REQ-018 Fulfillment facts domain foundation"
+const OwnershipSummary = "FulfillmentRecord, EvidenceDispute, BoardingVerified, NoShowRecorded, FulfillmentCompleted, EvidenceDisputeOpened, EvidenceDisputeResolved"

--- a/services/fulfillment/internal/domain/profile_test.go
+++ b/services/fulfillment/internal/domain/profile_test.go
@@ -13,4 +13,15 @@ func TestSkeletonProfileMatchesDomain(t *testing.T) {
 	if Health() != "ok" {
 		t.Fatalf("unexpected health value")
 	}
+	// Verify REQ-018 is listed as a work package.
+	found := false
+	for _, wp := range profile.WorkPackages {
+		if wp == "REQ-018" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("REQ-018 not found in work packages: %v", profile.WorkPackages)
+	}
 }

--- a/services/fulfillment/internal/domain/types.go
+++ b/services/fulfillment/internal/domain/types.go
@@ -1,0 +1,290 @@
+package domain
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// ============================================================
+// Canonical ID types following docs/08-contracts/shared-primitives.md
+// ============================================================
+
+// FulfillmentRecordID is a fulfillment record identifier (fr-<uuid>).
+type FulfillmentRecordID string
+
+func (id FulfillmentRecordID) Validate() error {
+	if matched, _ := regexp.MatchString(`^fr-[a-zA-Z0-9\-]+$`, string(id)); !matched {
+		return fmt.Errorf("invalid FulfillmentRecordID: %q", string(id))
+	}
+	return nil
+}
+
+// EvidenceDisputeID is a dispute identifier (disp-<uuid>).
+type EvidenceDisputeID string
+
+func (id EvidenceDisputeID) Validate() error {
+	if matched, _ := regexp.MatchString(`^disp-[a-zA-Z0-9\-]+$`, string(id)); !matched {
+		return fmt.Errorf("invalid EvidenceDisputeID: %q", string(id))
+	}
+	return nil
+}
+
+// EntitlementRef references an entitlement (ent-<uuid>).
+type EntitlementRef string
+
+func (r EntitlementRef) Validate() error {
+	if matched, _ := regexp.MatchString(`^ent-[a-zA-Z0-9\-]+$`, string(r)); !matched {
+		return fmt.Errorf("invalid EntitlementRef: %q", string(r))
+	}
+	return nil
+}
+
+// SegmentBookingRef references a segment booking (sb-<uuid>).
+type SegmentBookingRef string
+
+func (r SegmentBookingRef) Validate() error {
+	if matched, _ := regexp.MatchString(`^sb-[a-zA-Z0-9\-]+$`, string(r)); !matched {
+		return fmt.Errorf("invalid SegmentBookingRef: %q", string(r))
+	}
+	return nil
+}
+
+// OrderRef references a journey order (ord-<uuid>).
+type OrderRef string
+
+func (r OrderRef) Validate() error {
+	if matched, _ := regexp.MatchString(`^ord-[a-zA-Z0-9\-]+$`, string(r)); !matched {
+		return fmt.Errorf("invalid OrderRef: %q", string(r))
+	}
+	return nil
+}
+
+// TravelerRef references a traveler (tvl-<uuid>).
+type TravelerRef string
+
+func (r TravelerRef) Validate() error {
+	if matched, _ := regexp.MatchString(`^tvl-[a-zA-Z0-9\-]+$`, string(r)); !matched {
+		return fmt.Errorf("invalid TravelerRef: %q", string(r))
+	}
+	return nil
+}
+
+// SegmentRef references a service segment (seg-<uuid>).
+type SegmentRef string
+
+func (r SegmentRef) Validate() error {
+	if matched, _ := regexp.MatchString(`^seg-[a-zA-Z0-9\-]+$`, string(r)); !matched {
+		return fmt.Errorf("invalid SegmentRef: %q", string(r))
+	}
+	return nil
+}
+
+// ============================================================
+// Enums
+// ============================================================
+
+// FulfillmentStatus represents the lifecycle state of a FulfillmentRecord.
+type FulfillmentStatus string
+
+const (
+	FulfillmentStatusNotOpened  FulfillmentStatus = "NOT_OPENED"
+	FulfillmentStatusReady      FulfillmentStatus = "READY"
+	FulfillmentStatusCheckedIn  FulfillmentStatus = "CHECKED_IN"
+	FulfillmentStatusBoarded    FulfillmentStatus = "BOARDED"
+	FulfillmentStatusCompleted  FulfillmentStatus = "COMPLETED"
+	FulfillmentStatusNoShow     FulfillmentStatus = "NO_SHOW"
+	FulfillmentStatusCancelled  FulfillmentStatus = "CANCELLED"
+)
+
+// FulfillmentSource represents the source of a fulfillment fact.
+type FulfillmentSource string
+
+const (
+	FulfillmentSourceGate      FulfillmentSource = "GATE"
+	FulfillmentSourceStation   FulfillmentSource = "STATION"
+	FulfillmentSourceProvider  FulfillmentSource = "PROVIDER"
+	FulfillmentSourceConductor FulfillmentSource = "CONDUCTOR"
+	FulfillmentSourceAdmin     FulfillmentSource = "ADMIN"
+	FulfillmentSourceSystem    FulfillmentSource = "SYSTEM"
+)
+
+// NoShowReason represents the reason for a no-show record.
+type NoShowReason string
+
+const (
+	NoShowReasonWindowExpired      NoShowReason = "BOARDING_WINDOW_EXPIRED"
+	NoShowReasonVerificationFailed NoShowReason = "VERIFICATION_FAILED"
+	NoShowReasonManualRecord       NoShowReason = "MANUAL_RECORD"
+)
+
+// DisputeType represents the type of evidence dispute.
+type DisputeType string
+
+const (
+	DisputeTypeOfflineConflict     DisputeType = "OFFLINE_EVIDENCE_CONFLICT"
+	DisputeTypeDuplicateBoarding   DisputeType = "DUPLICATE_BOARDING"
+	DisputeTypeUnrecognizedCheckIn DisputeType = "UNRECOGNIZED_CHECK_IN"
+)
+
+// DisputeStatus represents the lifecycle state of an EvidenceDispute.
+type DisputeStatus string
+
+const (
+	DisputeStatusOpen     DisputeStatus = "OPEN"
+	DisputeStatusResolved DisputeStatus = "RESOLVED"
+)
+
+// DisputeResolution represents the outcome of a resolved dispute.
+type DisputeResolution string
+
+const (
+	DisputeResolutionUpheld       DisputeResolution = "UPHELD"
+	DisputeResolutionRejected     DisputeResolution = "REJECTED"
+	DisputeResolutionInconclusive DisputeResolution = "INCONCLUSIVE"
+)
+
+// CompletionSource represents the source of fulfillment completion.
+type CompletionSource string
+
+const (
+	CompletionSourceArrival  CompletionSource = "ARRIVAL"
+	CompletionSourceProvider CompletionSource = "PROVIDER"
+	CompletionSourceAdmin    CompletionSource = "ADMIN"
+	CompletionSourceSystem   CompletionSource = "SYSTEM"
+)
+
+// ============================================================
+// Location Snapshot
+// ============================================================
+
+// LocationSnapshot captures the location context of a fulfillment event.
+type LocationSnapshot struct {
+	PlaceID     string `json:"placeId,omitempty"`
+	NodeID      string `json:"nodeId,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+}
+
+// ============================================================
+// Domain Events
+// ============================================================
+
+// DomainEvent is the interface all fulfillment domain events implement.
+type DomainEvent interface {
+	EventType() string
+	OccurredAt() time.Time
+}
+
+// BoardingVerifiedEvent is emitted when boarding is verified.
+type BoardingVerifiedEvent struct {
+	FulfillmentRecordID FulfillmentRecordID
+	EntitlementID       EntitlementRef
+	SegmentBookingID    SegmentBookingRef
+	JourneyOrderID      OrderRef
+	TravelerID          TravelerRef
+	SegmentRef          SegmentRef
+	Source              FulfillmentSource
+	SourceEventID       string
+	eventTime           time.Time
+	ReceivedAt          time.Time
+	LocationSnapshot    *LocationSnapshot
+}
+
+func (e BoardingVerifiedEvent) EventType() string   { return "BoardingVerified" }
+func (e BoardingVerifiedEvent) OccurredAt() time.Time { return e.eventTime }
+
+// NoShowRecordedEvent is emitted when a no-show is recorded.
+type NoShowRecordedEvent struct {
+	FulfillmentRecordID FulfillmentRecordID
+	EntitlementID       EntitlementRef
+	SegmentBookingID    SegmentBookingRef
+	JourneyOrderID      OrderRef
+	TravelerID          TravelerRef
+	SegmentRef          SegmentRef
+	Reason              NoShowReason
+	assessedAt          time.Time
+}
+
+func (e NoShowRecordedEvent) EventType() string   { return "NoShowRecorded" }
+func (e NoShowRecordedEvent) OccurredAt() time.Time { return e.assessedAt }
+
+// FulfillmentCompletedEvent is emitted when fulfillment is completed.
+type FulfillmentCompletedEvent struct {
+	FulfillmentRecordID FulfillmentRecordID
+	EntitlementID       EntitlementRef
+	SegmentBookingID    SegmentBookingRef
+	JourneyOrderID      OrderRef
+	TravelerID          TravelerRef
+	completedAt         time.Time
+	CompletionSource    CompletionSource
+}
+
+func (e FulfillmentCompletedEvent) EventType() string   { return "FulfillmentCompleted" }
+func (e FulfillmentCompletedEvent) OccurredAt() time.Time { return e.completedAt }
+
+// EvidenceDisputeOpenedEvent is emitted when a dispute is opened.
+type EvidenceDisputeOpenedEvent struct {
+	DisputeID           EvidenceDisputeID
+	FulfillmentRecordID FulfillmentRecordID
+	EntitlementID       EntitlementRef
+	DisputeType         DisputeType
+	EvidenceSummary     string
+	openedAt            time.Time
+	OpenedBy            string
+}
+
+func (e EvidenceDisputeOpenedEvent) EventType() string   { return "EvidenceDisputeOpened" }
+func (e EvidenceDisputeOpenedEvent) OccurredAt() time.Time { return e.openedAt }
+
+// EvidenceDisputeResolvedEvent is emitted when a dispute is resolved.
+type EvidenceDisputeResolvedEvent struct {
+	DisputeID           EvidenceDisputeID
+	FulfillmentRecordID FulfillmentRecordID
+	Resolution          DisputeResolution
+	Reason              string
+	resolvedAt          time.Time
+	ResolvedBy          string
+}
+
+func (e EvidenceDisputeResolvedEvent) EventType() string   { return "EvidenceDisputeResolved" }
+func (e EvidenceDisputeResolvedEvent) OccurredAt() time.Time { return e.resolvedAt }
+
+// ============================================================
+// Value Objects for Events
+// ============================================================
+
+// BoardingFact is a value object representing a verified boarding fact.
+type BoardingFact struct {
+	EntitlementID    EntitlementRef
+	SegmentBookingID SegmentBookingRef
+	SegmentRef       SegmentRef
+	Source           FulfillmentSource
+	SourceEventID    string
+	OccurredAt       time.Time
+	ReceivedAt       time.Time
+}
+
+// Validate checks that the boarding fact references a known entitlement.
+func (f BoardingFact) Validate() error {
+	if err := f.EntitlementID.Validate(); err != nil {
+		return fmt.Errorf("boarding fact: %w", err)
+	}
+	if err := f.SegmentBookingID.Validate(); err != nil {
+		return fmt.Errorf("boarding fact: %w", err)
+	}
+	if strings.TrimSpace(f.SourceEventID) == "" {
+		return fmt.Errorf("boarding fact: sourceEventId is required")
+	}
+	return nil
+}
+
+// AuditEntry represents a single audit trail entry.
+type AuditEntry struct {
+	CommandID     string
+	Actor         string
+	Reason        string
+	PreviousState FulfillmentStatus
+	NewState      FulfillmentStatus
+	OccurredAt    time.Time
+}


### PR DESCRIPTION
Implement the Fulfillment domain foundation in Go.

## Changes

- **FulfillmentRecord aggregate** with RecordCheckIn, VerifyBoarding, RecordNoShow, CompleteFulfillment commands
- **EvidenceDispute aggregate** with OpenEvidenceDispute, ResolveEvidenceDispute commands
- **Domain events**: BoardingVerified, NoShowRecorded, FulfillmentCompleted, EvidenceDisputeOpened, EvidenceDisputeResolved
- **Contract specification** at docs/08-contracts/events/fulfillment.md
- **Canonical ID types** following shared-primitives.md conventions
- **Unit tests** for all aggregates covering invariants, idempotency, state transitions, and event emission
- Updated service profile, service-catalog.json, and project-index.yaml

## Key invariants

- Gate/station check-in events map to Boarded facts via entitlement reference; a fact must reference a known EntitlementRef.
- Without a trusted completion fact, entitlements are never auto-marked Used.
- Duplicate boarding events for the same entitlement + segment are idempotent.
- Offline evidence disputes are recorded as separate fact records with their own lifecycle, never mutating the original fact.

## Validation

- `cd services/fulfillment && go test ./...` passes (35 tests)
- `make check` passes for all fulfillment-related checks