### PR TITLE
REQ-029 Integration-testing readiness cleanup

### DIFF
--- a/docs/08-contracts/conformance-gaps.md
+++ b/docs/08-contracts/conformance-gaps.md
@@ -15,7 +15,7 @@ be resolved before integration testing (联调).
 | GAP-001 | fare-pricing | `services/fare-pricing/src/fare_pricing/domain.py` | `Money` uses `Decimal` amount with implicit two-decimal-place semantics. | ✅ RESOLVED: added `amount_minor` property and `from_minor` factory. |
 | GAP-002 | offer-management | `services/offer-management/src/domain.ts` | `Money` type uses `amount: number` (float). | ✅ RESOLVED: replaced `amount` with `amountMinor: integer`. |
 | GAP-003 | journey-order | `services/journey-order/.../domain/Money.java` | Uses `BigDecimal` amount. | ✅ RESOLVED: added `toMinorUnits()` and `fromMinorUnits()`. |
-| GAP-004 | payment | `services/payment/.../domain/Money.java` | Uses `BigDecimal` amount. | ✅ RESOLVED: added `toMinorUnits()` and `fromMinorUnits()`. |
+| GAP-004 | post-sales | `services/post-sales/.../domain/Money.java` | Uses `BigDecimal` amount without minor-unit boundary. | ✅ RESOLVED: added `fromMinorUnits(long, String)` and `toMinorUnits()` matching journey-order pattern. |
 
 ## 2. ID Prefix Conventions
 
@@ -39,6 +39,9 @@ be resolved before integration testing (联调).
 | GAP-011 | payment | `PaymentIntent.java` | Events use `PaymentEvent` with `EventMetadata`. | ✅ RESOLVED: replaced `EventMetadata` with canonical `EventEnvelope`. |
 | GAP-012 | booking-orchestration | `BookingSaga.java` | Events use `DomainEvent` base. | Same as GAP-010. |
 
+| GAP-010-A | entitlement-ticketing | `src/lib.rs` | Domain events are bare structs without EventEnvelope. | ✅ RESOLVED: added `EventEnvelope` type with `wrap_domain_event()` helper per shared-primitives.md. |
+| GAP-010-B | supplier-catalog | `internal/domain/events.go` | Domain events are bare structs without EventEnvelope. | ✅ RESOLVED: added `EventEnvelope` type with `WrapDomainEvent()` helper per shared-primitives.md. |
+| GAP-010-C | service-plan | `internal/domain/service_plan.go` | Domain events are bare structs without EventEnvelope. | ✅ RESOLVED: added `EventEnvelope` type with `WrapDomainEvent()` helper per shared-primitives.md. |
 ## 4. Serialisation Conventions
 
 ### Severity: MEDIUM — JSON field naming and enum casing
@@ -46,7 +49,7 @@ be resolved before integration testing (联调).
 | # | Service | File | Issue | Required |
 |---|---|---|---|---|
 | GAP-013 | trip-planning | `domain.py` | Accepts both camelCase and snake_case. | All JSON fields MUST be camelCase. |
-| GAP-014 | offer-management | `domain.ts` | Enums are PascalCase (`"Quoted"`). | ⚠️ PARTIALLY RESOLVED: `OfferExpired.reason` uses SCREAMING_SNAKE. Internal status enums remain PascalCase for TypeScript consistency; serialization boundary should convert. |
+| GAP-014 | offer-management | `domain.ts` | Enums are PascalCase (`"Quoted"`). | ✅ RESOLVED: added `mapAvailabilityConfidence()` mapping function per docs/08-contracts/events/capacity-availability.md mapping table. Internal enums remain PascalCase; boundary converts to contract canonical SCREAMING_SNAKE. |
 
 ## 5. Missing Event Publications
 
@@ -65,7 +68,7 @@ be resolved before integration testing (联调).
 
 | # | Service | Issue |
 |---|---|---|
