### PR TITLE
REQ-030: HTTP API contract specification (all implemented services)

### DIFF
--- a/docs/08-contracts/api/README.md
+++ b/docs/08-contracts/api/README.md
@@ -75,11 +75,19 @@ Every error response returns the following JSON body:
 All cross-context value objects **MUST** reference
 `docs/08-contracts/shared-primitives.md` for their shapes. Do not redefine:
 
-- **Money**: `{ "currency": "CNY", "amount": "100.00" }` (ISO 4217 currency, decimal string)
-- **Timestamps**: ISO-8601 instant format (e.g. `"2026-07-05T10:30:00Z"`)
-- **IDs**: UUID v7 strings with optional prefix (e.g. `"ord-<uuid>"`, `"off-<uuid>"`)
-- **TravelerRef**: `"tvl-<uuid>"`
-- **Event envelope fields**: `eventId`, `occurredAt`, `sourceCommandId`, `causationId`, `correlationId`, `schemaVersion`, `attributes`
+- **Money**: `{ "currency": "CNY", "minorUnits": 12345 }` — ISO-4217 uppercase
+  code + integer minor units. Never floats, never decimal strings
+  (shared-primitives.md §3).
+- **Timestamps**: RFC3339 UTC (e.g. `"2026-07-05T10:30:00Z"`).
+- **IDs**: prefixed strings per the shared-primitives.md §2 prefix table.
+  The prefix is part of the canonical identity and is REQUIRED, not
+  optional (e.g. `"ord-<uuid>"`, `"pi-<uuid>"`).
+- **TravelerRef**: string ID `"tvl-<uuid>"`, or the structured form
+  `{travelerId, travelerType, maskedDocumentRef?, eligibilityRef?}` where a
+  rich reference is needed (shared-primitives.md).
+- **Event envelope fields**: `eventId`, `eventType`, `occurredAt`,
+  `correlationId`, `causationId`, `producer`, `schemaVersion`, `payload`
+  (shared-primitives.md §1).
 
 ### Pagination Convention
 

--- a/docs/08-contracts/api/README.md
+++ b/docs/08-contracts/api/README.md
@@ -1,0 +1,147 @@
+# HTTP API Contract
+
+Last updated: 2026-07-05
+
+## Purpose
+
+This directory defines the authoritative HTTP API contract for every bounded
+context service in the Train Ticket platform. Every service's HTTP layer must
+conform to this specification exactly.
+
+This is the **synchronous-command counterpart** of the event contract in
+`docs/08-contracts/events/`. Where a command is exposed via HTTP, the
+endpoint definition here is the normative reference. Event-driven-only
+commands are marked "bus-only, no HTTP endpoint" and must not have HTTP
+endpoints.
+
+## Base Conventions
+
+### Path Pattern
+
+```
+/api/v1/<resource>
+```
+
+All endpoints use the `/api/v1/` prefix. Path segments are lowercase with
+hyphens (kebab-case). Example: `/api/v1/journey-orders`.
+
+### Content Type
+
+All requests and responses use `Content-Type: application/json` (JSON only).
+Fields use **camelCase** naming. Enums use **SCREAMING_SNAKE_CASE** (same
+serialization rules as `shared-primitives.md`).
+
+### Standard Request Headers
+
+| Header | Required | Description |
+|---|---|---|
+| `Idempotency-Key` | REQUIRED on every state-changing POST | Client-generated unique key for safe retry. Server must return the original response on replay. Format: UUID v7. |
+| `X-Correlation-Id` | RECOMMENDED | End-to-end trace identifier propagated through all services. Generated at the edge if absent. Format: UUID v7. |
+
+### Standard Response Headers
+
+| Header | Description |
+|---|---|
+| `X-Correlation-Id` | Echoed from request or generated if absent. |
+| `X-Request-Id` | Server-assigned unique request identifier for this HTTP call. |
+
+### Canonical Error Body
+
+Every error response returns the following JSON body:
+
+```json
+{
+  "code": "SCREAMING_SNAKE_ERROR_CODE",
+  "message": "Human-readable description",
+  "correlationId": "uuid-v7",
+  "details": {}
+}
+```
+
+#### Shared Error Codes
+
+| Code | HTTP Status | Description |
+|---|---|---|
+| `VALIDATION_FAILED` | 400 | Request body failed structural validation (missing required field, wrong type, enum mismatch). |
+| `NOT_FOUND` | 404 | The requested resource or referenced aggregate was not found. |
+| `CONFLICT` | 409 | The request conflicts with the current state of the resource (e.g. duplicate creation, version mismatch). |
+| `IDEMPOTENCY_KEY_REUSED` | 422 | The `Idempotency-Key` was reused with a different request body. Server must reject with this code. |
+| `PRECONDITION_FAILED` | 412 | A precondition specified in the request (e.g. expected version, state check) was not met. |
+| `DOMAIN_RULE_VIOLATION` | 422 | The request violates a domain rule (e.g. cannot refund a ticket that has already been used). |
+| `UNAVAILABLE` | 503 | The service is temporarily unavailable (e.g. downstream dependency failure, rate limited). |
+
+### Money, Timestamps, IDs, TravelerRef, etc.
+
+All cross-context value objects **MUST** reference
+`docs/08-contracts/shared-primitives.md` for their shapes. Do not redefine:
+
+- **Money**: `{ "currency": "CNY", "amount": "100.00" }` (ISO 4217 currency, decimal string)
+- **Timestamps**: ISO-8601 instant format (e.g. `"2026-07-05T10:30:00Z"`)
+- **IDs**: UUID v7 strings with optional prefix (e.g. `"ord-<uuid>"`, `"off-<uuid>"`)
+- **TravelerRef**: `"tvl-<uuid>"`
+- **Event envelope fields**: `eventId`, `occurredAt`, `sourceCommandId`, `causationId`, `correlationId`, `schemaVersion`, `attributes`
+
+### Pagination Convention
+
+List/query endpoints returning multiple items support pagination via query
+parameters:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `limit` | integer | 20 | Maximum number of items to return (max 100). |
+| `offset` | integer | 0 | Number of items to skip. |
+
+Response:
+
+```json
+{
+  "items": [...],
+  "total": 42,
+  "limit": 20,
+  "offset": 0
+}
+```
+
+### Health / Readiness Endpoints
+
+All services expose the following endpoints (already defined in platform
+profiles):
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/healthz` | GET | Liveness check. Returns `200 OK` if the process is alive. |
+| `/readyz` | GET | Readiness check. Returns `200 OK` if the service can accept traffic (dependencies available). |
+
+These endpoints do not require authentication, idempotency keys, or
+correlation IDs.
+
+## Context Files
+
+| # | File | Context | Implemented |
+|---|---|---|---|
+| 1 | `place-network.md` | Place & Network | go |
+| 2 | `service-plan.md` | Service Plan | go |
+| 3 | `capacity-availability.md` | Capacity & Availability | rust |
+| 4 | `fare-pricing.md` | Fare & Pricing | python |
+| 5 | `trip-planning.md` | Trip Planning | python |
+| 6 | `offer-management.md` | Offer Management | typescript |
+| 7 | `journey-order.md` | Journey Order | java |
+| 8 | `booking-orchestration.md` | Booking Orchestration | java |
+| 9 | `provider-integration.md` | Provider Integration | go |
+| 10 | `payment.md` | Payment | java |
+| 11 | `traveler-profile.md` | Traveler Profile | java |
+| 12 | `entitlement-ticketing.md` | Entitlement & Ticketing | rust |
+| 13 | `notification.md` | Notification | typescript |
+| 14 | `risk-compliance.md` | Risk & Compliance | python |
+| 15 | `admin-audit.md` | Admin & Audit | java |
+| 16 | `supplier-catalog.md` | Supplier Catalog | go |
+| 17 | `post-sales.md` | Post Sales | java |
+| 18 | `fulfillment.md` | Fulfillment | go |
+| 19 | `account.md` | Account | typescript |
+| 20 | `customer-service.md` | Customer Service | typescript |
+| 21 | `finance-settlement.md` | Finance & Settlement | java |
+| 22 | `reporting.md` | Reporting | python |
+
+## Open Issues
+
+- No open issues at this revision.

--- a/docs/08-contracts/api/account.md
+++ b/docs/08-contracts/api/account.md
@@ -4,6 +4,9 @@ Last updated: 2026-07-05
 
 ## Overview
 
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
+timestamps, and Money.
+
 Account manages user accounts, sessions, and account lifecycle (freeze,
 unfreeze, closure). It is the identity and authentication foundation.
 

--- a/docs/08-contracts/api/account.md
+++ b/docs/08-contracts/api/account.md
@@ -1,0 +1,128 @@
+# Account — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Account manages user accounts, sessions, and account lifecycle (freeze,
+unfreeze, closure). It is the identity and authentication foundation.
+
+## Endpoints
+
+### Create Account
+
+**POST** `/api/v1/accounts`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `accountId` | string | no | Optional client-generated account ID. Generated if absent. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `accountId` | string | Canonical account ID (`acct_<uuid>`). |
+| `status` | enum | `ACTIVE`, `FROZEN`, `CLOSED` |
+| `createdAt` | timestamp | Creation time. |
+
+**Error codes:** `VALIDATION_FAILED`, `CONFLICT`
+
+### Get Account
+
+**GET** `/api/v1/accounts/{accountId}`
+
+**Response (200):** Full account details.
+
+**Error codes:** `NOT_FOUND`
+
+### Freeze Account
+
+**POST** `/api/v1/accounts/{accountId}/freeze`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `reason` | string | yes | Reason for freezing. |
+| `operator` | string | yes | Who initiated the freeze. |
+| `caseRef` | string | no | Customer service case reference. |
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `accountId` | string | Account ID. |
+| `status` | enum | `FROZEN` |
+| `frozenAt` | timestamp | When freeze was applied. |
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`
+
+### Unfreeze Account
+
+**POST** `/api/v1/accounts/{accountId}/unfreeze`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `reason` | string | yes | Reason for unfreezing. |
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `accountId` | string | Account ID. |
+| `status` | enum | `ACTIVE` |
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`
+
+### Update Preference
+
+**PATCH** `/api/v1/accounts/{accountId}/preferences`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `preferenceKey` | string | yes | Preference key. |
+| `value` | string | yes | Preference value. |
+
+**Response (200):** Updated account details.
+
+**Error codes:** `NOT_FOUND`, `VALIDATION_FAILED`
+
+### Start Account Closure
+
+**POST** `/api/v1/accounts/{accountId}/start-closure`
+
+**Idempotency:** REQUIRED
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `accountId` | string | Account ID. |
+| `closureRequestId` | string | Closure request ID. |
+| `status` | enum | `CLOSURE_INITIATED` |
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`
+
+## Bus-only commands
+
+- `OpenSession` (bus-only: triggered by auth gateway)
+- `RevokeSession` (bus-only: triggered by auth gateway)
+- `CompleteAccountClosure` (bus-only: saga internal)
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/admin-audit.md
+++ b/docs/08-contracts/api/admin-audit.md
@@ -1,0 +1,106 @@
+# Admin & Audit — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Admin & Audit provides operator management, manual action requests/approvals,
+and audit trail queries. These endpoints are for internal operations use.
+
+## Endpoints
+
+### Register Operator
+
+**POST** `/api/v1/admin/operators`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `email` | string | yes | Operator email address. |
+| `role` | enum | yes | `ADMIN`, `OPERATOR`, `SUPER_OPERATOR`, `AUDITOR` |
+| `scopes` | string[] | yes | List of permission scopes. |
+| `displayName` | string | yes | Operator display name. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `operatorId` | string | Canonical operator ID (`op-<uuid>`). |
+| `email` | string | Operator email. |
+| `role` | enum | Assigned role. |
+| `scopes` | string[] | Permission scopes. |
+| `status` | enum | `ACTIVE`, `SUSPENDED` |
+
+**Error codes:** `VALIDATION_FAILED`, `CONFLICT`
+
+### Request Manual Action
+
+**POST** `/api/v1/admin/manual-actions`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `targetDomain` | string | yes | Target bounded context (e.g. `journey-order`, `payment`). |
+| `targetCommand` | string | yes | Target domain command (e.g. `RequestManualOrderAction`). |
+| `businessRef` | string | yes | Business reference (order ID, payment ID). |
+| `reasonCode` | string | yes | Reason code (e.g. `CUSTOMER_REQUEST`). |
+| `description` | string | yes | Human-readable description. |
+| `requestedByOperatorId` | string | yes | Operator requesting the action. |
+| `requiresApproval` | boolean | yes | Whether four-eyes approval is needed. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `manualActionId` | string | Canonical manual action ID (`ma-<uuid>`). |
+| `targetDomain` | string | Target domain. |
+| `status` | enum | `REQUESTED`, `APPROVED`, `REJECTED`, `EXECUTED`, `FAILED` |
+
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `DOMAIN_RULE_VIOLATION`
+
+### Approve Manual Action
+
+**POST** `/api/v1/admin/manual-actions/{manualActionId}/approve`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `approvedByOperatorId` | string | yes | Approving operator ID. |
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `manualActionId` | string | Action ID. |
+| `status` | enum | `APPROVED` |
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`
+
+### List Audit Trail
+
+**GET** `/api/v1/admin/audit-trail?businessRef={ref}&limit=20&offset=0`
+
+**Query parameters:** `businessRef` (optional), `limit`, `offset`
+
+**Response (200):** Paginated list of audit entries.
+
+### Get Operator
+
+**GET** `/api/v1/admin/operators/{operatorId}`
+
+**Response (200):** Operator details.
+
+**Error codes:** `NOT_FOUND`
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/admin-audit.md
+++ b/docs/08-contracts/api/admin-audit.md
@@ -7,6 +7,9 @@ Last updated: 2026-07-05
 Admin & Audit provides operator management, manual action requests/approvals,
 and audit trail queries. These endpoints are for internal operations use.
 
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
+timestamps, and Money.
+
 ## Endpoints
 
 ### Register Operator
@@ -100,6 +103,17 @@ and audit trail queries. These endpoints are for internal operations use.
 **Response (200):** Operator details.
 
 **Error codes:** `NOT_FOUND`
+
+## Bus-only commands
+
+The following commands are consumed from the event bus only and have no HTTP
+endpoint:
+
+| Command | Trigger | Description |
+|---|---|---|
+| `RejectManualAction` | Admin UI | Reject a manual action with reason. |
+| `ExecuteManualAction` | Admin & Audit (internal) | Execute an approved manual action against the target domain. |
+| `RecordAuditEntry` | Any bounded context | Record an audit entry for a business action. |
 
 ## Open Issues
 

--- a/docs/08-contracts/api/booking-orchestration.md
+++ b/docs/08-contracts/api/booking-orchestration.md
@@ -1,0 +1,101 @@
+# Booking Orchestration — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Booking Orchestration manages the booking saga for a journey order. It
+coordinates segment reservations, capacity holds, payment, and ticketing
+steps. Endpoints in this section are **internal** — they are called by other
+services (not end-user clients).
+
+## Internal Endpoints
+
+### Start Booking Saga
+
+**POST** `/api/v1/internal/booking-sagas`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `journeyOrderId` | string | yes | Parent order ID (`ord-<uuid>`). |
+| `accountId` | string | yes | Owning account. |
+| `offerId` | string | yes | Source offer ID. |
+| `travelerRefs` | array | yes | Traveler references. |
+| `segmentRefs` | string[] | yes | Segment references. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `sagaId` | string | Canonical saga ID (`saga-<uuid>`). |
+| `journeyOrderId` | string | Parent order ID. |
+| `status` | enum | `STARTED`, `RESERVING`, `HELD`, `WAITING_PAYMENT`, `TICKETING`, `COMPLETED`, `FAILED` |
+| `startedAt` | timestamp | Saga start time. |
+
+**Error codes:** `VALIDATION_FAILED`, `CONFLICT`, `PRECONDITION_FAILED`
+
+### Get Saga Status
+
+**GET** `/api/v1/internal/booking-sagas/{sagaId}`
+
+**Response (200):** Full saga details including step statuses.
+
+**Error codes:** `NOT_FOUND`
+
+### Request Segment Reservation
+
+**POST** `/api/v1/internal/booking-sagas/{sagaId}/request-reservation`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `segmentRef` | string | yes | Service segment reference. |
+| `travelerRef` | string | yes | Traveler reference. |
+| `segmentBookingId` | string | yes | Segment booking ID (`sb-<uuid>`). |
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `segmentBookingId` | string | Segment booking ID. |
+| `status` | enum | `REQUESTED`, `CONFIRMED`, `FAILED` |
+
+**Error codes:** `NOT_FOUND`, `CONFLICT`, `UNAVAILABLE`
+
+### Mark Segment Ticketed
+
+**POST** `/api/v1/internal/booking-sagas/{sagaId}/mark-ticketed`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `segmentBookingId` | string | yes | Segment booking ID. |
+| `entitlementId` | string | yes | Issued entitlement ID. |
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `segmentBookingId` | string | Segment booking ID. |
+| `status` | enum | `TICKETED` |
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`
+
+## Bus-only commands
+
+- `ConfirmSegmentReservation` (internal: triggered by capacity/provider events)
+- `CancelSegmentBooking` (internal: triggered by post-sales saga)
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/booking-orchestration.md
+++ b/docs/08-contracts/api/booking-orchestration.md
@@ -4,6 +4,9 @@ Last updated: 2026-07-05
 
 ## Overview
 
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
+timestamps, and Money.
+
 Booking Orchestration manages the booking saga for a journey order. It
 coordinates segment reservations, capacity holds, payment, and ticketing
 steps. Endpoints in this section are **internal** — they are called by other

