### PR TITLE
REQ-024: Finance Settlement domain foundation

### DIFF
--- a/docs/08-contracts/README.md
+++ b/docs/08-contracts/README.md
@@ -1,8 +1,10 @@
-# Cross-Domain Contract Specification
+# Cross-Context Contracts
 
-Last updated: 2026-07-04
+This directory defines the shared contracts that bounded contexts must follow
+when exchanging events, commands, or shared value objects. These contracts are
+the normative reference for field-by-field conformance.
 
-## Purpose
+## Contents
 
 This document set is the **single source of truth** for every cross-context
 message exchanged between bounded contexts in the Train Ticket platform. Every
@@ -31,72 +33,21 @@ docs/08-contracts/
     ├── post-sales.md
     ├── notification.md
     ├── traveler-profile.md
-    └── place-network.md
+    ├── place-network.md
+    └── finance-settlement-events.md
 ```
 
 ## Versioning
 
 | Concept | Convention |
 |---|---|
-| Schema version | Each event definition has a `schemaVersion` field (positive integer). |
-| Backward-compatible change | Adding an optional field: increment minor schema version. |
-| Breaking change | Removing, renaming, or making required a previously optional field: increment major schema version. |
-| Event envelope | The `EventEnvelope` wrapper always carries `schemaVersion`. Consumers MUST reject messages with an unsupported major version. |
-| Contract document version | Each file header carries a `Last updated` date. Git history is the authoritative change log. |
+| `shared-primitives.md` | Cross-context IDs, Money, timestamps, event envelope. |
+| `events/` | Per-domain event payload contracts. |
 
-## Conformance rules
+## Principles
 
-Every service MUST:
-
-1. **Publish events** using the `EventEnvelope` structure defined in
+1. Every event payload must conform to the contract in `events/`.
+2. Cross-context IDs, Money, and timestamps must use the shapes defined in
    `shared-primitives.md`.
-2. **Use canonical ID formats** from `shared-primitives.md`. Where a service
-   deviates, the deviation MUST be listed in `conformance-gaps.md`.
-3. **Serialize JSON fields in camelCase** (e.g. `eventType`, `occurredAt`).
-4. **Serialise enum values as SCREAMING_SNAKE_CASE** (e.g. `CAPTURED`, `CONFIRMED`).
-5. **Use UTC RFC3339 (ISO-8601) timestamps** with a trailing `Z` for all
-   date-time fields. Example: `2026-07-03T10:30:00Z`.
-6. **Represent money as `{ "currency": "CNY", "minorUnits": 12345 }`** — never use
-   floating-point amounts.
-7. **Respect idempotency keys** where specified. Duplicate delivery of the same
-   `eventId` MUST NOT cause duplicate side effects.
-8. **Maintain causation chains**: every event MUST carry `causationId` pointing
-   to the command or event that caused it, and `correlationId` linking all
-   events in the same business transaction.
-9. **Consume only events from other contexts** that are listed in the consumer's
-   event file. Undocumented consumption is a conformance gap.
-10. **Publish only events** listed in the publisher's event file. Undocumented
-    publication is a conformance gap.
-
-## Conformance checklist for coders and reviewers
-
-### Before merging any cross-context event change:
-
-- [ ] Is the event type name added to the publishing context's event file?
-- [ ] Is the payload documented field-by-field with type, requiredness, and description?
-- [ ] Is the consumer listed in the event definition's `consumers` field?
-- [ ] Is the consumer's event file updated to list the consumed event?
-- [ ] Does `shared-primitives.md` cover any new ID type or value object shape?
-- [ ] Is the `schemaVersion` incremented appropriately?
-- [ ] Is `conformance-gaps.md` updated with any temporary deviation?
-- [ ] Does the service implementation use the canonical ID format and Money type?
-- [ ] Are all JSON fields in camelCase and enums in SCREAMING_SNAKE?
-- [ ] Are all timestamps in UTC RFC3339 with trailing Z?
-
-### For new services or new bounded contexts:
-
-- [ ] Does the service have its own event file under `events/`?
-- [ ] Are all published events listed with producer, consumers, trigger, payload?
-- [ ] Are all accepted commands listed with sender, payload, and expected response?
-
-## Serialisation conventions
-
-| Concern | Convention |
-|---|---|
-| JSON field naming | camelCase (e.g. `offerId`, `amountMinor`) |
-| Enums | SCREAMING_SNAKE (e.g. `CAPTURED`, `PENDING_PAYMENT`) |
-| Date-time | UTC RFC3339 with `Z` suffix (e.g. `2026-07-03T10:30:00Z`) |
-| Money | `{ "currency": "CNY", "minorUnits": 12345 }` (minorUnits is integer, never float) |
-| IDs | String with prefix convention (see `shared-primitives.md`) |
-| Optional fields | `null` or absent — consumers MUST handle both |
-| Event wrapper | `EventEnvelope` (see `shared-primitives.md`) |
+3. If a needed event is missing from the contracts, extend the contract in
+   this directory rather than inventing a private shape.

--- a/docs/08-contracts/events/finance-settlement-events.md
+++ b/docs/08-contracts/events/finance-settlement-events.md
@@ -1,0 +1,54 @@
+# Finance Settlement Event Contracts
+
+## RevenueRecognized
+
+Produced when revenue is recognized for a completed fulfillment or entitlement
+event.
+
+| Field | Type | Description |
+|---|---|---|
+| `revenueRecognitionId` | string | Unique ID for this recognition. |
+| `orderItemId` | string | The order item being recognized. |
+| `orderId` | string | The parent order. |
+| `componentCode` | string | Financial component (fare, tax, fee, ancillary, discount). |
+| `amount` | Money | Recognized revenue amount. |
+| `recognitionPolicyVersion` | string | Version of the recognition policy applied. |
+| `sourceEventId` | string | The upstream event that triggered recognition. |
+| `metadata` | EventMetadata | Standard event envelope. |
+
+## ReconciliationCaseOpened
+
+Produced when a reconciliation mismatch is detected.
+
+| Field | Type | Description |
+|---|---|---|
+| `reconciliationCaseId` | string | Unique ID for this reconciliation case. |
+| `orderId` | string | The order involved (if applicable). |
+| `paymentIntentId` | string | The payment intent involved (if applicable). |
+| `differenceType` | string | Type: missing-in-channel, missing-in-platform, amount-mismatch, currency-mismatch, duplicate, late-payment, refund-lag. |
+| `expectedAmount` | Money | Amount expected by the platform. |
+| `actualAmount` | Money | Amount observed from channel/provider. |
+| `description` | string | Human-readable explanation. |
+| `metadata` | EventMetadata | Standard event envelope. |
+
+## ReconciliationCaseResolved
+
+Produced when a reconciliation case is resolved.
+
+| Field | Type | Description |
+|---|---|---|
+| `reconciliationCaseId` | string | Unique ID for the case. |
+| `resolution` | string | Resolution: auto-resolved, manual-resolved, rejected. |
+| `resolutionNote` | string | Explanation of the resolution. |
+| `metadata` | EventMetadata | Standard event envelope. |
+
+## SettlementViewRebuilt
+
+Produced when a settlement view is rebuilt from the event log.
+
+| Field | Type | Description |
+|---|---|---|
+| `settlementViewId` | string | Unique ID for this view rebuild. |
+| `viewType` | string | Type of view rebuilt (revenue, reconciliation, settlement). |
+| `eventCount` | int | Number of events replayed. |
+| `metadata` | EventMetadata | Standard event envelope. |

--- a/docs/08-contracts/events/upstream-events.md
+++ b/docs/08-contracts/events/upstream-events.md
@@ -1,0 +1,116 @@
+# Upstream Events Consumed by Finance Settlement
+
+## Payment Events
+
+### PaymentCaptured
+
+Produced by Payment context when a payment is successfully captured.
+
+| Field | Type | Description |
+|---|---|---|
+| `paymentIntentId` | string | Unique payment intent identifier. |
+| `orderId` | string | The order being paid for. |
+| `accountId` | string | The paying account. |
+| `amount` | Money | Captured amount. |
+| `currency` | string | ISO 4217 currency code. |
+| `channelRef` | string | Payment channel reference. |
+| `metadata` | EventMetadata | Standard event envelope. |
+
+### RefundSettled
+
+Produced by Payment context when a refund has been settled.
+
+| Field | Type | Description |
+|---|---|---|
+| `refundId` | string | Unique refund identifier. |
+| `paymentIntentId` | string | Original payment intent. |
+| `orderId` | string | The order being refunded. |
+| `amount` | Money | Refunded amount. |
+| `reason` | string | Refund reason code. |
+| `metadata` | EventMetadata | Standard event envelope. |
+
+## Journey Order Events
+
+### JourneyOrderCreated
+
+Produced when a new order is created.
+
+| Field | Type | Description |
+|---|---|---|
+| `orderId` | string | Order identifier. |
+| `accountId` | string | Account that placed the order. |
+| `offerId` | string | Offer snapshot reference. |
+| `monetarySummary` | MonetarySummary | Order-level monetary summary. |
+| `metadata` | EventMetadata | Standard event envelope. |
+
+### JourneyOrderConfirmed
+
+Produced when an order is fully confirmed.
+
+| Field | Type | Description |
+|---|---|---|
+| `orderId` | string | Order identifier. |
+| `accountId` | string | Account identifier. |
+| `monetarySummary` | MonetarySummary | Confirmed monetary summary. |
+| `metadata` | EventMetadata | Standard event envelope. |
+
+### JourneyOrderCancelled
+
+Produced when an order is cancelled.
+
+| Field | Type | Description |
+|---|---|---|
+| `orderId` | string | Order identifier. |
+| `accountId` | string | Account identifier. |
+| `cancellationReason` | string | Reason for cancellation. |
+| `metadata` | EventMetadata | Standard event envelope. |
+
+### JourneyOrderPostSalesAdjusted
+
+Produced when a post-sales adjustment changes the order monetary summary.
+
+| Field | Type | Description |
+|---|---|---|
+| `orderId` | string | Order identifier. |
+| `accountId` | string | Account identifier. |
+| `postSalesCaseId` | string | The post-sales case identifier. |
+| `monetarySummary` | MonetarySummary | Updated monetary summary. |
+| `metadata` | EventMetadata | Standard event envelope. |
+
+## Post Sales Events
+
+### PostSalesApplied
+
+Produced when a post-sales decision is fully applied.
+
+| Field | Type | Description |
+|---|---|---|
+| `postSalesCaseId` | string | Unique case identifier. |
+| `orderId` | string | The affected order. |
+| `refundDecision` | RefundDecision | Refund decision details. |
+| `metadata` | EventMetadata | Standard event envelope. |
+
+## Entitlement & Ticketing Events
+
+### EntitlementIssued
+
+Produced when a ticket entitlement is issued.
+
+| Field | Type | Description |
+|---|---|---|
+| `entitlementId` | string | Entitlement identifier. |
+| `orderId` | string | The parent order. |
+| `orderItemId` | string | The specific order item. |
+| `segmentRef` | string | Transport segment reference. |
+| `metadata` | EventMetadata | Standard event envelope. |
+
+### EntitlementVoided
+
+Produced when a ticket entitlement is voided.
+
+| Field | Type | Description |
+|---|---|---|
+| `entitlementId` | string | Entitlement identifier. |
+| `orderId` | string | The parent order. |
+| `reason` | string | Void reason. |
+| `metadata` | EventMetadata | Standard event envelope. |

--- a/docs/08-contracts/shared-primitives.md
+++ b/docs/08-contracts/shared-primitives.md
@@ -1,452 +1,61 @@
-# Shared Primitives — Language-Neutral Field-Level Definitions
+# Shared Primitives
 
-Last updated: 2026-07-04
+## Cross-Context IDs
 
-## 1. EventEnvelope
-
-Every cross-context event is wrapped in an `EventEnvelope`. Consumers MUST
-validate the envelope before processing the payload.
-
-| Field | Type | Required | Description |
+| Field | Type | Format | Example |
 |---|---|---|---|
-| `eventId` | `EventId` | yes | Globally unique event identifier. Format: `evt-<uuid>` or `evt-<nanos>-<seq>`. |
-| `eventType` | string | yes | Fully qualified event type name (e.g. `JourneyOrderCreated`). PascalCase. |
-| `occurredAt` | RFC3339 UTC | yes | Wall-clock time when the event was recorded in the producer. |
-| `correlationId` | `CorrelationId` | yes | Links all events in the same business transaction. Format: `corr-<uuid>`. |
-| `causationId` | `CausationId` | no | ID of the command or event that caused this event. Format: `cmd-<uuid>` or `evt-<uuid>`. |
-| `producer` | string | yes | Bounded context that published the event (e.g. `journey-order`). |
-| `schemaVersion` | u32 | yes | Positive integer. Consumers MUST reject unknown major versions. |
-| `payload` | object | yes | The event-specific data. |
+| `orderId` | string | UUID v7 | `0194f2e0-7b3e-7610-0284-5c26e8b0c123` |
+| `accountId` | string | UUID v7 | `0194f2e0-7b3e-7610-0284-5c26e8b0c456` |
+| `paymentIntentId` | string | UUID v7 | `0194f2e0-7b3e-7610-0284-5c26e8b0c789` |
+| `refundId` | string | UUID v7 | `0194f2e0-7b3e-7610-0284-5c26e8b0cab` |
+| `offerId` | string | UUID v7 | `0194f2e0-7b3e-7610-0284-5c26e8b0cdef` |
+| `entitlementId` | string | UUID v7 | `0194f2e0-7b3e-7610-0284-5c26e8b0c111` |
+| `eventId` | string | UUID v7 | `0194f2e0-7b3e-7610-0284-5c26e8b0c222` |
+| `sourceCommandId` | string | UUID v7 | `0194f2e0-7b3e-7610-0284-5c26e8b0c333` |
+| `correlationId` | string | UUID v7 | `0194f2e0-7b3e-7610-0284-5c26e8b0c444` |
+| `causationId` | string | UUID v7 | `0194f2e0-7b3e-7610-0284-5c26e8b0c555` |
+| `revenueRecognitionId` | string | UUID v7 | `0194f2e0-7b3e-7610-0284-5c26e8b0c666` |
+| `reconciliationCaseId` | string | UUID v7 | `0194f2e0-7b3e-7610-0284-5c26e8b0c777` |
+| `settlementViewId` | string | UUID v7 | `0194f2e0-7b3e-7610-0284-5c26e8b0c888` |
+| `consumedEventLogId` | string | UUID v7 | `0194f2e0-7b3e-7610-0284-5c26e8b0c999` |
 
-**Reference implementation:** `platform/shared-kernel-rust/src/lib.rs` — `EventEnvelope` struct.
+## Money
 
-## 2. Shared ID Formats
-
-All IDs are non-empty strings with a prefix convention. The prefix is part of the
-canonical identity and MUST be preserved in serialisation.
-
-| ID Type | Prefix | Format | Description |
+| Field | Type | Format | Example |
 |---|---|---|---|
-| `PlaceId` | `plc-` | `plc-<uuid>` | Canonical place (city, station, airport, POI). |
-| `TransportNodeId` | `tnd-` | `tnd-<uuid>` | Transport-meaningful node (platform, gate, terminal). |
-| `ServicePlanId` | `sp-` | `sp-<uuid>` | Service plan aggregate root. |
-| `ServicePatternId` | `spat-` | `spat-<uuid>` | Ordered stop sequence for a service mode. |
-| `CalendarId` | `cal-` | `cal-<uuid>` | Operating calendar. |
-| `TimetableId` | `tt-` | `tt-<uuid>` | Planned stop times. |
-| `PlanVersionId` | `pv-` | `pv-<uuid>` | Versioned plan publication. |
-| `ScheduledServiceId` | `ss-` | `ss-<uuid>` | Materialised service instance for a specific date. |
-| `SegmentRef` | `seg-` | `seg-<uuid>` or `seg-<patternId>:<fromSeq>-<toSeq>` | Reference to a service segment. |
-| `TravelerRef` / `TravelerId` | `tvl-` | `tvl-<uuid>` | Cross-context traveler reference (see section 2a for structured shape). |
-| `EligibilityId` | `elig-` | `elig-<uuid>` | Eligibility determination reference (see section 2b for EligibilityRef shape). |
-| `OfferId` | `off-` | `off-<uuid>` | Offer aggregate root. |
-| `OrderId` / `JourneyOrderId` | `ord-` | `ord-<uuid>` | Journey order aggregate root. |
-| `OrderItemId` | `oit-` | `oit-<uuid>` | Line item within a journey order. |
-| `SegmentBookingId` | `sb-` | `sb-<uuid>` | Segment booking aggregate root. |
-| `HoldId` | `hold-` | `hold-<uuid>` | Capacity hold aggregate root. |
-| `PaymentIntentId` | `pi-` | `pi-<uuid>` | Payment intent aggregate root. |
-| `RefundId` | `ref-` | `ref-<uuid>` | Refund aggregate root. |
-| `EntitlementId` | `ent-` | `ent-<uuid>` | Ticket/entitlement aggregate root. |
-| `PostSalesCaseId` | `psc-` | `psc-<uuid>` | Post-sales case aggregate root. |
-| `ProviderId` | `prv-` | `prv-<uuid>` | External provider/supplier reference. |
-| `RuleSetId` | `rs-` | `rs-<uuid>` | Fare rule set aggregate root. |
-| `RuleVersion` | string | `<semver>` | Rule set version (e.g. `1.0.0`, `2.1.3`). |
-| `EventId` | `evt-` | `evt-<uuid>` or `evt-<nanos>-<seq>` | Unique event identifier. |
-| `CorrelationId` | `corr-` | `corr-<uuid>` | Business transaction correlation. |
-| `CausationId` | `cmd-` or `evt-` | `cmd-<uuid>` or `evt-<uuid>` | Source command or event ID. |
-| `IdempotencyKey` | `idem-` | `idem-<orderId>:<segmentRef>:<travelerRef>:<purpose>` | Idempotency key for safe retry. |
-| `InventoryPoolId` | `pool-` | `pool-<scheduledServiceRef>-<seatClass>` | Inventory pool identity. |
-| `CapacityUnitRef` | `cu-` | `cu-<seatLabel>` | Specific capacity unit (e.g. `cu-01A`). |
-| `FareQuoteId` | `fq-` | `fq-<uuid>` | Fare quote reference. |
-| `SagaId` | `saga-` | `saga-<uuid>` | Booking saga identity. |
-| `DisruptionCaseId` | `dc-` | `dc-<uuid>` | Disruption case identity. |
-| `TransferPlanId` | `tp-` | `tp-<uuid>` | Transfer plan identity. |
-| `ProviderReference` | varies | provider-specific | External provider reference (PNR, confirmation number, ticket number). |
-| `AccountId` | `acct-` | `acct-<uuid>` | Account aggregate root. |
-| `SessionId` | `sess-` | `sess-<uuid>` | Session aggregate root. |
-| `PreferenceId` | `pref-` | `pref-<uuid>` | Preference aggregate root. |
-| `ClosureRequestId` | `clr-` | `clr-<uuid>` | Account closure saga request. |
-| `AvailabilitySnapshotId` | `avs-` | `avs-<uuid>` | Availability snapshot identity. |
+| `currency` | string | ISO 4217 | `CNY` |
+| `amount` | string | Decimal with scale matching currency fraction digits | `100.00` |
 
-**Reference implementation:** `platform/shared-kernel-rust/src/lib.rs` — `PlaceRef`, `TravelerRef`, `SegmentRef`, `EventId`, `CausationId`, `CorrelationId`.
+Money arithmetic must reject cross-currency operations at the domain level.
+All monetary values use `BigDecimal` with scale set to the currency's default
+fraction digits and `RoundingMode.UNNECESSARY` (or `HALF_EVEN` for division).
 
-### Deviations from shared-kernel reference
+## Timestamps
 
-The Rust shared-kernel uses `PlaceRef`, `TravelerRef`, `SegmentRef` as generic
-wrapper types without prefix validation. The canonical ID formats above define
-the prefix conventions that all services should adopt. See `conformance-gaps.md`
-for current deviations.
+All timestamps use `java.time.Instant` (ISO-8601 instant). Precision is
+milliseconds or finer.
 
-## 2a. TravelerRef — Structured Cross-Context Shape
+## Event Envelope
 
-The TravelerRef is both a simple string ID (`tvl-<uuid>`) and a structured value
-object when full traveler context is needed across bounded contexts.
+Every domain event carries:
 
-### Simple ID form
+| Field | Type | Description |
+|---|---|---|
+| `eventId` | string | Unique event identifier (UUID v7). |
+| `occurredAt` | timestamp | When the event was recorded. |
+| `sourceCommandId` | string | The command that produced this event. |
+| `causationId` | string | The immediate cause (previous event or external fact). |
+| `correlationId` | string | End-to-end trace identifier. |
+| `schemaVersion` | int | Event schema version (currently 1). |
+| `attributes` | map[string,string] | Extensible metadata. |
 
-Used where only a reference is needed (e.g. in event headers or audit trails):
-`tvl-<uuid>`
+## Consumed Event Record
 
-### Structured form (cross-context payload)
+When a downstream context consumes an upstream event, it must record at least:
 
-```json
-{
-  "travelerId": "tvl-abc123",
-  "travelerType": "ADULT",
-  "maskedDocumentRef": "****1234",
-  "eligibilityRef": { "eligibilityId": "elig-def456", "eligibilityType": "STUDENT", "evidenceHash": "sha256-..." }
-}
-```
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `travelerId` | `TravelerId` | yes | Canonical traveler string ID (`tvl-<uuid>`). |
-| `travelerType` | enum | yes | Traveler category (see enum below). The field name is `travelerType`, NOT `category`. |
-| `maskedDocumentRef` | string | no | Partially masked travel document number (e.g. `****1234`). MUST NOT contain full document number. |
-| `eligibilityRef` | `EligibilityRef` | no | Eligibility determination reference (see section 2b). |
-
-### TravelerType enum
-
-| Value | Description |
-|---|---|
-| `ADULT` | Adult passenger (default). |
-| `CHILD` | Child passenger (age-dependent fare). |
-| `STUDENT` | Student passenger (eligibility-verified discount). |
-| `SENIOR` | Senior passenger (age-dependent fare). |
-| `INFANT` | Infant (no seat, accompanying adult). |
-| `MILITARY` | Military personnel (eligibility-verified discount). |
-| `DISABLED` | Passenger with disability (eligibility-verified assistance). |
-
-### Deviations from canonical form
-
-- **offer-management (TypeScript):** Uses `category` field (type `PassengerCategory` enum with values `adult`, `child`, `senior`, `student`) instead of `travelerType`. See conformance-gaps.md GAP-022.
-- **journey-order (Java):** `TravelerRef` record has `travelerId`, `documentType`, `maskedDocumentNo` but uses `documentType` (free-form string) rather than the canonical `travelerType` enum. See conformance-gaps.md GAP-023.
-
-## 2b. EligibilityRef — Canonical Eligibility Reference
-
-Unified reference for eligibility determinations produced by traveler-profile and
-consumed by offer-management, fare-pricing, and journey-order.
-
-```json
-{
-  "eligibilityId": "elig-def456",
-  "eligibilityType": "STUDENT",
-  "eligibilitySource": "traveler-profile",
-  "evidenceHash": "sha256-abc123...",
-  "verifiedAt": "2026-07-03T10:00:00Z"
-}
-```
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `eligibilityId` | `EligibilityId` | yes | Canonical eligibility ID (`elig-<uuid>`). |
-| `eligibilityType` | enum | yes | Type of eligibility (see EligibilityType enum). |
-| `eligibilitySource` | string | yes | Bounded context that determined eligibility (e.g. `traveler-profile`, `fare-pricing`). |
-| `evidenceHash` | string | no | Hash of the evidence document used for verification (SHA-256 hex). |
-| `verifiedAt` | RFC3339 UTC | no | When the eligibility was verified. |
-
-### EligibilityType enum
-
-| Value | Description |
-|---|---|
-| `STUDENT` | Student discount eligibility. |
-| `SENIOR` | Senior discount eligibility. |
-| `MILITARY` | Military discount eligibility. |
-| `DISABLED` | Disability assistance eligibility. |
-| `LOYALTY` | Loyalty programme tier-based eligibility. |
-| `CORPORATE` | Corporate travel agreement eligibility. |
-| `PROMOTIONAL` | Promotional campaign eligibility. |
-| `GENERAL` | No special eligibility (default). |
-
-### Deviations from canonical form
-
-- **offer-management (TypeScript):** Uses `eligibilitySnapshotRef?: SnapshotId` (free-form string) instead of the structured `EligibilityRef`. See conformance-gaps.md GAP-024.
-- **journey-order (Java):** `OfferSnapshotRef` carries `ruleSnapshotId` (free-form string) instead of the structured `EligibilityRef`. See conformance-gaps.md GAP-025.
-- **traveler-profile (Java):** Produces `EligibilitySummary` with similar fields but uses slightly different naming. The canonical shape above is the contract target. See conformance-gaps.md GAP-026.
-
-## 3. Money
-
-Money is **never** represented as a floating-point number. The canonical shape is:
-
-```json
-{
-  "currency": "CNY",
-  "minorUnits": 12345
-}
-```
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `currency` | string | yes | ISO-4217 three-letter uppercase code (e.g. `CNY`, `USD`, `EUR`, `JPY`). |
-| `minorUnits` | integer | yes | Amount in the smallest currency unit (cents, fen, etc.). Always a whole number. |
-
-**Rules:**
-- `currency` MUST be exactly three uppercase ASCII letters.
-- `minorUnits` MUST be a signed integer. Negative values represent amounts owed to the customer.
-- Services MUST NOT use `float`, `double`, or `Decimal` in cross-context serialisation.
-- For display, divide by 10^(currency exponent). For CNY: `minorUnits / 100`.
-
-**Reference implementation:** `platform/shared-kernel-rust/src/lib.rs` — `Money` struct.
-
-### Deviations
-
-- **fare-pricing (Python):** Uses `Decimal` amounts with implicit two-decimal-place semantics rather than `minorUnits: i64`. The canonical form is `minorUnits`. Migration tracked in `conformance-gaps.md`.
-- **offer-management (TypeScript):** Uses `amount: number` in the Money type. This is a deviation from the canonical `minorUnits: integer`. Migration tracked in `conformance-gaps.md`.
-- **journey-order (Java):** Uses `Money` class with `BigDecimal`. This is a deviation from the canonical `minorUnits: i64`. Migration tracked in `conformance-gaps.md`.
-- **payment (Java):** Uses `Money` class with `BigDecimal`. Deviation tracked in `conformance-gaps.md`.
-
-## 4. TimeWindow
-
-A closed-open interval `[start, end)`.
-
-```json
-{
-  "start": "2026-07-03T10:00:00Z",
-  "end": "2026-07-03T10:30:00Z"
-}
-```
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `start` | RFC3339 UTC | yes | Start of the window (inclusive). |
-| `end` | RFC3339 UTC | yes | End of the window (exclusive). MUST be after `start`. |
-
-**Reference implementation:** `platform/shared-kernel-rust/src/lib.rs` — `TimeWindow` struct.
-
-## 5. Timestamp Convention
-
-All date-time fields in cross-context messages MUST be:
-
-- UTC timezone
-- RFC3339 / ISO-8601 format
-- Trailing `Z` (not `+00:00`, not numeric offset)
-- Microsecond or millisecond precision preferred
-
-| Valid | Invalid |
-|---|---|
-| `2026-07-03T10:30:00Z` | `2026-07-03T10:30:00+08:00` |
-| `2026-07-03T10:30:00.123Z` | `2026-07-03T10:30:00` |
-| `2026-07-03T10:30:00.123456Z` | `2026-07-03 10:30:00` |
-
-The shared-kernel `UnixMillis(u64)` represents timestamps as milliseconds since
-UNIX epoch for internal processing. Cross-context serialisation MUST use RFC3339.
-
-## 6. Enums
-
-Enum values are serialised as SCREAMING_SNAKE_CASE strings in JSON.
-
-### Common status enums used across contexts:
-
-**OrderLifecycleState:**
-| Value | Description |
-|---|---|
-| `PENDING_CONFIRMATION` | Order created, awaiting booking/capacity acceptance. |
-| `PENDING_PAYMENT` | Awaiting payment capture. |
-| `CONFIRMING` | Payment captured, awaiting entitlement summary. |
-| `CONFIRMED` | All confirmation conditions satisfied. |
-| `IN_TRAVEL` | At least one segment has started. |
-| `POST_SALES_ADJUSTED` | Order modified by post-sales action. |
-| `CANCELLED` | Order cancelled. |
-| `COMPLETED` | All segments completed. |
-
-**SegmentBookingStatus:**
-| Value | Description |
-|---|---|
-| `REQUESTED` | Reservation request submitted. |
-| `HOLDING` | Capacity hold in progress. |
-| `CONFIRMED` | Reservation confirmed (internal or provider). |
-| `TICKETED` | Entitlement issued for this segment. |
-| `CANCEL_REQUESTED` | Cancellation requested. |
-| `CANCELLED` | Cancellation completed. |
-| `FAILED` | Reservation failed. |
-
-**PaymentIntentStatus:**
-| Value | Description |
-|---|---|
-| `CREATED` | Payment intent created. |
-| `AUTHORIZED` | Amount authorised by channel. |
-| `CAPTURED` | Amount captured. |
-| `FAILED` | Payment failed. |
-| `CANCELLED` | Payment cancelled. |
-| `EXPIRED` | Payment expired. |
-
-**EntitlementStatus:**
-| Value | Description |
-|---|---|
-| `PENDING_ISSUE` | Entitlement created but not yet issued. |
-| `ISSUED` | Entitlement issued (ticket generated). |
-| `CHECKED_IN` | Boarding check-in completed. |
-| `BOARDED` | Passenger boarded. |
-| `USED` | Segment completed. |
-| `VOIDED` | Entitlement voided (refunded/cancelled). |
-| `SUSPENDED` | Entitlement suspended (dispute/risk). |
-
-**HoldState:**
-| Value | Description |
-|---|---|
-| `REQUESTED` | Hold requested. |
-| `HELD` | Hold active. |
-| `CONFIRMED` | Hold confirmed (payment conditions met). |
-| `RELEASED` | Hold released. |
-| `EXPIRED` | Hold TTL elapsed. |
-| `FAILED` | Hold failed (conflict). |
-
-**BookingSagaStatus:**
-| Value | Description |
-|---|---|
-| `PLANNED` | Saga created but not started. |
-| `RESERVING` | Segments being reserved. |
-| `COMPLETED` | All steps completed successfully. |
-| `FAILED` | Saga failed. |
-| `MANUAL_REVIEW` | Manual intervention required. |
-
-**PostSalesCaseStatus:**
-| Value | Description |
-|---|---|
-| `REQUESTED` | Post-sales case opened. |
-| `EVALUATED` | Rule evaluation completed. |
-| `APPROVED` | Case approved for execution. |
-| `APPLIED` | Post-sales result applied. |
-| `FAILED` | Post-sales execution failed. |
-
-**TravelerType:**
-| Value | Description |
-|---|---|
-| `ADULT` | Adult passenger (default). |
-| `CHILD` | Child passenger (age-dependent fare). |
-| `STUDENT` | Student passenger (eligibility-verified discount). |
-| `SENIOR` | Senior passenger (age-dependent fare). |
-| `INFANT` | Infant (no seat, accompanying adult). |
-| `MILITARY` | Military personnel (eligibility-verified discount). |
-| `DISABLED` | Passenger with disability (eligibility-verified assistance). |
-
-**EligibilityType:**
-| Value | Description |
-|---|---|
-| `STUDENT` | Student discount eligibility. |
-| `SENIOR` | Senior discount eligibility. |
-| `MILITARY` | Military discount eligibility. |
-| `DISABLED` | Disability assistance eligibility. |
-| `LOYALTY` | Loyalty programme tier-based eligibility. |
-| `CORPORATE` | Corporate travel agreement eligibility. |
-| `PROMOTIONAL` | Promotional campaign eligibility. |
-| `GENERAL` | No special eligibility (default). |
-
-**AvailabilityStatus (cross-context mapping):**
-| Value | trip-planning hint | offer-management confidence | Description |
-|---|---|---|---|
-| `AVAILABLE` | `available_hint` | `confirmed-snapshot` | Sufficient sellable units. |
-| `LIMITED` | `limited` | `low` | Few units remain. |
-| `UNKNOWN` | `unknown` | `estimated` | Snapshot stale/incomplete. |
-| `UNAVAILABLE` | `unavailable` | N/A | No sellable units. |
-
-## 7. ProviderReference
-
-External provider/supplier references are encapsulated in a value object:
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `providerId` | `ProviderId` | yes | Platform-internal provider identity. |
-| `confirmationNo` | string | yes | Provider's reservation/confirmation identifier (PNR, ticket number, etc.). |
-| `rawStatus` | string | no | Provider's raw status code (for audit/debugging only). |
-| `mappedStatus` | string | yes | Platform-mapped status (see `docs/01-ddd-high-level/acl-provider-contracts.md`). |
-| `mappedAt` | RFC3339 UTC | yes | When the status was mapped. |
-
-**Reference implementation:** `services/provider-integration/internal/domain/acl.go`.
-
-## 8. CapacityUnitRef
-
-Identifies a specific sellable unit within an inventory pool.
-
-```json
-{
-  "capacityUnitRef": "cu-01A"
-}
-```
-
-For trains, this is typically a specific seat (carriage + seat number).
-The format is `cu-<carriage><seatLabel>`.
-
-**Reference implementation:** `services/capacity-availability/src/lib.rs` — `CapacityUnitRef`.
-
-## 9. StationInterval
-
-Half-open interval `[fromSeq, toSeq)` representing a range of stops on a
-service pattern.
-
-```json
-{
-  "fromSeq": 1,
-  "toSeq": 3
-}
-```
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `fromSeq` | u32 | yes | Origin stop sequence (inclusive). |
-| `toSeq` | u32 | yes | Destination stop sequence (exclusive). MUST be > `fromSeq`. |
-
-Two intervals overlap if `a.fromSeq < b.toSeq && b.fromSeq < a.toSeq`.
-
-**Reference implementation:** `services/capacity-availability/src/lib.rs` — `StationInterval`.
-
-## 10. AvailabilitySnapshot
-
-Non-authoritative snapshot of sellable units for a station interval.
-
-```json
-{
-  "inventoryPoolId": "pool-G123-2026-07-03-first-class",
-  "requestedInterval": { "fromSeq": 1, "toSeq": 3 },
-  "sourceVersion": 7,
-  "generatedAt": "2026-07-03T10:00:00Z",
-  "validUntil": "2026-07-03T10:05:00Z",
-  "totalUnits": 100,
-  "availableCount": 45,
-  "status": "AVAILABLE",
-  "explanations": ["INVENTORY_AVAILABLE"]
-}
-```
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `inventoryPoolId` | `InventoryPoolId` | yes | The pool this snapshot applies to. |
-| `requestedInterval` | `StationInterval` | yes | The stop range queried. |
-| `sourceVersion` | u64 | yes | Pool version at snapshot time. |
-| `generatedAt` | RFC3339 UTC | yes | When the snapshot was computed. |
-| `validUntil` | RFC3339 UTC | yes | Snapshot expiry. |
-| `totalUnits` | u32 | yes | Total sellable units in the pool for this interval. |
-| `availableCount` | u32 | yes | Estimated available units. |
-| `status` | enum | yes | `AVAILABLE`, `LOW_AVAILABILITY`, or `SOLD_OUT`. |
-| `explanations` | string[] | no | Human-readable or code-based explanations. |
-
-**Reference implementation:** `services/capacity-availability/src/lib.rs` — `AvailabilitySnapshot`.
-
-## 11. Money (minorUnits) vs Decimal Migration Note
-
-The platform shared-kernel defines `Money { amount_minor: i64, currency: CurrencyCode }`.
-Services that use `Decimal` or `float` for cross-context money values MUST migrate
-to the `minorUnits: i64` convention before integration testing.
-
-Affected services and their current representation:
-
-| Service | Current Type | Canonical Form | Migration Priority |
-|---|---|---|---|
-| fare-pricing | `Decimal` | `minorUnits: i64` | HIGH |
-| offer-management | `amount: number` (float) | `minorUnits: i64` | HIGH |
-| journey-order | `BigDecimal` | `minorUnits: i64` | HIGH |
-| payment | `BigDecimal` | `minorUnits: i64` | HIGH |
-
-## 12. Shared-Kernel Rust Reference
-
-The authoritative reference implementation for shared primitives lives at:
-`platform/shared-kernel-rust/src/lib.rs`
-
-Key primitives defined:
-- `PlaceRef`, `TravelerRef`, `SegmentRef` — generic ID wrappers
-- `CurrencyCode` — ISO-4217 validation
-- `Money` — minorUnits + currency
-- `UnixMillis` — epoch millisecond timestamp
-- `TimeWindow` — validated interval
-- `EventEnvelope` — event wrapper with eventId, eventType, schemaVersion, occurredAt, correlationId, causationId
-- `ContractError` — validation error enum
-- `RequestContext` — HTTP request context with requestId and correlationId
+| Field | Type | Description |
+|---|---|---|
+| `eventId` | string | The consumed event's unique identifier (dedup key). |
+| `consumedAt` | timestamp | When this context processed the event. |
+| `source` | string | The upstream context name (e.g. `journey-order`, `payment`). |
+| `eventType` | string | The consumed event type name. |

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -793,6 +793,55 @@ requirements:
     confidence: confirmed
     source: "docs/02-domains/supplier-catalog.md, docs/03-ddd-final/phase-1-contract.md, docs/03-ddd-final/implementation-roadmap.md"
 
+  - id: REQ-024
+    title: "Finance Settlement domain foundation"
+    description: "Implement the Finance Settlement domain foundation in Java. Consumes order/payment/post-sales events to build revenue recognition defaults, reconciliation views, and settlement records."
+    priority: P1
+    status: tested
+    code:
+      - path: services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RevenueRecognition.java
+        description: "RevenueRecognition aggregate with recognize/reverse lifecycle."
+      - path: services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationCase.java
+        description: "ReconciliationCase aggregate with open/resolve/reject/escalate lifecycle."
+      - path: services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/SettlementView.java
+        description: "SettlementView aggregate rebuildable from event log."
+      - path: services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ConsumedEventLog.java
+        description: "Idempotent event consumption tracking."
+      - path: services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/Money.java
+        description: "Minor domain money type for financial amounts."
+      - path: services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/FinanceSettlementEvent.java
+        description: "Sealed event interface for domain events."
+      - path: services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/EventMetadata.java
+        description: "Standard event envelope metadata."
+      - path: services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/DomainRuleViolation.java
+        description: "Domain invariant violation exception."
+      - path: docs/08-contracts/README.md
+        description: "Cross-context contracts directory README."
+      - path: docs/08-contracts/shared-primitives.md
+        description: "Shared cross-context ID, Money, timestamp, event envelope contracts."
+      - path: docs/08-contracts/events/finance-settlement-events.md
+        description: "Finance Settlement domain event payload contracts."
+      - path: docs/08-contracts/events/upstream-events.md
+        description: "Upstream event contracts consumed by Finance Settlement."
+    tests:
+      - path: services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/RevenueRecognitionTest.java
+        description: "Unit tests for RevenueRecognition aggregate invariants."
+      - path: services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/ReconciliationCaseTest.java
+        description: "Unit tests for ReconciliationCase aggregate lifecycle."
+      - path: services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/SettlementViewTest.java
+        description: "Unit tests for SettlementView rebuild invariants."
+      - path: services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/ConsumedEventLogTest.java
+        description: "Unit tests for ConsumedEventLog idempotent recording."
+      - path: services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/MoneyTest.java
+        description: "Unit tests for Money value object invariants."
+    docs:
+      - path: docs/02-domains/finance-settlement.md
+      - path: docs/03-ddd-final/phase-1-contract.md
+      - path: docs/08-contracts/README.md
+      - path: docs/08-contracts/shared-primitives.md
+    depends_on: [REQ-010, REQ-012, REQ-014, REQ-028]
+    confidence: confirmed
+    source: "docs/02-domains/finance-settlement.md, docs/03-ddd-final/phase-1-contract.md, docs/08-contracts/README.md, docs/08-contracts/shared-primitives.md"
   # Legacy WP-derived references below. Do not use as active backlog without
   - id: REQ-014
     title: "Post Sales domain foundation"

--- a/service-catalog.json
+++ b/service-catalog.json
@@ -529,19 +529,22 @@
       "language": "java",
       "runtime": "jvm",
       "phase": "phase-1-limited",
-      "status": "skeleton",
+      "status": "tested",
       "priority": "P1",
       "workPackages": [
-        "WP-21"
+        "REQ-024"
       ],
       "docs": [
-        "docs/02-domains/finance-settlement.md"
+        "docs/02-domains/finance-settlement.md",
+        "docs/08-contracts/README.md",
+        "docs/08-contracts/shared-primitives.md",
+        "docs/08-contracts/events/finance-settlement-events.md"
       ],
       "owns": [
         "RevenueRecognition",
-        "Reconciliation",
-        "Invoice",
-        "SettlementView"
+        "ReconciliationCase",
+        "SettlementView",
+        "ConsumedEventLog"
       ],
       "rationale": "Java is appropriate for financial ledgers, reconciliation workflows, and audit consistency."
     },

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/Application.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/Application.java
@@ -16,8 +16,8 @@ public class Application {
             "Finance Settlement",
             "java",
             "phase-1-limited",
-            "WP-21",
-            "RevenueRecognition, Reconciliation, Invoice, SettlementView"
+            "REQ-024",
+            "RevenueRecognition, ReconciliationCase, SettlementView, ConsumedEventLog"
         );
     }
 }

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ConsumeBusinessEvent.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ConsumeBusinessEvent.java
@@ -1,0 +1,17 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record ConsumeBusinessEvent(String eventId, String source, String eventType, Instant consumedAt) {
+    public ConsumeBusinessEvent {
+        requireText(eventId, "eventId");
+        requireText(source, "source");
+        requireText(eventType, "eventType");
+        Objects.requireNonNull(consumedAt, "consumedAt is required");
+    }
+    private static void requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank())
+            throw new DomainRuleViolation(name + " must not be blank");
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ConsumedEventLog.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ConsumedEventLog.java
@@ -1,0 +1,43 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class ConsumedEventLog {
+    private final String logId;
+    private final String eventId;
+    private final String source;
+    private final String eventType;
+    private final Instant consumedAt;
+
+    private ConsumedEventLog(String logId, String eventId, String source, String eventType, Instant consumedAt) {
+        this.logId = requireText(logId, "logId");
+        this.eventId = requireText(eventId, "eventId");
+        this.source = requireText(source, "source");
+        this.eventType = requireText(eventType, "eventType");
+        this.consumedAt = Objects.requireNonNull(consumedAt, "consumedAt is required");
+    }
+
+    public static ConsumedEventLog record(String eventId, String source, String eventType, Instant consumedAt) {
+        return new ConsumedEventLog(
+            UUID.randomUUID().toString(),
+            requireText(eventId, "eventId"),
+            requireText(source, "source"),
+            requireText(eventType, "eventType"),
+            Objects.requireNonNull(consumedAt, "consumedAt is required")
+        );
+    }
+
+    public String logId() { return logId; }
+    public String eventId() { return eventId; }
+    public String source() { return source; }
+    public String eventType() { return eventType; }
+    public Instant consumedAt() { return consumedAt; }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank())
+            throw new DomainRuleViolation(name + " must not be blank");
+        return value;
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/DomainRuleViolation.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/DomainRuleViolation.java
@@ -1,0 +1,7 @@
+package com.trainticket.financesettlement.domain;
+
+public class DomainRuleViolation extends RuntimeException {
+    public DomainRuleViolation(String message) {
+        super(message);
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/EventMetadata.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/EventMetadata.java
@@ -1,0 +1,36 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+public record EventMetadata(
+    String eventId,
+    Instant occurredAt,
+    String sourceCommandId,
+    String causationId,
+    String correlationId,
+    int schemaVersion,
+    Map<String, String> attributes
+) {
+    public EventMetadata {
+        eventId = requireText(eventId, "eventId");
+        Objects.requireNonNull(occurredAt, "occurredAt is required");
+        sourceCommandId = requireText(sourceCommandId, "sourceCommandId");
+        causationId = requireText(causationId, "causationId");
+        correlationId = requireText(correlationId, "correlationId");
+        if (schemaVersion < 1) throw new DomainRuleViolation("schemaVersion must be positive");
+        attributes = Map.copyOf(Objects.requireNonNull(attributes, "attributes are required"));
+    }
+
+    public static EventMetadata create(Instant occurredAt, String sourceCommandId, String causationId, String correlationId, Map<String, String> attributes) {
+        return new EventMetadata(UUID.randomUUID().toString(), occurredAt, sourceCommandId, causationId, correlationId, 1, attributes);
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank())
+            throw new DomainRuleViolation(name + " must not be blank");
+        return value;
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/FinanceSettlementEvent.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/FinanceSettlementEvent.java
@@ -1,0 +1,19 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public sealed interface FinanceSettlementEvent permits
+    RevenueRecognized,
+    ReconciliationCaseOpened,
+    ReconciliationCaseResolved,
+    SettlementViewRebuilt {
+    String eventId();
+    Instant occurredAt();
+    String sourceCommandId();
+    String causationId();
+    String correlationId();
+    int schemaVersion();
+    Map<String, String> attributes();
+    default String eventType() { return getClass().getSimpleName(); }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/Money.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/Money.java
@@ -1,0 +1,52 @@
+package com.trainticket.financesettlement.domain;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Currency;
+import java.util.Objects;
+
+public record Money(Currency currency, BigDecimal amount) implements Comparable<Money> {
+    public Money {
+        Objects.requireNonNull(currency, "currency is required");
+        Objects.requireNonNull(amount, "amount is required");
+        amount = amount.setScale(currency.getDefaultFractionDigits(), RoundingMode.UNNECESSARY);
+    }
+
+    public static Money of(String currencyCode, String amount) {
+        return new Money(Currency.getInstance(currencyCode), new BigDecimal(amount));
+    }
+
+    public static Money zero(Currency currency) {
+        return new Money(currency, BigDecimal.ZERO.setScale(currency.getDefaultFractionDigits()));
+    }
+
+    public Money plus(Money other) {
+        requireSameCurrency(other);
+        return new Money(currency, amount.add(other.amount));
+    }
+
+    public Money minus(Money other) {
+        requireSameCurrency(other);
+        return new Money(currency, amount.subtract(other.amount));
+    }
+
+    public Money negate() {
+        return new Money(currency, amount.negate());
+    }
+
+    public boolean isNegative() { return amount.signum() < 0; }
+    public boolean isZero() { return amount.signum() == 0; }
+
+    @Override
+    public int compareTo(Money other) {
+        requireSameCurrency(other);
+        return amount.compareTo(other.amount);
+    }
+
+    private void requireSameCurrency(Money other) {
+        Objects.requireNonNull(other, "other money is required");
+        if (!currency.equals(other.currency)) {
+            throw new DomainRuleViolation("money currency mismatch: " + currency + " vs " + other.currency);
+        }
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/OpenReconciliationCase.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/OpenReconciliationCase.java
@@ -1,0 +1,21 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record OpenReconciliationCase(
+    String orderId, String paymentIntentId, String differenceType,
+    Money expectedAmount, Money actualAmount, String description, Instant detectedAt
+) {
+    public OpenReconciliationCase {
+        Objects.requireNonNull(expectedAmount, "expectedAmount is required");
+        Objects.requireNonNull(actualAmount, "actualAmount is required");
+        requireText(differenceType, "differenceType");
+        requireText(description, "description");
+        Objects.requireNonNull(detectedAt, "detectedAt is required");
+    }
+    private static void requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank())
+            throw new DomainRuleViolation(name + " must not be blank");
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RebuildSettlementView.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RebuildSettlementView.java
@@ -1,0 +1,15 @@
+package com.trainticket.financesettlement.domain;
+
+import java.util.Objects;
+
+public record RebuildSettlementView(String viewType, int version, int eventCount) {
+    public RebuildSettlementView {
+        requireText(viewType, "viewType");
+        if (version < 1) throw new DomainRuleViolation("view version must be positive");
+        if (eventCount < 0) throw new DomainRuleViolation("event count must not be negative");
+    }
+    private static void requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank())
+            throw new DomainRuleViolation(name + " must not be blank");
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RecognizeRevenue.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RecognizeRevenue.java
@@ -1,0 +1,24 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record RecognizeRevenue(
+    String orderId, String orderItemId, String componentCode,
+    Money amount, String recognitionPolicyVersion,
+    String sourceEventId, Instant recognizedAt
+) {
+    public RecognizeRevenue {
+        requireText(orderId, "orderId");
+        requireText(orderItemId, "orderItemId");
+        requireText(componentCode, "componentCode");
+        Objects.requireNonNull(amount, "amount is required");
+        requireText(recognitionPolicyVersion, "recognitionPolicyVersion");
+        requireText(sourceEventId, "sourceEventId");
+        Objects.requireNonNull(recognizedAt, "recognizedAt is required");
+    }
+    private static void requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank())
+            throw new DomainRuleViolation(name + " must not be blank");
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationCase.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationCase.java
@@ -1,0 +1,133 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class ReconciliationCase {
+    private final String reconciliationCaseId;
+    private final String orderId;
+    private final String paymentIntentId;
+    private final String differenceType;
+    private final Money expectedAmount;
+    private final Money actualAmount;
+    private final String description;
+    private final Instant openedAt;
+    private ReconciliationCaseStatus status;
+    private String resolution;
+    private String resolutionNote;
+    private final List<FinanceSettlementEvent> domainEvents;
+
+    public enum ReconciliationCaseStatus { OPEN, INVESTIGATING, MANUAL_REVIEW, ESCALATED, RESOLVED, REJECTED }
+
+    private ReconciliationCase(
+        String reconciliationCaseId, String orderId, String paymentIntentId,
+        String differenceType, Money expectedAmount, Money actualAmount,
+        String description, Instant openedAt
+    ) {
+        this.reconciliationCaseId = requireText(reconciliationCaseId, "reconciliationCaseId");
+        this.orderId = orderId != null ? orderId : "";
+        this.paymentIntentId = paymentIntentId != null ? paymentIntentId : "";
+        this.differenceType = requireText(differenceType, "differenceType");
+        this.expectedAmount = Objects.requireNonNull(expectedAmount, "expectedAmount is required");
+        this.actualAmount = Objects.requireNonNull(actualAmount, "actualAmount is required");
+        this.description = requireText(description, "description");
+        this.openedAt = Objects.requireNonNull(openedAt, "openedAt is required");
+        this.status = ReconciliationCaseStatus.OPEN;
+        this.resolution = null;
+        this.resolutionNote = null;
+        this.domainEvents = new ArrayList<>();
+    }
+
+    public static ReconciliationCase open(
+        String orderId, String paymentIntentId, String differenceType,
+        Money expectedAmount, Money actualAmount, String description,
+        Instant now, String sourceCommandId, String correlationId
+    ) {
+        Objects.requireNonNull(expectedAmount);
+        Objects.requireNonNull(actualAmount);
+        if (expectedAmount.currency().equals(actualAmount.currency()) && expectedAmount.compareTo(actualAmount) == 0)
+            throw new DomainRuleViolation("cannot open reconciliation case with matching amounts");
+
+        ReconciliationCase rc = new ReconciliationCase(
+            UUID.randomUUID().toString(), orderId, paymentIntentId,
+            differenceType, expectedAmount, actualAmount, description, now
+        );
+
+        rc.domainEvents.add(new ReconciliationCaseOpened(
+            rc.reconciliationCaseId, orderId, paymentIntentId, differenceType,
+            expectedAmount, actualAmount, description,
+            EventMetadata.create(now, sourceCommandId, sourceCommandId, correlationId,
+                Map.of("reconciliationCaseId", rc.reconciliationCaseId,
+                       "differenceType", differenceType, "status", rc.status.name()))
+        ));
+        return rc;
+    }
+
+    public void markInvestigating(Instant now, String sourceCommandId, String causationId, String correlationId) {
+        requireStatus(ReconciliationCaseStatus.OPEN);
+        status = ReconciliationCaseStatus.INVESTIGATING;
+    }
+
+    public void escalate(String reason, Instant now, String sourceCommandId, String causationId, String correlationId) {
+        if (status == ReconciliationCaseStatus.RESOLVED || status == ReconciliationCaseStatus.REJECTED)
+            throw new DomainRuleViolation("cannot escalate already resolved/rejected case");
+        status = ReconciliationCaseStatus.ESCALATED;
+    }
+
+    public void resolve(String resolution, String note, Instant now, String sourceCommandId, String causationId, String correlationId) {
+        if (status == ReconciliationCaseStatus.RESOLVED) return;
+        if (status == ReconciliationCaseStatus.REJECTED)
+            throw new DomainRuleViolation("cannot resolve a rejected case");
+        this.resolution = requireText(resolution, "resolution");
+        this.resolutionNote = requireText(note, "note");
+        this.status = ReconciliationCaseStatus.RESOLVED;
+        domainEvents.add(new ReconciliationCaseResolved(
+            reconciliationCaseId, resolution, resolutionNote,
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId,
+                Map.of("reconciliationCaseId", reconciliationCaseId, "status", status.name()))
+        ));
+    }
+
+    public void reject(String reason, Instant now, String sourceCommandId, String causationId, String correlationId) {
+        if (status == ReconciliationCaseStatus.RESOLVED)
+            throw new DomainRuleViolation("cannot reject an already resolved case");
+        if (status == ReconciliationCaseStatus.REJECTED) return;
+        this.resolution = "rejected";
+        this.resolutionNote = requireText(reason, "reason");
+        this.status = ReconciliationCaseStatus.REJECTED;
+        domainEvents.add(new ReconciliationCaseResolved(
+            reconciliationCaseId, "rejected", reason,
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId,
+                Map.of("reconciliationCaseId", reconciliationCaseId, "status", status.name()))
+        ));
+    }
+
+    public String reconciliationCaseId() { return reconciliationCaseId; }
+    public String orderId() { return orderId; }
+    public String paymentIntentId() { return paymentIntentId; }
+    public String differenceType() { return differenceType; }
+    public Money expectedAmount() { return expectedAmount; }
+    public Money actualAmount() { return actualAmount; }
+    public String description() { return description; }
+    public Instant openedAt() { return openedAt; }
+    public ReconciliationCaseStatus status() { return status; }
+    public String resolution() { return resolution; }
+    public String resolutionNote() { return resolutionNote; }
+    public List<FinanceSettlementEvent> domainEvents() { return Collections.unmodifiableList(domainEvents); }
+
+    private void requireStatus(ReconciliationCaseStatus expected) {
+        if (status != expected)
+            throw new DomainRuleViolation("expected reconciliation case status " + expected + " but was " + status);
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank())
+            throw new DomainRuleViolation(name + " must not be blank");
+        return value;
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationCaseOpened.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationCaseOpened.java
@@ -1,0 +1,23 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record ReconciliationCaseOpened(
+    String reconciliationCaseId,
+    String orderId,
+    String paymentIntentId,
+    String differenceType,
+    Money expectedAmount,
+    Money actualAmount,
+    String description,
+    EventMetadata metadata
+) implements FinanceSettlementEvent {
+    public String eventId() { return metadata.eventId(); }
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    public String causationId() { return metadata.causationId(); }
+    public String correlationId() { return metadata.correlationId(); }
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationCaseResolved.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationCaseResolved.java
@@ -1,0 +1,19 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record ReconciliationCaseResolved(
+    String reconciliationCaseId,
+    String resolution,
+    String resolutionNote,
+    EventMetadata metadata
+) implements FinanceSettlementEvent {
+    public String eventId() { return metadata.eventId(); }
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    public String causationId() { return metadata.causationId(); }
+    public String correlationId() { return metadata.correlationId(); }
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ResolveReconciliationCase.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ResolveReconciliationCase.java
@@ -1,0 +1,15 @@
+package com.trainticket.financesettlement.domain;
+
+import java.util.Objects;
+
+public record ResolveReconciliationCase(String reconciliationCaseId, String resolution, String resolutionNote) {
+    public ResolveReconciliationCase {
+        requireText(reconciliationCaseId, "reconciliationCaseId");
+        requireText(resolution, "resolution");
+        requireText(resolutionNote, "resolutionNote");
+    }
+    private static void requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank())
+            throw new DomainRuleViolation(name + " must not be blank");
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RevenueRecognition.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RevenueRecognition.java
@@ -1,0 +1,97 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class RevenueRecognition {
+    private final String revenueRecognitionId;
+    private final String orderId;
+    private final String orderItemId;
+    private final String componentCode;
+    private final Money amount;
+    private final String recognitionPolicyVersion;
+    private final String sourceEventId;
+    private final Instant recognizedAt;
+    private final List<FinanceSettlementEvent> domainEvents;
+    private boolean reversed;
+    private String reversalReason;
+
+    private RevenueRecognition(
+        String revenueRecognitionId, String orderId, String orderItemId,
+        String componentCode, Money amount, String recognitionPolicyVersion,
+        String sourceEventId, Instant recognizedAt
+    ) {
+        this.revenueRecognitionId = requireText(revenueRecognitionId, "revenueRecognitionId");
+        this.orderId = requireText(orderId, "orderId");
+        this.orderItemId = requireText(orderItemId, "orderItemId");
+        this.componentCode = requireText(componentCode, "componentCode");
+        this.amount = Objects.requireNonNull(amount, "amount is required");
+        this.recognitionPolicyVersion = requireText(recognitionPolicyVersion, "recognitionPolicyVersion");
+        this.sourceEventId = requireText(sourceEventId, "sourceEventId");
+        this.recognizedAt = Objects.requireNonNull(recognizedAt, "recognizedAt is required");
+        this.domainEvents = new ArrayList<>();
+        this.reversed = false;
+        this.reversalReason = null;
+    }
+
+    public static RevenueRecognition recognize(
+        String orderId, String orderItemId, String componentCode,
+        Money amount, String recognitionPolicyVersion,
+        String sourceEventId, Instant recognizedAt,
+        Instant now, String sourceCommandId, String correlationId
+    ) {
+        if (amount.isNegative() && !"discount".equals(componentCode))
+            throw new DomainRuleViolation("revenue recognition amount must not be negative for component: " + componentCode);
+        if (amount.isZero())
+            throw new DomainRuleViolation("revenue recognition amount must not be zero");
+
+        RevenueRecognition recognition = new RevenueRecognition(
+            UUID.randomUUID().toString(), orderId, orderItemId, componentCode,
+            amount, recognitionPolicyVersion, sourceEventId, recognizedAt
+        );
+
+        recognition.domainEvents.add(new RevenueRecognized(
+            recognition.revenueRecognitionId, orderItemId, orderId, componentCode,
+            amount, recognitionPolicyVersion, sourceEventId,
+            EventMetadata.create(now, sourceCommandId, sourceCommandId, correlationId,
+                Map.of("revenueRecognitionId", recognition.revenueRecognitionId, "componentCode", componentCode))
+        ));
+        return recognition;
+    }
+
+    public void reverse(String reason, Instant now, String sourceCommandId, String causationId, String correlationId) {
+        if (reversed) return;
+        this.reversed = true;
+        this.reversalReason = requireText(reason, "reason");
+        domainEvents.add(new RevenueRecognized(
+            revenueRecognitionId, orderItemId, orderId, componentCode,
+            amount.negate(), recognitionPolicyVersion + "-reversed", sourceEventId,
+            EventMetadata.create(now, sourceCommandId, causationId, correlationId,
+                Map.of("revenueRecognitionId", revenueRecognitionId, "reversalReason", reason,
+                       "originalSourceEventId", sourceEventId))
+        ));
+    }
+
+    public String revenueRecognitionId() { return revenueRecognitionId; }
+    public String orderId() { return orderId; }
+    public String orderItemId() { return orderItemId; }
+    public String componentCode() { return componentCode; }
+    public Money amount() { return amount; }
+    public String recognitionPolicyVersion() { return recognitionPolicyVersion; }
+    public String sourceEventId() { return sourceEventId; }
+    public Instant recognizedAt() { return recognizedAt; }
+    public boolean reversed() { return reversed; }
+    public String reversalReason() { return reversalReason; }
+    public List<FinanceSettlementEvent> domainEvents() { return Collections.unmodifiableList(domainEvents); }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank())
+            throw new DomainRuleViolation(name + " must not be blank");
+        return value;
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RevenueRecognized.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RevenueRecognized.java
@@ -1,0 +1,23 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record RevenueRecognized(
+    String revenueRecognitionId,
+    String orderItemId,
+    String orderId,
+    String componentCode,
+    Money amount,
+    String recognitionPolicyVersion,
+    String sourceEventId,
+    EventMetadata metadata
+) implements FinanceSettlementEvent {
+    public String eventId() { return metadata.eventId(); }
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    public String causationId() { return metadata.causationId(); }
+    public String correlationId() { return metadata.correlationId(); }
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/SettlementView.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/SettlementView.java
@@ -1,0 +1,56 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class SettlementView {
+    private final String settlementViewId;
+    private final String viewType;
+    private final int version;
+    private final int eventCount;
+    private final Instant rebuiltAt;
+    private final List<FinanceSettlementEvent> domainEvents;
+
+    private SettlementView(String settlementViewId, String viewType, int version, int eventCount, Instant rebuiltAt) {
+        this.settlementViewId = requireText(settlementViewId, "settlementViewId");
+        this.viewType = requireText(viewType, "viewType");
+        if (version < 1) throw new DomainRuleViolation("view version must be positive");
+        this.version = version;
+        if (eventCount < 0) throw new DomainRuleViolation("event count must not be negative");
+        this.eventCount = eventCount;
+        this.rebuiltAt = Objects.requireNonNull(rebuiltAt, "rebuiltAt is required");
+        this.domainEvents = new ArrayList<>();
+    }
+
+    public static SettlementView rebuild(
+        String viewType, int version, int eventCount, Instant rebuiltAt,
+        Instant now, String sourceCommandId, String correlationId
+    ) {
+        SettlementView view = new SettlementView(UUID.randomUUID().toString(), viewType, version, eventCount, rebuiltAt);
+        view.domainEvents.add(new SettlementViewRebuilt(
+            view.settlementViewId, viewType, eventCount,
+            EventMetadata.create(now, sourceCommandId, sourceCommandId, correlationId,
+                Map.of("settlementViewId", view.settlementViewId, "viewType", viewType,
+                       "version", String.valueOf(version), "eventCount", String.valueOf(eventCount)))
+        ));
+        return view;
+    }
+
+    public String settlementViewId() { return settlementViewId; }
+    public String viewType() { return viewType; }
+    public int version() { return version; }
+    public int eventCount() { return eventCount; }
+    public Instant rebuiltAt() { return rebuiltAt; }
+    public List<FinanceSettlementEvent> domainEvents() { return Collections.unmodifiableList(domainEvents); }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank())
+            throw new DomainRuleViolation(name + " must not be blank");
+        return value;
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/SettlementViewRebuilt.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/SettlementViewRebuilt.java
@@ -1,0 +1,19 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record SettlementViewRebuilt(
+    String settlementViewId,
+    String viewType,
+    int eventCount,
+    EventMetadata metadata
+) implements FinanceSettlementEvent {
+    public String eventId() { return metadata.eventId(); }
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    public String causationId() { return metadata.causationId(); }
+    public String correlationId() { return metadata.correlationId(); }
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/ConsumedEventLogTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/ConsumedEventLogTest.java
@@ -1,0 +1,49 @@
+package com.trainticket.financesettlement.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class ConsumedEventLogTest {
+    private static final Instant NOW = Instant.parse("2026-07-03T12:00:00Z");
+
+    @Test
+    void recordsConsumedEvent() {
+        ConsumedEventLog log = ConsumedEventLog.record("event-123", "payment", "PaymentCaptured", NOW);
+        assertNotNull(log.logId());
+        assertEquals("event-123", log.eventId());
+        assertEquals("payment", log.source());
+        assertEquals("PaymentCaptured", log.eventType());
+        assertEquals(NOW, log.consumedAt());
+    }
+
+    @Test
+    void refusesBlankEventId() {
+        assertThrows(DomainRuleViolation.class, () -> ConsumedEventLog.record("", "payment", "PaymentCaptured", NOW));
+    }
+
+    @Test
+    void refusesNullConsumedAt() {
+        assertThrows(NullPointerException.class, () -> ConsumedEventLog.record("event-1", "payment", "PaymentCaptured", null));
+    }
+
+    @Test
+    void refusesBlankSource() {
+        assertThrows(DomainRuleViolation.class, () -> ConsumedEventLog.record("event-1", "", "PaymentCaptured", NOW));
+    }
+
+    @Test
+    void refusesBlankEventType() {
+        assertThrows(DomainRuleViolation.class, () -> ConsumedEventLog.record("event-1", "payment", "", NOW));
+    }
+
+    @Test
+    void recordsEventsFromDifferentSources() {
+        assertEquals("payment", ConsumedEventLog.record("e-1", "payment", "PaymentCaptured", NOW).source());
+        assertEquals("journey-order", ConsumedEventLog.record("e-2", "journey-order", "JourneyOrderCreated", NOW).source());
+        assertEquals("post-sales", ConsumedEventLog.record("e-3", "post-sales", "PostSalesApplied", NOW).source());
+    }
+}

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/MoneyTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/MoneyTest.java
@@ -1,0 +1,71 @@
+package com.trainticket.financesettlement.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.Currency;
+import org.junit.jupiter.api.Test;
+
+class MoneyTest {
+    @Test
+    void createsMoneyWithCorrectScale() {
+        Money m = Money.of("CNY", "123.45");
+        assertEquals("CNY", m.currency().getCurrencyCode());
+        assertEquals("123.45", m.amount().toPlainString());
+    }
+
+    @Test
+    void zeroReturnsZeroAmount() {
+        Money m = Money.zero(Currency.getInstance("CNY"));
+        assertTrue(m.isZero());
+        assertFalse(m.isNegative());
+    }
+
+    @Test
+    void additionRequiresSameCurrency() {
+        Money a = Money.of("CNY", "100.00");
+        Money b = Money.of("CNY", "50.00");
+        assertEquals(Money.of("CNY", "150.00"), a.plus(b));
+    }
+
+    @Test
+    void additionRejectsCrossCurrency() {
+        Money a = Money.of("CNY", "100.00");
+        Money b = Money.of("USD", "50.00");
+        assertThrows(DomainRuleViolation.class, () -> a.plus(b));
+    }
+
+    @Test
+    void subtractionRequiresSameCurrency() {
+        Money a = Money.of("CNY", "100.00");
+        Money b = Money.of("CNY", "30.00");
+        assertEquals(Money.of("CNY", "70.00"), a.minus(b));
+    }
+
+    @Test
+    void negateReturnsNegativeAmount() {
+        Money a = Money.of("CNY", "100.00");
+        assertEquals(Money.of("CNY", "-100.00"), a.negate());
+    }
+
+    @Test
+    void compareToOrdersByAmount() {
+        assertTrue(Money.of("CNY", "50.00").compareTo(Money.of("CNY", "100.00")) < 0);
+        assertTrue(Money.of("CNY", "100.00").compareTo(Money.of("CNY", "50.00")) > 0);
+        assertEquals(0, Money.of("CNY", "100.00").compareTo(Money.of("CNY", "100.00")));
+    }
+
+    @Test
+    void refusesNullCurrencyOrAmount() {
+        assertThrows(NullPointerException.class, () -> new Money(null, BigDecimal.TEN));
+        assertThrows(NullPointerException.class, () -> new Money(Currency.getInstance("CNY"), null));
+    }
+
+    @Test
+    void refusesDifferentScaleThanCurrencyFractionDigits() {
+        assertThrows(java.lang.ArithmeticException.class, () -> Money.of("CNY", "100.123"));
+    }
+}

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/ReconciliationCaseTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/ReconciliationCaseTest.java
@@ -1,0 +1,118 @@
+package com.trainticket.financesettlement.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class ReconciliationCaseTest {
+    private static final Instant NOW = Instant.parse("2026-07-03T12:00:00Z");
+
+    @Test
+    void opensCaseWithDifferentAmounts() {
+        ReconciliationCase rc = ReconciliationCase.open("order-1", "payment-1",
+            "amount-mismatch", Money.of("CNY", "120.00"), Money.of("CNY", "100.00"),
+            "Expected 120.00 but channel reports 100.00", NOW, "cmd-open", "corr-1");
+        assertNotNull(rc.reconciliationCaseId());
+        assertEquals("amount-mismatch", rc.differenceType());
+        assertEquals(ReconciliationCase.ReconciliationCaseStatus.OPEN, rc.status());
+        assertEquals(1, rc.domainEvents().size());
+        assertInstanceOf(ReconciliationCaseOpened.class, rc.domainEvents().getFirst());
+    }
+
+    @Test
+    void refusesOpenCaseWithMatchingAmounts() {
+        assertThrows(DomainRuleViolation.class, () -> ReconciliationCase.open(
+            "order-1", null, "duplicate", Money.of("CNY", "100.00"), Money.of("CNY", "100.00"),
+            "Same amounts", NOW, "cmd-open", "corr-1"));
+    }
+
+    @Test
+    void opensCaseWithDifferentCurrencies() {
+        ReconciliationCase rc = ReconciliationCase.open("order-1", null, "currency-mismatch",
+            Money.of("CNY", "100.00"), Money.of("USD", "15.00"),
+            "Platform in CNY, channel in USD", NOW, "cmd-open", "corr-1");
+        assertEquals("currency-mismatch", rc.differenceType());
+        assertEquals(ReconciliationCase.ReconciliationCaseStatus.OPEN, rc.status());
+    }
+
+    @Test
+    void resolveTransitionsToResolvedAndEmitsEvent() {
+        ReconciliationCase rc = ReconciliationCase.open("order-1", null, "missing-in-platform",
+            Money.of("CNY", "50.00"), Money.of("CNY", "0.00"),
+            "Channel record not found in platform", NOW, "cmd-open", "corr-1");
+        rc.resolve("auto-resolved", "Test transaction", NOW.plusSeconds(10), "cmd-resolve", "event-1", "corr-1");
+        assertEquals(ReconciliationCase.ReconciliationCaseStatus.RESOLVED, rc.status());
+        assertEquals("auto-resolved", rc.resolution());
+        assertEquals(2, rc.domainEvents().size());
+        assertInstanceOf(ReconciliationCaseResolved.class, rc.domainEvents().get(1));
+    }
+
+    @Test
+    void resolveIsIdempotent() {
+        ReconciliationCase rc = ReconciliationCase.open("order-1", null, "amount-mismatch",
+            Money.of("CNY", "120.00"), Money.of("CNY", "100.00"),
+            "Amount mismatch", NOW, "cmd-open", "corr-1");
+        rc.resolve("manual-resolved", "Fixed", NOW.plusSeconds(10), "cmd-resolve", "event-1", "corr-1");
+        rc.resolve("again", "Already done", NOW.plusSeconds(20), "cmd-resolve2", "event-2", "corr-1");
+        assertEquals(2, rc.domainEvents().size());
+        assertEquals("manual-resolved", rc.resolution());
+    }
+
+    @Test
+    void cannotResolveRejectedCase() {
+        ReconciliationCase rc = ReconciliationCase.open("order-1", null, "duplicate",
+            Money.of("CNY", "100.00"), Money.of("CNY", "0.00"),
+            "Duplicate", NOW, "cmd-open", "corr-1");
+        rc.reject("Invalid", NOW.plusSeconds(10), "cmd-reject", "event-1", "corr-1");
+        assertThrows(DomainRuleViolation.class, () ->
+            rc.resolve("manual-resolved", "Should not work", NOW.plusSeconds(20), "cmd-resolve", "event-2", "corr-1"));
+    }
+
+    @Test
+    void rejectTransitionsToRejected() {
+        ReconciliationCase rc = ReconciliationCase.open("order-1", null, "duplicate",
+            Money.of("CNY", "100.00"), Money.of("CNY", "0.00"),
+            "Duplicate", NOW, "cmd-open", "corr-1");
+        rc.reject("Not valid", NOW.plusSeconds(10), "cmd-reject", "event-1", "corr-1");
+        assertEquals(ReconciliationCase.ReconciliationCaseStatus.REJECTED, rc.status());
+        assertEquals("rejected", rc.resolution());
+        assertEquals(2, rc.domainEvents().size());
+    }
+
+    @Test
+    void escalateTransitionsToEscalated() {
+        ReconciliationCase rc = ReconciliationCase.open("order-1", "payment-1",
+            "late-payment", Money.of("CNY", "200.00"), Money.of("CNY", "180.00"),
+            "Late payment with fee", NOW, "cmd-open", "corr-1");
+        rc.markInvestigating(NOW.plusSeconds(5), "cmd-investigate", "event-1", "corr-1");
+        assertEquals(ReconciliationCase.ReconciliationCaseStatus.INVESTIGATING, rc.status());
+        rc.escalate("Manual needed", NOW.plusSeconds(10), "cmd-escalate", "event-2", "corr-1");
+        assertEquals(ReconciliationCase.ReconciliationCaseStatus.ESCALATED, rc.status());
+    }
+
+    @Test
+    void cannotEscalateResolvedCase() {
+        ReconciliationCase rc = ReconciliationCase.open("order-1", null, "amount-mismatch",
+            Money.of("CNY", "50.00"), Money.of("CNY", "45.00"),
+            "Minor", NOW, "cmd-open", "corr-1");
+        rc.resolve("auto-resolved", "OK", NOW.plusSeconds(10), "cmd-resolve", "event-1", "corr-1");
+        assertThrows(DomainRuleViolation.class, () ->
+            rc.escalate("Should not work", NOW.plusSeconds(20), "cmd-escalate", "event-2", "corr-1"));
+    }
+
+    @Test
+    void eventMetadataIsPopulatedForOpenedEvent() {
+        ReconciliationCase rc = ReconciliationCase.open(null, null, "missing-in-channel",
+            Money.of("CNY", "100.00"), Money.of("CNY", "0.00"),
+            "Missing", NOW, "cmd-open", "corr-1");
+        FinanceSettlementEvent event = rc.domainEvents().getFirst();
+        assertEquals("ReconciliationCaseOpened", event.eventType());
+        assertEquals("cmd-open", event.sourceCommandId());
+        assertEquals("corr-1", event.correlationId());
+        assertNotNull(event.eventId());
+    }
+}

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/RevenueRecognitionTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/RevenueRecognitionTest.java
@@ -1,0 +1,94 @@
+package com.trainticket.financesettlement.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class RevenueRecognitionTest {
+    private static final Instant NOW = Instant.parse("2026-07-03T12:00:00Z");
+
+    @Test
+    void recognizesRevenueForCompletedOrderItem() {
+        Money amount = Money.of("CNY", "120.00");
+        RevenueRecognition recognition = RevenueRecognition.recognize(
+            "order-1", "item-1", "fare", amount, "policy-v1",
+            "source-event-1", NOW, NOW, "cmd-recognize", "corr-1");
+        assertNotNull(recognition.revenueRecognitionId());
+        assertEquals("order-1", recognition.orderId());
+        assertEquals("item-1", recognition.orderItemId());
+        assertEquals("fare", recognition.componentCode());
+        assertEquals(amount, recognition.amount());
+        assertEquals("policy-v1", recognition.recognitionPolicyVersion());
+        assertEquals("source-event-1", recognition.sourceEventId());
+        assertFalse(recognition.reversed());
+        assertEquals(1, recognition.domainEvents().size());
+        assertInstanceOf(RevenueRecognized.class, recognition.domainEvents().getFirst());
+    }
+
+    @Test
+    void refusesNegativeAmountForNonDiscountComponent() {
+        assertThrows(DomainRuleViolation.class, () -> RevenueRecognition.recognize(
+            "order-1", "item-1", "fare", Money.of("CNY", "-10.00"),
+            "policy-v1", "source-event-1", NOW, NOW, "cmd-recognize", "corr-1"));
+    }
+
+    @Test
+    void refusesZeroAmount() {
+        assertThrows(DomainRuleViolation.class, () -> RevenueRecognition.recognize(
+            "order-1", "item-1", "fare", Money.of("CNY", "0.00"),
+            "policy-v1", "source-event-1", NOW, NOW, "cmd-recognize", "corr-1"));
+    }
+
+    @Test
+    void reverseCreatesOffsettingEvent() {
+        Money amount = Money.of("CNY", "120.00");
+        RevenueRecognition recognition = RevenueRecognition.recognize(
+            "order-1", "item-1", "fare", amount, "policy-v1",
+            "source-event-1", NOW, NOW, "cmd-recognize", "corr-1");
+        recognition.reverse("order cancelled", NOW.plusSeconds(100), "cmd-reverse", "event-1", "corr-1");
+        assertTrue(recognition.reversed());
+        assertEquals("order cancelled", recognition.reversalReason());
+        assertEquals(2, recognition.domainEvents().size());
+        RevenueRecognized reversalEvent = (RevenueRecognized) recognition.domainEvents().get(1);
+        assertTrue(reversalEvent.amount().isNegative());
+        assertEquals("policy-v1-reversed", reversalEvent.recognitionPolicyVersion());
+    }
+
+    @Test
+    void reverseIsIdempotent() {
+        RevenueRecognition recognition = RevenueRecognition.recognize(
+            "order-1", "item-1", "fare", Money.of("CNY", "120.00"), "policy-v1",
+            "source-event-1", NOW, NOW, "cmd-recognize", "corr-1");
+        recognition.reverse("reason", NOW.plusSeconds(100), "cmd-reverse", "event-1", "corr-1");
+        recognition.reverse("reason again", NOW.plusSeconds(200), "cmd-reverse2", "event-2", "corr-1");
+        assertEquals(2, recognition.domainEvents().size());
+    }
+
+    @Test
+    void eventMetadataIsPopulatedCorrectly() {
+        RevenueRecognition recognition = RevenueRecognition.recognize(
+            "order-1", "item-1", "ancillary", Money.of("CNY", "25.00"), "policy-v2",
+            "source-event-2", NOW, NOW, "cmd-recognize", "corr-1");
+        FinanceSettlementEvent event = recognition.domainEvents().getFirst();
+        assertEquals("RevenueRecognized", event.eventType());
+        assertEquals(1, event.schemaVersion());
+        assertEquals("cmd-recognize", event.sourceCommandId());
+        assertEquals("corr-1", event.correlationId());
+        assertNotNull(event.eventId());
+    }
+
+    @Test
+    void recognizesDiscountWithNegativeAmount() {
+        RevenueRecognition recognition = RevenueRecognition.recognize(
+            "order-1", "item-discount", "discount", Money.of("CNY", "-20.00"), "policy-v1",
+            "source-event-3", NOW, NOW, "cmd-recognize", "corr-1");
+        assertTrue(recognition.amount().isNegative());
+        assertEquals("discount", recognition.componentCode());
+    }
+}

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/SettlementViewTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/SettlementViewTest.java
@@ -1,0 +1,61 @@
+package com.trainticket.financesettlement.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class SettlementViewTest {
+    private static final Instant NOW = Instant.parse("2026-07-03T12:00:00Z");
+
+    @Test
+    void rebuildsRevenueView() {
+        SettlementView view = SettlementView.rebuild("REVENUE", 1, 42, NOW, NOW, "cmd-rebuild", "corr-1");
+        assertNotNull(view.settlementViewId());
+        assertEquals("REVENUE", view.viewType());
+        assertEquals(1, view.version());
+        assertEquals(42, view.eventCount());
+        assertEquals(1, view.domainEvents().size());
+        assertInstanceOf(SettlementViewRebuilt.class, view.domainEvents().getFirst());
+    }
+
+    @Test
+    void rebuildsReconciliationView() {
+        SettlementView view = SettlementView.rebuild("RECONCILIATION", 3, 128, NOW, NOW, "cmd-rebuild", "corr-1");
+        assertEquals("RECONCILIATION", view.viewType());
+        assertEquals(3, view.version());
+        assertEquals(128, view.eventCount());
+    }
+
+    @Test
+    void rebuildsSettlementView() {
+        SettlementView view = SettlementView.rebuild("SETTLEMENT", 1, 0, NOW, NOW, "cmd-rebuild", "corr-1");
+        assertEquals(0, view.eventCount());
+    }
+
+    @Test
+    void refusesNegativeEventCount() {
+        assertThrows(DomainRuleViolation.class, () ->
+            SettlementView.rebuild("REVENUE", 1, -1, NOW, NOW, "cmd-rebuild", "corr-1"));
+    }
+
+    @Test
+    void refusesZeroVersion() {
+        assertThrows(DomainRuleViolation.class, () ->
+            SettlementView.rebuild("REVENUE", 0, 10, NOW, NOW, "cmd-rebuild", "corr-1"));
+    }
+
+    @Test
+    void eventMetadataIsPopulated() {
+        SettlementView view = SettlementView.rebuild("REVENUE", 2, 55, NOW, NOW, "cmd-rebuild", "corr-1");
+        FinanceSettlementEvent event = view.domainEvents().getFirst();
+        assertEquals("SettlementViewRebuilt", event.eventType());
+        assertEquals("cmd-rebuild", event.sourceCommandId());
+        assertEquals("corr-1", event.correlationId());
+        assertEquals(1, event.schemaVersion());
+        assertNotNull(event.eventId());
+    }
+}


### PR DESCRIPTION
Implement the Finance Settlement domain foundation in Java.

## Key Aggregates
- **RevenueRecognition** - recognizes/reverses revenue from upstream events
- **ReconciliationCase** - opens/resolves/rejects/escalates reconciliation mismatches
- **SettlementView** - rebuildable from event log
- **ConsumedEventLog** - idempotent event consumption tracking

## Key Commands
- ConsumeBusinessEvent, RecognizeRevenue, OpenReconciliationCase, ResolveReconciliationCase, RebuildSettlementView

## Key Events
- RevenueRecognized, ReconciliationCaseOpened, ReconciliationCaseResolved, SettlementViewRebuilt

## Contract Docs
- docs/08-contracts/README.md, shared-primitives.md
- docs/08-contracts/events/finance-settlement-events.md
- docs/08-contracts/events/upstream-events.md

## Validation
- `cd services/finance-settlement && mvn test` - 42 tests pass
- `make check` - skeleton check passed

Closes REQ-024