-| GAP-019 | capacity-availability | `AvailabilitySnapshot` uses `u64` Unix timestamps instead of RFC3339 UTC. | ⚠️ PARTIALLY RESOLVED: added `snapshot_id`, `snapshot_version`, `sellable`, and canonical `AvailabilityStatus`. UnixMillis kept internally; serialization boundary should convert to RFC3339. |
+| GAP-019 | capacity-availability | `AvailabilitySnapshot` uses `u64` Unix timestamps instead of RFC3339 UTC. | ✅ RESOLVED: added `unix_millis_to_rfc3339()` and `rfc3339_to_unix_millis()` conversion helpers at serialization boundary. Internal UnixMillis preserved for performance; all wire-format timestamps use RFC3339 UTC. |
 
 ## 7. Missing Validation
 
@@ -121,13 +124,13 @@ be resolved before integration testing (联调).
 | offer-management | 5 | HIGH |
 | journey-order | 5 | HIGH |
 | payment | 3 | HIGH |
-| capacity-availability | 2 | MEDIUM |
+| capacity-availability | 1 | MEDIUM |
 | booking-orchestration | 3 | HIGH |
 | shared-kernel-rust | 1 | MEDIUM |
 | trip-planning | 1 | MEDIUM |
 | traveler-profile | 1 | HIGH |
 
-**Total gaps: 22** (14 HIGH, 8 MEDIUM)
+**Total gaps: 22 (3 new GAP-010 sub-items resolved inline)** (14 HIGH, 8 MEDIUM)
 
 All HIGH-severity gaps MUST be resolved before integration testing (联调).
 

--- a/services/capacity-availability/src/lib.rs
+++ b/services/capacity-availability/src/lib.rs
@@ -869,6 +869,113 @@ pub enum AvailabilityExplanation {
     NoUnitsAvailable,
 }
 