--- a/docs/08-contracts/api/capacity-availability.md
+++ b/docs/08-contracts/api/capacity-availability.md
@@ -4,6 +4,9 @@ Last updated: 2026-07-05
 
 ## Overview
 
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
+timestamps, and Money.
+
 Capacity & Availability manages inventory for scheduled services: availability
 snapshots, capacity holds, and capacity release. It is the authoritative
 source for seat/unit availability.

--- a/docs/08-contracts/api/capacity-availability.md
+++ b/docs/08-contracts/api/capacity-availability.md
@@ -1,0 +1,121 @@
+# Capacity & Availability — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Capacity & Availability manages inventory for scheduled services: availability
+snapshots, capacity holds, and capacity release. It is the authoritative
+source for seat/unit availability.
+
+## Endpoints
+
+### Query Availability Snapshot
+
+Returns a non-authoritative availability snapshot for a service segment.
+
+**GET** `/api/v1/availability-snapshots?scheduledServiceRef={ssRef}&segmentRef={segRef}`
+
+**Query parameters:**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `scheduledServiceRef` | string | yes | Scheduled service reference. |
+| `segmentRef` | string | yes | Service segment reference. |
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `snapshotId` | string | Stable snapshot identity (`avs-<uuid>`). |
+| `snapshotVersion` | integer | Monotonically increasing version. |
+| `scheduledServiceRef` | string | Scheduled service reference. |
+| `segmentRef` | string | Segment reference. |
+| `capturedAt` | timestamp | When snapshot was captured. |
+| `validUntil` | timestamp | Snapshot expiry. |
+| `sellable` | boolean | Whether at least one unit is sellable. |
+| `remainingByClass` | array | Per-class remaining counts. |
+| `totalUnits` | integer | Total sellable units. |
+| `availableCount` | integer | Estimated available units. |
+| `status` | enum | `AVAILABLE`, `LIMITED`, `UNKNOWN`, `UNAVAILABLE` |
+
+**RemainingByClass item:**
+
+| Field | Type | Description |
+|---|---|---|
+| `classRef` | string | Seat class reference. |
+| `total` | integer | Total units in this class. |
+| `available` | integer | Estimated available units. |
+
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`
+
+### Hold Capacity
+
+Places a hold on capacity for a segment.
+
+**POST** `/api/v1/capacity-holds`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `segmentRef` | string | yes | Service segment reference. |
+| `travelerRef` | string | yes | Traveler reference (`tvl-<uuid>`). |
+| `classRef` | string | yes | Seat class reference. |
+| `quantity` | integer | yes | Number of units to hold. |
+| `segmentBookingId` | string | yes | Segment booking ID (`sb-<uuid>`) for correlation. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `holdId` | string | Hold identifier (`hold-<uuid>`). |
+| `segmentRef` | string | Service segment. |
+| `status` | enum | `HELD`, `CONFIRMED`, `RELEASED`, `EXPIRED` |
+| `heldUntil` | timestamp | Hold expiry time. |
+
+**Error codes:** `VALIDATION_FAILED`, `CONFLICT`, `DOMAIN_RULE_VIOLATION`, `UNAVAILABLE`
+
+### Confirm a Hold
+
+**POST** `/api/v1/capacity-holds/{holdId}/confirm`
+
+**Idempotency:** REQUIRED
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `holdId` | string | Hold identifier. |
+| `status` | enum | `CONFIRMED` |
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `CONFLICT`
+
+### Release a Hold
+
+**POST** `/api/v1/capacity-holds/{holdId}/release`
+
+**Idempotency:** REQUIRED
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `holdId` | string | Hold identifier. |
+| `status` | enum | `RELEASED` |
+
+**Error codes:** `NOT_FOUND`, `CONFLICT`
+
+### Get Capacity Hold
+
+**GET** `/api/v1/capacity-holds/{holdId}`
+
+**Response (200):** Full hold details.
+
+**Error codes:** `NOT_FOUND`
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/customer-service.md
+++ b/docs/08-contracts/api/customer-service.md
@@ -8,6 +8,9 @@ Customer Service manages support cases, evidence attachment, case
 classification, and resolution. These endpoints are for customer service
 operators and automated support flows.
 
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
+timestamps, and Money.
+
 ## Endpoints
 
 ### Open Support Case
@@ -74,9 +77,9 @@ operators and automated support flows.
 
 **Error codes:** `NOT_FOUND`, `VALIDATION_FAILED`
 
-### Update Case Status
+### Classify Support Case
 
-**PATCH** `/api/v1/support-cases/{caseId}/status`
+**POST** `/api/v1/support-cases/{caseId}/classify`
 
 **Idempotency:** REQUIRED
 
@@ -84,12 +87,107 @@ operators and automated support flows.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `status` | enum | yes | `IN_PROGRESS`, `RESOLVED`, `CLOSED` |
-| `resolution` | string | no | Resolution description. |
+| `classification` | string | yes | Classification code. |
+| `priority` | enum | yes | `LOW`, `NORMAL`, `HIGH`, `URGENT` |
 
 **Response (200):** Updated case.
 
-**Error codes:** `NOT_FOUND`, `VALIDATION_FAILED`, `PRECONDITION_FAILED`
+**Error codes:** `NOT_FOUND`, `VALIDATION_FAILED`
+
+### Assign Support Case
+
+**POST** `/api/v1/support-cases/{caseId}/assign`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `assignedTo` | string | no | Operator ID to assign (`op-<uuid>`). |
+| `ownerQueue` | string | yes | Target queue name. |
+
+**Response (200):** Updated case.
+
+**Error codes:** `NOT_FOUND`, `VALIDATION_FAILED`
+
+### Escalate Case
+
+**POST** `/api/v1/support-cases/{caseId}/escalate`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `targetQueue` | string | yes | Target escalation queue. |
+| `reason` | string | yes | Escalation reason. |
+
+**Response (200):** Updated case.
+
+**Error codes:** `NOT_FOUND`, `VALIDATION_FAILED`
+
+### Resolve Case
+
+**POST** `/api/v1/support-cases/{caseId}/resolve`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `summary` | string | yes | Resolution summary. |
+| `resolutionCode` | string | yes | Resolution code. |
+
+**Response (200):** Updated case.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`
+
+### Close Case
+
+**POST** `/api/v1/support-cases/{caseId}/close`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `reason` | enum | yes | `RESOLVED`, `ESCALATED`, `DUPLICATE`, `NO_FURTHER_ACTION`, `CUSTOMER_CLOSED` |
+
+**Response (200):** Updated case.
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`
+
+### Reopen Case
+
+**POST** `/api/v1/support-cases/{caseId}/reopen`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `reason` | string | yes | Reason for reopening. |
+| `requesterRef` | string | yes | Reference to the requester. |
+
+**Response (200):** Updated case.
+
+**Error codes:** `NOT_FOUND`, `VALIDATION_FAILED`
+
+## Bus-only commands
+
+The following commands are consumed from the event bus only and have no HTTP
+endpoint:
+
+| Command | Trigger | Description |
+|---|---|---|
+| `RequestManualAction` | Customer Service UI | Request a manual action against a target domain (e.g. payment, order). |
+| `RecordActionOutcome` | Customer Service UI / Admin & Audit | Record the outcome of a manual action. |
+| `AppendTimelineEntry` | Customer Service UI / Internal | Append an event to the case timeline. |
 
 ## Open Issues
 

--- a/docs/08-contracts/api/customer-service.md
+++ b/docs/08-contracts/api/customer-service.md
@@ -1,0 +1,96 @@
+# Customer Service — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Customer Service manages support cases, evidence attachment, case
+classification, and resolution. These endpoints are for customer service
+operators and automated support flows.
+
+## Endpoints
+
+### Open Support Case
+
+**POST** `/api/v1/support-cases`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `requesterRef` | string | yes | Reference to the requester (`tvl-<uuid>` or `usr-<uuid>`). |
+| `channel` | enum | yes | `APP`, `WEB`, `PHONE`, `IM`, `EMAIL`, `IN_APP_MESSAGE`, `BOT`, `OPERATOR_CONSOLE` |
+| `classification` | string | no | Initial classification code. |
+| `priority` | enum | no | `LOW`, `NORMAL`, `HIGH`, `URGENT` |
+| `description` | string | yes | Case description from the requester. |
+| `businessReferences` | object | no | References to business objects. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `caseId` | string | Canonical case ID (`sc-<uuid>`). |
+| `requesterRef` | string | Requester reference. |
+| `channel` | enum | Channel. |
+| `priority` | enum | Priority. |
+| `status` | enum | `OPENED`, `IN_PROGRESS`, `RESOLVED`, `CLOSED` |
+| `createdAt` | timestamp | Creation time. |
+
+**Error codes:** `VALIDATION_FAILED`, `CONFLICT`
+
+### Get Support Case
+
+**GET** `/api/v1/support-cases/{caseId}`
+
+**Response (200):** Full case details.
+
+**Error codes:** `NOT_FOUND`
+
+### Attach Evidence
+
+**POST** `/api/v1/support-cases/{caseId}/evidence`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `evidenceType` | enum | yes | `SCREENSHOT`, `CALL_RECORDING`, `CHAT_TRANSCRIPT`, `EMAIL`, `CHANNEL_RECEIPT`, `PROVIDER_SUMMARY`, `DOCUMENT`, `OTHER` |
+| `reference` | string | yes | External reference URI or path. |
+| `summary` | string | yes | Human-readable summary. |
+| `accessLevel` | enum | yes | `PUBLIC`, `INTERNAL`, `SENSITIVE`, `RESTRICTED` |
+| `attachedBy` | string | yes | Operator reference (`op-<uuid>`). |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `evidenceId` | string | Evidence ID (`evid-<uuid>`). |
+| `caseId` | string | Case ID. |
+| `evidenceType` | enum | Type. |
+
+**Error codes:** `NOT_FOUND`, `VALIDATION_FAILED`
+
+### Update Case Status
+
+**PATCH** `/api/v1/support-cases/{caseId}/status`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `status` | enum | yes | `IN_PROGRESS`, `RESOLVED`, `CLOSED` |
+| `resolution` | string | no | Resolution description. |
+
+**Response (200):** Updated case.
+
+**Error codes:** `NOT_FOUND`, `VALIDATION_FAILED`, `PRECONDITION_FAILED`
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/entitlement-ticketing.md
+++ b/docs/08-contracts/api/entitlement-ticketing.md
@@ -7,6 +7,9 @@ Last updated: 2026-07-05
 Entitlement & Ticketing manages ticket/credential issuance, voiding, and
 status queries. It is the authoritative source for ticket credentials.
 
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
+timestamps, and Money.
+
 ## Endpoints
 
 ### Issue Entitlement
@@ -78,6 +81,17 @@ status queries. It is the authoritative source for ticket credentials.
 **Query parameters:** `journeyOrderId` (required), `limit`, `offset`
 
 **Response (200):** Paginated response.
+
+## Bus-only commands
+
+The following commands are consumed from the event bus only and have no HTTP
+endpoint:
+
+| Command | Trigger | Description |
+|---|---|---|
+| `SuspendEntitlement` | risk-compliance, post-sales, disruption-recovery | Suspend an entitlement due to risk, dispute, or provider conflict. |
+| `ResumeEntitlement` | risk-compliance, post-sales, customer-service | Resume a suspended entitlement. |
+| `BindProviderCredential` | provider-integration | Bind a provider-issued credential to an entitlement. |
 
 ## Open Issues
 

--- a/docs/08-contracts/api/entitlement-ticketing.md
+++ b/docs/08-contracts/api/entitlement-ticketing.md
@@ -1,0 +1,84 @@
+# Entitlement & Ticketing — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Entitlement & Ticketing manages ticket/credential issuance, voiding, and
+status queries. It is the authoritative source for ticket credentials.
+
+## Endpoints
+
+### Issue Entitlement
+
+**POST** `/api/v1/entitlements`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `segmentBookingId` | string | yes | Reference to the segment booking (`sb-<uuid>`). |
+| `journeyOrderId` | string | yes | Reference to the journey order (`ord-<uuid>`). |
+| `travelerRef` | string | yes | Traveler reference (`tvl-<uuid>`). |
+| `segmentRef` | string | yes | Segment reference (`seg-<uuid>`). |
+| `issuePurpose` | string | yes | Purpose: `INITIAL`, `REPLACEMENT`, `MANUAL_RECOVERY`, `PROVIDER_REBUILD`, `DISRUPTION_REPLACEMENT` |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `entitlementId` | string | Canonical entitlement ID (`ent-<uuid>`). |
+| `segmentBookingId` | string | Segment booking ID. |
+| `journeyOrderId` | string | Order ID. |
+| `credentialNo` | string | Unique credential/ticket number. |
+| `credentialType` | string | Type: `E_TICKET`, `PAPER_TICKET`, `PICKUP_CODE`, `BOARDING_PASS`, `FERRY_TICKET`, `COACH_E_TICKET`, `RIDE_CODE` |
+| `status` | enum | `ISSUED`, `VOIDED`, `BOARDED`, `NO_SHOW`, `SUSPENDED` |
+| `issuedAt` | timestamp | Issue timestamp. |
+
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `PRECONDITION_FAILED`, `CONFLICT`, `DOMAIN_RULE_VIOLATION`
+
+### Void Entitlement
+
+**POST** `/api/v1/entitlements/{entitlementId}/void`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `reason` | string | yes | `REFUND`, `CHANGE`, `DISRUPTION`, `RISK`, `MANUAL_CORRECTION` |
+| `policy` | string | yes | `NORMAL`, `EXCEPTIONAL_RULE` |
+| `businessCaseRef` | string | no | Reference to the post-sales or recovery case. |
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `entitlementId` | string | Entitlement ID. |
+| `status` | enum | `VOIDED` |
+| `voidedAt` | timestamp | Void timestamp. |
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`
+
+### Get Entitlement
+
+**GET** `/api/v1/entitlements/{entitlementId}`
+
+**Response (200):** Full entitlement details.
+
+**Error codes:** `NOT_FOUND`
+
+### List Entitlements by Order
+
+**GET** `/api/v1/entitlements?journeyOrderId={orderId}&limit=20&offset=0`
+
+**Query parameters:** `journeyOrderId` (required), `limit`, `offset`
+
+**Response (200):** Paginated response.
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/fare-pricing.md
+++ b/docs/08-contracts/api/fare-pricing.md
@@ -1,0 +1,80 @@
+# Fare & Pricing — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Fare & Pricing computes fare quotes, price breakdowns, and adjustment quotes
+(refund/change fees). It is the authoritative source for all monetary
+calculations.
+
+## Endpoints
+
+### Compute Fare Quote
+
+**POST** `/api/v1/fare-quotes`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `travelerRefs` | string[] | yes | Traveler references (`tvl-<uuid>`). |
+| `channel` | string | yes | Sales channel. |
+| `currency` | string | yes | ISO-4217 currency code. |
+| `segmentRefs` | string[] | yes | Service segment references. |
+| `fareRuleRefs` | string[] | no | Specific fare rules to apply. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `quoteId` | string | Canonical quote ID (`fq-<uuid>`). |
+| `status` | enum | `QUOTED`, `FAILED` |
+| `breakdown` | object | Price breakdown (if `QUOTED`). |
+| `ruleSnapshot` | object | Snapshot of rules used (if `QUOTED`). |
+| `validFrom` | timestamp | Quote validity start. |
+| `validUntil` | timestamp | Quote validity end. |
+| `failedReason` | string | Failure reason (if `FAILED`). |
+
+**Error codes:** `VALIDATION_FAILED`, `DOMAIN_RULE_VIOLATION`, `UNAVAILABLE`
+
+### Compute Adjustment Quote (Refund/Change)
+
+**POST** `/api/v1/adjustment-quotes`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `purpose` | enum | yes | `REFUND`, `CHANGE` |
+| `entitlementIds` | string[] | yes | Entitlements to adjust. |
+| `journeyOrderId` | string | yes | Parent order ID. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `adjustmentQuoteId` | string | Adjustment quote ID. |
+| `purpose` | enum | As requested. |
+| `status` | enum | `QUOTED`, `FAILED` |
+| `refundableAmount` | object | Money amount refundable to customer. |
+| `amountDue` | object | Money amount due from customer. |
+| `validUntil` | timestamp | Adjustment quote expiry. |
+
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `DOMAIN_RULE_VIOLATION`
+
+### Get Fare Quote
+
+**GET** `/api/v1/fare-quotes/{quoteId}`
+
+**Response (200):** Full quote details.
+
+**Error codes:** `NOT_FOUND`
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/fare-pricing.md
+++ b/docs/08-contracts/api/fare-pricing.md
@@ -8,6 +8,9 @@ Fare & Pricing computes fare quotes, price breakdowns, and adjustment quotes
 (refund/change fees). It is the authoritative source for all monetary
 calculations.
 
+Field shapes reference docs/08-contracts/shared-primitives.md for Money,
+timestamps, and cross-context IDs.
+
 ## Endpoints
 
 ### Compute Fare Quote
@@ -22,7 +25,6 @@ calculations.
 |---|---|---|---|
 | `travelerRefs` | string[] | yes | Traveler references (`tvl-<uuid>`). |
 | `channel` | string | yes | Sales channel. |
-| `currency` | string | yes | ISO-4217 currency code. |
 | `segmentRefs` | string[] | yes | Service segment references. |
 | `fareRuleRefs` | string[] | no | Specific fare rules to apply. |
 

--- a/docs/08-contracts/api/finance-settlement.md
+++ b/docs/08-contracts/api/finance-settlement.md
@@ -1,0 +1,57 @@
+# Finance & Settlement — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Finance & Settlement handles revenue recognition, reconciliation cases, and
+settlement views. It consumes upstream events and produces financial records.
+All commands are **bus-only** — there are no external HTTP endpoints for
+financial operations. Query endpoints are provided for reporting and audit.
+
+## Query Endpoints
+
+### Get Revenue Recognition
+
+**GET** `/api/v1/revenue-recognitions/{revenueRecognitionId}`
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `revenueRecognitionId` | string | Unique ID. |
+| `orderItemId` | string | Order item. |
+| `orderId` | string | Parent order. |
+| `componentCode` | string | Financial component (`fare`, `tax`, `fee`, `ancillary`, `discount`). |
+| `amount` | object | Recognized amount (Money). |
+| `recognitionPolicyVersion` | string | Policy version. |
+| `recognizedAt` | timestamp | When recognized. |
+
+**Error codes:** `NOT_FOUND`
+
+### Get Reconciliation Case
+
+**GET** `/api/v1/reconciliation-cases/{reconciliationCaseId}`
+
+**Response (200):** Full reconciliation case details.
+
+**Error codes:** `NOT_FOUND`
+
+### List Reconciliation Cases
+
+**GET** `/api/v1/reconciliation-cases?orderId={orderId}&limit=20&offset=0`
+
+**Response (200):** Paginated response.
+
+## Bus-only commands
+
+| Command | Trigger | Description |
+|---|---|---|
+| `RecognizeRevenue` | `EntitlementIssued`, `BoardingVerified` | Recognize revenue from fulfillment events. |
+| `OpenReconciliationCase` | Mismatch detection | Open a reconciliation case. |
+| `ResolveReconciliationCase` | Manual or auto | Resolve a reconciliation case. |
+| `RebuildSettlementView` | Manual or scheduled | Rebuild a settlement view from event log. |
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/finance-settlement.md
+++ b/docs/08-contracts/api/finance-settlement.md
@@ -4,6 +4,9 @@ Last updated: 2026-07-05
 
 ## Overview
 
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
+timestamps, and Money.
+
 Finance & Settlement handles revenue recognition, reconciliation cases, and
 settlement views. It consumes upstream events and produces financial records.
 All commands are **bus-only** — there are no external HTTP endpoints for