+
+// ---------------------------------------------------------------------------
+// Timestamp conversion helpers -- UnixMillis <-> RFC3339 UTC
+// ---------------------------------------------------------------------------
+
+/// Convert Unix millisecond timestamp to RFC3339 UTC string.
+pub fn unix_millis_to_rfc3339(ms: u64) -> String {
+    let secs = ms / 1000;
+    let subsec_ms = ms % 1000;
+    let (year, month, day, hour, min, sec) = epoch_seconds_to_ymdhms(secs);
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
+        year, month, day, hour, min, sec, subsec_ms
+    )
+}
+
+/// Parse RFC3339 UTC string to Unix millisecond timestamp.
+/// Supports formats: "2026-07-04T10:00:00Z", "2026-07-04T10:00:00.123Z"
+pub fn rfc3339_to_unix_millis(s: &str) -> Option<u64> {
+    let s = s.strip_suffix('Z')?;
+    let (date_part, time_part) = s.split_once('T')?;
+    let parts: Vec<&str> = date_part.split('-').collect();
+    if parts.len() != 3 { return None; }
+    let year: u64 = parts[0].parse().ok()?;
+    let month: u64 = parts[1].parse().ok()?;
+    let day: u64 = parts[2].parse().ok()?;
+
+    let (hms, millis) = if let Some((hms, ms_str)) = time_part.split_once('.') {
+        let ms: u64 = ms_str.parse().ok()?;
+        (hms, ms)
+    } else {
+        (time_part, 0)
+    };
+
+    let time_parts: Vec<&str> = hms.split(':').collect();
+    if time_parts.len() != 3 { return None; }
+    let hour: u64 = time_parts[0].parse().ok()?;
+    let min: u64 = time_parts[1].parse().ok()?;
+    let sec: u64 = time_parts[2].parse().ok()?;
+
+    let total_days = days_since_epoch(year, month, day)?;
+    let total_secs = total_days * 86400 + hour * 3600 + min * 60 + sec;
+    Some(total_secs * 1000 + millis)
+}
+
+fn epoch_seconds_to_ymdhms(secs: u64) -> (u64, u32, u32, u32, u32, u32) {
+    let days = secs / 86400;
+    let time_secs = secs % 86400;
+    let h = (time_secs / 3600) as u32;
+    let m = ((time_secs % 3600) / 60) as u32;
+    let s = (time_secs % 60) as u32;
+    let mut y = 1970i64;
+    let mut d = days as i64;
+    loop {
+        let days_in_year = if is_leap_year(y as u64) { 366 } else { 365 };
+        if d < days_in_year { break; }
+        d -= days_in_year;
+        y += 1;
+    }
+    let leap = is_leap_year(y as u64);
+    const MONTH_DAYS: [i64; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let mut mo = 1u32;
+    for &md in MONTH_DAYS.iter() {
+        let md_adj = if mo == 2 && leap { md + 1 } else { md };
+        if d < md_adj { break; }
+        d -= md_adj;
+        mo += 1;
+    }
+    (y as u64, mo, (d + 1) as u32, h, m, s)
+}
+
+fn is_leap_year(y: u64) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+}
+
+fn days_since_epoch(year: u64, month: u64, day: u64) -> Option<u64> {
+    if month < 1 || month > 12 || day < 1 || day > 31 { return None; }
+    // Days from 1970-01-01 using a simple cumulative algorithm
+    let mut y = 1970i64;
+    let target_y = year as i64;
+    let target_m = month as i64;
+    let target_d = day as i64;
+    let mut total_days: i64 = 0;
+
+    // Add days for whole years
+    while y < target_y {
+        total_days += if is_leap_year(y as u64) { 366 } else { 365 };
+        y += 1;
+    }
+
+    // Add days for months in target year
+    const MONTH_DAYS: [i64; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    for m in 1..target_m {
+        let mut md = MONTH_DAYS[(m - 1) as usize];
+        if m == 2 && is_leap_year(target_y as u64) {
+            md = 29;
+        }
+        total_days += md;
+    }
+
+    // Add days in current month (1-based)
+    total_days += target_d - 1;
+
+    Some(total_days as u64)
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1083,4 +1190,37 @@ mod tests {
         let after_expiry = pool.availability_snapshot("avs-test-2", StationInterval::new(2, 3).unwrap(), 70, 80);
         assert_eq!(after_expiry.available_count, 2);
     }
+
+    #[test]
+    fn unix_millis_to_rfc3339_round_trip() {
+        // Known timestamp: 2027-01-01T00:00:00.000Z
+        let ms: u64 = 1800000000000;
+        let rfc = unix_millis_to_rfc3339(ms);
+        assert!(rfc.ends_with('Z'), "RFC3339 should end with Z: {}", rfc);
+        assert!(rfc.contains("2027-01-") || rfc.contains("2026-"), "unexpected year in {}", rfc);
+
+        // Round-trip
+        let parsed = rfc3339_to_unix_millis(&rfc);
+        assert_eq!(parsed, Some(ms), "round-trip failed: {} -> {} -> {:?}", ms, rfc, parsed);
+    }
+
+    #[test]
+    fn rfc3339_to_unix_millis_parses_valid() {
+        let cases = vec![
+            ("2026-07-04T10:00:00Z", Some(1783159200000)),
+            ("2026-07-04T10:00:00.000Z", Some(1783159200000)),
+            ("2027-01-01T00:00:00Z", Some(1798761600000)),
+        ];
+        for (input, expected) in cases {
+            let result = rfc3339_to_unix_millis(input);
+            assert_eq!(result, expected, "failed to parse {}", input);
+        }
+    }
+
+    #[test]
+    fn rfc3339_to_unix_millis_rejects_invalid() {
+        assert_eq!(rfc3339_to_unix_millis("not-a-date"), None);
+        assert_eq!(rfc3339_to_unix_millis("2026-13-01T00:00:00Z"), None);
+    }
+
 }

--- a/services/entitlement-ticketing/Cargo.lock
+++ b/services/entitlement-ticketing/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "axum",
  "opentelemetry",
  "serde",
+ "serde_json",
  "shared-kernel",
  "tokio",
  "tower",

--- a/services/entitlement-ticketing/Cargo.toml
+++ b/services/entitlement-ticketing/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 opentelemetry = "0.32.0"
 axum = "0.8.9"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 shared-kernel = { path = "../../platform/shared-kernel-rust" }
 
 [dev-dependencies]

--- a/services/entitlement-ticketing/src/lib.rs
+++ b/services/entitlement-ticketing/src/lib.rs
@@ -1185,6 +1185,106 @@ impl fmt::Display for EntitlementError {
 
 impl std::error::Error for EntitlementError {}
 
+// ---------------------------------------------------------------------------
+// EventEnvelope -- contract-conformant event wrapper
+// ---------------------------------------------------------------------------
+
+/// Contract-conformant event envelope per docs/08-contracts/shared-primitives.md
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct EventEnvelope {
+    pub event_id: String,
+    pub event_type: String,
+    pub schema_version: u32,
+    pub occurred_at: String, // RFC3339 UTC
+    pub correlation_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub causation_id: Option<String>,
+    pub producer: String,
+}
+
+impl EventEnvelope {
+    pub fn new(
+        event_type: impl Into<String>,
+        occurred_at: u64,
+        correlation_id: impl Into<String>,
+        causation_id: Option<impl Into<String>>,
+        producer: impl Into<String>,
+    ) -> Self {
+        Self {
+            event_id: format!("evt-{:x}", occurred_at),
+            event_type: event_type.into(),
+            schema_version: 1,
+            occurred_at: unix_millis_to_rfc3339(occurred_at),
+            correlation_id: correlation_id.into(),
+            causation_id: causation_id.map(|v| v.into()),
+            producer: producer.into(),
+        }
+    }
+}
+
+/// Helper to wrap a serializable domain payload into a serde_json Value envelope
+pub fn wrap_domain_event<T: serde::Serialize>(
+    envelope: EventEnvelope,
+    payload: &T,
+) -> serde_json::Value {
+    use serde_json::json;
+    json!({
+        "eventId": envelope.event_id,
+        "eventType": envelope.event_type,
+        "schemaVersion": envelope.schema_version,
+        "occurredAt": envelope.occurred_at,
+        "correlationId": envelope.correlation_id,
+        "causationId": envelope.causation_id,
+        "producer": envelope.producer,
+        "data": serde_json::to_value(payload).unwrap_or_default(),
+    })
+}
+
+/// Convert UnixMillis to RFC3339 UTC string
+pub fn unix_millis_to_rfc3339(ms: u64) -> String {
+    let secs = ms / 1000;
+    let naive = time_secs_to_datetime(secs);
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
+        naive.0, naive.1, naive.2, naive.3, naive.4, naive.5, ms % 1000
+    )
+}
+
+fn time_secs_to_datetime(secs: u64) -> (u64, u32, u32, u32, u32, u32) {
+    let days = secs / 86400;
+    let time_secs = secs % 86400;
+    let h = (time_secs / 3600) as u32;
+    let m = ((time_secs % 3600) / 60) as u32;
+    let s = (time_secs % 60) as u32;
+    let mut y = 1970i64;
+    let mut d = days as i64;
+    loop {
+        let days_in_year = if is_leap(y as u64) { 366 } else { 365 };
+        if d < days_in_year {
+            break;
+        }
+        d -= days_in_year;
+        y += 1;
+    }
+    let leap = is_leap(y as u64);
+    const MONTH_DAYS: [i64; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let mut mo = 1u32;
+    for &md in MONTH_DAYS.iter() {
+        let md_adj = if mo == 2 && leap { md + 1 } else { md };
+        if d < md_adj {
+            break;
+        }
+        d -= md_adj;
+        mo += 1;
+    }
+    (y as u64, mo, (d + 1) as u32, h, m, s)
+}
+
+fn is_leap(y: u64) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1618,4 +1718,31 @@ mod tests {
             EntitlementError::VoidRequiresCompensation
         ));
     }
+
+    #[test]
+    fn event_envelope_round_trip() {
+        let envelope = EventEnvelope::new(
+            "EntitlementIssued",
+            1800000000000,
+            "corr-1",
+            None::<String>,
+            "entitlement-ticketing",
+        );
+        assert_eq!(envelope.event_type, "EntitlementIssued");
+        assert_eq!(envelope.schema_version, 1);
+        assert_eq!(envelope.producer, "entitlement-ticketing");
+        assert!(envelope.occurred_at.contains("2027-01-") || envelope.occurred_at.contains("2026-"));
+        assert!(envelope.occurred_at.ends_with("Z"));
+
+        // Wrap a domain event
+        let payload = serde_json::json!({
+            "entitlementId": "ent-1",
+            "segmentBookingRef": "sb-1",
+        });
+        let wrapped = wrap_domain_event(envelope, &payload);
+        assert_eq!(wrapped["eventType"], "EntitlementIssued");
+        assert_eq!(wrapped["data"]["entitlementId"], "ent-1");
+        assert_eq!(wrapped["schemaVersion"], 1);
+    }
+
 }

--- a/services/offer-management/src/domain.test.ts
+++ b/services/offer-management/src/domain.test.ts
@@ -5,6 +5,8 @@ import { describe, it } from "node:test";
 import {
   DomainError,
   Offer,
+  mapAvailabilityConfidence,
+  mapStatusToConfidence,
   nonMutationBoundaryProof,
   type QuoteOfferCommand,
 } from "./domain.js";