--- a/docs/08-contracts/api/fulfillment.md
+++ b/docs/08-contracts/api/fulfillment.md
@@ -1,0 +1,80 @@
+# Fulfillment — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Fulfillment records physical journey events: boarding verification, no-show
+recording, and fulfillment status queries. These events are recorded after
+the passenger travels.
+
+## Endpoints
+
+### Verify Boarding
+
+**POST** `/api/v1/fulfillment-records/boarding`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `entitlementId` | string | yes | Reference to the entitlement (`ent-<uuid>`). |
+| `segmentBookingId` | string | yes | Reference to the segment booking (`sb-<uuid>`). |
+| `journeyOrderId` | string | yes | Reference to the journey order (`ord-<uuid>`). |
+| `travelerId` | string | yes | Traveler reference (`tvl-<uuid>`). |
+| `segmentRef` | string | yes | Segment reference (`seg-<uuid>`). |
+| `source` | string | yes | Source: `GATE`, `STATION`, `PROVIDER`, `CONDUCTOR`, `ADMIN` |
+| `sourceEventId` | string | yes | Source event identifier for idempotency. |
+| `occurredAt` | timestamp | yes | When boarding physically occurred. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `fulfillmentRecordId` | string | Fulfillment record ID (`fr-<uuid>`). |
+| `entitlementId` | string | Entitlement reference. |
+| `status` | enum | `BOARDED` |
+| `occurredAt` | timestamp | When boarding occurred. |
+
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `CONFLICT`, `DOMAIN_RULE_VIOLATION`
+
+### Record No-Show
+
+**POST** `/api/v1/fulfillment-records/no-show`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `entitlementId` | string | yes | Reference to the entitlement. |
+| `segmentBookingId` | string | yes | Segment booking reference. |
+| `journeyOrderId` | string | yes | Order reference. |
+| `travelerId` | string | yes | Traveler reference. |
+| `segmentRef` | string | yes | Segment reference. |
+| `reason` | string | yes | `BOARDING_WINDOW_EXPIRED`, `VERIFICATION_FAILED`, `MANUAL_RECORD` |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `fulfillmentRecordId` | string | Fulfillment record ID. |
+| `status` | enum | `NO_SHOW` |
+| `assessedAt` | timestamp | When no-show was assessed. |
+
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `CONFLICT`
+
+### Get Fulfillment Record
+
+**GET** `/api/v1/fulfillment-records/{fulfillmentRecordId}`
+
+**Response (200):** Full record details.
+
+**Error codes:** `NOT_FOUND`
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/fulfillment.md
+++ b/docs/08-contracts/api/fulfillment.md
@@ -8,6 +8,9 @@ Fulfillment records physical journey events: boarding verification, no-show
 recording, and fulfillment status queries. These events are recorded after
 the passenger travels.
 
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
+timestamps, and Money.
+
 ## Endpoints
 
 ### Verify Boarding
@@ -74,6 +77,17 @@ the passenger travels.
 **Response (200):** Full record details.
 
 **Error codes:** `NOT_FOUND`
+
+## Bus-only commands
+
+The following commands are consumed from the event bus only and have no HTTP
+endpoint:
+
+| Command | Trigger | Description |
+|---|---|---|
+| `RecordCheckIn` | station-device, provider-integration, admin-audit | Record a passenger check-in at station or gate. |
+| `OpenEvidenceDispute` | system, admin-audit, customer-service | Open an evidence dispute for conflicting offline data. |
+| `ResolveEvidenceDispute` | admin-audit, customer-service | Resolve an evidence dispute. |
 
 ## Open Issues
 

--- a/docs/08-contracts/api/journey-order.md
+++ b/docs/08-contracts/api/journey-order.md
@@ -4,6 +4,9 @@ Last updated: 2026-07-05
 
 ## Overview
 
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
+timestamps, and Money.
+
 Journey Order is the commercial order aggregate. It manages order creation,
 state transitions (pending payment, confirmed, adjusted), and order queries.
 It references but does not own payments, capacity, or entitlements.