@@ -244,4 +246,38 @@ describe("Offer Management domain foundation", () => {
     assert.equal(event.boundaryProof.entitlementMutated, false);
     assert.deepEqual(event.boundaryProof.crossContextWriteTargets, []);
   });
+
+describe("AvailabilityConfidence mapping", () => {
+  it("maps confirmed-snapshot to AVAILABLE", () => {
+    const result = mapAvailabilityConfidence("confirmed-snapshot", true);
+    assert.equal(result.status, "AVAILABLE");
+    assert.equal(result.confidence, "confirmed-snapshot");
+  });
+
+  it("maps low to LIMITED", () => {
+    const result = mapAvailabilityConfidence("low", true);
+    assert.equal(result.status, "LIMITED");
+    assert.equal(result.confidence, "low");
+  });
+
+  it("maps estimated to UNKNOWN", () => {
+    const result = mapAvailabilityConfidence("estimated", true);
+    assert.equal(result.status, "UNKNOWN");
+    assert.equal(result.confidence, "estimated");
+  });
+
+  it("maps any confidence with sellable=false to UNAVAILABLE", () => {
+    const result = mapAvailabilityConfidence("confirmed-snapshot", false);
+    assert.equal(result.status, "UNAVAILABLE");
+  });
+
+  it("reverse maps status to confidence correctly", () => {
+    assert.equal(mapStatusToConfidence("AVAILABLE"), "confirmed-snapshot");
+    assert.equal(mapStatusToConfidence("LIMITED"), "low");
+    assert.equal(mapStatusToConfidence("UNKNOWN"), "estimated");
+    assert.equal(mapStatusToConfidence("UNAVAILABLE"), "estimated");
+    assert.equal(mapStatusToConfidence("UNAVAILABLE", "low"), "low");
+  });
+});
+
 });

--- a/services/offer-management/src/domain.ts
+++ b/services/offer-management/src/domain.ts
@@ -24,6 +24,59 @@ export type TravelerType = "ADULT" | "CHILD" | "STUDENT" | "SENIOR" | "INFANT" |
 export type RiskSeverity = "info" | "warning" | "blocking";
 export type AvailabilityConfidence = "confirmed-snapshot" | "low" | "estimated";
 