--- a/docs/08-contracts/api/journey-order.md
+++ b/docs/08-contracts/api/journey-order.md
@@ -1,0 +1,89 @@
+# Journey Order — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Journey Order is the commercial order aggregate. It manages order creation,
+state transitions (pending payment, confirmed, adjusted), and order queries.
+It references but does not own payments, capacity, or entitlements.
+
+## Endpoints
+
+### Create Journey Order
+
+**POST** `/api/v1/journey-orders`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `accountId` | string | yes | Owning account. |
+| `offerId` | string | yes | Source offer ID (`off-<uuid>`). |
+| `offerVersion` | integer | yes | Version of the offer at quote time. |
+| `travelerRefs` | array | yes | Traveler references (`tvl-<uuid>`). |
+| `segmentRefs` | string[] | yes | Segment references. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `orderId` | string | Canonical order ID (`ord-<uuid>`). |
+| `accountId` | string | Owning account. |
+| `offerId` | string | Source offer ID. |
+| `monetarySummary` | object | Price breakdown at creation. |
+| `status` | enum | `CREATED`, `PENDING_PAYMENT`, `CONFIRMED`, `CANCELLED`, `ADJUSTED` |
+| `travelerRefs` | array | Traveler references. |
+| `segmentRefs` | string[] | Segment references. |
+| `createdAt` | timestamp | Order creation time. |
+
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND` (offerId), `CONFLICT`, `IDEMPOTENCY_KEY_REUSED`
+
+### Get Journey Order
+
+**GET** `/api/v1/journey-orders/{orderId}`
+
+**Response (200):** Full order details including status, monetary summary, timestamps.
+
+**Error codes:** `NOT_FOUND`
+
+### List Journey Orders
+
+**GET** `/api/v1/journey-orders?accountId={accountId}&limit=20&offset=0&status=CONFIRMED`
+
+**Query parameters:** `accountId` (optional filter), `status` (optional filter), `limit`, `offset`
+
+**Response (200):** Paginated response with `items`, `total`, `limit`, `offset`.
+
+### Cancel Journey Order
+
+**POST** `/api/v1/journey-orders/{orderId}/cancel`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `reason` | string | yes | Cancellation reason. |
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `orderId` | string | Order ID. |
+| `status` | enum | `CANCELLED` |
+| `cancelledAt` | timestamp | Cancellation time. |
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`
+
+## Bus-only commands
+
+- `MarkPendingPayment` (internal: triggered by booking saga)
+- `ConfirmJourneyOrder` (internal: triggered by booking saga)
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/notification.md
+++ b/docs/08-contracts/api/notification.md
@@ -1,0 +1,32 @@
+# Notification — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Notification manages notification tasks: scheduling, dispatching, and
+recording delivery receipts. All notification commands are **bus-only** —
+there are no external HTTP endpoints for sending notifications.
+Notifications are triggered by events published by other contexts.
+
+## Bus-only commands
+
+The following commands are consumed from the event bus only and have no HTTP
+endpoint:
+
+| Command | Trigger | Description |
+|---|---|---|
+| `ScheduleNotification` | Domain events (e.g. `JourneyOrderConfirmed`, `EntitlementIssued`) | Schedule a notification for a recipient. |
+| `DispatchNotification` | Internal scheduler | Dispatch a scheduled notification via the appropriate channel. |
+| `RecordDeliveryReceipt` | Channel callback | Record delivery success or failure. |
+
+## Health endpoints only
+
+- `GET /healthz` — liveness
+- `GET /readyz` — readiness
+
+No business HTTP endpoints are exposed.
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/notification.md
+++ b/docs/08-contracts/api/notification.md
@@ -9,6 +9,9 @@ recording delivery receipts. All notification commands are **bus-only** —
 there are no external HTTP endpoints for sending notifications.
 Notifications are triggered by events published by other contexts.
 
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs
+and timestamps.
+
 ## Bus-only commands
 
 The following commands are consumed from the event bus only and have no HTTP
@@ -19,6 +22,7 @@ endpoint:
 | `ScheduleNotification` | Domain events (e.g. `JourneyOrderConfirmed`, `EntitlementIssued`) | Schedule a notification for a recipient. |
 | `DispatchNotification` | Internal scheduler | Dispatch a scheduled notification via the appropriate channel. |
 | `RecordDeliveryReceipt` | Channel callback | Record delivery success or failure. |
+| `CancelNotification` | Manual or business event | Cancel a scheduled notification. |
 
 ## Health endpoints only
 

--- a/docs/08-contracts/api/offer-management.md
+++ b/docs/08-contracts/api/offer-management.md
@@ -1,0 +1,61 @@
+# Offer Management — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Offer Management creates priced offers that combine an itinerary, price
+snapshot, availability snapshot, and rule snapshot into a time-limited
+commercial offer. Offers do not lock inventory.
+
+## Endpoints
+
+### Quote Offer
+
+**POST** `/api/v1/offers`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `accountId` | string | yes | Account requesting the offer. |
+| `channelId` | string | yes | Sales channel. |
+| `itineraryRef` | string | yes | Reference to a Trip Planning itinerary. |
+| `travelerRefs` | string[] | yes | Traveler references for pricing. |
+| `quoteRequestId` | string | no | Client-generated request correlation. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `offerId` | string | Canonical offer ID (`off-<uuid>`). |
+| `offerVersion` | integer | Version of this offer. |
+| `total` | object | Total offer price (Money). |
+| `expiresAt` | timestamp | Offer validity expiry. |
+| `priceGuaranteeLevel` | enum | `FIXED_UNTIL_EXPIRY`, `ESTIMATED_ONLY`, `PROVIDER_FINAL_CONFIRM_REQUIRED` |
+| `downstreamReference` | object | Minimal reference for order creation. |
+| `itineraryRef` | string | Source itinerary reference. |
+| `travelerSetHash` | string | Hash of traveler set. |
+
+**Error codes:** `VALIDATION_FAILED`, `DOMAIN_RULE_VIOLATION`, `UNAVAILABLE`
+
+### Get Offer
+
+**GET** `/api/v1/offers/{offerId}`
+
+**Response (200):** Full offer details.
+
+**Error codes:** `NOT_FOUND`
+
+## Bus-only commands
+
+The following commands are consumed from the event bus only and have no HTTP
+endpoint:
+
+- `RefreshOffer` (internal: triggered by upstream snapshot changes)
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/offer-management.md
+++ b/docs/08-contracts/api/offer-management.md
@@ -4,6 +4,9 @@ Last updated: 2026-07-05
 
 ## Overview
 
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
+timestamps, and Money.
+
 Offer Management creates priced offers that combine an itinerary, price
 snapshot, availability snapshot, and rule snapshot into a time-limited
 commercial offer. Offers do not lock inventory.

--- a/docs/08-contracts/api/payment.md
+++ b/docs/08-contracts/api/payment.md
@@ -1,0 +1,106 @@
+# Payment — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Payment manages payment intents, authorization, capture, and refunds. It is
+the authoritative source for all payment transactions. Payment events do not
+directly modify order or entitlement state.
+
+## Endpoints
+
+### Create Payment Intent
+
+**POST** `/api/v1/payment-intents`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `businessRef` | string | yes | Reference to the business object (order ID). |
+| `purpose` | string | yes | Payment purpose (e.g. `purchase`). |
+| `amount` | object | yes | Amount to collect (Money). |
+| `currency` | string | yes | ISO-4217 currency code. |
+| `payerRef` | string | yes | Payer identifier. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `paymentIntentId` | string | Canonical payment intent ID (`pi-<uuid>`). |
+| `businessRef` | string | Business reference. |
+| `amount` | object | Amount (Money). |
+| `status` | enum | `CREATED`, `AUTHORIZED`, `CAPTURED`, `FAILED`, `REFUNDED` |
+| `createdAt` | timestamp | Creation timestamp. |
+
+**Error codes:** `VALIDATION_FAILED`, `CONFLICT`, `DOMAIN_RULE_VIOLATION`
+
+### Capture Payment
+
+**POST** `/api/v1/payment-intents/{paymentIntentId}/capture`
+
+**Idempotency:** REQUIRED
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `paymentIntentId` | string | Payment intent ID. |
+| `status` | enum | `CAPTURED` |
+| `capturedAmount` | object | Captured amount (Money). |
+| `channelTransactionId` | string | Channel transaction reference. |
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `UNAVAILABLE`
+
+### Request Refund
+
+**POST** `/api/v1/refunds`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `paymentIntentId` | string | yes | Original payment intent ID. |
+| `amount` | object | yes | Amount to refund (Money). |
+| `reason` | string | yes | Refund reason. |
+| `businessCaseRef` | string | no | Reference to post-sales case that authorized the refund. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `refundId` | string | Canonical refund ID. |
+| `paymentIntentId` | string | Original payment intent. |
+| `amount` | object | Refund amount (Money). |
+| `status` | enum | `REQUESTED`, `SETTLED`, `FAILED` |
+
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `DOMAIN_RULE_VIOLATION`
+
+### Get Payment Intent
+
+**GET** `/api/v1/payment-intents/{paymentIntentId}`
+
+**Response (200):** Full payment intent details.
+
+**Error codes:** `NOT_FOUND`
+
+### Get Refund
+
+**GET** `/api/v1/refunds/{refundId}`
+
+**Response (200):** Full refund details.
+
+**Error codes:** `NOT_FOUND`
+
+## Bus-only commands
+
+- `SettleRefund` (internal: triggered by channel callback)
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/payment.md
+++ b/docs/08-contracts/api/payment.md
@@ -8,6 +8,9 @@ Payment manages payment intents, authorization, capture, and refunds. It is
 the authoritative source for all payment transactions. Payment events do not
 directly modify order or entitlement state.
 
+Field shapes reference docs/08-contracts/shared-primitives.md for Money,
+timestamps, and cross-context IDs.
+
 ## Endpoints
 
 ### Create Payment Intent
@@ -22,8 +25,7 @@ directly modify order or entitlement state.
 |---|---|---|---|
 | `businessRef` | string | yes | Reference to the business object (order ID). |
 | `purpose` | string | yes | Payment purpose (e.g. `purchase`). |
-| `amount` | object | yes | Amount to collect (Money). |
-| `currency` | string | yes | ISO-4217 currency code. |
+| `amount` | object | yes | Amount to collect (Money — see shared-primitives.md). |
 | `payerRef` | string | yes | Payer identifier. |
 
 **Response (201):**
@@ -33,10 +35,32 @@ directly modify order or entitlement state.
 | `paymentIntentId` | string | Canonical payment intent ID (`pi-<uuid>`). |
 | `businessRef` | string | Business reference. |
 | `amount` | object | Amount (Money). |
-| `status` | enum | `CREATED`, `AUTHORIZED`, `CAPTURED`, `FAILED`, `REFUNDED` |
+| `status` | enum | `CREATED`, `AUTHORIZED`, `CAPTURED`, `FAILED`, `CANCELLED` |
 | `createdAt` | timestamp | Creation timestamp. |
 
 **Error codes:** `VALIDATION_FAILED`, `CONFLICT`, `DOMAIN_RULE_VIOLATION`
+
+### Cancel Payment Intent
+
+**POST** `/api/v1/payment-intents/{paymentIntentId}/cancel`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `reason` | string | yes | Reason for cancellation. |
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `paymentIntentId` | string | Payment intent ID. |
+| `status` | enum | `CANCELLED` |
+| `cancelledAt` | timestamp | When cancellation was recorded. |
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`
 
 ### Capture Payment
 

--- a/docs/08-contracts/api/place-network.md
+++ b/docs/08-contracts/api/place-network.md
@@ -4,6 +4,9 @@ Last updated: 2026-07-05
 
 ## Overview
 
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
+timestamps, and Money.
+
 Place & Network manages geographic places (cities, stations, airports) and
 transport nodes (platforms, gates). It serves as the reference master data
 for all location lookups.

--- a/docs/08-contracts/api/place-network.md
+++ b/docs/08-contracts/api/place-network.md
@@ -1,0 +1,104 @@
+# Place & Network — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Place & Network manages geographic places (cities, stations, airports) and
+transport nodes (platforms, gates). It serves as the reference master data
+for all location lookups.
+
+## Endpoints
+
+### Create a Place
+
+Registers a new geographic place.
+
+**POST** `/api/v1/places`
+
+**Idempotency:** REQUIRED (`Idempotency-Key`)
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `placeType` | enum | yes | `CITY`, `STATION`, `AIRPORT`, `PORT` |
+| `canonicalName` | string | yes | Display name of the place. |
+| `code` | string | no | Short code (e.g. IATA/station code). |
+| `timezone` | string | no | IANA timezone identifier. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `placeId` | string | Canonical place ID (`plc-<uuid>`). |
+| `placeType` | enum | As requested. |
+| `canonicalName` | string | Display name. |
+| `status` | enum | `ACTIVE`, `DRAFT`, `DEPRECATED`, `RETIRED` |
+| `createdAt` | timestamp | Creation time. |
+
+**Error codes:** `VALIDATION_FAILED`, `CONFLICT`
+
+### Get a Place
+
+**GET** `/api/v1/places/{placeId}`
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `placeId` | string | Canonical place ID. |
+| `placeType` | enum | Type of place. |
+| `canonicalName` | string | Display name. |
+| `code` | string | Short code, if set. |
+| `timezone` | string | IANA timezone, if set. |
+| `status` | enum | Current status. |
+| `nodes` | array | List of associated transport nodes. |
+
+**Error codes:** `NOT_FOUND`
+
+### List Places
+
+**GET** `/api/v1/places?limit=20&offset=0&status=ACTIVE`
+
+**Query parameters:** `limit`, `offset`, `status` (optional filter)
+
+**Response (200):** Paginated response with `items`, `total`, `limit`, `offset`.
+
+### Create a Transport Node
+
+**POST** `/api/v1/transport-nodes`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `placeId` | string | yes | Parent place ID (`plc-<uuid>`). |
+| `displayName` | string | yes | Display name (e.g. "Platform 3"). |
+| `servingModes` | string[] | yes | Transport modes served (e.g. `["RAIL"]`). |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `nodeId` | string | Canonical node ID (`tnd-<uuid>`). |
+| `placeId` | string | Parent place. |
+| `displayName` | string | Display name. |
+| `servingModes` | string[] | Transport modes. |
+| `createdAt` | timestamp | Creation time. |
+
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND` (placeId), `CONFLICT`
+
+### Get a Transport Node
+
+**GET** `/api/v1/transport-nodes/{nodeId}`
+
+**Response (200):** Node details as above.
+
+**Error codes:** `NOT_FOUND`
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/post-sales.md
+++ b/docs/08-contracts/api/post-sales.md
@@ -8,6 +8,9 @@ Post Sales manages post-sales cases: cancellations, refunds, changes, and
 compensation. It evaluates eligibility, approves or rejects cases, and
 orchestrates downstream actions (entitlement voiding, refunds).
 
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
+timestamps, and Money.
+
 ## Endpoints
 
 ### Open Post-Sales Case
@@ -78,6 +81,17 @@ orchestrates downstream actions (entitlement voiding, refunds).
 **Response (200):** Full case details.
 
 **Error codes:** `NOT_FOUND`
+
+## Bus-only commands
+
+The following commands are consumed from the event bus only and have no HTTP
+endpoint:
+
+| Command | Trigger | Description |
+|---|---|---|
+| `QuotePostSalesDecision` | post-sales (internal) | Quote a decision with amounts and eligibility for a post-sales case. |
+| `StartPostSalesExecution` | post-sales (internal) | Start execution of an approved post-sales case. |
+| `ApplyPostSalesResult` | post-sales (internal) | Apply the result of post-sales execution to the case. |
 
 ## Open Issues
 