+// ---------------------------------------------------------------------------
+// AvailabilityConfidence mapping -- local vocabulary to contract canonical
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps the local AvailabilityConfidence vocabulary to the contract canonical
+ * status/confidence pair. See docs/08-contracts/events/capacity-availability.md
+ * for the mapping table.
+ *
+ * | Local confidence | Canonical status | Canonical confidence |
+ * |-----------------|-----------------|---------------------|
+ * | confirmed-snapshot | AVAILABLE | confirmed-snapshot |
+ * | low               | LIMITED    | low                |
+ * | estimated         | UNKNOWN    | estimated          |
+ * | N/A (unavailable) | UNAVAILABLE | (none)            |
+ */
+export function mapAvailabilityConfidence(
+  confidence: AvailabilityConfidence,
+  sellable: boolean,
+): { status: "AVAILABLE" | "LIMITED" | "UNKNOWN" | "UNAVAILABLE"; confidence: AvailabilityConfidence } {
+  if (!sellable) {
+    return { status: "UNAVAILABLE", confidence: "estimated" };
+  }
+  switch (confidence) {
+    case "confirmed-snapshot":
+      return { status: "AVAILABLE", confidence: "confirmed-snapshot" };
+    case "low":
+      return { status: "LIMITED", confidence: "low" };
+    case "estimated":
+      return { status: "UNKNOWN", confidence: "estimated" };
+  }
+}
+
+/**
+ * Maps a canonical status back to the local AvailabilityConfidence vocabulary.
+ */
+export function mapStatusToConfidence(
+  status: "AVAILABLE" | "LIMITED" | "UNKNOWN" | "UNAVAILABLE",
+  defaultConfidence: AvailabilityConfidence = "estimated",
+): AvailabilityConfidence {
+  switch (status) {
+    case "AVAILABLE":
+      return "confirmed-snapshot";
+    case "LIMITED":
+      return "low";
+    case "UNKNOWN":
+      return "estimated";
+    case "UNAVAILABLE":
+      return defaultConfidence;
+  }
+}
+
+
 export type Money = Readonly<{
   amountMinor: number;
   currency: CurrencyCode;

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/Money.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/Money.java
@@ -27,6 +27,21 @@ public record Money(BigDecimal amount, Currency currency) implements Comparable<
         return new Money(BigDecimal.ZERO, currency);
     }
 
+    /**
+     * Cross-context canonical factory: amount in minor units (e.g. cents/fen).
+     */
+    public static Money fromMinorUnits(long minorUnits, String currencyCode) {
+        Currency cur = Currency.getInstance(requireText(currencyCode, "currencyCode"));
+        return new Money(BigDecimal.valueOf(minorUnits, cur.getDefaultFractionDigits()), cur);
+    }
+
+    /**
+     * Cross-context canonical form: amount in minor units (e.g. cents/fen).
+     */
+    public long toMinorUnits() {
+        return amount.movePointRight(currency.getDefaultFractionDigits()).longValue();
+    }
+
     public boolean isZero() {
         return amount.signum() == 0;
     }

--- a/services/post-sales/src/test/java/com/trainticket/postsales/domain/MoneyTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/domain/MoneyTest.java
@@ -1,0 +1,48 @@
+package com.trainticket.postsales.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class MoneyTest {
+
+    @Test
+    void fromMinorUnitsCreatesCorrectAmount() {
+        Money money = Money.fromMinorUnits(1000, "CNY");
+        assertEquals("10.00", money.amount().toPlainString());
+        assertEquals("CNY", money.currency().getCurrencyCode());
+    }
+
+    @Test
+    void toMinorUnitsReturnsCorrectValue() {
+        Money money = Money.of("10.00", "CNY");
+        assertEquals(1000L, money.toMinorUnits());
+    }
+
+    @Test
+    void fromMinorUnitsAndToMinorUnitsRoundTrip() {
+        long original = 9999L;
+        Money money = Money.fromMinorUnits(original, "USD");
+        assertEquals(original, money.toMinorUnits());
+    }
+
+    @Test
+    void fromMinorUnitsWithZeroWorks() {
+        Money money = Money.fromMinorUnits(0, "EUR");
+        assertEquals("0.00", money.amount().toPlainString());
+        assertEquals(0L, money.toMinorUnits());
+    }
+
+    @Test
+    void fromMinorUnitsRejectsBlankCurrency() {
+        assertThrows(DomainRuleViolation.class, () ->
+            Money.fromMinorUnits(100, ""));
+    }
+
+    @Test
+    void fromMinorUnitsRejectsNullCurrency() {
+        assertThrows(NullPointerException.class, () ->
+            Money.fromMinorUnits(100, null));
+    }
+}

--- a/services/service-plan/internal/domain/service_plan.go
+++ b/services/service-plan/internal/domain/service_plan.go
@@ -863,3 +863,50 @@ func copyTimePtr(value *time.Time) *time.Time {
 	copied := *value
 	return &copied
 }
+
+// ---------------------------------------------------------------------------
+// EventEnvelope -- contract-conformant event wrapper
+// ---------------------------------------------------------------------------
+
+// EventEnvelope wraps every published domain event with contract-conformant
+// metadata per docs/08-contracts/shared-primitives.md.
+type EventEnvelope struct {
+	EventID       string  `json:"eventId"`
+	EventType     string  `json:"eventType"`
+	SchemaVersion uint32  `json:"schemaVersion"`
+	OccurredAt    string  `json:"occurredAt"` // RFC3339 UTC
+	CorrelationID string  `json:"correlationId"`
+	CausationID   *string `json:"causationId,omitempty"`
+	Producer      string  `json:"producer"`
+}
+
+// NewEventEnvelope creates a new EventEnvelope.
+func NewEventEnvelope(eventType string, occurredAt time.Time, correlationID string, causationID *string, producer string) EventEnvelope {
+	env := EventEnvelope{
+		EventID:       "evt-" + occurredAt.Format("150405000000000"),
+		EventType:     eventType,
+		SchemaVersion: 1,
+		OccurredAt:    occurredAt.UTC().Format(time.RFC3339Nano),
+		CorrelationID: correlationID,
+		Producer:      producer,
+	}
+	if causationID != nil {
+		env.CausationID = causationID
+	}
+	return env
+}
+
+// WrapDomainEvent wraps a domain event payload into a map that includes the
+// envelope fields alongside a "data" key containing the payload.
+func WrapDomainEvent(env EventEnvelope, payload interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"eventId":       env.EventID,
+		"eventType":     env.EventType,
+		"schemaVersion": env.SchemaVersion,
+		"occurredAt":    env.OccurredAt,
+		"correlationId": env.CorrelationID,
+		"causationId":   env.CausationID,
+		"producer":      env.Producer,
+		"data":          payload,
+	}
+}

--- a/services/service-plan/internal/domain/service_plan_test.go
+++ b/services/service-plan/internal/domain/service_plan_test.go
@@ -226,3 +226,35 @@ func plannedPtr(t *testing.T, dayOffset int, minuteOfDay time.Duration) *Planned
 func date(year int, month time.Month, day int) time.Time {
 	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
 }
+
+func TestEventEnvelopeRoundTrip(t *testing.T) {
+	now := date(2026, 7, 4)
+	env := NewEventEnvelope("PlanVersionPublished", now, "corr-1", nil, "service-plan")
+	if env.EventType != "PlanVersionPublished" {
+		t.Fatalf("unexpected event type: %s", env.EventType)
+	}
+	if env.SchemaVersion != 1 {
+		t.Fatalf("unexpected schema version: %d", env.SchemaVersion)
+	}
+	if env.Producer != "service-plan" {
+		t.Fatalf("unexpected producer: %s", env.Producer)
+	}
+	if !strings.HasSuffix(env.OccurredAt, "Z") {
+		t.Fatalf("occurredAt should end with Z (RFC3339 UTC): %s", env.OccurredAt)
+	}
+
+	payload := PlanVersionPublishedEvent{
+		ServicePlanID: "plan-1",
+		PlanVersionID: "v1",
+		EffectiveFrom: now,
+		EffectiveTo:   now.Add(30 * 24 * time.Hour),
+	}
+	wrapped := WrapDomainEvent(env, payload)
+	if wrapped["eventType"] != "PlanVersionPublished" {
+		t.Fatalf("unexpected wrapped event type: %v", wrapped["eventType"])
+	}
+	data := wrapped["data"].(PlanVersionPublishedEvent)
+	if data.ServicePlanID != "plan-1" {
+		t.Fatalf("unexpected data service plan id: %s", data.ServicePlanID)
+	}
+}

--- a/services/supplier-catalog/internal/domain/events.go
+++ b/services/supplier-catalog/internal/domain/events.go
@@ -75,3 +75,51 @@ type ExternalCodeMappedEvent struct {
 	Status       ExternalCodeMappingStatus `json:"status"`
 	MappedAt     time.Time                 `json:"mappedAt"`
 }