--- a/docs/08-contracts/api/post-sales.md
+++ b/docs/08-contracts/api/post-sales.md
@@ -1,0 +1,84 @@
+# Post Sales — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Post Sales manages post-sales cases: cancellations, refunds, changes, and
+compensation. It evaluates eligibility, approves or rejects cases, and
+orchestrates downstream actions (entitlement voiding, refunds).
+
+## Endpoints
+
+### Open Post-Sales Case
+
+**POST** `/api/v1/post-sales-cases`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `journeyOrderId` | string | yes | Parent order ID (`ord-<uuid>`). |
+| `caseType` | enum | yes | `CANCELLATION`, `REFUND`, `CHANGE`, `REBOOK`, `COMPENSATION` |
+| `scope` | object | yes | Affected order items, segments, travelers, entitlements. |
+| `reasonCode` | string | yes | Business reason for the case. |
+| `actorRef` | string | yes | Who requested the case (account ID or operator ID). |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `caseId` | string | Canonical case ID (`psc-<uuid>`). |
+| `journeyOrderId` | string | Parent order. |
+| `caseType` | enum | Case type. |
+| `status` | enum | `OPENED`, `EVALUATING`, `APPROVED`, `REJECTED`, `APPLIED`, `FAILED` |
+| `createdAt` | timestamp | Creation time. |
+
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `DOMAIN_RULE_VIOLATION`
+
+### Evaluate Post-Sales Eligibility
+
+**POST** `/api/v1/post-sales-cases/{caseId}/evaluate`
+
+**Idempotency:** REQUIRED
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `caseId` | string | Case ID. |
+| `eligible` | boolean | Whether the request is eligible. |
+| `adjustmentQuoteId` | string | Reference to fare-pricing adjustment quote. |
+| `refundableAmount` | object | Amount refundable (Money). |
+| `amountDue` | object | Amount due (Money). |
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `UNAVAILABLE`
+
+### Approve Post-Sales Case
+
+**POST** `/api/v1/post-sales-cases/{caseId}/approve`
+
+**Idempotency:** REQUIRED
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `caseId` | string | Case ID. |
+| `status` | enum | `APPROVED` |
+
+**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`
+
+### Get Post-Sales Case
+
+**GET** `/api/v1/post-sales-cases/{caseId}`
+
+**Response (200):** Full case details.
+
+**Error codes:** `NOT_FOUND`
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/provider-integration.md
+++ b/docs/08-contracts/api/provider-integration.md
@@ -1,0 +1,61 @@
+# Provider Integration — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Provider Integration manages external provider (supplier) communication. It
+translates internal commands to provider-specific protocols, handles
+idempotency, and normalizes responses. Endpoints in this section are
+**internal** — called by Booking Orchestration, not end-user clients.
+
+## Internal Endpoints
+
+### Request Provider Reservation
+
+**POST** `/api/v1/internal/provider-reservations`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `segmentBookingId` | string | yes | Platform segment booking ID (`sb-<uuid>`). |
+| `providerConfigRef` | string | yes | Provider configuration reference. |
+| `reservationPayload` | object | yes | Provider-specific reservation payload. |
+| `idempotencyKey` | string | yes | Idempotency key for safe retry. |
+
+**Response (202):**
+
+| Field | Type | Description |
+|---|---|---|
+| `segmentBookingId` | string | Segment booking ID. |
+| `status` | enum | `PENDING`, `CONFIRMED`, `FAILED`, `TIMED_OUT` |
+| `providerReference` | string | Provider's confirmation reference (if confirmed). |
+
+**Error codes:** `VALIDATION_FAILED`, `UNAVAILABLE`
+
+### Cancel Provider Reservation
+
+**POST** `/api/v1/internal/provider-reservations/{segmentBookingId}/cancel`
+
+**Idempotency:** REQUIRED
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `segmentBookingId` | string | Segment booking ID. |
+| `cancellationStatus` | enum | `CANCELLED`, `PENDING`, `FAILED` |
+
+**Error codes:** `NOT_FOUND`, `UNAVAILABLE`
+
+## Bus-only commands
+
+- `ProviderReservationConfirmed` (published event, not a command)
+- `ProviderReservationFailed` (published event, not a command)
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/provider-integration.md
+++ b/docs/08-contracts/api/provider-integration.md
@@ -9,6 +9,9 @@ translates internal commands to provider-specific protocols, handles
 idempotency, and normalizes responses. Endpoints in this section are
 **internal** — called by Booking Orchestration, not end-user clients.
 
+
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
+timestamps, and Money.
 ## Internal Endpoints
 
 ### Request Provider Reservation

--- a/docs/08-contracts/api/reporting.md
+++ b/docs/08-contracts/api/reporting.md
@@ -1,0 +1,62 @@
+# Reporting — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Reporting manages metric definitions, dashboard read models, and report
+queries. It consumes events from all contexts and provides read-only query
+endpoints. All write commands are **bus-only**.
+
+## Query Endpoints
+
+### List Metrics
+
+**GET** `/api/v1/metrics?category=operational&limit=20&offset=0`
+
+**Response (200):** Paginated response with metric definitions.
+
+### Get Metric
+
+**GET** `/api/v1/metrics/{metricId}`
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `metricId` | string | Unique metric identifier. |
+| `name` | string | Human-readable name. |
+| `description` | string | Business definition. |
+| `owner` | string | Owner team. |
+| `category` | string | Category. |
+| `granularity` | string | Aggregation granularity. |
+| `version` | string | Current version. |
+| `expression` | string | Calculation expression. |
+
+**Error codes:** `NOT_FOUND`
+
+### Query Dashboard
+
+**GET** `/api/v1/dashboards/{dashboardId}`
+
+**Response (200):** Dashboard read model snapshot.
+
+**Error codes:** `NOT_FOUND`
+
+### List Dashboard Rebuilds
+
+**GET** `/api/v1/dashboards/{dashboardId}/rebuilds?limit=20&offset=0`
+
+**Response (200):** Paginated list of rebuild runs.
+
+## Bus-only commands
+
+| Command | Trigger | Description |
+|---|---|---|
+| `DefineMetric` | Admin UI | Draft a new metric definition. |
+| `PublishMetricVersion` | Admin UI | Publish a metric version. |
+| `RebuildReadModel` | Manual or scheduled | Rebuild a dashboard read model. |
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/reporting.md
+++ b/docs/08-contracts/api/reporting.md
@@ -8,6 +8,9 @@ Reporting manages metric definitions, dashboard read models, and report
 queries. It consumes events from all contexts and provides read-only query
 endpoints. All write commands are **bus-only**.
 
+
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs
+and timestamps.
 ## Query Endpoints
 
 ### List Metrics

--- a/docs/08-contracts/api/risk-compliance.md
+++ b/docs/08-contracts/api/risk-compliance.md
@@ -8,6 +8,9 @@ Risk & Compliance performs risk assessments for orders, payments, post-sales
 requests, and account actions. It also issues challenges when additional
 verification is needed.
 
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
+timestamps, and Money.
+
 ## Endpoints
 
 ### Assess Risk
@@ -51,7 +54,16 @@ verification is needed.
 
 ## Bus-only commands
 
-- `IssueChallenge` (internal: triggered by `CHALLENGE` decision)
+The following commands are consumed from the event bus only and have no HTTP
+endpoint:
+
+| Command | Trigger | Description |
+|---|---|---|
+| `IssueChallenge` | Risk system (internal) | Issue a challenge when the risk decision is `CHALLENGE`. |
+| `ResolveChallenge` | Customer / Operator | Resolve a challenge with outcome (PASSED/FAILED). |
+| `BlockSubject` | Risk system (internal) | Block a subject (order, payment, account) from proceeding. |
+| `AllowSubject` | Risk system (internal) | Allow a previously blocked subject to proceed. |
+| `RecordEvidence` | Risk system (internal) | Record risk evidence for audit trail. |
 
 ## Open Issues
 

--- a/docs/08-contracts/api/risk-compliance.md
+++ b/docs/08-contracts/api/risk-compliance.md
@@ -1,0 +1,58 @@
+# Risk & Compliance — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Risk & Compliance performs risk assessments for orders, payments, post-sales
+requests, and account actions. It also issues challenges when additional
+verification is needed.
+
+## Endpoints
+
+### Assess Risk
+
+**POST** `/api/v1/risk-assessments`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `subjectRef` | string | yes | Subject of assessment (order ID, payment intent ID, account ID). |
+| `scenario` | string | yes | Risk scenario: `order_risk`, `payment_risk`, `post_sales_risk`, `account_risk` |
+| `context` | object | yes | Contextual data for the assessment. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `assessmentId` | string | Canonical assessment ID (`asmt-<uuid>`). |
+| `subjectRef` | string | Subject reference. |
+| `scenario` | string | Risk scenario. |
+| `decision` | enum | `ALLOW`, `DENY`, `CHALLENGE`, `HOLD` |
+| `score` | integer | Risk score (0-1000). |
+| `level` | enum | `LOW`, `MEDIUM`, `HIGH`, `CRITICAL` |
+| `policyVersion` | string | Policy version used. |
+| `reasonCode` | string | Machine-readable reason code. |
+| `reasonExplanation` | string | Human-readable explanation. |
+| `assessedAt` | timestamp | When assessment completed. |
+
+**Error codes:** `VALIDATION_FAILED`, `UNAVAILABLE`
+
+### Get Risk Assessment
+
+**GET** `/api/v1/risk-assessments/{assessmentId}`
+
+**Response (200):** Full assessment details.
+
+**Error codes:** `NOT_FOUND`
+
+## Bus-only commands
+
+- `IssueChallenge` (internal: triggered by `CHALLENGE` decision)
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/service-plan.md
+++ b/docs/08-contracts/api/service-plan.md
@@ -1,0 +1,83 @@
+# Service Plan — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Service Plan manages scheduled services (train runs), service segments (route
+sections), and the association between routes and services. It provides the
+master schedule data used by Trip Planning and Capacity.
+
+## Endpoints
+
+### Create a Scheduled Service
+
+**POST** `/api/v1/scheduled-services`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `serviceRef` | string | no | External service reference (optional; generated if absent). |
+| `carrierId` | string | yes | Carrier operating the service (`car-<uuid>`). |
+| `serviceNumber` | string | yes | Public service number (e.g. "G1234"). |
+| `departureTime` | timestamp | yes | Scheduled departure at origin. |
+| `arrivalTime` | timestamp | yes | Scheduled arrival at destination. |
+| `originNodeId` | string | yes | Origin transport node ID. |
+| `destinationNodeId` | string | yes | Destination transport node ID. |
+| `status` | enum | no | `ACTIVE`, `SUSPENDED`, `CANCELLED` (default `ACTIVE`). |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `scheduledServiceRef` | string | Reference (`ss-<uuid>`). |
+| `serviceNumber` | string | Public service number. |
+| `status` | enum | Current status. |
+
+**Error codes:** `VALIDATION_FAILED`, `CONFLICT`, `NOT_FOUND`
+
+### Get Scheduled Service
+
+**GET** `/api/v1/scheduled-services/{serviceRef}`
+
+**Response (200):** Full service details.
+
+**Error codes:** `NOT_FOUND`
+
+### List Scheduled Services
+
+**GET** `/api/v1/scheduled-services?limit=20&offset=0&carrierId=...`
+
+**Response (200):** Paginated response.
+
+### Create a Service Segment
+
+**POST** `/api/v1/service-segments`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `scheduledServiceRef` | string | yes | Parent scheduled service. |
+| `originStopRef` | string | yes | Origin stop node ID. |
+| `destinationStopRef` | string | yes | Destination stop node ID. |
+| `departureTime` | timestamp | yes | Segment departure time. |
+| `arrivalTime` | timestamp | yes | Segment arrival time. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `segmentRef` | string | Segment reference (`seg-<uuid>`). |
+| `scheduledServiceRef` | string | Parent service. |
+
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `CONFLICT`
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/service-plan.md
+++ b/docs/08-contracts/api/service-plan.md
@@ -4,6 +4,9 @@ Last updated: 2026-07-05
 
 ## Overview
 
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
+timestamps, and Money.
+
 Service Plan manages scheduled services (train runs), service segments (route
 sections), and the association between routes and services. It provides the
 master schedule data used by Trip Planning and Capacity.

--- a/docs/08-contracts/api/supplier-catalog.md
+++ b/docs/08-contracts/api/supplier-catalog.md
@@ -1,0 +1,106 @@
+# Supplier Catalog — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Supplier Catalog manages suppliers, carriers, and commercial contracts. It is
+the master data source for provider integration and fare pricing.
+
+## Endpoints
+
+### Register Supplier
+
+**POST** `/api/v1/suppliers`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `legalName` | string | yes | Legal entity name. |
+| `brandName` | string | yes | Brand or trading name. |
+| `supplierCode` | string | yes | Short supplier code. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `supplierId` | string | Canonical supplier ID (`sup-<uuid>`). |
+| `legalName` | string | Legal name. |
+| `brandName` | string | Brand name. |
+| `status` | enum | `DRAFT`, `UNDER_REVIEW`, `ACTIVE`, `SUSPENDED`, `INACTIVE`, `REJECTED`, `ARCHIVED` |
+| `registeredAt` | timestamp | Registration time. |
+
+**Error codes:** `VALIDATION_FAILED`, `CONFLICT`
+
+### Get Supplier
+
+**GET** `/api/v1/suppliers/{supplierId}`
+
+**Response (200):** Full supplier details.
+
+**Error codes:** `NOT_FOUND`
+
+### List Suppliers
+
+**GET** `/api/v1/suppliers?status=ACTIVE&limit=20&offset=0`
+
+**Response (200):** Paginated response.
+
+### Register Carrier
+
+**POST** `/api/v1/carriers`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `supplierId` | string | yes | Parent supplier ID (`sup-<uuid>`). |
+| `name` | string | yes | Carrier display name. |
+| `code` | string | yes | Carrier code (e.g. `BJRAIL`, `CA`). |
+| `transportMode` | string | yes | `RAIL`, `AIR`, `COACH`, `FERRY`, `RIDE_HAILING` |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `carrierId` | string | Canonical carrier ID (`car-<uuid>`). |
+| `supplierId` | string | Parent supplier. |
+| `name` | string | Carrier name. |
+| `code` | string | Carrier code. |
+| `transportMode` | string | Transport mode. |
+
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `CONFLICT`
+
+### Activate Contract
+
+**POST** `/api/v1/contracts`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `supplierId` | string | yes | Supplier ID. |
+| `carrierId` | string | yes | Carrier ID. |
+| `contractRef` | string | yes | External contract reference. |
+| `effectiveFrom` | timestamp | yes | Contract effective date. |
+| `effectiveUntil` | timestamp | no | Contract expiry date. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `contractId` | string | Contract ID. |
+| `status` | enum | `DRAFT`, `PUBLISHED`, `SUSPENDED`, `TERMINATED` |
+
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `CONFLICT`
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/supplier-catalog.md
+++ b/docs/08-contracts/api/supplier-catalog.md
@@ -7,6 +7,9 @@ Last updated: 2026-07-05
 Supplier Catalog manages suppliers, carriers, and commercial contracts. It is
 the master data source for provider integration and fare pricing.
 
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
+timestamps, and Money.
+
 ## Endpoints
 
 ### Register Supplier
@@ -100,6 +103,17 @@ the master data source for provider integration and fare pricing.
 | `status` | enum | `DRAFT`, `PUBLISHED`, `SUSPENDED`, `TERMINATED` |
 
 **Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `CONFLICT`
+
+## Bus-only commands
+
+The following commands are consumed from the event bus only and have no HTTP
+endpoint:
+
+| Command | Trigger | Description |
+|---|---|---|
+| `SuspendContract` | Admin UI / Automated policy | Suspend an active contract. |
+| `DeclareProductCapability` | Admin UI / Capability discovery | Declare a product capability for a supplier contract. |
+| `MapExternalCode` | Admin UI / Import batch / ACL | Map an external supplier code to an internal platform reference. |
 
 ## Open Issues
 

--- a/docs/08-contracts/api/traveler-profile.md
+++ b/docs/08-contracts/api/traveler-profile.md
@@ -4,6 +4,9 @@ Last updated: 2026-07-05
 
 ## Overview
 
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
+timestamps, and Money.
+
 Traveler Profile manages traveler identities, travel documents, contact
 information, and eligibility determinations (student, senior, military
 discounts).

--- a/docs/08-contracts/api/traveler-profile.md
+++ b/docs/08-contracts/api/traveler-profile.md
@@ -1,0 +1,83 @@
+# Traveler Profile — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Traveler Profile manages traveler identities, travel documents, contact
+information, and eligibility determinations (student, senior, military
+discounts).
+
+## Endpoints
+
+### Create Traveler Profile
+
+**POST** `/api/v1/travelers`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `accountId` | string | yes | Owning account. |
+| `travelerType` | enum | yes | `ADULT`, `CHILD`, `INFANT`, `STUDENT`, `SENIOR`, `MILITARY` |
+| `givenName` | string | yes | Given name. |
+| `familyName` | string | yes | Family name. |
+| `documentType` | enum | no | `ID_CARD`, `PASSPORT`, `OTHER` |
+| `documentNumber` | string | no | Travel document number (will be masked in snapshots). |
+| `contactEmail` | string | no | Contact email. |
+| `contactPhone` | string | no | Contact phone number. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `travelerId` | string | Canonical traveler ID (`tvl-<uuid>`). |
+| `snapshotVersion` | string | Initial snapshot version. |
+| `travelerType` | enum | Traveler type. |
+| `createdAt` | timestamp | Creation time. |
+
+**Error codes:** `VALIDATION_FAILED`, `CONFLICT`
+
+### Get Traveler Profile
+
+**GET** `/api/v1/travelers/{travelerId}`
+
+**Response (200):** Full traveler profile (document numbers masked).
+
+**Error codes:** `NOT_FOUND`
+
+### Update Traveler Profile
+
+**PATCH** `/api/v1/travelers/{travelerId}`
+
+**Idempotency:** REQUIRED
+
+**Request:** Partial fields from the create request.
+
+**Response (200):** Updated traveler profile.
+
+**Error codes:** `NOT_FOUND`, `VALIDATION_FAILED`
+
+### Determine Eligibility
+
+**POST** `/api/v1/travelers/{travelerId}/eligibility`
+
+**Idempotency:** REQUIRED
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `travelerId` | string | Traveler ID. |
+| `eligibilityRef` | string | Eligibility reference. |
+| `eligible` | boolean | Whether the traveler is eligible. |
+| `validFrom` | timestamp | Eligibility validity start. |
+| `validUntil` | timestamp | Eligibility validity end. |
+
+**Error codes:** `NOT_FOUND`, `UNAVAILABLE`
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/trip-planning.md
+++ b/docs/08-contracts/api/trip-planning.md
@@ -1,0 +1,72 @@
+# Trip Planning — HTTP API
+
+Last updated: 2026-07-05
+
+## Overview
+
+Trip Planning searches for itineraries based on a traveler's intent. It
+returns candidate itineraries with non-authoritative price and availability
+hints. It does not lock inventory or create offers.
+
+## Endpoints
+
+### Search Itineraries
+
+**POST** `/api/v1/itineraries/search`
+
+**Idempotency:** NOT REQUIRED (query endpoint; idempotency key is ignored if present)
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `originRef` | string | yes | Origin place or node reference. |
+| `destinationRef` | string | yes | Destination place or node reference. |
+| `departureDate` | string | yes | Departure date (ISO-8601 date, e.g. `"2026-07-10"`). |
+| `returnDate` | string | no | Return date for round trips. |
+| `travelerRefs` | string[] | yes | Traveler references for pricing hints. |
+| `channel` | string | yes | Sales channel. |
+| `maxResults` | integer | no | Maximum results to return (default 10, max 50). |
+
+**Response (200):**
+
+| Field | Type | Description |
+|---|---|---|
+| `intentRef` | string | Hash/fingerprint of the original request. |
+| `itineraries` | array | Ordered list of candidate itineraries. |
+| `planningSnapshotRefs` | string[] | References to upstream snapshots used. |
+
+**Itinerary:**
+
+| Field | Type | Description |
+|---|---|---|
+| `itineraryRef` | string | Stable itinerary reference (`itin_<sha256>`). |
+| `legs` | array | Ordered legs comprising the itinerary. |
+| `priceHint` | object | Non-authoritative price estimate. |
+| `availabilityHint` | object | Non-authoritative availability estimate. |
+
+**LegCandidate:**
+
+| Field | Type | Description |
+|---|---|---|
+| `servicePlanRef` | string | Reference to the service plan. |
+| `serviceSegmentRef` | string | Reference to the service segment. |
+| `originStopRef` | string | Origin stop reference. |
+| `destinationStopRef` | string | Destination stop reference. |
+| `departureTime` | timestamp | Scheduled departure. |
+| `arrivalTime` | timestamp | Scheduled arrival. |
+| `mode` | string | Transport mode (default: `train`). |
+
+**Error codes:** `VALIDATION_FAILED`, `UNAVAILABLE`
+
+### Get Itinerary
+
+**GET** `/api/v1/itineraries/{itineraryRef}`
+
+**Response (200):** Full itinerary details.
+
+**Error codes:** `NOT_FOUND`
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/api/trip-planning.md
+++ b/docs/08-contracts/api/trip-planning.md
@@ -4,6 +4,9 @@ Last updated: 2026-07-05
 
 ## Overview
 
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs,
+timestamps, and Money.
+
 Trip Planning searches for itineraries based on a traveler's intent. It
 returns candidate itineraries with non-authoritative price and availability
 hints. It does not lock inventory or create offers.

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -941,6 +941,65 @@ requirements:
     confidence: confirmed
     source: "docs/03-ddd-final/phase-1-contract.md, docs/03-ddd-final/implementation-roadmap.md"
 
+  - id: REQ-030
+    title: "HTTP API contract specification (all implemented services)"
+    description: "Author the authoritative HTTP API contract under docs/08-contracts/api/. Every service's HTTP layer must conform to this spec exactly. This is the synchronous-command counterpart of the existing event contract in docs/08-contracts/events/."
+    priority: P0
+    status: implemented
+    code: []
+    tests: []
+    docs:
+      - path: docs/08-contracts/api/README.md
+        description: "Cross-cutting API conventions: base path, headers, canonical errors, pagination, health endpoints."
+      - path: docs/08-contracts/api/place-network.md
+        description: "Place & Network HTTP API contract."
+      - path: docs/08-contracts/api/service-plan.md
+        description: "Service Plan HTTP API contract."
+      - path: docs/08-contracts/api/capacity-availability.md
+        description: "Capacity & Availability HTTP API contract."
+      - path: docs/08-contracts/api/fare-pricing.md
+        description: "Fare & Pricing HTTP API contract."
+      - path: docs/08-contracts/api/trip-planning.md
+        description: "Trip Planning HTTP API contract."
+      - path: docs/08-contracts/api/offer-management.md
+        description: "Offer Management HTTP API contract."
+      - path: docs/08-contracts/api/journey-order.md
+        description: "Journey Order HTTP API contract."
+      - path: docs/08-contracts/api/booking-orchestration.md
+        description: "Booking Orchestration HTTP API contract."
+      - path: docs/08-contracts/api/provider-integration.md
+        description: "Provider Integration HTTP API contract."
+      - path: docs/08-contracts/api/payment.md
+        description: "Payment HTTP API contract."
+      - path: docs/08-contracts/api/traveler-profile.md
+        description: "Traveler Profile HTTP API contract."
+      - path: docs/08-contracts/api/entitlement-ticketing.md
+        description: "Entitlement & Ticketing HTTP API contract."
+      - path: docs/08-contracts/api/notification.md
+        description: "Notification HTTP API contract."
+      - path: docs/08-contracts/api/risk-compliance.md
+        description: "Risk & Compliance HTTP API contract."
+      - path: docs/08-contracts/api/admin-audit.md
+        description: "Admin & Audit HTTP API contract."
+      - path: docs/08-contracts/api/supplier-catalog.md
+        description: "Supplier Catalog HTTP API contract."
+      - path: docs/08-contracts/api/post-sales.md
+        description: "Post Sales HTTP API contract."
+      - path: docs/08-contracts/api/fulfillment.md
+        description: "Fulfillment HTTP API contract."
+      - path: docs/08-contracts/api/account.md
+        description: "Account HTTP API contract."
+      - path: docs/08-contracts/api/customer-service.md
+        description: "Customer Service HTTP API contract."
+      - path: docs/08-contracts/api/finance-settlement.md
+        description: "Finance & Settlement HTTP API contract."
+      - path: docs/08-contracts/api/reporting.md
+        description: "Reporting HTTP API contract."
+    depends_on:
+      - REQ-029
+    confidence: confirmed
+    source: "docs/08-contracts/events/, docs/03-ddd-final/phase-1-contract.md"
+
   - id: REQ-101
     title: "WP-01 Shared kernel contracts"
     description: "Define common IDs, value objects, and event envelope."


### PR DESCRIPTION
## Summary

Author the authoritative HTTP API contract under `docs/08-contracts/api/`. Every service's HTTP layer must conform to this spec exactly. This is the synchronous-command counterpart of the existing event contract in `docs/08-contracts/events/`.

## Deliverables

1. `docs/08-contracts/api/README.md` — cross-cutting API conventions
2. 22 context API contract files (one per implemented context)
3. Updated `project-index.yaml` with REQ-030 (status: implemented)

## Validation

All validation checks pass:
- README exists
- 23 files (README + 22 contexts)
- Idempotency-Key header documented
- X-Correlation-Id header documented
- IDEMPOTENCY_KEY_REUSED error code documented
- shared-primitives.md reference in README
- /api/v1 in journey-order.md
- bus-only marked in notification.md
- `make check` passes