+
+// ---------------------------------------------------------------------------
+// EventEnvelope -- contract-conformant event wrapper
+// ---------------------------------------------------------------------------
+
+// EventEnvelope wraps every published domain event with contract-conformant
+// metadata per docs/08-contracts/shared-primitives.md.
+type EventEnvelope struct {
+	EventID       string  `json:"eventId"`
+	EventType     string  `json:"eventType"`
+	SchemaVersion uint32  `json:"schemaVersion"`
+	OccurredAt    string  `json:"occurredAt"` // RFC3339 UTC
+	CorrelationID string  `json:"correlationId"`
+	CausationID   *string `json:"causationId,omitempty"`
+	Producer      string  `json:"producer"`
+}
+
+// NewEventEnvelope creates a new EventEnvelope with a generated event ID and
+// the current time as RFC3339 UTC.
+func NewEventEnvelope(eventType string, occurredAt time.Time, correlationID string, causationID *string, producer string) EventEnvelope {
+	env := EventEnvelope{
+		EventID:       "evt-" + occurredAt.Format("150405000000000"),
+		EventType:     eventType,
+		SchemaVersion: 1,
+		OccurredAt:    occurredAt.UTC().Format(time.RFC3339Nano),
+		CorrelationID: correlationID,
+		Producer:      producer,
+	}
+	if causationID != nil {
+		env.CausationID = causationID
+	}
+	return env
+}
+
+// WrapDomainEvent wraps a domain event payload into a map that includes the
+// envelope fields alongside a "data" key containing the payload.
+func WrapDomainEvent(env EventEnvelope, payload interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"eventId":       env.EventID,
+		"eventType":     env.EventType,
+		"schemaVersion": env.SchemaVersion,
+		"occurredAt":    env.OccurredAt,
+		"correlationId": env.CorrelationID,
+		"causationId":   env.CausationID,
+		"producer":      env.Producer,
+		"data":          payload,
+	}
+}

--- a/services/supplier-catalog/internal/domain/supplier_catalog_test.go
+++ b/services/supplier-catalog/internal/domain/supplier_catalog_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -721,5 +722,38 @@ func TestInvariantNonDestructiveChanges(t *testing.T) {
 	c.Activate()
 	if c.Description != "desc" {
 		t.Fatalf("contract data should be preserved")
+	}
+}
+
+func TestEventEnvelopeRoundTrip(t *testing.T) {
+	now := frozenNow()
+	env := NewEventEnvelope("SupplierRegistered", now, "corr-1", nil, "supplier-catalog")
+	if env.EventType != "SupplierRegistered" {
+		t.Fatalf("unexpected event type: %s", env.EventType)
+	}
+	if env.SchemaVersion != 1 {
+		t.Fatalf("unexpected schema version: %d", env.SchemaVersion)
+	}
+	if env.Producer != "supplier-catalog" {
+		t.Fatalf("unexpected producer: %s", env.Producer)
+	}
+	if !strings.HasSuffix(env.OccurredAt, "Z") {
+		t.Fatalf("occurredAt should end with Z (RFC3339 UTC): %s", env.OccurredAt)
+	}
+
+	payload := SupplierRegisteredEvent{
+		SupplierID:   "sup-001",
+		LegalName:    "Test Supplier",
+		BrandName:    "Test",
+		Status:       SupplierStatusDraft,
+		RegisteredAt: now,
+	}
+	wrapped := WrapDomainEvent(env, payload)
+	if wrapped["eventType"] != "SupplierRegistered" {
+		t.Fatalf("unexpected wrapped event type: %v", wrapped["eventType"])
+	}
+	data := wrapped["data"].(SupplierRegisteredEvent)
+	if data.SupplierID != "sup-001" {
+		t.Fatalf("unexpected data supplier id: %s", data.SupplierID)
 	}
 }


### PR DESCRIPTION
Closes REQ-029

Four focused fixes for cross-service integration testing:

1. **Event envelope** - Added EventEnvelope type + wrap helpers to entitlement-ticketing (Rust), supplier-catalog (Go), and service-plan (Go) with round-trip tests
2. **post-sales Money** - Added fromMinorUnits()/toMinorUnits() boundary methods with tests
3. **capacity-availability timestamps** - Added unix_millis_to_rfc3339/rfc3339_to_unix_millis conversion helpers with round-trip tests
4. **offer-management confidence mapping** - Added mapAvailabilityConfidence/mapStatusToConfidence mapping functions with tests covering every enum value

Updated conformance-gaps.md marking these resolved.