### PR TITLE
REQ-033: offer-management HTTP API and event-bus adapter

### DIFF
--- a/services/offer-management/package-lock.json
+++ b/services/offer-management/package-lock.json
@@ -8,10 +8,11 @@
       "name": "@trainticket/offer-management",
       "version": "0.1.0",
       "dependencies": {
-        "fastify": "5.9.0"
+        "fastify": "5.9.0",
+        "ioredis": "^5.11.1"
       },
       "devDependencies": {
-        "@types/node": "26.0.1",
+        "@types/node": "^26.0.1",
         "typescript": "6.0.3"
       }
     },
@@ -126,6 +127,12 @@
         "ipaddr.js": "^2.1.0"
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmmirror.com/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+      "license": "MIT"
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmmirror.com/@pinojs/redact/-/redact-0.4.0.tgz",
@@ -210,6 +217,15 @@
         "fastq": "^1.17.1"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmmirror.com/cookie/-/cookie-1.1.1.tgz",
@@ -221,6 +237,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/dequal": {
@@ -349,6 +391,28 @@
         "node": ">=20"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmmirror.com/ioredis/-/ioredis-5.11.1.tgz",
+      "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.10.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "redis-parser": "3.0.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "2.4.0",
       "resolved": "https://registry.npmmirror.com/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
@@ -418,6 +482,12 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/on-exit-leak-free": {
@@ -495,6 +565,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/require-from-string": {
@@ -613,6 +704,12 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/thread-stream": {
       "version": "4.2.0",

--- a/services/offer-management/package.json
+++ b/services/offer-management/package.json
@@ -8,10 +8,11 @@
     "test": "rm -rf test-output && tsc --noEmit false --outDir test-output && node --test test-output/**/*.test.js"
   },
   "dependencies": {
-    "fastify": "5.9.0"
+    "fastify": "5.9.0",
+    "ioredis": "^5.11.1"
   },
   "devDependencies": {
-    "@types/node": "26.0.1",
+    "@types/node": "^26.0.1",
     "typescript": "6.0.3"
   }
 }

--- a/services/offer-management/src/adapters/messaging/in-memory.ts
+++ b/services/offer-management/src/adapters/messaging/in-memory.ts
@@ -45,6 +45,7 @@ export class InMemoryEventPublisher implements EventPublisher {
 export class InMemoryEventSubscriber implements EventSubscriber {
   public readonly received: EventEnvelope[] = [];
   private handler: EventHandler | null = null;
+  private readonly processedEventIds = new Set<string>();
 
   async subscribe(
     _streams: readonly string[],
@@ -59,15 +60,24 @@ export class InMemoryEventSubscriber implements EventSubscriber {
   /** Simulate receiving an event. Returns the handler result. */
   async simulateEvent(envelope: EventEnvelope): Promise<"ack" | "retry" | "dlq"> {
     this.received.push(envelope);
-    if (this.handler) {
-      return await this.handler(envelope);
+    if (this.processedEventIds.has(envelope.eventId)) {
+      return "ack";
     }
-    return "ack";
+    if (!this.handler) {
+      this.processedEventIds.add(envelope.eventId);
+      return "ack";
+    }
+    const result = await this.handler(envelope);
+    if (result === "ack") {
+      this.processedEventIds.add(envelope.eventId);
+    }
+    return result;
   }
 
   /** Reset state. */
   reset(): void {
     this.received.length = 0;
     this.handler = null;
+    this.processedEventIds.clear();
   }
 }

--- a/services/offer-management/src/adapters/messaging/in-memory.ts
+++ b/services/offer-management/src/adapters/messaging/in-memory.ts
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------------
+// In-memory fake implementations of EventPublisher and EventSubscriber ports
+// for use in unit tests (no live Redis required).
+// ---------------------------------------------------------------------------
+
+import { EventPublisher, EventSubscriber, PublishFailed, type EventEnvelope, type EventHandler } from "../../ports/messaging.js";
+
+/**
+ * In-memory fake EventPublisher that stores published envelopes in an array.
+ */
+export class InMemoryEventPublisher implements EventPublisher {
+  public readonly published: EventEnvelope[] = [];
+  public failNext = false;
+
+  async publish(envelope: EventEnvelope): Promise<void> {
+    if (this.failNext) {
+      this.failNext = false;
+      throw new PublishFailed("Simulated publish failure");
+    }
+    this.published.push(envelope);
+  }
+
+  /** Convenience: find all published envelopes for a given producer. */
+  findByProducer(producer: string): EventEnvelope[] {
+    return this.published.filter((e) => e.producer === producer);
+  }
+
+  /** Convenience: find all published envelopes of a given event type. */
+  findByEventType(eventType: string): EventEnvelope[] {
+    return this.published.filter((e) => e.eventType === eventType);
+  }
+
+  /** Reset state. */
+  reset(): void {
+    this.published.length = 0;
+    this.failNext = false;
+  }
+}
+
+/**
+ * In-memory fake EventSubscriber that captures handler invocations.
+ * Does not actually poll; instead, `simulateEvent` can be called to
+ * trigger the handler with a given envelope.
+ */
+export class InMemoryEventSubscriber implements EventSubscriber {
+  public readonly received: EventEnvelope[] = [];
+  private handler: EventHandler | null = null;
+
+  async subscribe(
+    _streams: readonly string[],
+    _group: string,
+    _consumerName: string,
+    handler: EventHandler,
+    _signal: AbortSignal,
+  ): Promise<void> {
+    this.handler = handler;
+  }
+
+  /** Simulate receiving an event. Returns the handler result. */
+  async simulateEvent(envelope: EventEnvelope): Promise<"ack" | "retry" | "dlq"> {
+    this.received.push(envelope);
+    if (this.handler) {
+      return await this.handler(envelope);
+    }
+    return "ack";
+  }
+
+  /** Reset state. */
+  reset(): void {
+    this.received.length = 0;
+    this.handler = null;
+  }
+}

--- a/services/offer-management/src/adapters/messaging/publisher.ts
+++ b/services/offer-management/src/adapters/messaging/publisher.ts
@@ -7,6 +7,7 @@
 import { type Redis } from "ioredis";
 
 import { EventPublisher, PublishFailed, type EventEnvelope } from "../../ports/messaging.js";
+import { streamKey } from "./stream-config.js";
 
 const MAX_RETRIES = 3;
 const RETRY_DELAY_MS = 100; // base delay, doubles each retry
@@ -19,13 +20,13 @@ export class RedisEventPublisher implements EventPublisher {
   constructor(private readonly redis: Redis) {}
 
   async publish(envelope: EventEnvelope): Promise<void> {
-    const streamKey = `events:${envelope.producer}`;
+    const targetStream = streamKey(envelope.producer);
     const envelopeJson = JSON.stringify(envelope);
     let lastError: Error | undefined;
 
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
       try {
-        await this.redis.xadd(streamKey, "MAXLEN", "~", "100000", "*", "envelope", envelopeJson);
+        await this.redis.xadd(targetStream, "MAXLEN", "~", "100000", "*", "envelope", envelopeJson);
         return;
       } catch (err) {
         lastError = err instanceof Error ? err : new Error(String(err));
@@ -36,7 +37,7 @@ export class RedisEventPublisher implements EventPublisher {
     }
 
     throw new PublishFailed(
-      `Failed to publish event ${envelope.eventId} to ${streamKey} after ${MAX_RETRIES} attempts`,
+      `Failed to publish event ${envelope.eventId} to ${targetStream} after ${MAX_RETRIES} attempts`,
       lastError,
     );
   }

--- a/services/offer-management/src/adapters/messaging/publisher.ts
+++ b/services/offer-management/src/adapters/messaging/publisher.ts
@@ -1,0 +1,43 @@
+// ---------------------------------------------------------------------------
+// Redis Streams adapter for EventPublisher
+// Implements the port defined in ../../ports/messaging.ts
+// Lives ONLY under adapters/messaging/ — no Redis types outside this module.
+// ---------------------------------------------------------------------------
+
+import { type Redis } from "ioredis";
+
+import { EventPublisher, PublishFailed, type EventEnvelope } from "../../ports/messaging.js";
+
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 100; // base delay, doubles each retry
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class RedisEventPublisher implements EventPublisher {
+  constructor(private readonly redis: Redis) {}
+
+  async publish(envelope: EventEnvelope): Promise<void> {
+    const streamKey = `events:${envelope.producer}`;
+    const envelopeJson = JSON.stringify(envelope);
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      try {
+        await this.redis.xadd(streamKey, "MAXLEN", "~", "100000", "*", "envelope", envelopeJson);
+        return;
+      } catch (err) {
+        lastError = err instanceof Error ? err : new Error(String(err));
+        if (attempt < MAX_RETRIES - 1) {
+          await sleep(RETRY_DELAY_MS * Math.pow(2, attempt));
+        }
+      }
+    }
+
+    throw new PublishFailed(
+      `Failed to publish event ${envelope.eventId} to ${streamKey} after ${MAX_RETRIES} attempts`,
+      lastError,
+    );
+  }
+}

--- a/services/offer-management/src/adapters/messaging/redis.ts
+++ b/services/offer-management/src/adapters/messaging/redis.ts
@@ -1,0 +1,24 @@
+import { Redis } from "ioredis";
+
+import { RedisEventPublisher } from "./publisher.js";
+import { RedisEventSubscriber } from "./subscriber.js";
+
+export type RedisMessagingAdapters = Readonly<{
+  publisher: RedisEventPublisher;
+  subscriber: RedisEventSubscriber;
+  close: () => Promise<void>;
+}>;
+
+export async function createRedisMessagingAdapters(redisUrl: string): Promise<RedisMessagingAdapters> {
+  const publisherRedis = new Redis(redisUrl, { lazyConnect: true });
+  const subscriberRedis = new Redis(redisUrl, { lazyConnect: true });
+  await Promise.all([publisherRedis.connect(), subscriberRedis.connect()]);
+
+  return {
+    publisher: new RedisEventPublisher(publisherRedis),
+    subscriber: new RedisEventSubscriber(subscriberRedis),
+    close: async () => {
+      await Promise.allSettled([publisherRedis.quit(), subscriberRedis.quit()]);
+    },
+  };
+}

--- a/services/offer-management/src/adapters/messaging/stream-config.ts
+++ b/services/offer-management/src/adapters/messaging/stream-config.ts
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------------
+// Stream configuration — stream names, group names, consumer naming
+// Lives ONLY under adapters/messaging/ — centralizes all stream-key strings.
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the stream key for a given producing context.
+ */
+export function streamKey(context: string): string {
+  return `events:${context}`;
+}
+
+/**
+ * Returns the dead-letter stream key for a given producing context.
+ */
+export function dlqStreamKey(context: string): string {
+  return `events:${context}:dlq`;
+}
+
+/**
+ * The stream that offer-management publishes to.
+ */
+export const OWN_STREAM = "events:offer-management";
+
+/**
+ * The dead-letter stream for offer-management.
+ */
+export const OWN_DLQ_STREAM = "events:offer-management:dlq";
+
+/**
+ * The consumer group name for offer-management.
+ */
+export const CONSUMER_GROUP = "offer-management";
+
+/**
+ * The streams that offer-management subscribes to, per messaging.md subscription table.
+ * Rows 6 (events:fare-pricing), 7 (events:trip-planning), 37 (events:traveler-profile).
+ */
+export const SUBSCRIBED_STREAMS: readonly string[] = [
+  "events:fare-pricing",
+  "events:trip-planning",
+  "events:traveler-profile",
+];
+
+/**
+ * Generate a consumer name for this instance.
+ */
+export function consumerName(instanceId?: string): string {
+  return `offer-management-${instanceId ?? "default"}`;
+}

--- a/services/offer-management/src/adapters/messaging/subscriber.ts
+++ b/services/offer-management/src/adapters/messaging/subscriber.ts
@@ -169,18 +169,37 @@ export class RedisEventSubscriber implements EventSubscriber {
       100,
     );
 
-    const entries = result[1] as Array<[string, string[], number?]>;
+    const entries = result[1] as Array<[string, string[]]>;
     if (!entries || entries.length === 0) return;
 
-    for (const [entryId, fields, claimedDeliveryCount] of entries) {
-      const deliveryCount = Number(claimedDeliveryCount ?? 1);
-      if (deliveryCount >= MAX_DELIVERY_COUNT) {
+    const deliveryCounts = await this.deliveryCounts(stream, group, entries.map(([entryId]) => entryId));
+    for (const [entryId, fields] of entries) {
+      if ((deliveryCounts.get(entryId) ?? 1) >= MAX_DELIVERY_COUNT) {
         await this.moveToDlq(stream, group, [entryId, fields]);
         continue;
       }
 
       await this.processEntry(stream, group, [entryId, fields], handler);
     }
+  }
+
+  private async deliveryCounts(stream: string, group: string, entryIds: readonly string[]): Promise<Map<string, number>> {
+    if (entryIds.length === 0) {
+      return new Map();
+    }
+
+    const counts = new Map<string, number>();
+    await Promise.all(entryIds.map(async (entryId) => {
+      const pending: any = await (this.redis as any).xpending(stream, group, entryId, entryId, 1);
+      const row = Array.isArray(pending) ? pending[0] : undefined;
+      if (Array.isArray(row) && row[0] === entryId) {
+        const deliveries = Number(row[3]);
+        if (Number.isFinite(deliveries)) {
+          counts.set(entryId, deliveries);
+        }
+      }
+    }));
+    return counts;
   }
 
   private async moveToDlq(

--- a/services/offer-management/src/adapters/messaging/subscriber.ts
+++ b/services/offer-management/src/adapters/messaging/subscriber.ts
@@ -1,0 +1,202 @@
+// ---------------------------------------------------------------------------
+// Redis Streams adapter for EventSubscriber
+// Implements the port defined in ../../ports/messaging.ts
+// Lives ONLY under adapters/messaging/ — no Redis types outside this module.
+// ---------------------------------------------------------------------------
+
+import { type Redis } from "ioredis";
+
+import { SubscribeFailed, type EventEnvelope, type EventHandler, type EventSubscriber } from "../../ports/messaging.js";
+
+const POLL_TIMEOUT_MS = 2000;
+const BATCH_SIZE = 10;
+const CLAIM_INTERVAL_MS = 60000;
+const MAX_DELIVERY_COUNT = 5;
+const MIN_IDLE_MS = 60000;
+
+export class RedisEventSubscriber implements EventSubscriber {
+  private redis: Redis;
+  private running = false;
+
+  constructor(redis: Redis) {
+    this.redis = redis;
+  }
+
+  async subscribe(
+    streams: readonly string[],
+    group: string,
+    consumerName: string,
+    handler: EventHandler,
+    signal: AbortSignal,
+  ): Promise<void> {
+    this.running = true;
+
+    // Create consumer groups (ignore BUSYGROUP errors)
+    for (const stream of streams) {
+      try {
+        await (this.redis as any).xgroup("CREATE", stream, group, "$", "MKSTREAM");
+      } catch (err: any) {
+        // BUSYGROUP means the group already exists — that's fine
+        if (!String(err).includes("BUSYGROUP")) {
+          throw new SubscribeFailed(`Failed to create consumer group ${group} on ${stream}`, err);
+        }
+      }
+    }
+
+    // Start background recovery loop
+    const recoveryTimer = setInterval(async () => {
+      if (!this.running) return;
+      for (const stream of streams) {
+        try {
+          await this.claimAndProcess(stream, group, consumerName, handler);
+        } catch {
+          // log and continue
+        }
+      }
+    }, CLAIM_INTERVAL_MS);
+
+    // Main polling loop
+    try {
+      while (this.running && !signal.aborted) {
+        for (const stream of streams) {
+          if (!this.running || signal.aborted) break;
+          try {
+            await this.pollStream(stream, group, consumerName, handler);
+          } catch {
+            // log and continue
+          }
+        }
+      }
+    } finally {
+      clearInterval(recoveryTimer);
+    }
+  }
+
+  stop(): void {
+    this.running = false;
+  }
+
+  private async pollStream(
+    stream: string,
+    group: string,
+    consumerName: string,
+    handler: EventHandler,
+  ): Promise<void> {
+    const results: any = await (this.redis as any).xreadgroup(
+      "GROUP",
+      group,
+      consumerName,
+      "BLOCK",
+      POLL_TIMEOUT_MS,
+      "COUNT",
+      BATCH_SIZE,
+      "STREAMS",
+      stream,
+      ">",
+    );
+
+    if (!results) return;
+
+    for (const [, entries] of results) {
+      for (const entry of entries) {
+        await this.processEntry(stream, group, entry, handler);
+      }
+    }
+  }
+
+  private async processEntry(
+    stream: string,
+    group: string,
+    entry: [string, string[]],
+    handler: EventHandler,
+  ): Promise<void> {
+    const [entryId, fields] = entry;
+
+    // Find the envelope field
+    const envelopeIdx = fields.indexOf("envelope");
+    if (envelopeIdx === -1 || envelopeIdx + 1 >= fields.length) {
+      // Malformed entry — ack and skip
+      await (this.redis as any).xack(stream, group, entryId);
+      return;
+    }
+
+    let envelope: EventEnvelope;
+    try {
+      envelope = JSON.parse(fields[envelopeIdx + 1]) as EventEnvelope;
+    } catch {
+      // Invalid JSON — ack and skip
+      await (this.redis as any).xack(stream, group, entryId);
+      return;
+    }
+
+    const result = await handler(envelope);
+
+    switch (result) {
+      case "ack":
+        await (this.redis as any).xack(stream, group, entryId);
+        break;
+      case "dlq": {
+        // Move to dead-letter stream
+        const dlqStream = `${stream}:dlq`;
+        await (this.redis as any).xadd(dlqStream, "MAXLEN", "~", "100000", "*", "envelope", JSON.stringify(envelope));
+        await (this.redis as any).xack(stream, group, entryId);
+        break;
+      }
+      case "retry":
+        // Leave in PEL for retry via XAUTOCLAIM
+        break;
+    }
+  }
+
+  private async claimAndProcess(
+    stream: string,
+    group: string,
+    consumerName: string,
+    handler: EventHandler,
+  ): Promise<void> {
+    // XAUTOCLAIM recovers pending messages from other consumers
+    const result: any = await (this.redis as any).xautoclaim(
+      stream,
+      group,
+      consumerName,
+      MIN_IDLE_MS,
+      "0",
+      "COUNT",
+      100,
+    );
+
+    // result is [nextStartId, [entries]]
+    const entries = result[1] as Array<[string, string[]]>;
+    if (!entries || entries.length === 0) return;
+
+    for (const entry of entries) {
+      // Check delivery count from the raw entry info
+      let deliveryCount = 1;
+      try {
+        const pendingInfo: any = await (this.redis as any).xpending(stream, group, "-", "+", 100);
+        for (const pentry of pendingInfo) {
+          if (pentry[0] === entry[0]) {
+            deliveryCount = pentry[3]; // delivery count
+            break;
+          }
+        }
+      } catch {
+        // ignore
+      }
+
+      if (deliveryCount >= MAX_DELIVERY_COUNT) {
+        // Move to DLQ
+        const dlqStream = `${stream}:dlq`;
+        const fields = entry[1];
+        const envelopeIdx = fields.indexOf("envelope");
+        if (envelopeIdx !== -1 && envelopeIdx + 1 < fields.length) {
+          await (this.redis as any).xadd(dlqStream, "MAXLEN", "~", "100000", "*", "envelope", fields[envelopeIdx + 1]);
+        }
+        await (this.redis as any).xack(stream, group, entry[0]);
+      } else {
+        // Process normally
+        await this.processEntry(stream, group, entry, handler);
+      }
+    }
+  }
+}

--- a/services/offer-management/src/adapters/messaging/subscriber.ts
+++ b/services/offer-management/src/adapters/messaging/subscriber.ts
@@ -19,9 +19,20 @@ export class RedisEventSubscriber implements EventSubscriber {
   private redis: Redis;
   private running = false;
   private readonly processedEventIds = new Set<string>();
+  private startedPromise: Promise<void>;
+  private resolveStarted!: () => void;
+  private rejectStarted!: (error: unknown) => void;
 
   constructor(redis: Redis) {
     this.redis = redis;
+    this.startedPromise = new Promise((resolve, reject) => {
+      this.resolveStarted = resolve;
+      this.rejectStarted = reject;
+    });
+  }
+
+  started(): Promise<void> {
+    return this.startedPromise;
   }
 
   async subscribe(
@@ -34,15 +45,22 @@ export class RedisEventSubscriber implements EventSubscriber {
     this.running = true;
 
     // Create consumer groups (ignore BUSYGROUP errors)
-    for (const stream of streams) {
-      try {
-        await (this.redis as any).xgroup("CREATE", stream, group, "$", "MKSTREAM");
-      } catch (err: any) {
-        // BUSYGROUP means the group already exists — that's fine
-        if (!String(err).includes("BUSYGROUP")) {
-          throw new SubscribeFailed(`Failed to create consumer group ${group} on ${stream}`, err);
+    try {
+      for (const stream of streams) {
+        try {
+          await (this.redis as any).xgroup("CREATE", stream, group, "$", "MKSTREAM");
+        } catch (err: any) {
+          // BUSYGROUP means the group already exists — that's fine
+          if (!String(err).includes("BUSYGROUP")) {
+            throw new SubscribeFailed(`Failed to create consumer group ${group} on ${stream}`, err);
+          }
         }
       }
+      this.resolveStarted();
+    } catch (error) {
+      this.running = false;
+      this.rejectStarted(error);
+      throw error;
     }
 
     // Start background recovery loop

--- a/services/offer-management/src/adapters/messaging/subscriber.ts
+++ b/services/offer-management/src/adapters/messaging/subscriber.ts
@@ -7,6 +7,7 @@
 import { type Redis } from "ioredis";
 
 import { SubscribeFailed, type EventEnvelope, type EventHandler, type EventSubscriber } from "../../ports/messaging.js";
+import { dlqStreamKey } from "./stream-config.js";
 
 const POLL_TIMEOUT_MS = 2000;
 const BATCH_SIZE = 10;
@@ -17,6 +18,7 @@ const MIN_IDLE_MS = 60000;
 export class RedisEventSubscriber implements EventSubscriber {
   private redis: Redis;
   private running = false;
+  private readonly processedEventIds = new Set<string>();
 
   constructor(redis: Redis) {
     this.redis = redis;
@@ -129,17 +131,20 @@ export class RedisEventSubscriber implements EventSubscriber {
       return;
     }
 
+    if (this.processedEventIds.has(envelope.eventId)) {
+      await (this.redis as any).xack(stream, group, entryId);
+      return;
+    }
+
     const result = await handler(envelope);
 
     switch (result) {
       case "ack":
+        this.processedEventIds.add(envelope.eventId);
         await (this.redis as any).xack(stream, group, entryId);
         break;
       case "dlq": {
-        // Move to dead-letter stream
-        const dlqStream = `${stream}:dlq`;
-        await (this.redis as any).xadd(dlqStream, "MAXLEN", "~", "100000", "*", "envelope", JSON.stringify(envelope));
-        await (this.redis as any).xack(stream, group, entryId);
+        await this.moveToDlq(stream, group, [entryId, fields], JSON.stringify(envelope));
         break;
       }
       case "retry":
@@ -154,7 +159,6 @@ export class RedisEventSubscriber implements EventSubscriber {
     consumerName: string,
     handler: EventHandler,
   ): Promise<void> {
-    // XAUTOCLAIM recovers pending messages from other consumers
     const result: any = await (this.redis as any).xautoclaim(
       stream,
       group,
@@ -165,38 +169,47 @@ export class RedisEventSubscriber implements EventSubscriber {
       100,
     );
 
-    // result is [nextStartId, [entries]]
-    const entries = result[1] as Array<[string, string[]]>;
+    const entries = result[1] as Array<[string, string[], number?]>;
     if (!entries || entries.length === 0) return;
 
-    for (const entry of entries) {
-      // Check delivery count from the raw entry info
-      let deliveryCount = 1;
-      try {
-        const pendingInfo: any = await (this.redis as any).xpending(stream, group, "-", "+", 100);
-        for (const pentry of pendingInfo) {
-          if (pentry[0] === entry[0]) {
-            deliveryCount = pentry[3]; // delivery count
-            break;
-          }
-        }
-      } catch {
-        // ignore
+    for (const [entryId, fields, claimedDeliveryCount] of entries) {
+      const deliveryCount = Number(claimedDeliveryCount ?? 1);
+      if (deliveryCount >= MAX_DELIVERY_COUNT) {
+        await this.moveToDlq(stream, group, [entryId, fields]);
+        continue;
       }
 
-      if (deliveryCount >= MAX_DELIVERY_COUNT) {
-        // Move to DLQ
-        const dlqStream = `${stream}:dlq`;
-        const fields = entry[1];
-        const envelopeIdx = fields.indexOf("envelope");
-        if (envelopeIdx !== -1 && envelopeIdx + 1 < fields.length) {
-          await (this.redis as any).xadd(dlqStream, "MAXLEN", "~", "100000", "*", "envelope", fields[envelopeIdx + 1]);
-        }
-        await (this.redis as any).xack(stream, group, entry[0]);
-      } else {
-        // Process normally
-        await this.processEntry(stream, group, entry, handler);
-      }
+      await this.processEntry(stream, group, [entryId, fields], handler);
     }
   }
+
+  private async moveToDlq(
+    stream: string,
+    group: string,
+    entry: [string, string[]],
+    envelopeJson?: string,
+  ): Promise<void> {
+    const [entryId, fields] = entry;
+    const envelopeIdx = fields.indexOf("envelope");
+    const serializedEnvelope = envelopeJson ?? (envelopeIdx !== -1 ? fields[envelopeIdx + 1] : undefined);
+
+    if (serializedEnvelope) {
+      await (this.redis as any).xadd(
+        dlqStreamKey(producerFromStream(stream)),
+        "MAXLEN",
+        "~",
+        "100000",
+        "*",
+        "envelope",
+        serializedEnvelope,
+      );
+    }
+
+    await (this.redis as any).xack(stream, group, entryId);
+  }
+
+}
+
+function producerFromStream(stream: string): string {
+  return stream.startsWith("events:") ? stream.slice("events:".length).replace(/:dlq$/, "") : stream;
 }

--- a/services/offer-management/src/app.test.ts
+++ b/services/offer-management/src/app.test.ts
@@ -4,6 +4,8 @@ import { beforeEach, describe, it } from "node:test";
 
 import { createApp, resetIdempotencyStore, resetOfferStore } from "./app.js";
 import { InMemoryEventPublisher } from "./adapters/messaging/in-memory.js";
+import { applyUpstreamEvent, InMemoryUpstreamStateRepository } from "./application/upstream-state.js";
+import { type EventEnvelope } from "./ports/messaging.js";
 import { type QuoteOfferCommand } from "./domain.js";
 
 describe("offer-management service operational foundation", () => {
@@ -122,7 +124,8 @@ describe("Offer Management HTTP API — POST /api/v1/offers", () => {
   });
 
   it("creates an offer and returns 201 with the expected response shape", async () => {
-    const app = createApp();
+    const upstreamRepository = await seededUpstreamRepository();
+    const app = createApp({}, { upstreamRepository });
     const idempotencyKey = crypto.randomUUID();
 
     const response = await app.inject({
@@ -160,7 +163,8 @@ describe("Offer Management HTTP API — POST /api/v1/offers", () => {
 
   it("publishes the quoted domain event envelope through the configured port", async () => {
     const publisher = new InMemoryEventPublisher();
-    const app = createApp({}, { publisher });
+    const upstreamRepository = await seededUpstreamRepository();
+    const app = createApp({}, { publisher, upstreamRepository });
 
     const response = await app.inject({
       method: "POST",
@@ -264,7 +268,8 @@ describe("Offer Management HTTP API — POST /api/v1/offers", () => {
   });
 
   it("idempotent replay returns the original 201 response", async () => {
-    const app = createApp();
+    const upstreamRepository = await seededUpstreamRepository();
+    const app = createApp({}, { upstreamRepository });
     const idempotencyKey = crypto.randomUUID();
 
     const request = {
@@ -288,7 +293,8 @@ describe("Offer Management HTTP API — POST /api/v1/offers", () => {
   });
 
   it("rejects idempotency key reused with different body using 422 IDEMPOTENCY_KEY_REUSED", async () => {
-    const app = createApp();
+    const upstreamRepository = await seededUpstreamRepository();
+    const app = createApp({}, { upstreamRepository });
     const idempotencyKey = crypto.randomUUID();
 
     await app.inject({
@@ -381,6 +387,63 @@ function makeInvalidQuoteCommand(request: { accountId: string; channelId: string
   };
 }
 
+async function seededUpstreamRepository(): Promise<InMemoryUpstreamStateRepository> {
+  const repository = new InMemoryUpstreamStateRepository();
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + 60 * 60 * 1000).toISOString();
+  const occurredAt = now.toISOString();
+
+  await applyUpstreamEvent(repository, makeEnvelope("ItineraryProposed", "trip-planning", {
+    intentRef: "intent-1",
+    planningSnapshotRefs: ["plan-1"],
+    itineraries: [{
+      itineraryRef: "itin-456",
+      itineraryVersion: "itinerary-v1",
+      legs: [{ servicePlanRef: "sp-1", serviceSegmentRef: "seg-1", originStopRef: "stop-a", destinationStopRef: "stop-b", departureTime: occurredAt, arrivalTime: expiresAt, mode: "train" }],
+      availabilitySnapshots: [{ segmentRef: "seg-1", snapshotId: "availability-1", snapshotVersion: "capacity-v1", capturedAt: occurredAt, expiresAt, sellable: true, status: "AVAILABLE", confidence: "confirmed-snapshot" }],
+    }],
+  }));
+  await applyUpstreamEvent(repository, makeEnvelope("FareQuoteComputed", "fare-pricing", {
+    quoteId: "fq-1",
+    inputHash: "input-1",
+    travelerRefs: ["tvl-001", "tvl-002"],
+    channel: "web",
+    currency: "CNY",
+    status: "QUOTED",
+    validFrom: occurredAt,
+    validUntil: expiresAt,
+    breakdown: { subtotal: { currency: "CNY", minorUnits: 20000 }, total: { currency: "CNY", minorUnits: 20000 }, priceSnapshotRef: "price-1" },
+    ruleSnapshot: { ruleSnapshotRef: "rule-1", pricingVersion: "pricing-v1", ruleVersion: "rule-v1" },
+  }));
+  await applyUpstreamEvent(repository, makeEnvelope("FareQuoteComputed", "fare-pricing", {
+    quoteId: "fq-2",
+    inputHash: "input-2",
+    travelerRefs: ["tvl-001"],
+    channel: "web",
+    currency: "CNY",
+    status: "QUOTED",
+    validFrom: occurredAt,
+    validUntil: expiresAt,
+    breakdown: { subtotal: { currency: "CNY", minorUnits: 10000 }, total: { currency: "CNY", minorUnits: 10000 }, priceSnapshotRef: "price-2" },
+    ruleSnapshot: { ruleSnapshotRef: "rule-2", pricingVersion: "pricing-v1", ruleVersion: "rule-v1" },
+  }));
+  await applyUpstreamEvent(repository, makeEnvelope("TravelerSnapshotUpdated", "traveler-profile", { travelerId: "tvl-001", snapshotVersion: "1", updatedAt: occurredAt, travelerType: "ADULT" }));
+  await applyUpstreamEvent(repository, makeEnvelope("TravelerSnapshotUpdated", "traveler-profile", { travelerId: "tvl-002", snapshotVersion: "1", updatedAt: occurredAt, travelerType: "ADULT" }));
+  return repository;
+}
+
+function makeEnvelope(eventType: string, producer: string, payload: Record<string, unknown>): EventEnvelope {
+  return {
+    eventId: `evt-${crypto.randomUUID()}`,
+    eventType,
+    schemaVersion: 1,
+    producer,
+    correlationId: `corr-${crypto.randomUUID()}`,
+    occurredAt: new Date().toISOString(),
+    payload,
+  };
+}
+
 describe("Offer Management HTTP API — GET /api/v1/offers/:offerId", () => {
   beforeEach(() => {
     resetIdempotencyStore();
@@ -388,7 +451,8 @@ describe("Offer Management HTTP API — GET /api/v1/offers/:offerId", () => {
   });
 
   it("returns 200 with full offer details for an existing offer", async () => {
-    const app = createApp();
+    const upstreamRepository = await seededUpstreamRepository();
+    const app = createApp({}, { upstreamRepository });
     const idempotencyKey = crypto.randomUUID();
 
     // Create an offer first

--- a/services/offer-management/src/app.test.ts
+++ b/services/offer-management/src/app.test.ts
@@ -3,6 +3,8 @@ import crypto from "node:crypto";
 import { beforeEach, describe, it } from "node:test";
 
 import { createApp, resetIdempotencyStore, resetOfferStore } from "./app.js";
+import { InMemoryEventPublisher } from "./adapters/messaging/in-memory.js";
+import { type QuoteOfferCommand } from "./domain.js";
 
 describe("offer-management service operational foundation", () => {
   beforeEach(() => {
@@ -156,6 +158,37 @@ describe("Offer Management HTTP API — POST /api/v1/offers", () => {
     assert.ok(response.headers["x-request-id"]);
   });
 
+  it("publishes the quoted domain event envelope through the configured port", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const app = createApp({}, { publisher });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/offers",
+      headers: {
+        "idempotency-key": crypto.randomUUID(),
+        "x-correlation-id": "corr-published-quote",
+      },
+      body: {
+        accountId: "acc-123",
+        channelId: "web",
+        itineraryRef: "itin-456",
+        travelerRefs: ["tvl-001"],
+      },
+    });
+
+    assert.equal(response.statusCode, 201);
+    assert.equal(publisher.published.length, 1);
+    const [envelope] = publisher.published;
+    assert.equal(envelope.producer, "offer-management");
+    assert.equal(envelope.eventType, "OfferQuoted");
+    assert.equal(envelope.schemaVersion, 1);
+    assert.equal(envelope.correlationId, "corr-published-quote");
+    assert.ok(envelope.eventId.startsWith("evt-"));
+    assert.equal((envelope.payload as { offerId: string }).offerId, response.json().offerId);
+    assert.deepEqual((envelope.payload as { total: unknown }).total, response.json().total);
+  });
+
   it("rejects request without Idempotency-Key with 400 VALIDATION_FAILED", async () => {
     const app = createApp();
 
@@ -206,6 +239,28 @@ describe("Offer Management HTTP API — POST /api/v1/offers", () => {
 
     assert.equal(response.statusCode, 400);
     assert.equal(response.json().code, "VALIDATION_FAILED");
+  });
+
+  it("surfaces domain invariant violations as 422 DOMAIN_RULE_VIOLATION", async () => {
+    const app = createApp({}, {
+      quoteCommandFactory: (request) => makeInvalidQuoteCommand(request),
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/offers",
+      headers: { "idempotency-key": crypto.randomUUID() },
+      body: {
+        accountId: "acc-123",
+        channelId: "web",
+        itineraryRef: "itin-456",
+        travelerRefs: ["tvl-001"],
+      },
+    });
+
+    assert.equal(response.statusCode, 422);
+    assert.equal(response.json().code, "DOMAIN_RULE_VIOLATION");
+    assert.equal(response.json().details.domainCode, "STALE_VALIDITY_WINDOW");
   });
 
   it("idempotent replay returns the original 201 response", async () => {
@@ -264,6 +319,67 @@ describe("Offer Management HTTP API — POST /api/v1/offers", () => {
     assert.equal(response.json().code, "IDEMPOTENCY_KEY_REUSED");
   });
 });
+
+function makeInvalidQuoteCommand(request: { accountId: string; channelId: string; itineraryRef: string; travelerRefs: readonly string[] }): QuoteOfferCommand {
+  const quotedAt = new Date("2026-07-05T10:00:00.000Z");
+  const staleExpiry = new Date("2026-07-05T09:59:00.000Z");
+  return {
+    offerId: `off-${crypto.randomUUID()}`,
+    quoteRequestId: "quote-request-invalid",
+    accountId: request.accountId,
+    channelId: request.channelId,
+    quotedAt,
+    validityWindow: { startsAt: quotedAt, expiresAt: staleExpiry },
+    itinerary: {
+      itineraryId: request.itineraryRef,
+      itineraryVersion: "v1",
+      sourceContext: "TripPlanning",
+      segmentRefs: ["seg-1"],
+    },
+    passengerMix: {
+      travelerSetHash: request.travelerRefs.join(","),
+      travelers: request.travelerRefs.map((travelerId) => ({ travelerId, travelerType: "ADULT" as const })),
+    },
+    items: [{
+      offerItemId: "item-1",
+      mode: "train",
+      segmentRef: "seg-1",
+      itemPrice: { currency: "CNY", amountMinor: 100 },
+      availabilitySnapshot: {
+        snapshotId: "availability-1",
+        snapshotVersion: "v1",
+        sourceContext: "CapacityAvailability",
+        capturedAt: quotedAt,
+        expiresAt: new Date("2026-07-05T10:15:00.000Z"),
+        sellable: true,
+        status: "AVAILABLE",
+        confidence: "confirmed-snapshot",
+      },
+      fareSnapshot: {
+        fareQuoteRef: "fare-1",
+        ruleSnapshotRef: "rule-1",
+        pricingVersion: "pricing-v1",
+        ruleVersion: "rule-v1",
+        sourceContext: "FarePricing",
+        capturedAt: quotedAt,
+        expiresAt: new Date("2026-07-05T10:15:00.000Z"),
+      },
+    }],
+    priceSnapshot: {
+      snapshotId: "price-1",
+      fareQuoteRef: "fare-1",
+      capturedAt: quotedAt,
+      expiresAt: new Date("2026-07-05T10:15:00.000Z"),
+      guaranteeLevel: "FixedUntilExpiry",
+      currency: "CNY",
+      subtotal: { currency: "CNY", amountMinor: 100 },
+      taxes: [],
+      fees: [],
+      discounts: [],
+      total: { currency: "CNY", amountMinor: 100 },
+    },
+  };
+}
 
 describe("Offer Management HTTP API — GET /api/v1/offers/:offerId", () => {
   beforeEach(() => {

--- a/services/offer-management/src/app.test.ts
+++ b/services/offer-management/src/app.test.ts
@@ -126,7 +126,7 @@ describe("Offer Management HTTP API — POST /api/v1/offers", () => {
   it("creates an offer and returns 201 with the expected response shape", async () => {
     const upstreamRepository = await seededUpstreamRepository();
     const app = createApp({}, { upstreamRepository });
-    const idempotencyKey = crypto.randomUUID();
+    const idempotencyKey = uuidV7();
 
     const response = await app.inject({
       method: "POST",
@@ -170,7 +170,7 @@ describe("Offer Management HTTP API — POST /api/v1/offers", () => {
       method: "POST",
       url: "/api/v1/offers",
       headers: {
-        "idempotency-key": crypto.randomUUID(),
+        "idempotency-key": uuidV7(),
         "x-correlation-id": "corr-published-quote",
       },
       body: {
@@ -191,6 +191,25 @@ describe("Offer Management HTTP API — POST /api/v1/offers", () => {
     assert.ok(envelope.eventId.startsWith("evt-"));
     assert.equal((envelope.payload as { offerId: string }).offerId, response.json().offerId);
     assert.deepEqual((envelope.payload as { total: unknown }).total, response.json().total);
+    assert.deepEqual(Object.keys(envelope.payload).sort(), [
+      "accountId",
+      "availabilitySnapshotRefs",
+      "channelId",
+      "downstreamReference",
+      "expiresAt",
+      "fareQuoteRefs",
+      "itineraryId",
+      "itineraryVersion",
+      "offerId",
+      "offerVersion",
+      "priceGuaranteeLevel",
+      "priceSnapshotRef",
+      "quoteRequestId",
+      "ruleSnapshotRefs",
+      "total",
+      "travelerSetHash",
+    ].sort());
+    assert.equal(Object.hasOwn(envelope.payload, "boundaryProof"), false);
   });
 
   it("rejects request without Idempotency-Key with 400 VALIDATION_FAILED", async () => {
@@ -212,13 +231,55 @@ describe("Offer Management HTTP API — POST /api/v1/offers", () => {
     assert.ok(response.json().message.includes("Idempotency-Key"));
   });
 
+  it("rejects malformed Idempotency-Key values with 400 VALIDATION_FAILED", async () => {
+    const app = createApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/offers",
+      headers: { "idempotency-key": "not-a-uuid-v7" },
+      body: {
+        accountId: "acc-123",
+        channelId: "web",
+        itineraryRef: "itin-456",
+        travelerRefs: ["tvl-001"],
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.json().code, "VALIDATION_FAILED");
+    assert.ok(response.json().message.includes("UUID v7"));
+  });
+
+  it("maps publish failures to 503 UNAVAILABLE", async () => {
+    const publisher = new InMemoryEventPublisher();
+    publisher.failNext = true;
+    const upstreamRepository = await seededUpstreamRepository();
+    const app = createApp({}, { publisher, upstreamRepository });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/offers",
+      headers: { "idempotency-key": uuidV7() },
+      body: {
+        accountId: "acc-123",
+        channelId: "web",
+        itineraryRef: "itin-456",
+        travelerRefs: ["tvl-001"],
+      },
+    });
+
+    assert.equal(response.statusCode, 503);
+    assert.equal(response.json().code, "UNAVAILABLE");
+  });
+
   it("rejects missing required fields with 400 VALIDATION_FAILED", async () => {
     const app = createApp();
 
     const response = await app.inject({
       method: "POST",
       url: "/api/v1/offers",
-      headers: { "idempotency-key": crypto.randomUUID() },
+      headers: { "idempotency-key": uuidV7() },
       body: { accountId: "acc-123" },
     });
 
@@ -232,7 +293,7 @@ describe("Offer Management HTTP API — POST /api/v1/offers", () => {
     const response = await app.inject({
       method: "POST",
       url: "/api/v1/offers",
-      headers: { "idempotency-key": crypto.randomUUID() },
+      headers: { "idempotency-key": uuidV7() },
       body: {
         accountId: "acc-123",
         channelId: "web",
@@ -253,7 +314,7 @@ describe("Offer Management HTTP API — POST /api/v1/offers", () => {
     const response = await app.inject({
       method: "POST",
       url: "/api/v1/offers",
-      headers: { "idempotency-key": crypto.randomUUID() },
+      headers: { "idempotency-key": uuidV7() },
       body: {
         accountId: "acc-123",
         channelId: "web",
@@ -270,7 +331,7 @@ describe("Offer Management HTTP API — POST /api/v1/offers", () => {
   it("idempotent replay returns the original 201 response", async () => {
     const upstreamRepository = await seededUpstreamRepository();
     const app = createApp({}, { upstreamRepository });
-    const idempotencyKey = crypto.randomUUID();
+    const idempotencyKey = uuidV7();
 
     const request = {
       method: "POST" as const,
@@ -295,7 +356,7 @@ describe("Offer Management HTTP API — POST /api/v1/offers", () => {
   it("rejects idempotency key reused with different body using 422 IDEMPOTENCY_KEY_REUSED", async () => {
     const upstreamRepository = await seededUpstreamRepository();
     const app = createApp({}, { upstreamRepository });
-    const idempotencyKey = crypto.randomUUID();
+    const idempotencyKey = uuidV7();
 
     await app.inject({
       method: "POST",
@@ -330,7 +391,7 @@ function makeInvalidQuoteCommand(request: { accountId: string; channelId: string
   const quotedAt = new Date("2026-07-05T10:00:00.000Z");
   const staleExpiry = new Date("2026-07-05T09:59:00.000Z");
   return {
-    offerId: `off-${crypto.randomUUID()}`,
+    offerId: `off-${uuidV7()}`,
     quoteRequestId: "quote-request-invalid",
     accountId: request.accountId,
     channelId: request.channelId,
@@ -405,7 +466,7 @@ async function seededUpstreamRepository(): Promise<InMemoryUpstreamStateReposito
   }));
   await applyUpstreamEvent(repository, makeEnvelope("FareQuoteComputed", "fare-pricing", {
     quoteId: "fq-1",
-    inputHash: "input-1",
+    inputHash: "intent-1",
     travelerRefs: ["tvl-001", "tvl-002"],
     channel: "web",
     currency: "CNY",
@@ -417,7 +478,7 @@ async function seededUpstreamRepository(): Promise<InMemoryUpstreamStateReposito
   }));
   await applyUpstreamEvent(repository, makeEnvelope("FareQuoteComputed", "fare-pricing", {
     quoteId: "fq-2",
-    inputHash: "input-2",
+    inputHash: "intent-1",
     travelerRefs: ["tvl-001"],
     channel: "web",
     currency: "CNY",
@@ -434,14 +495,31 @@ async function seededUpstreamRepository(): Promise<InMemoryUpstreamStateReposito
 
 function makeEnvelope(eventType: string, producer: string, payload: Record<string, unknown>): EventEnvelope {
   return {
-    eventId: `evt-${crypto.randomUUID()}`,
+    eventId: `evt-${uuidV7()}`,
     eventType,
     schemaVersion: 1,
     producer,
-    correlationId: `corr-${crypto.randomUUID()}`,
+    correlationId: `corr-${uuidV7()}`,
     occurredAt: new Date().toISOString(),
     payload,
   };
+}
+
+function uuidV7(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  const timestamp = BigInt(Date.now());
+
+  bytes[0] = Number((timestamp >> 40n) & 0xffn);
+  bytes[1] = Number((timestamp >> 32n) & 0xffn);
+  bytes[2] = Number((timestamp >> 24n) & 0xffn);
+  bytes[3] = Number((timestamp >> 16n) & 0xffn);
+  bytes[4] = Number((timestamp >> 8n) & 0xffn);
+  bytes[5] = Number(timestamp & 0xffn);
+  bytes[6] = (bytes[6] & 0x0f) | 0x70;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
 describe("Offer Management HTTP API — GET /api/v1/offers/:offerId", () => {
@@ -453,7 +531,7 @@ describe("Offer Management HTTP API — GET /api/v1/offers/:offerId", () => {
   it("returns 200 with full offer details for an existing offer", async () => {
     const upstreamRepository = await seededUpstreamRepository();
     const app = createApp({}, { upstreamRepository });
-    const idempotencyKey = crypto.randomUUID();
+    const idempotencyKey = uuidV7();
 
     // Create an offer first
     const createResponse = await app.inject({

--- a/services/offer-management/src/app.test.ts
+++ b/services/offer-management/src/app.test.ts
@@ -1,9 +1,15 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import crypto from "node:crypto";
+import { beforeEach, describe, it } from "node:test";
 
-import { createApp } from "./index.js";
+import { createApp, resetIdempotencyStore, resetOfferStore } from "./app.js";
 
 describe("offer-management service operational foundation", () => {
+  beforeEach(() => {
+    resetIdempotencyStore();
+    resetOfferStore();
+  });
+
   it("serves health, liveness, readiness, and metadata with request correlation headers", async () => {
     const app = createApp();
 
@@ -47,7 +53,7 @@ describe("offer-management service operational foundation", () => {
     assert.equal(response.headers["x-correlation-id"], response.headers["x-request-id"]);
   });
 
-  it("returns the standard error envelope for missing routes", async () => {
+  it("returns the standard error body for missing routes", async () => {
     const app = createApp();
 
     const response = await app.inject({
@@ -57,14 +63,11 @@ describe("offer-management service operational foundation", () => {
     });
 
     assert.equal(response.statusCode, 404);
-    assert.deepEqual(response.json(), {
-      error: {
-        code: "NOT_FOUND",
-        message: "Route GET /missing was not found",
-        requestId: "req-offer-management-404",
-        correlationId: "req-offer-management-404",
-      },
-    });
+    const body = response.json();
+    assert.equal(body.code, "NOT_FOUND");
+    assert.equal(body.message, "Route GET /missing was not found");
+    assert.equal(body.correlationId, "req-offer-management-404");
+    assert.deepEqual(body.details, {});
   });
 
   it("exposes a no-op-by-default opt-in tracing seam", async () => {
@@ -107,5 +110,217 @@ describe("offer-management service operational foundation", () => {
     ]);
 
     assert.equal((await createApp().inject("/health")).statusCode, 200);
+  });
+});
+
+describe("Offer Management HTTP API — POST /api/v1/offers", () => {
+  beforeEach(() => {
+    resetIdempotencyStore();
+    resetOfferStore();
+  });
+
+  it("creates an offer and returns 201 with the expected response shape", async () => {
+    const app = createApp();
+    const idempotencyKey = crypto.randomUUID();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/offers",
+      headers: {
+        "idempotency-key": idempotencyKey,
+        "x-correlation-id": "corr-quote-1",
+      },
+      body: {
+        accountId: "acc-123",
+        channelId: "web",
+        itineraryRef: "itin-456",
+        travelerRefs: ["tvl-001", "tvl-002"],
+        quoteRequestId: "qr-789",
+      },
+    });
+
+    assert.equal(response.statusCode, 201);
+    const body = response.json();
+    assert.ok(body.offerId.startsWith("off-"));
+    assert.equal(body.offerVersion, 1);
+    assert.equal(typeof body.total, "object");
+    assert.equal(typeof body.total.currency, "string");
+    assert.equal(typeof body.total.minorUnits, "number");
+    assert.equal(typeof body.expiresAt, "string");
+    assert.equal(body.priceGuaranteeLevel, "FIXED_UNTIL_EXPIRY");
+    assert.ok(body.downstreamReference.offerId.startsWith("off-"));
+    assert.equal(body.downstreamReference.offerVersion, 1);
+    assert.equal(body.itineraryRef, "itin-456");
+    assert.equal(body.travelerSetHash, "tvl-001,tvl-002");
+    assert.equal(response.headers["x-correlation-id"], "corr-quote-1");
+    assert.ok(response.headers["x-request-id"]);
+  });
+
+  it("rejects request without Idempotency-Key with 400 VALIDATION_FAILED", async () => {
+    const app = createApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/offers",
+      body: {
+        accountId: "acc-123",
+        channelId: "web",
+        itineraryRef: "itin-456",
+        travelerRefs: ["tvl-001"],
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.json().code, "VALIDATION_FAILED");
+    assert.ok(response.json().message.includes("Idempotency-Key"));
+  });
+
+  it("rejects missing required fields with 400 VALIDATION_FAILED", async () => {
+    const app = createApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/offers",
+      headers: { "idempotency-key": crypto.randomUUID() },
+      body: { accountId: "acc-123" },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.json().code, "VALIDATION_FAILED");
+  });
+
+  it("rejects empty travelerRefs with 400 VALIDATION_FAILED", async () => {
+    const app = createApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/offers",
+      headers: { "idempotency-key": crypto.randomUUID() },
+      body: {
+        accountId: "acc-123",
+        channelId: "web",
+        itineraryRef: "itin-456",
+        travelerRefs: [],
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.json().code, "VALIDATION_FAILED");
+  });
+
+  it("idempotent replay returns the original 201 response", async () => {
+    const app = createApp();
+    const idempotencyKey = crypto.randomUUID();
+
+    const request = {
+      method: "POST" as const,
+      url: "/api/v1/offers",
+      headers: { "idempotency-key": idempotencyKey },
+      body: {
+        accountId: "acc-123",
+        channelId: "web",
+        itineraryRef: "itin-456",
+        travelerRefs: ["tvl-001"],
+      },
+    };
+
+    const first = await app.inject(request);
+    assert.equal(first.statusCode, 201);
+
+    const second = await app.inject(request);
+    assert.equal(second.statusCode, 201);
+    assert.deepEqual(second.json(), first.json());
+  });
+
+  it("rejects idempotency key reused with different body using 422 IDEMPOTENCY_KEY_REUSED", async () => {
+    const app = createApp();
+    const idempotencyKey = crypto.randomUUID();
+
+    await app.inject({
+      method: "POST",
+      url: "/api/v1/offers",
+      headers: { "idempotency-key": idempotencyKey },
+      body: {
+        accountId: "acc-123",
+        channelId: "web",
+        itineraryRef: "itin-456",
+        travelerRefs: ["tvl-001"],
+      },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/offers",
+      headers: { "idempotency-key": idempotencyKey },
+      body: {
+        accountId: "acc-456",
+        channelId: "mobile",
+        itineraryRef: "itin-789",
+        travelerRefs: ["tvl-002"],
+      },
+    });
+
+    assert.equal(response.statusCode, 422);
+    assert.equal(response.json().code, "IDEMPOTENCY_KEY_REUSED");
+  });
+});
+
+describe("Offer Management HTTP API — GET /api/v1/offers/:offerId", () => {
+  beforeEach(() => {
+    resetIdempotencyStore();
+    resetOfferStore();
+  });
+
+  it("returns 200 with full offer details for an existing offer", async () => {
+    const app = createApp();
+    const idempotencyKey = crypto.randomUUID();
+
+    // Create an offer first
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/api/v1/offers",
+      headers: { "idempotency-key": idempotencyKey },
+      body: {
+        accountId: "acc-123",
+        channelId: "web",
+        itineraryRef: "itin-456",
+        travelerRefs: ["tvl-001"],
+      },
+    });
+    const { offerId } = createResponse.json();
+
+    // Get the offer
+    const getResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/offers/${offerId}`,
+    });
+
+    assert.equal(getResponse.statusCode, 200);
+    const body = getResponse.json();
+    assert.equal(body.offerId, offerId);
+    assert.equal(body.offerVersion, 1);
+    assert.equal(body.status, "Quoted");
+    assert.equal(body.accountId, "acc-123");
+    assert.equal(body.channelId, "web");
+    assert.equal(body.itineraryRef, "itin-456");
+    assert.equal(typeof body.total, "object");
+    assert.equal(typeof body.expiresAt, "string");
+    assert.equal(typeof body.priceGuaranteeLevel, "string");
+    assert.equal(typeof body.downstreamReference, "object");
+    assert.equal(typeof body.items, "object");
+    assert.equal(typeof body.createdAt, "string");
+  });
+
+  it("returns 404 NOT_FOUND for a non-existent offer", async () => {
+    const app = createApp();
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/v1/offers/non-existent-id",
+    });
+
+    assert.equal(response.statusCode, 404);
+    assert.equal(response.json().code, "NOT_FOUND");
+    assert.ok(response.json().message.includes("non-existent-id"));
   });
 });

--- a/services/offer-management/src/app.ts
+++ b/services/offer-management/src/app.ts
@@ -8,6 +8,7 @@ import {
   isDomainError,
   type OfferRepository,
 } from "./application/offers.js";
+import { PublishFailed } from "./ports/messaging.js";
 import {
   InMemoryUpstreamStateRepository,
   buildQuoteOfferCommand,
@@ -214,6 +215,10 @@ export function createApp(instrumentation: InstrumentationHooks = {}, dependenci
       sendError(reply, 400, "VALIDATION_FAILED", "Idempotency-Key header is required on state-changing POST", ctx);
       return reply;
     }
+    if (!isUuidV7(idempotencyKey)) {
+      sendError(reply, 400, "VALIDATION_FAILED", "Idempotency-Key must be a UUID v7", ctx);
+      return reply;
+    }
 
     // Idempotency replay check
     const existing = idempotencyStore.get(idempotencyKey);
@@ -254,6 +259,10 @@ export function createApp(instrumentation: InstrumentationHooks = {}, dependenci
     } catch (error) {
       if (isDomainError(error)) {
         sendError(reply, 422, "DOMAIN_RULE_VIOLATION", error.message, ctx, { domainCode: error.code });
+        return reply;
+      }
+      if (error instanceof PublishFailed) {
+        sendError(reply, 503, "UNAVAILABLE", "Offer event could not be published", ctx);
         return reply;
       }
       throw error;
@@ -317,6 +326,10 @@ function validateQuoteOfferRequest(body: Record<string, unknown>): string | null
 
 function errorMessage(error: unknown): string {
   return error instanceof Error && error.message.length > 0 ? error.message : "Internal server error";
+}
+
+function isUuidV7(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
 }
 
 function healthBody(): HealthStatus {

--- a/services/offer-management/src/app.ts
+++ b/services/offer-management/src/app.ts
@@ -191,6 +191,7 @@ export function createApp(instrumentation: InstrumentationHooks = {}): FastifyIn
 
   // Health / metadata
   app.get("/health", async () => healthBody());
+  app.get("/healthz", async () => healthBody());
   app.get("/metadata", async () => metadata());
   app.get("/live", async () => probeBody("live"));
   app.get("/livez", async () => probeBody("live"));

--- a/services/offer-management/src/app.ts
+++ b/services/offer-management/src/app.ts
@@ -22,13 +22,11 @@ export type ServiceMetadata = Readonly<{
   }>;
 }>;
 
-export type ErrorEnvelope = Readonly<{
-  error: Readonly<{
-    code: string;
-    message: string;
-    requestId: string;
-    correlationId: string;
-  }>;
+export type ErrorBody = Readonly<{
+  code: string;
+  message: string;
+  correlationId: string;
+  details: Readonly<Record<string, unknown>>;
 }>;
 
 export type RequestContext = Readonly<{
@@ -110,6 +108,65 @@ export function metadata(): ServiceMetadata {
   };
 }
 
+// ---------------------------------------------------------------------------
+// In-memory idempotency store (single-instance only)
+// ---------------------------------------------------------------------------
+type IdempotencyRecord = Readonly<{
+  requestBody: unknown;
+  responseBody: unknown;
+  statusCode: number;
+}>;
+
+const idempotencyStore = new Map<string, IdempotencyRecord>();
+
+export function resetIdempotencyStore(): void {
+  idempotencyStore.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Offer store (in-memory for now, replace with real repository later)
+// ---------------------------------------------------------------------------
+interface OfferRecord {
+  offerId: string;
+  offerVersion: number;
+  total: { currency: string; minorUnits: number };
+  expiresAt: string;
+  priceGuaranteeLevel: string;
+  downstreamReference: { offerId: string; offerVersion: number; priceSnapshotRef: string; ruleSnapshotRef: string };
+  itineraryRef: string;
+  travelerSetHash: string;
+  status: string;
+  accountId: string;
+  channelId: string;
+  quoteRequestId: string;
+  createdAt: string;
+  items: ReadonlyArray<Record<string, unknown>>;
+  priceSnapshot: Record<string, unknown>;
+  passengerMix: Record<string, unknown>;
+  validityWindow: Record<string, unknown>;
+  riskDisclosures: ReadonlyArray<Record<string, unknown>>;
+}
+
+const offerStore = new Map<string, OfferRecord>();
+
+export function resetOfferStore(): void {
+  offerStore.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Money conversion helpers
+// ---------------------------------------------------------------------------
+function moneyToApi(money: { amountMinor: number; currency: string }): { currency: string; minorUnits: number } {
+  return { currency: money.currency, minorUnits: money.amountMinor };
+}
+
+function moneyFromApi(money: { currency: string; minorUnits: number }): { amountMinor: number; currency: string } {
+  return { amountMinor: money.minorUnits, currency: money.currency };
+}
+
+// ---------------------------------------------------------------------------
+// App factory
+// ---------------------------------------------------------------------------
 export function createApp(instrumentation: InstrumentationHooks = {}): FastifyInstance {
   const app: FastifyInstance = Fastify({ logger: false });
   const spans = new WeakMap<FastifyRequest, TraceSpan>();
@@ -132,23 +189,176 @@ export function createApp(instrumentation: InstrumentationHooks = {}): FastifyIn
     await span?.end?.({ ...traceContext(request), statusCode: reply.statusCode });
   });
 
+  // Health / metadata
   app.get("/health", async () => healthBody());
   app.get("/metadata", async () => metadata());
-
   app.get("/live", async () => probeBody("live"));
   app.get("/livez", async () => probeBody("live"));
   app.get("/ready", async () => probeBody("ready"));
   app.get("/readyz", async () => probeBody("ready"));
 
+  // -----------------------------------------------------------------------
+  // Offer Management API — POST /api/v1/offers
+  // -----------------------------------------------------------------------
+  app.post<{
+    Body: {
+      accountId?: string;
+      channelId?: string;
+      itineraryRef?: string;
+      travelerRefs?: string[];
+      quoteRequestId?: string;
+    };
+  }>("/api/v1/offers", async (request, reply) => {
+    const ctx = requestContext(request);
+    const idempotencyKey = request.headers["idempotency-key"] as string | undefined;
+
+    if (!idempotencyKey) {
+      return sendError(reply, 400, "VALIDATION_FAILED", "Idempotency-Key header is required on state-changing POST", ctx);
+    }
+
+    // Idempotency replay check
+    const existing = idempotencyStore.get(idempotencyKey);
+    if (existing) {
+      // Validate request body matches (IDEMPOTENCY_KEY_REUSED if different)
+      if (JSON.stringify(existing.requestBody) !== JSON.stringify(request.body)) {
+        return sendError(reply, 422, "IDEMPOTENCY_KEY_REUSED", "Idempotency-Key was reused with a different request body", ctx);
+      }
+      return reply.status(existing.statusCode).send(existing.responseBody);
+    }
+
+    // Validate request body
+    const validationError = validateQuoteOfferRequest(request.body);
+    if (validationError) {
+      return sendError(reply, 400, "VALIDATION_FAILED", validationError, ctx);
+    }
+
+    const { accountId, channelId, itineraryRef, travelerRefs, quoteRequestId } = request.body;
+
+    // Create the offer (domain logic)
+    const offerId = `off-${randomUUID()}`;
+    const offerVersion = 1;
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + 10 * 60 * 1000); // 10 min validity
+
+    const offerRecord: OfferRecord = {
+      offerId,
+      offerVersion,
+      total: { currency: "CNY", minorUnits: 0 },
+      expiresAt: expiresAt.toISOString(),
+      priceGuaranteeLevel: "FIXED_UNTIL_EXPIRY",
+      downstreamReference: {
+        offerId,
+        offerVersion,
+        priceSnapshotRef: "",
+        ruleSnapshotRef: "",
+      },
+      itineraryRef: itineraryRef ?? "",
+      travelerSetHash: travelerRefs ? travelerRefs.sort().join(",") : "",
+      status: "Quoted",
+      accountId: accountId ?? "",
+      channelId: channelId ?? "",
+      quoteRequestId: quoteRequestId ?? "",
+      createdAt: now.toISOString(),
+      items: [],
+      priceSnapshot: {},
+      passengerMix: {},
+      validityWindow: {},
+      riskDisclosures: [],
+    };
+    offerStore.set(offerId, offerRecord);
+
+    const responseBody = {
+      offerId: offerRecord.offerId,
+      offerVersion: offerRecord.offerVersion,
+      total: offerRecord.total,
+      expiresAt: offerRecord.expiresAt,
+      priceGuaranteeLevel: offerRecord.priceGuaranteeLevel,
+      downstreamReference: offerRecord.downstreamReference,
+      itineraryRef: offerRecord.itineraryRef,
+      travelerSetHash: offerRecord.travelerSetHash,
+    };
+
+    // Store idempotency record
+    idempotencyStore.set(idempotencyKey, {
+      requestBody: request.body,
+      responseBody,
+      statusCode: 201,
+    });
+
+    return reply.status(201).send(responseBody);
+  });
+
+  // -----------------------------------------------------------------------
+  // Offer Management API — GET /api/v1/offers/:offerId
+  // -----------------------------------------------------------------------
+  app.get<{
+    Params: { offerId: string };
+  }>("/api/v1/offers/:offerId", async (request, reply) => {
+    const ctx = requestContext(request);
+    const { offerId } = request.params;
+
+    const offer = offerStore.get(offerId);
+    if (!offer) {
+      return sendError(reply, 404, "NOT_FOUND", `Offer ${offerId} not found`, ctx);
+    }
+
+    return reply.status(200).send({
+      offerId: offer.offerId,
+      offerVersion: offer.offerVersion,
+      status: offer.status,
+      accountId: offer.accountId,
+      channelId: offer.channelId,
+      quoteRequestId: offer.quoteRequestId,
+      itineraryRef: offer.itineraryRef,
+      travelerSetHash: offer.travelerSetHash,
+      total: offer.total,
+      expiresAt: offer.expiresAt,
+      priceGuaranteeLevel: offer.priceGuaranteeLevel,
+      downstreamReference: offer.downstreamReference,
+      items: offer.items,
+      priceSnapshot: offer.priceSnapshot,
+      passengerMix: offer.passengerMix,
+      validityWindow: offer.validityWindow,
+      riskDisclosures: offer.riskDisclosures,
+      createdAt: offer.createdAt,
+    });
+  });
+
+  // 404 handler
   app.setNotFoundHandler((request, reply) => {
     sendError(reply, 404, "NOT_FOUND", `Route ${request.method} ${request.url} was not found`, requestContext(request));
   });
 
+  // Error handler
   app.setErrorHandler((error, request, reply) => {
     sendError(reply, 500, "INTERNAL_ERROR", errorMessage(error), requestContext(request));
   });
 
   return app;
+}
+
+function validateQuoteOfferRequest(body: Record<string, unknown>): string | null {
+  if (!body || typeof body !== "object") {
+    return "Request body must be a JSON object";
+  }
+  if (typeof body.accountId !== "string" || (body.accountId as string).trim().length === 0) {
+    return "accountId is required and must be a non-empty string";
+  }
+  if (typeof body.channelId !== "string" || (body.channelId as string).trim().length === 0) {
+    return "channelId is required and must be a non-empty string";
+  }
+  if (typeof body.itineraryRef !== "string" || (body.itineraryRef as string).trim().length === 0) {
+    return "itineraryRef is required and must be a non-empty string";
+  }
+  if (!Array.isArray(body.travelerRefs) || body.travelerRefs.length === 0) {
+    return "travelerRefs is required and must be a non-empty array of strings";
+  }
+  for (const ref of body.travelerRefs) {
+    if (typeof ref !== "string" || ref.trim().length === 0) {
+      return "Each travelerRef must be a non-empty string";
+    }
+  }
+  return null;
 }
 
 function errorMessage(error: unknown): string {
@@ -186,13 +396,11 @@ function headerValue(value: string | string[] | undefined): string | undefined {
 }
 
 function sendError(reply: AppReply, statusCode: number, code: string, message: string, context: RequestContext): void {
-  const envelope: ErrorEnvelope = {
-    error: {
-      code,
-      message,
-      requestId: context.requestId,
-      correlationId: context.correlationId,
-    },
+  const body: ErrorBody = {
+    code,
+    message,
+    correlationId: context.correlationId,
+    details: {},
   };
-  reply.status(statusCode).send(envelope);
+  reply.status(statusCode).send(body);
 }

--- a/services/offer-management/src/app.ts
+++ b/services/offer-management/src/app.ts
@@ -7,8 +7,13 @@ import {
   OfferApplicationService,
   isDomainError,
   type OfferRepository,
-  type QuoteOfferRequest,
 } from "./application/offers.js";
+import {
+  InMemoryUpstreamStateRepository,
+  buildQuoteOfferCommand,
+  type QuoteOfferRequest,
+  type UpstreamStateRepository,
+} from "./application/upstream-state.js";
 import { type QuoteOfferCommand } from "./domain.js";
 import { type EventPublisher } from "./ports/messaging.js";
 import { serviceProfile } from "./profile.js";
@@ -138,13 +143,16 @@ export function resetIdempotencyStore(): void {
 type AppDependencies = Readonly<{
   repository?: OfferRepository;
   publisher?: EventPublisher;
-  quoteCommandFactory?: (request: QuoteOfferRequest) => QuoteOfferCommand;
+  quoteCommandFactory?: (request: QuoteOfferRequest) => QuoteOfferCommand | Promise<QuoteOfferCommand>;
+  upstreamRepository?: UpstreamStateRepository;
 }>;
 
 const defaultOfferRepository = new InMemoryOfferRepository();
+const defaultUpstreamRepository = new InMemoryUpstreamStateRepository();
 
 export function resetOfferStore(): void {
   defaultOfferRepository.clear();
+  defaultUpstreamRepository.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -152,10 +160,11 @@ export function resetOfferStore(): void {
 // ---------------------------------------------------------------------------
 export function createApp(instrumentation: InstrumentationHooks = {}, dependencies: AppDependencies = {}): FastifyInstance {
   const app: FastifyInstance = Fastify({ logger: false });
+  const upstreamRepository = dependencies.upstreamRepository ?? defaultUpstreamRepository;
   const offerService = new OfferApplicationService(
     dependencies.repository ?? defaultOfferRepository,
     dependencies.publisher,
-    dependencies.quoteCommandFactory,
+    dependencies.quoteCommandFactory ?? ((request) => buildQuoteOfferCommand(upstreamRepository, request)),
   );
   const spans = new WeakMap<FastifyRequest, TraceSpan>();
 

--- a/services/offer-management/src/app.ts
+++ b/services/offer-management/src/app.ts
@@ -2,6 +2,15 @@ import { randomUUID } from "node:crypto";
 
 import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from "fastify";
 
+import {
+  InMemoryOfferRepository,
+  OfferApplicationService,
+  isDomainError,
+  type OfferRepository,
+  type QuoteOfferRequest,
+} from "./application/offers.js";
+import { type QuoteOfferCommand } from "./domain.js";
+import { type EventPublisher } from "./ports/messaging.js";
 import { serviceProfile } from "./profile.js";
 
 export type HealthStatus = Readonly<{
@@ -124,51 +133,30 @@ export function resetIdempotencyStore(): void {
 }
 
 // ---------------------------------------------------------------------------
-// Offer store (in-memory for now, replace with real repository later)
+// Offer application service dependencies
 // ---------------------------------------------------------------------------
-interface OfferRecord {
-  offerId: string;
-  offerVersion: number;
-  total: { currency: string; minorUnits: number };
-  expiresAt: string;
-  priceGuaranteeLevel: string;
-  downstreamReference: { offerId: string; offerVersion: number; priceSnapshotRef: string; ruleSnapshotRef: string };
-  itineraryRef: string;
-  travelerSetHash: string;
-  status: string;
-  accountId: string;
-  channelId: string;
-  quoteRequestId: string;
-  createdAt: string;
-  items: ReadonlyArray<Record<string, unknown>>;
-  priceSnapshot: Record<string, unknown>;
-  passengerMix: Record<string, unknown>;
-  validityWindow: Record<string, unknown>;
-  riskDisclosures: ReadonlyArray<Record<string, unknown>>;
-}
+type AppDependencies = Readonly<{
+  repository?: OfferRepository;
+  publisher?: EventPublisher;
+  quoteCommandFactory?: (request: QuoteOfferRequest) => QuoteOfferCommand;
+}>;
 
-const offerStore = new Map<string, OfferRecord>();
+const defaultOfferRepository = new InMemoryOfferRepository();
 
 export function resetOfferStore(): void {
-  offerStore.clear();
-}
-
-// ---------------------------------------------------------------------------
-// Money conversion helpers
-// ---------------------------------------------------------------------------
-function moneyToApi(money: { amountMinor: number; currency: string }): { currency: string; minorUnits: number } {
-  return { currency: money.currency, minorUnits: money.amountMinor };
-}
-
-function moneyFromApi(money: { currency: string; minorUnits: number }): { amountMinor: number; currency: string } {
-  return { amountMinor: money.minorUnits, currency: money.currency };
+  defaultOfferRepository.clear();
 }
 
 // ---------------------------------------------------------------------------
 // App factory
 // ---------------------------------------------------------------------------
-export function createApp(instrumentation: InstrumentationHooks = {}): FastifyInstance {
+export function createApp(instrumentation: InstrumentationHooks = {}, dependencies: AppDependencies = {}): FastifyInstance {
   const app: FastifyInstance = Fastify({ logger: false });
+  const offerService = new OfferApplicationService(
+    dependencies.repository ?? defaultOfferRepository,
+    dependencies.publisher,
+    dependencies.quoteCommandFactory,
+  );
   const spans = new WeakMap<FastifyRequest, TraceSpan>();
 
   app.addHook("onRequest", async (request, reply) => {
@@ -214,7 +202,8 @@ export function createApp(instrumentation: InstrumentationHooks = {}): FastifyIn
     const idempotencyKey = request.headers["idempotency-key"] as string | undefined;
 
     if (!idempotencyKey) {
-      return sendError(reply, 400, "VALIDATION_FAILED", "Idempotency-Key header is required on state-changing POST", ctx);
+      sendError(reply, 400, "VALIDATION_FAILED", "Idempotency-Key header is required on state-changing POST", ctx);
+      return reply;
     }
 
     // Idempotency replay check
@@ -222,7 +211,8 @@ export function createApp(instrumentation: InstrumentationHooks = {}): FastifyIn
     if (existing) {
       // Validate request body matches (IDEMPOTENCY_KEY_REUSED if different)
       if (JSON.stringify(existing.requestBody) !== JSON.stringify(request.body)) {
-        return sendError(reply, 422, "IDEMPOTENCY_KEY_REUSED", "Idempotency-Key was reused with a different request body", ctx);
+        sendError(reply, 422, "IDEMPOTENCY_KEY_REUSED", "Idempotency-Key was reused with a different request body", ctx);
+        return reply;
       }
       return reply.status(existing.statusCode).send(existing.responseBody);
     }
@@ -230,63 +220,35 @@ export function createApp(instrumentation: InstrumentationHooks = {}): FastifyIn
     // Validate request body
     const validationError = validateQuoteOfferRequest(request.body);
     if (validationError) {
-      return sendError(reply, 400, "VALIDATION_FAILED", validationError, ctx);
+      sendError(reply, 400, "VALIDATION_FAILED", validationError, ctx);
+      return reply;
     }
 
     const { accountId, channelId, itineraryRef, travelerRefs, quoteRequestId } = request.body;
 
-    // Create the offer (domain logic)
-    const offerId = `off-${randomUUID()}`;
-    const offerVersion = 1;
-    const now = new Date();
-    const expiresAt = new Date(now.getTime() + 10 * 60 * 1000); // 10 min validity
+    try {
+      const { response: responseBody } = await offerService.quoteOffer({
+        accountId: accountId!,
+        channelId: channelId!,
+        itineraryRef: itineraryRef!,
+        travelerRefs: travelerRefs!,
+        quoteRequestId,
+      }, ctx.correlationId);
 
-    const offerRecord: OfferRecord = {
-      offerId,
-      offerVersion,
-      total: { currency: "CNY", minorUnits: 0 },
-      expiresAt: expiresAt.toISOString(),
-      priceGuaranteeLevel: "FIXED_UNTIL_EXPIRY",
-      downstreamReference: {
-        offerId,
-        offerVersion,
-        priceSnapshotRef: "",
-        ruleSnapshotRef: "",
-      },
-      itineraryRef: itineraryRef ?? "",
-      travelerSetHash: travelerRefs ? travelerRefs.sort().join(",") : "",
-      status: "Quoted",
-      accountId: accountId ?? "",
-      channelId: channelId ?? "",
-      quoteRequestId: quoteRequestId ?? "",
-      createdAt: now.toISOString(),
-      items: [],
-      priceSnapshot: {},
-      passengerMix: {},
-      validityWindow: {},
-      riskDisclosures: [],
-    };
-    offerStore.set(offerId, offerRecord);
+      idempotencyStore.set(idempotencyKey, {
+        requestBody: request.body,
+        responseBody,
+        statusCode: 201,
+      });
 
-    const responseBody = {
-      offerId: offerRecord.offerId,
-      offerVersion: offerRecord.offerVersion,
-      total: offerRecord.total,
-      expiresAt: offerRecord.expiresAt,
-      priceGuaranteeLevel: offerRecord.priceGuaranteeLevel,
-      downstreamReference: offerRecord.downstreamReference,
-      itineraryRef: offerRecord.itineraryRef,
-      travelerSetHash: offerRecord.travelerSetHash,
-    };
-
-    // Store idempotency record
-    idempotencyStore.set(idempotencyKey, {
-      requestBody: request.body,
-      responseBody,
-      statusCode: 201,
-    });
-
-    return reply.status(201).send(responseBody);
+      return reply.status(201).send(responseBody);
+    } catch (error) {
+      if (isDomainError(error)) {
+        sendError(reply, 422, "DOMAIN_RULE_VIOLATION", error.message, ctx, { domainCode: error.code });
+        return reply;
+      }
+      throw error;
+    }
   });
 
   // -----------------------------------------------------------------------
@@ -298,31 +260,13 @@ export function createApp(instrumentation: InstrumentationHooks = {}): FastifyIn
     const ctx = requestContext(request);
     const { offerId } = request.params;
 
-    const offer = offerStore.get(offerId);
+    const offer = await offerService.getOffer(offerId);
     if (!offer) {
-      return sendError(reply, 404, "NOT_FOUND", `Offer ${offerId} not found`, ctx);
+      sendError(reply, 404, "NOT_FOUND", `Offer ${offerId} not found`, ctx);
+      return reply;
     }
 
-    return reply.status(200).send({
-      offerId: offer.offerId,
-      offerVersion: offer.offerVersion,
-      status: offer.status,
-      accountId: offer.accountId,
-      channelId: offer.channelId,
-      quoteRequestId: offer.quoteRequestId,
-      itineraryRef: offer.itineraryRef,
-      travelerSetHash: offer.travelerSetHash,
-      total: offer.total,
-      expiresAt: offer.expiresAt,
-      priceGuaranteeLevel: offer.priceGuaranteeLevel,
-      downstreamReference: offer.downstreamReference,
-      items: offer.items,
-      priceSnapshot: offer.priceSnapshot,
-      passengerMix: offer.passengerMix,
-      validityWindow: offer.validityWindow,
-      riskDisclosures: offer.riskDisclosures,
-      createdAt: offer.createdAt,
-    });
+    return reply.status(200).send(offer);
   });
 
   // 404 handler
@@ -396,12 +340,19 @@ function headerValue(value: string | string[] | undefined): string | undefined {
   return candidate && candidate.trim().length > 0 ? candidate : undefined;
 }
 
-function sendError(reply: AppReply, statusCode: number, code: string, message: string, context: RequestContext): void {
+function sendError(
+  reply: AppReply,
+  statusCode: number,
+  code: string,
+  message: string,
+  context: RequestContext,
+  details: Readonly<Record<string, unknown>> = {},
+): void {
   const body: ErrorBody = {
     code,
     message,
     correlationId: context.correlationId,
-    details: {},
+    details,
   };
   reply.status(statusCode).send(body);
 }

--- a/services/offer-management/src/application/offers.ts
+++ b/services/offer-management/src/application/offers.ts
@@ -1,0 +1,385 @@
+import {
+  DomainError,
+  Offer,
+  type Money,
+  type OfferDomainEvent,
+  type OfferItem,
+  type OfferSnapshot,
+  type PriceGuaranteeLevel,
+  type PriceSnapshot,
+  type QuoteOfferCommand,
+  type RiskDisclosure,
+  type TravelerType,
+} from "../domain.js";
+import { type EventEnvelope, type EventPublisher } from "../ports/messaging.js";
+
+export type QuoteOfferRequest = Readonly<{
+  accountId: string;
+  channelId: string;
+  itineraryRef: string;
+  travelerRefs: readonly string[];
+  quoteRequestId?: string;
+}>;
+
+export type ApiMoney = Readonly<{
+  currency: string;
+  minorUnits: number;
+}>;
+
+export type OfferQuoteResponse = Readonly<{
+  offerId: string;
+  offerVersion: number;
+  total: ApiMoney;
+  expiresAt: string;
+  priceGuaranteeLevel: ApiPriceGuaranteeLevel;
+  downstreamReference: Readonly<{
+    offerId: string;
+    offerVersion: number;
+    priceSnapshotRef: string;
+    ruleSnapshotRef: string;
+  }>;
+  itineraryRef: string;
+  travelerSetHash: string;
+}>;
+
+export type OfferDetailsResponse = OfferQuoteResponse & Readonly<{
+  status: string;
+  accountId: string;
+  channelId: string;
+  quoteRequestId: string;
+  items: readonly Record<string, unknown>[];
+  priceSnapshot: Record<string, unknown>;
+  passengerMix: Record<string, unknown>;
+  validityWindow: Record<string, unknown>;
+  riskDisclosures: readonly Record<string, unknown>[];
+  createdAt: string;
+}>;
+
+type ApiPriceGuaranteeLevel = "FIXED_UNTIL_EXPIRY" | "ESTIMATED_ONLY" | "PROVIDER_FINAL_CONFIRM_REQUIRED";
+
+type QuoteOfferResult = Readonly<{
+  response: OfferQuoteResponse;
+  event: EventEnvelope;
+}>;
+
+export interface OfferRepository {
+  save(snapshot: OfferSnapshot): Promise<void>;
+  findById(offerId: string): Promise<OfferSnapshot | undefined>;
+  clear(): void;
+}
+
+export class InMemoryOfferRepository implements OfferRepository {
+  private readonly offers = new Map<string, OfferSnapshot>();
+
+  async save(snapshot: OfferSnapshot): Promise<void> {
+    this.offers.set(snapshot.offerId, snapshot);
+  }
+
+  async findById(offerId: string): Promise<OfferSnapshot | undefined> {
+    return this.offers.get(offerId);
+  }
+
+  clear(): void {
+    this.offers.clear();
+  }
+}
+
+type QuoteCommandFactory = (request: QuoteOfferRequest) => QuoteOfferCommand;
+
+export class OfferApplicationService {
+  constructor(
+    private readonly repository: OfferRepository,
+    private readonly publisher?: EventPublisher,
+    private readonly quoteCommandFactory: QuoteCommandFactory = toQuoteOfferCommand,
+  ) {}
+
+  async quoteOffer(request: QuoteOfferRequest, correlationId: string): Promise<QuoteOfferResult> {
+    const quoted = Offer.quote(this.quoteCommandFactory(request));
+    const snapshot = quoted.offer.toSnapshot();
+    await this.repository.save(snapshot);
+
+    const envelope = toEventEnvelope(quoted.event, correlationId);
+    await this.publisher?.publish(envelope);
+
+    return {
+      response: toQuoteResponse(snapshot, quoted.event.downstreamReference),
+      event: envelope,
+    };
+  }
+
+  async getOffer(offerId: string): Promise<OfferDetailsResponse | undefined> {
+    const snapshot = await this.repository.findById(offerId);
+    return snapshot ? toDetailsResponse(snapshot) : undefined;
+  }
+}
+
+export function isDomainError(error: unknown): error is DomainError {
+  return error instanceof DomainError;
+}
+
+export function moneyToApi(money: Money): ApiMoney {
+  return { currency: money.currency, minorUnits: money.amountMinor };
+}
+
+function moneyFromApi(money: ApiMoney): Money {
+  return { currency: money.currency, amountMinor: money.minorUnits };
+}
+
+function toQuoteOfferCommand(request: QuoteOfferRequest): QuoteOfferCommand {
+  const quotedAt = new Date();
+  const expiresAt = new Date(quotedAt.getTime() + 10 * 60 * 1000);
+  const upstreamExpiresAt = new Date(quotedAt.getTime() + 15 * 60 * 1000);
+  const travelerSetHash = [...request.travelerRefs].sort().join(",");
+  const offerId = `off-${uuidV7()}`;
+  const currency = "CNY";
+  const itemAmount = 10000;
+  const total = moneyFromApi({ currency, minorUnits: itemAmount });
+  const fareQuoteRef = `fq-${uuidV7()}`;
+  const ruleSnapshotRef = `rule-${uuidV7()}`;
+  const priceSnapshotRef = `ps-${uuidV7()}`;
+  const availabilitySnapshotRef = `av-${uuidV7()}`;
+
+  const item: OfferItem = {
+    offerItemId: `ofi-${uuidV7()}`,
+    mode: "train",
+    segmentRef: `${request.itineraryRef}:segment:1`,
+    itemPrice: total,
+    availabilitySnapshot: {
+      snapshotId: availabilitySnapshotRef,
+      snapshotVersion: "capacity-v1",
+      sourceContext: "CapacityAvailability",
+      capturedAt: quotedAt,
+      expiresAt: upstreamExpiresAt,
+      sellable: true,
+      status: "AVAILABLE",
+      confidence: "confirmed-snapshot",
+    },
+    fareSnapshot: {
+      fareQuoteRef,
+      ruleSnapshotRef,
+      pricingVersion: "pricing-v1",
+      ruleVersion: "rule-v1",
+      sourceContext: "FarePricing",
+      capturedAt: quotedAt,
+      expiresAt: upstreamExpiresAt,
+    },
+  };
+
+  const priceSnapshot: PriceSnapshot = {
+    snapshotId: priceSnapshotRef,
+    fareQuoteRef,
+    capturedAt: quotedAt,
+    expiresAt: upstreamExpiresAt,
+    guaranteeLevel: "FixedUntilExpiry",
+    currency,
+    subtotal: total,
+    taxes: [],
+    fees: [],
+    discounts: [],
+    total,
+  };
+
+  return {
+    offerId,
+    quoteRequestId: request.quoteRequestId ?? `cmd-${uuidV7()}`,
+    accountId: request.accountId,
+    channelId: request.channelId,
+    quotedAt,
+    validityWindow: {
+      startsAt: quotedAt,
+      expiresAt,
+    },
+    itinerary: {
+      itineraryId: request.itineraryRef,
+      itineraryVersion: "v1",
+      sourceContext: "TripPlanning",
+      segmentRefs: [item.segmentRef ?? request.itineraryRef],
+    },
+    passengerMix: {
+      travelerSetHash,
+      travelers: request.travelerRefs.map((travelerId) => ({
+        travelerId,
+        travelerType: inferTravelerType(travelerId),
+      })),
+    },
+    items: [item],
+    priceSnapshot,
+    riskDisclosures: [],
+  };
+}
+
+function inferTravelerType(_travelerId: string): TravelerType {
+  return "ADULT";
+}
+
+function toQuoteResponse(
+  snapshot: OfferSnapshot,
+  downstreamReference: OfferQuoteResponse["downstreamReference"],
+): OfferQuoteResponse {
+  return {
+    offerId: snapshot.offerId,
+    offerVersion: snapshot.offerVersion,
+    total: moneyToApi(snapshot.priceSnapshot.total),
+    expiresAt: toUtcIso(snapshot.validityWindow.expiresAt),
+    priceGuaranteeLevel: priceGuaranteeToApi(snapshot.priceSnapshot.guaranteeLevel),
+    downstreamReference,
+    itineraryRef: snapshot.itinerary.itineraryId,
+    travelerSetHash: snapshot.passengerMix.travelerSetHash,
+  };
+}
+
+function toDetailsResponse(snapshot: OfferSnapshot): OfferDetailsResponse {
+  return {
+    ...toQuoteResponse(snapshot, {
+      offerId: snapshot.offerId,
+      offerVersion: snapshot.offerVersion,
+      priceSnapshotRef: snapshot.priceSnapshot.snapshotId,
+      ruleSnapshotRef: snapshot.items[0]?.fareSnapshot.ruleSnapshotRef ?? "",
+    }),
+    status: snapshot.status,
+    accountId: snapshot.accountId,
+    channelId: snapshot.channelId,
+    quoteRequestId: snapshot.quoteRequestId,
+    items: snapshot.items.map(offerItemToApi),
+    priceSnapshot: priceSnapshotToApi(snapshot.priceSnapshot),
+    passengerMix: passengerMixToApi(snapshot),
+    validityWindow: {
+      startsAt: toUtcIso(snapshot.validityWindow.startsAt),
+      expiresAt: toUtcIso(snapshot.validityWindow.expiresAt),
+    },
+    riskDisclosures: snapshot.riskDisclosures.map(riskDisclosureToApi),
+    createdAt: toUtcIso(snapshot.quotedAt),
+  };
+}
+
+function toEventEnvelope(event: OfferDomainEvent, correlationId: string): EventEnvelope {
+  return {
+    eventId: event.eventId,
+    eventType: event.eventType,
+    schemaVersion: event.schemaVersion,
+    producer: event.producer,
+    causationId: event.causationId,
+    correlationId,
+    occurredAt: toUtcIso(event.occurredAt),
+    payload: eventPayloadToApi(event),
+  };
+}
+
+function eventPayloadToApi(event: OfferDomainEvent): Record<string, unknown> {
+  if (event.type === "OfferQuoted") {
+    return {
+      offerId: event.offerId,
+      offerVersion: event.offerVersion,
+      quoteRequestId: event.quoteRequestId,
+      accountId: event.accountId,
+      channelId: event.channelId,
+      itineraryId: event.itineraryId,
+      itineraryVersion: event.itineraryVersion,
+      travelerSetHash: event.travelerSetHash,
+      availabilitySnapshotRefs: event.availabilitySnapshotRefs,
+      priceSnapshotRef: event.priceSnapshotRef,
+      fareQuoteRefs: event.fareQuoteRefs,
+      ruleSnapshotRefs: event.ruleSnapshotRefs,
+      total: moneyToApi(event.total),
+      expiresAt: toUtcIso(event.expiresAt),
+      priceGuaranteeLevel: priceGuaranteeToApi(event.priceGuaranteeLevel),
+      downstreamReference: event.downstreamReference,
+      boundaryProof: event.boundaryProof,
+    };
+  }
+
+  return {
+    offerId: event.offerId,
+    offerVersion: event.offerVersion,
+    expiredAt: toUtcIso(event.expiredAt),
+    previousStatus: event.previousStatus,
+    reason: event.reason,
+    boundaryProof: event.boundaryProof,
+  };
+}
+
+function offerItemToApi(item: OfferItem): Record<string, unknown> {
+  return {
+    offerItemId: item.offerItemId,
+    mode: item.mode,
+    segmentRef: item.segmentRef,
+    fareSnapshot: {
+      ...item.fareSnapshot,
+      capturedAt: toUtcIso(item.fareSnapshot.capturedAt),
+      expiresAt: toUtcIso(item.fareSnapshot.expiresAt),
+    },
+    availabilitySnapshot: {
+      ...item.availabilitySnapshot,
+      capturedAt: toUtcIso(item.availabilitySnapshot.capturedAt),
+      expiresAt: toUtcIso(item.availabilitySnapshot.expiresAt),
+    },
+    itemPrice: moneyToApi(item.itemPrice),
+  };
+}
+
+function priceSnapshotToApi(snapshot: PriceSnapshot): Record<string, unknown> {
+  return {
+    snapshotId: snapshot.snapshotId,
+    fareQuoteRef: snapshot.fareQuoteRef,
+    capturedAt: toUtcIso(snapshot.capturedAt),
+    expiresAt: toUtcIso(snapshot.expiresAt),
+    guaranteeLevel: priceGuaranteeToApi(snapshot.guaranteeLevel),
+    currency: snapshot.currency,
+    subtotal: moneyToApi(snapshot.subtotal),
+    taxes: snapshot.taxes.map(priceLineToApi),
+    fees: snapshot.fees.map(priceLineToApi),
+    discounts: snapshot.discounts.map(priceLineToApi),
+    total: moneyToApi(snapshot.total),
+  };
+}
+
+function priceLineToApi(line: PriceSnapshot["taxes"][number]): Record<string, unknown> {
+  return {
+    code: line.code,
+    description: line.description,
+    amount: moneyToApi(line.amount),
+  };
+}
+
+function passengerMixToApi(snapshot: OfferSnapshot): Record<string, unknown> {
+  return {
+    travelerSetHash: snapshot.passengerMix.travelerSetHash,
+    travelers: snapshot.passengerMix.travelers,
+  };
+}
+
+function riskDisclosureToApi(disclosure: RiskDisclosure): Record<string, unknown> {
+  return { ...disclosure };
+}
+
+function priceGuaranteeToApi(level: PriceGuaranteeLevel): ApiPriceGuaranteeLevel {
+  switch (level) {
+    case "FixedUntilExpiry":
+      return "FIXED_UNTIL_EXPIRY";
+    case "EstimatedOnly":
+      return "ESTIMATED_ONLY";
+    case "ProviderFinalConfirmRequired":
+      return "PROVIDER_FINAL_CONFIRM_REQUIRED";
+  }
+}
+
+function toUtcIso(value: Date): string {
+  return value.toISOString();
+}
+
+function uuidV7(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  const timestamp = BigInt(Date.now());
+
+  bytes[0] = Number((timestamp >> 40n) & 0xffn);
+  bytes[1] = Number((timestamp >> 32n) & 0xffn);
+  bytes[2] = Number((timestamp >> 24n) & 0xffn);
+  bytes[3] = Number((timestamp >> 16n) & 0xffn);
+  bytes[4] = Number((timestamp >> 8n) & 0xffn);
+  bytes[5] = Number(timestamp & 0xffn);
+  bytes[6] = (bytes[6] & 0x0f) | 0x70;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/services/offer-management/src/application/offers.ts
+++ b/services/offer-management/src/application/offers.ts
@@ -185,7 +185,6 @@ function eventPayloadToApi(event: OfferDomainEvent): Record<string, unknown> {
       expiresAt: toUtcIso(event.expiresAt),
       priceGuaranteeLevel: priceGuaranteeToApi(event.priceGuaranteeLevel),
       downstreamReference: event.downstreamReference,
-      boundaryProof: event.boundaryProof,
     };
   }
 
@@ -193,9 +192,8 @@ function eventPayloadToApi(event: OfferDomainEvent): Record<string, unknown> {
     offerId: event.offerId,
     offerVersion: event.offerVersion,
     expiredAt: toUtcIso(event.expiredAt),
-    previousStatus: event.previousStatus,
+    previousStatus: offerStatusToApi(event.previousStatus),
     reason: event.reason,
-    boundaryProof: event.boundaryProof,
   };
 }
 
@@ -261,6 +259,17 @@ function priceGuaranteeToApi(level: PriceGuaranteeLevel): ApiPriceGuaranteeLevel
       return "ESTIMATED_ONLY";
     case "ProviderFinalConfirmRequired":
       return "PROVIDER_FINAL_CONFIRM_REQUIRED";
+  }
+}
+
+function offerStatusToApi(status: string): "QUOTED" | "ACCEPTED" {
+  switch (status) {
+    case "Quoted":
+      return "QUOTED";
+    case "Accepted":
+      return "ACCEPTED";
+    default:
+      throw new DomainError("INVALID_EXPIRABLE_STATUS", `OfferExpired previousStatus ${status} is not publishable`);
   }
 }
 

--- a/services/offer-management/src/application/offers.ts
+++ b/services/offer-management/src/application/offers.ts
@@ -9,17 +9,9 @@ import {
   type PriceSnapshot,
   type QuoteOfferCommand,
   type RiskDisclosure,
-  type TravelerType,
 } from "../domain.js";
 import { type EventEnvelope, type EventPublisher } from "../ports/messaging.js";
-
-export type QuoteOfferRequest = Readonly<{
-  accountId: string;
-  channelId: string;
-  itineraryRef: string;
-  travelerRefs: readonly string[];
-  quoteRequestId?: string;
-}>;
+import { type QuoteOfferRequest } from "./upstream-state.js";
 
 export type ApiMoney = Readonly<{
   currency: string;
@@ -84,17 +76,17 @@ export class InMemoryOfferRepository implements OfferRepository {
   }
 }
 
-type QuoteCommandFactory = (request: QuoteOfferRequest) => QuoteOfferCommand;
+type QuoteCommandFactory = (request: QuoteOfferRequest) => QuoteOfferCommand | Promise<QuoteOfferCommand>;
 
 export class OfferApplicationService {
   constructor(
     private readonly repository: OfferRepository,
-    private readonly publisher?: EventPublisher,
-    private readonly quoteCommandFactory: QuoteCommandFactory = toQuoteOfferCommand,
+    private readonly publisher: EventPublisher | undefined,
+    private readonly quoteCommandFactory: QuoteCommandFactory,
   ) {}
 
   async quoteOffer(request: QuoteOfferRequest, correlationId: string): Promise<QuoteOfferResult> {
-    const quoted = Offer.quote(this.quoteCommandFactory(request));
+    const quoted = Offer.quote(await this.quoteCommandFactory(request));
     const snapshot = quoted.offer.toSnapshot();
     await this.repository.save(snapshot);
 
@@ -119,97 +111,6 @@ export function isDomainError(error: unknown): error is DomainError {
 
 export function moneyToApi(money: Money): ApiMoney {
   return { currency: money.currency, minorUnits: money.amountMinor };
-}
-
-function moneyFromApi(money: ApiMoney): Money {
-  return { currency: money.currency, amountMinor: money.minorUnits };
-}
-
-function toQuoteOfferCommand(request: QuoteOfferRequest): QuoteOfferCommand {
-  const quotedAt = new Date();
-  const expiresAt = new Date(quotedAt.getTime() + 10 * 60 * 1000);
-  const upstreamExpiresAt = new Date(quotedAt.getTime() + 15 * 60 * 1000);
-  const travelerSetHash = [...request.travelerRefs].sort().join(",");
-  const offerId = `off-${uuidV7()}`;
-  const currency = "CNY";
-  const itemAmount = 10000;
-  const total = moneyFromApi({ currency, minorUnits: itemAmount });
-  const fareQuoteRef = `fq-${uuidV7()}`;
-  const ruleSnapshotRef = `rule-${uuidV7()}`;
-  const priceSnapshotRef = `ps-${uuidV7()}`;
-  const availabilitySnapshotRef = `av-${uuidV7()}`;
-
-  const item: OfferItem = {
-    offerItemId: `ofi-${uuidV7()}`,
-    mode: "train",
-    segmentRef: `${request.itineraryRef}:segment:1`,
-    itemPrice: total,
-    availabilitySnapshot: {
-      snapshotId: availabilitySnapshotRef,
-      snapshotVersion: "capacity-v1",
-      sourceContext: "CapacityAvailability",
-      capturedAt: quotedAt,
-      expiresAt: upstreamExpiresAt,
-      sellable: true,
-      status: "AVAILABLE",
-      confidence: "confirmed-snapshot",
-    },
-    fareSnapshot: {
-      fareQuoteRef,
-      ruleSnapshotRef,
-      pricingVersion: "pricing-v1",
-      ruleVersion: "rule-v1",
-      sourceContext: "FarePricing",
-      capturedAt: quotedAt,
-      expiresAt: upstreamExpiresAt,
-    },
-  };
-
-  const priceSnapshot: PriceSnapshot = {
-    snapshotId: priceSnapshotRef,
-    fareQuoteRef,
-    capturedAt: quotedAt,
-    expiresAt: upstreamExpiresAt,
-    guaranteeLevel: "FixedUntilExpiry",
-    currency,
-    subtotal: total,
-    taxes: [],
-    fees: [],
-    discounts: [],
-    total,
-  };
-
-  return {
-    offerId,
-    quoteRequestId: request.quoteRequestId ?? `cmd-${uuidV7()}`,
-    accountId: request.accountId,
-    channelId: request.channelId,
-    quotedAt,
-    validityWindow: {
-      startsAt: quotedAt,
-      expiresAt,
-    },
-    itinerary: {
-      itineraryId: request.itineraryRef,
-      itineraryVersion: "v1",
-      sourceContext: "TripPlanning",
-      segmentRefs: [item.segmentRef ?? request.itineraryRef],
-    },
-    passengerMix: {
-      travelerSetHash,
-      travelers: request.travelerRefs.map((travelerId) => ({
-        travelerId,
-        travelerType: inferTravelerType(travelerId),
-      })),
-    },
-    items: [item],
-    priceSnapshot,
-    riskDisclosures: [],
-  };
-}
-
-function inferTravelerType(_travelerId: string): TravelerType {
-  return "ADULT";
 }
 
 function toQuoteResponse(
@@ -365,21 +266,4 @@ function priceGuaranteeToApi(level: PriceGuaranteeLevel): ApiPriceGuaranteeLevel
 
 function toUtcIso(value: Date): string {
   return value.toISOString();
-}
-
-function uuidV7(): string {
-  const bytes = crypto.getRandomValues(new Uint8Array(16));
-  const timestamp = BigInt(Date.now());
-
-  bytes[0] = Number((timestamp >> 40n) & 0xffn);
-  bytes[1] = Number((timestamp >> 32n) & 0xffn);
-  bytes[2] = Number((timestamp >> 24n) & 0xffn);
-  bytes[3] = Number((timestamp >> 16n) & 0xffn);
-  bytes[4] = Number((timestamp >> 8n) & 0xffn);
-  bytes[5] = Number(timestamp & 0xffn);
-  bytes[6] = (bytes[6] & 0x0f) | 0x70;
-  bytes[8] = (bytes[8] & 0x3f) | 0x80;
-
-  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
-  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }

--- a/services/offer-management/src/application/upstream-state.ts
+++ b/services/offer-management/src/application/upstream-state.ts
@@ -1,0 +1,472 @@
+import { DomainError, mapStatusToConfidence, type AvailabilityConfidence, type OfferItem, type PassengerMix, type PriceGuaranteeLevel, type PriceSnapshot, type QuoteOfferCommand, type TravelerRef, type TravelerType } from "../domain.js";
+import { type EventEnvelope, type EventHandler } from "../ports/messaging.js";
+
+export type QuoteOfferRequest = Readonly<{
+  accountId: string;
+  channelId: string;
+  itineraryRef: string;
+  travelerRefs: readonly string[];
+  quoteRequestId?: string;
+}>;
+
+type MoneyLike = Readonly<{ currency: string; minorUnits: number }>;
+
+type StoredItinerary = Readonly<{
+  itineraryRef: string;
+  itineraryVersion: string;
+  segmentRefs: readonly string[];
+  modeBySegment: ReadonlyMap<string, OfferItem["mode"]>;
+  availabilityBySegment: ReadonlyMap<string, StoredAvailability>;
+}>;
+
+type StoredAvailability = Readonly<{
+  snapshotId: string;
+  snapshotVersion: string;
+  capturedAt: Date;
+  expiresAt: Date;
+  sellable: boolean;
+  status: "AVAILABLE" | "LIMITED" | "UNKNOWN" | "UNAVAILABLE";
+  confidence: AvailabilityConfidence;
+}>;
+
+type StoredFareQuote = Readonly<{
+  quoteId: string;
+  channelId: string;
+  travelerRefs: readonly string[];
+  currency: string;
+  validFrom: Date;
+  validUntil: Date;
+  total: MoneyLike;
+  subtotal: MoneyLike;
+  ruleSnapshotRef: string;
+  pricingVersion: string;
+  ruleVersion: string;
+  priceSnapshotRef: string;
+  guaranteeLevel: PriceGuaranteeLevel;
+}>;
+
+type StoredTraveler = Readonly<{
+  travelerId: string;
+  travelerType: TravelerType;
+  maskedDocumentRef?: string;
+  eligibilityRef?: TravelerRef["eligibilityRef"];
+}>;
+
+export interface UpstreamStateRepository {
+  saveItinerary(itinerary: StoredItinerary): Promise<void>;
+  findItinerary(itineraryRef: string): Promise<StoredItinerary | undefined>;
+  saveFareQuote(fareQuote: StoredFareQuote): Promise<void>;
+  findFareQuote(channelId: string, travelerRefs: readonly string[]): Promise<StoredFareQuote | undefined>;
+  saveTraveler(traveler: StoredTraveler): Promise<void>;
+  findTraveler(travelerId: string): Promise<StoredTraveler | undefined>;
+  removeTravelerEligibility(travelerId: string, eligibilityId: string): Promise<void>;
+  clear(): void;
+}
+
+export class InMemoryUpstreamStateRepository implements UpstreamStateRepository {
+  private readonly itineraries = new Map<string, StoredItinerary>();
+  private readonly fareQuotesByKey = new Map<string, StoredFareQuote>();
+  private readonly travelers = new Map<string, StoredTraveler>();
+
+  async saveItinerary(itinerary: StoredItinerary): Promise<void> {
+    this.itineraries.set(itinerary.itineraryRef, itinerary);
+  }
+
+  async findItinerary(itineraryRef: string): Promise<StoredItinerary | undefined> {
+    return this.itineraries.get(itineraryRef);
+  }
+
+  async saveFareQuote(fareQuote: StoredFareQuote): Promise<void> {
+    this.fareQuotesByKey.set(fareQuoteKey(fareQuote.channelId, fareQuote.travelerRefs), fareQuote);
+  }
+
+  async findFareQuote(channelId: string, travelerRefs: readonly string[]): Promise<StoredFareQuote | undefined> {
+    return this.fareQuotesByKey.get(fareQuoteKey(channelId, travelerRefs));
+  }
+
+  async saveTraveler(traveler: StoredTraveler): Promise<void> {
+    this.travelers.set(traveler.travelerId, traveler);
+  }
+
+  async findTraveler(travelerId: string): Promise<StoredTraveler | undefined> {
+    return this.travelers.get(travelerId);
+  }
+
+  async removeTravelerEligibility(travelerId: string, eligibilityId: string): Promise<void> {
+    const traveler = this.travelers.get(travelerId);
+    if (traveler?.eligibilityRef?.eligibilityId === eligibilityId) {
+      this.travelers.set(travelerId, { ...traveler, eligibilityRef: undefined });
+    }
+  }
+
+  clear(): void {
+    this.itineraries.clear();
+    this.fareQuotesByKey.clear();
+    this.travelers.clear();
+  }
+}
+
+export function createUpstreamEventHandler(repository: UpstreamStateRepository): EventHandler {
+  return async (envelope) => {
+    await applyUpstreamEvent(repository, envelope);
+    return "ack";
+  };
+}
+
+export async function applyUpstreamEvent(repository: UpstreamStateRepository, envelope: EventEnvelope): Promise<void> {
+  switch (envelope.eventType) {
+    case "ItineraryProposed":
+      await storeItineraries(repository, envelope.payload);
+      return;
+    case "FareQuoteComputed":
+      await storeFareQuote(repository, envelope.payload);
+      return;
+    case "TravelerSnapshotUpdated":
+      await storeTravelerSnapshot(repository, envelope.payload);
+      return;
+    case "EligibilityDetermined":
+      await storeEligibility(repository, envelope.payload);
+      return;
+    case "EligibilityExpired":
+      await expireEligibility(repository, envelope.payload);
+      return;
+    default:
+      return;
+  }
+}
+
+export async function buildQuoteOfferCommand(repository: UpstreamStateRepository, request: QuoteOfferRequest): Promise<QuoteOfferCommand> {
+  const itinerary = await repository.findItinerary(request.itineraryRef);
+  if (!itinerary) {
+    throw new DomainError("MISSING_ITINERARY_SNAPSHOT", `No consumed Trip Planning itinerary found for ${request.itineraryRef}`);
+  }
+
+  const fareQuote = await repository.findFareQuote(request.channelId, request.travelerRefs);
+  if (!fareQuote) {
+    throw new DomainError("MISSING_FARE_QUOTE", "No consumed Fare Pricing quote matches channelId and travelerRefs");
+  }
+
+  const travelers = await Promise.all(request.travelerRefs.map((travelerId) => repository.findTraveler(travelerId)));
+  const missingTraveler = request.travelerRefs.find((_, index) => !travelers[index]);
+  if (missingTraveler) {
+    throw new DomainError("MISSING_TRAVELER_SNAPSHOT", `No consumed Traveler Profile snapshot found for ${missingTraveler}`);
+  }
+
+  const quotedAt = new Date();
+  const offerExpiresAt = new Date(Math.min(quotedAt.getTime() + 10 * 60 * 1000, fareQuote.validUntil.getTime()));
+  const passengerMix: PassengerMix = {
+    travelerSetHash: travelerSetHash(request.travelerRefs),
+    travelers: travelers.map((traveler) => ({
+      travelerId: traveler!.travelerId,
+      travelerType: traveler!.travelerType,
+      maskedDocumentRef: traveler!.maskedDocumentRef,
+      eligibilityRef: traveler!.eligibilityRef,
+    })),
+  };
+
+  const itemPrice = { currency: fareQuote.currency, amountMinor: fareQuote.total.minorUnits };
+  const items: OfferItem[] = itinerary.segmentRefs.map((segmentRef, index) => {
+    const availability = itinerary.availabilityBySegment.get(segmentRef);
+    if (!availability) {
+      throw new DomainError("MISSING_AVAILABILITY_SNAPSHOT", `No availability snapshot was consumed for segment ${segmentRef}`);
+    }
+    return {
+      offerItemId: `ofi-${uuidV7()}`,
+      mode: itinerary.modeBySegment.get(segmentRef) ?? "train",
+      segmentRef,
+      itemPrice: index === 0 ? itemPrice : { currency: fareQuote.currency, amountMinor: 0 },
+      availabilitySnapshot: {
+        snapshotId: availability.snapshotId,
+        snapshotVersion: availability.snapshotVersion,
+        sourceContext: "CapacityAvailability",
+        capturedAt: availability.capturedAt,
+        expiresAt: availability.expiresAt,
+        sellable: availability.sellable,
+        status: availability.status,
+        confidence: availability.confidence,
+      },
+      fareSnapshot: {
+        fareQuoteRef: fareQuote.quoteId,
+        ruleSnapshotRef: fareQuote.ruleSnapshotRef,
+        pricingVersion: fareQuote.pricingVersion,
+        ruleVersion: fareQuote.ruleVersion,
+        sourceContext: "FarePricing",
+        capturedAt: fareQuote.validFrom,
+        expiresAt: fareQuote.validUntil,
+      },
+    };
+  });
+
+  const priceSnapshot: PriceSnapshot = {
+    snapshotId: fareQuote.priceSnapshotRef,
+    fareQuoteRef: fareQuote.quoteId,
+    capturedAt: fareQuote.validFrom,
+    expiresAt: fareQuote.validUntil,
+    guaranteeLevel: fareQuote.guaranteeLevel,
+    currency: fareQuote.currency,
+    subtotal: { currency: fareQuote.currency, amountMinor: fareQuote.subtotal.minorUnits },
+    taxes: [],
+    fees: [],
+    discounts: [],
+    total: { currency: fareQuote.currency, amountMinor: fareQuote.total.minorUnits },
+  };
+
+  return {
+    offerId: `off-${uuidV7()}`,
+    quoteRequestId: request.quoteRequestId ?? `cmd-${uuidV7()}`,
+    accountId: request.accountId,
+    channelId: request.channelId,
+    itinerary: {
+      itineraryId: itinerary.itineraryRef,
+      itineraryVersion: itinerary.itineraryVersion,
+      sourceContext: "TripPlanning",
+      segmentRefs: itinerary.segmentRefs,
+    },
+    passengerMix,
+    validityWindow: { startsAt: quotedAt, expiresAt: offerExpiresAt },
+    items,
+    priceSnapshot,
+    riskDisclosures: [],
+    quotedAt,
+  };
+}
+
+async function storeItineraries(repository: UpstreamStateRepository, payload: Record<string, unknown>): Promise<void> {
+  const itineraries = arrayOfObjects(payload.itineraries);
+  for (const itinerary of itineraries) {
+    const itineraryRef = stringField(itinerary, "itineraryRef");
+    if (!itineraryRef) continue;
+    const legs = arrayOfObjects(itinerary.legs);
+    const segmentRefs = legs.map((leg, index) => stringField(leg, "serviceSegmentRef") ?? `${itineraryRef}:segment:${index + 1}`);
+    const modeBySegment = new Map<string, OfferItem["mode"]>();
+    for (const [index, leg] of legs.entries()) {
+      modeBySegment.set(segmentRefs[index], transportMode(stringField(leg, "mode")));
+    }
+    const availabilityBySegment = availabilitySnapshots(itinerary, segmentRefs);
+    await repository.saveItinerary({
+      itineraryRef,
+      itineraryVersion: stringField(itinerary, "itineraryVersion") ?? stringField(payload, "snapshotVersion") ?? "v1",
+      segmentRefs,
+      modeBySegment,
+      availabilityBySegment,
+    });
+  }
+}
+
+async function storeFareQuote(repository: UpstreamStateRepository, payload: Record<string, unknown>): Promise<void> {
+  if (stringField(payload, "status") !== "QUOTED") return;
+  const quoteId = stringField(payload, "quoteId");
+  const channelId = stringField(payload, "channel") ?? stringField(payload, "channelId");
+  const travelerRefs = stringArray(payload.travelerRefs);
+  const currency = stringField(payload, "currency");
+  const validFrom = dateField(payload, "validFrom");
+  const validUntil = dateField(payload, "validUntil");
+  const breakdown = objectField(payload, "breakdown");
+  const ruleSnapshot = objectField(payload, "ruleSnapshot");
+  if (!quoteId || !channelId || travelerRefs.length === 0 || !currency || !validFrom || !validUntil || !breakdown) return;
+
+  const total = moneyField(breakdown, "total") ?? moneyField(payload, "total");
+  if (!total) return;
+
+  await repository.saveFareQuote({
+    quoteId,
+    channelId,
+    travelerRefs,
+    currency,
+    validFrom,
+    validUntil,
+    total,
+    subtotal: moneyField(breakdown, "subtotal") ?? total,
+    ruleSnapshotRef: stringField(ruleSnapshot, "ruleSnapshotRef") ?? stringField(ruleSnapshot, "ruleSnapshotId") ?? stringField(ruleSnapshot, "snapshotId") ?? `${quoteId}:rules`,
+    pricingVersion: stringField(ruleSnapshot, "pricingVersion") ?? stringField(payload, "pricingVersion") ?? "pricing-v1",
+    ruleVersion: stringField(ruleSnapshot, "ruleVersion") ?? stringField(payload, "ruleVersion") ?? "rule-v1",
+    priceSnapshotRef: stringField(breakdown, "priceSnapshotRef") ?? stringField(payload, "priceSnapshotRef") ?? `${quoteId}:price`,
+    guaranteeLevel: priceGuarantee(stringField(payload, "priceGuaranteeLevel") ?? stringField(breakdown, "priceGuaranteeLevel")),
+  });
+}
+
+async function storeTravelerSnapshot(repository: UpstreamStateRepository, payload: Record<string, unknown>): Promise<void> {
+  const travelerId = stringField(payload, "travelerId");
+  if (!travelerId) return;
+  const existing = await repository.findTraveler(travelerId);
+  await repository.saveTraveler({
+    travelerId,
+    travelerType: travelerType(stringField(payload, "travelerType")),
+    maskedDocumentRef: stringField(payload, "maskedDocumentRef"),
+    eligibilityRef: existing?.eligibilityRef,
+  });
+}
+
+async function storeEligibility(repository: UpstreamStateRepository, payload: Record<string, unknown>): Promise<void> {
+  const travelerId = stringField(payload, "travelerId");
+  const eligibility = objectField(payload, "eligibilityRef");
+  if (!travelerId || !eligibility) return;
+  const existing = await repository.findTraveler(travelerId);
+  await repository.saveTraveler({
+    travelerId,
+    travelerType: existing?.travelerType ?? "ADULT",
+    maskedDocumentRef: existing?.maskedDocumentRef,
+    eligibilityRef: {
+      eligibilityId: stringField(eligibility, "eligibilityId") ?? stringField(eligibility, "id") ?? "unknown",
+      eligibilityType: stringField(eligibility, "eligibilityType") ?? "UNKNOWN",
+      eligibilitySource: stringField(eligibility, "eligibilitySource") ?? "traveler-profile",
+      evidenceHash: stringField(eligibility, "evidenceHash"),
+      verifiedAt: stringField(payload, "determinedAt"),
+    },
+  });
+}
+
+async function expireEligibility(repository: UpstreamStateRepository, payload: Record<string, unknown>): Promise<void> {
+  const travelerId = stringField(payload, "travelerId");
+  const eligibilityId = stringField(payload, "eligibilityId");
+  if (travelerId && eligibilityId) {
+    await repository.removeTravelerEligibility(travelerId, eligibilityId);
+  }
+}
+
+function availabilitySnapshots(itinerary: Record<string, unknown>, segmentRefs: readonly string[]): ReadonlyMap<string, StoredAvailability> {
+  const bySegment = new Map<string, StoredAvailability>();
+  for (const candidate of [...arrayOfObjects(itinerary.availabilitySnapshots), ...arrayOfObjects(itinerary.availabilityHint ? [itinerary.availabilityHint] : [])]) {
+    const segmentRef = stringField(candidate, "segmentRef") ?? stringField(candidate, "serviceSegmentRef") ?? (segmentRefs.length === 1 ? segmentRefs[0] : undefined);
+    if (!segmentRef) continue;
+    const expiresAt = dateField(candidate, "expiresAt") ?? dateField(candidate, "validUntil");
+    if (!expiresAt) continue;
+    const capturedAt = dateField(candidate, "capturedAt") ?? dateField(candidate, "updatedAt") ?? new Date();
+    const status = availabilityStatus(stringField(candidate, "status"));
+    bySegment.set(segmentRef, {
+      snapshotId: stringField(candidate, "snapshotId") ?? stringField(candidate, "availabilitySnapshotRef") ?? stringField(candidate, "availabilitySnapshotId") ?? `${segmentRef}:availability`,
+      snapshotVersion: stringField(candidate, "snapshotVersion") ?? "v1",
+      capturedAt,
+      expiresAt,
+      sellable: booleanField(candidate, "sellable") ?? status !== "UNAVAILABLE",
+      status,
+      confidence: mapStatusToConfidence(status, availabilityConfidence(stringField(candidate, "confidence"))),
+    });
+  }
+  return bySegment;
+}
+
+function fareQuoteKey(channelId: string, travelerRefs: readonly string[]): string {
+  return `${channelId}:${travelerSetHash(travelerRefs)}`;
+}
+
+function travelerSetHash(travelerRefs: readonly string[]): string {
+  return [...travelerRefs].sort().join(",");
+}
+
+function objectField(source: unknown, key: string): Record<string, unknown> | undefined {
+  if (!source || typeof source !== "object") return undefined;
+  const value = (source as Record<string, unknown>)[key];
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
+}
+
+function arrayOfObjects(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter((entry): entry is Record<string, unknown> => Boolean(entry) && typeof entry === "object" && !Array.isArray(entry)) : [];
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0) : [];
+}
+
+function stringField(source: unknown, key: string): string | undefined {
+  if (!source || typeof source !== "object") return undefined;
+  const value = (source as Record<string, unknown>)[key];
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function booleanField(source: Record<string, unknown>, key: string): boolean | undefined {
+  const value = source[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function dateField(source: unknown, key: string): Date | undefined {
+  const value = stringField(source, key);
+  if (!value) return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function moneyField(source: Record<string, unknown>, key: string): MoneyLike | undefined {
+  const value = objectField(source, key);
+  const currency = stringField(value, "currency");
+  const minorUnits = value?.minorUnits;
+  return currency && typeof minorUnits === "number" && Number.isFinite(minorUnits) ? { currency, minorUnits } : undefined;
+}
+
+function availabilityStatus(value: string | undefined): StoredAvailability["status"] {
+  switch (value) {
+    case "AVAILABLE":
+    case "LIMITED":
+    case "UNKNOWN":
+    case "UNAVAILABLE":
+      return value;
+    default:
+      return "AVAILABLE";
+  }
+}
+
+function availabilityConfidence(value: string | undefined): AvailabilityConfidence {
+  switch (value) {
+    case "confirmed-snapshot":
+    case "low":
+    case "estimated":
+      return value;
+    default:
+      return "estimated";
+  }
+}
+
+function travelerType(value: string | undefined): TravelerType {
+  switch (value) {
+    case "ADULT":
+    case "CHILD":
+    case "STUDENT":
+    case "SENIOR":
+    case "INFANT":
+    case "MILITARY":
+    case "DISABLED":
+      return value;
+    default:
+      return "ADULT";
+  }
+}
+
+function transportMode(value: string | undefined): OfferItem["mode"] {
+  switch (value) {
+    case "transfer":
+    case "ancillary":
+      return value;
+    default:
+      return "train";
+  }
+}
+
+function priceGuarantee(value: string | undefined): PriceGuaranteeLevel {
+  switch (value) {
+    case "ESTIMATED_ONLY":
+    case "EstimatedOnly":
+      return "EstimatedOnly";
+    case "PROVIDER_FINAL_CONFIRM_REQUIRED":
+    case "ProviderFinalConfirmRequired":
+      return "ProviderFinalConfirmRequired";
+    default:
+      return "FixedUntilExpiry";
+  }
+}
+
+function uuidV7(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  const timestamp = BigInt(Date.now());
+
+  bytes[0] = Number((timestamp >> 40n) & 0xffn);
+  bytes[1] = Number((timestamp >> 32n) & 0xffn);
+  bytes[2] = Number((timestamp >> 24n) & 0xffn);
+  bytes[3] = Number((timestamp >> 16n) & 0xffn);
+  bytes[4] = Number((timestamp >> 8n) & 0xffn);
+  bytes[5] = Number(timestamp & 0xffn);
+  bytes[6] = (bytes[6] & 0x0f) | 0x70;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/services/offer-management/src/application/upstream-state.ts
+++ b/services/offer-management/src/application/upstream-state.ts
@@ -17,6 +17,7 @@ type StoredItinerary = Readonly<{
   segmentRefs: readonly string[];
   modeBySegment: ReadonlyMap<string, OfferItem["mode"]>;
   availabilityBySegment: ReadonlyMap<string, StoredAvailability>;
+  inputHash?: string;
 }>;
 
 type StoredAvailability = Readonly<{
@@ -31,6 +32,7 @@ type StoredAvailability = Readonly<{
 
 type StoredFareQuote = Readonly<{
   quoteId: string;
+  inputHash: string;
   channelId: string;
   travelerRefs: readonly string[];
   currency: string;
@@ -56,7 +58,7 @@ export interface UpstreamStateRepository {
   saveItinerary(itinerary: StoredItinerary): Promise<void>;
   findItinerary(itineraryRef: string): Promise<StoredItinerary | undefined>;
   saveFareQuote(fareQuote: StoredFareQuote): Promise<void>;
-  findFareQuote(channelId: string, travelerRefs: readonly string[]): Promise<StoredFareQuote | undefined>;
+  findFareQuote(itineraryRef: string, channelId: string, travelerRefs: readonly string[]): Promise<StoredFareQuote | undefined>;
   saveTraveler(traveler: StoredTraveler): Promise<void>;
   findTraveler(travelerId: string): Promise<StoredTraveler | undefined>;
   removeTravelerEligibility(travelerId: string, eligibilityId: string): Promise<void>;
@@ -77,11 +79,11 @@ export class InMemoryUpstreamStateRepository implements UpstreamStateRepository 
   }
 
   async saveFareQuote(fareQuote: StoredFareQuote): Promise<void> {
-    this.fareQuotesByKey.set(fareQuoteKey(fareQuote.channelId, fareQuote.travelerRefs), fareQuote);
+    this.fareQuotesByKey.set(fareQuoteKey(fareQuote.inputHash, fareQuote.channelId, fareQuote.travelerRefs), fareQuote);
   }
 
-  async findFareQuote(channelId: string, travelerRefs: readonly string[]): Promise<StoredFareQuote | undefined> {
-    return this.fareQuotesByKey.get(fareQuoteKey(channelId, travelerRefs));
+  async findFareQuote(itineraryRef: string, channelId: string, travelerRefs: readonly string[]): Promise<StoredFareQuote | undefined> {
+    return this.fareQuotesByKey.get(fareQuoteKey(itineraryRef, channelId, travelerRefs));
   }
 
   async saveTraveler(traveler: StoredTraveler): Promise<void> {
@@ -141,9 +143,10 @@ export async function buildQuoteOfferCommand(repository: UpstreamStateRepository
     throw new DomainError("MISSING_ITINERARY_SNAPSHOT", `No consumed Trip Planning itinerary found for ${request.itineraryRef}`);
   }
 
-  const fareQuote = await repository.findFareQuote(request.channelId, request.travelerRefs);
+  const fareQuoteLookupKey = itinerary.inputHash ?? request.itineraryRef;
+  const fareQuote = await repository.findFareQuote(fareQuoteLookupKey, request.channelId, request.travelerRefs);
   if (!fareQuote) {
-    throw new DomainError("MISSING_FARE_QUOTE", "No consumed Fare Pricing quote matches channelId and travelerRefs");
+    throw new DomainError("MISSING_FARE_QUOTE", "No consumed Fare Pricing quote matches itinerary/fare input, channelId, and travelerRefs");
   }
 
   const travelers = await Promise.all(request.travelerRefs.map((travelerId) => repository.findTraveler(travelerId)));
@@ -249,6 +252,7 @@ async function storeItineraries(repository: UpstreamStateRepository, payload: Re
       segmentRefs,
       modeBySegment,
       availabilityBySegment,
+      inputHash: stringField(itinerary, "inputHash") ?? stringField(payload, "intentRef"),
     });
   }
 }
@@ -256,6 +260,7 @@ async function storeItineraries(repository: UpstreamStateRepository, payload: Re
 async function storeFareQuote(repository: UpstreamStateRepository, payload: Record<string, unknown>): Promise<void> {
   if (stringField(payload, "status") !== "QUOTED") return;
   const quoteId = stringField(payload, "quoteId");
+  const inputHash = stringField(payload, "inputHash");
   const channelId = stringField(payload, "channel") ?? stringField(payload, "channelId");
   const travelerRefs = stringArray(payload.travelerRefs);
   const currency = stringField(payload, "currency");
@@ -263,13 +268,18 @@ async function storeFareQuote(repository: UpstreamStateRepository, payload: Reco
   const validUntil = dateField(payload, "validUntil");
   const breakdown = objectField(payload, "breakdown");
   const ruleSnapshot = objectField(payload, "ruleSnapshot");
-  if (!quoteId || !channelId || travelerRefs.length === 0 || !currency || !validFrom || !validUntil || !breakdown) return;
+  if (!quoteId || !inputHash || !channelId || travelerRefs.length === 0 || !currency || !validFrom || !validUntil || !breakdown || !ruleSnapshot) return;
 
   const total = moneyField(breakdown, "total") ?? moneyField(payload, "total");
-  if (!total) return;
+  const ruleSnapshotRef = stringField(ruleSnapshot, "ruleSnapshotRef") ?? stringField(ruleSnapshot, "ruleSnapshotId") ?? stringField(ruleSnapshot, "snapshotId");
+  const pricingVersion = stringField(ruleSnapshot, "pricingVersion") ?? stringField(payload, "pricingVersion");
+  const ruleVersion = stringField(ruleSnapshot, "ruleVersion") ?? stringField(payload, "ruleVersion");
+  const priceSnapshotRef = stringField(breakdown, "priceSnapshotRef") ?? stringField(payload, "priceSnapshotRef");
+  if (!total || !ruleSnapshotRef || !pricingVersion || !ruleVersion || !priceSnapshotRef) return;
 
   await repository.saveFareQuote({
     quoteId,
+    inputHash,
     channelId,
     travelerRefs,
     currency,
@@ -277,10 +287,10 @@ async function storeFareQuote(repository: UpstreamStateRepository, payload: Reco
     validUntil,
     total,
     subtotal: moneyField(breakdown, "subtotal") ?? total,
-    ruleSnapshotRef: stringField(ruleSnapshot, "ruleSnapshotRef") ?? stringField(ruleSnapshot, "ruleSnapshotId") ?? stringField(ruleSnapshot, "snapshotId") ?? `${quoteId}:rules`,
-    pricingVersion: stringField(ruleSnapshot, "pricingVersion") ?? stringField(payload, "pricingVersion") ?? "pricing-v1",
-    ruleVersion: stringField(ruleSnapshot, "ruleVersion") ?? stringField(payload, "ruleVersion") ?? "rule-v1",
-    priceSnapshotRef: stringField(breakdown, "priceSnapshotRef") ?? stringField(payload, "priceSnapshotRef") ?? `${quoteId}:price`,
+    ruleSnapshotRef,
+    pricingVersion,
+    ruleVersion,
+    priceSnapshotRef,
     guaranteeLevel: priceGuarantee(stringField(payload, "priceGuaranteeLevel") ?? stringField(breakdown, "priceGuaranteeLevel")),
   });
 }
@@ -288,10 +298,12 @@ async function storeFareQuote(repository: UpstreamStateRepository, payload: Reco
 async function storeTravelerSnapshot(repository: UpstreamStateRepository, payload: Record<string, unknown>): Promise<void> {
   const travelerId = stringField(payload, "travelerId");
   if (!travelerId) return;
+  const parsedTravelerType = travelerType(stringField(payload, "travelerType"));
+  if (!parsedTravelerType) return;
   const existing = await repository.findTraveler(travelerId);
   await repository.saveTraveler({
     travelerId,
-    travelerType: travelerType(stringField(payload, "travelerType")),
+    travelerType: parsedTravelerType,
     maskedDocumentRef: stringField(payload, "maskedDocumentRef"),
     eligibilityRef: existing?.eligibilityRef,
   });
@@ -300,16 +312,20 @@ async function storeTravelerSnapshot(repository: UpstreamStateRepository, payloa
 async function storeEligibility(repository: UpstreamStateRepository, payload: Record<string, unknown>): Promise<void> {
   const travelerId = stringField(payload, "travelerId");
   const eligibility = objectField(payload, "eligibilityRef");
-  if (!travelerId || !eligibility) return;
+  const eligibilityId = stringField(eligibility, "eligibilityId") ?? stringField(eligibility, "id");
+  const eligibilityType = stringField(eligibility, "eligibilityType");
+  const eligibilitySource = stringField(eligibility, "eligibilitySource");
+  if (!travelerId || !eligibility || !eligibilityId || !eligibilityType || !eligibilitySource) return;
   const existing = await repository.findTraveler(travelerId);
+  if (!existing) return;
   await repository.saveTraveler({
     travelerId,
-    travelerType: existing?.travelerType ?? "ADULT",
-    maskedDocumentRef: existing?.maskedDocumentRef,
+    travelerType: existing.travelerType,
+    maskedDocumentRef: existing.maskedDocumentRef,
     eligibilityRef: {
-      eligibilityId: stringField(eligibility, "eligibilityId") ?? stringField(eligibility, "id") ?? "unknown",
-      eligibilityType: stringField(eligibility, "eligibilityType") ?? "UNKNOWN",
-      eligibilitySource: stringField(eligibility, "eligibilitySource") ?? "traveler-profile",
+      eligibilityId,
+      eligibilityType,
+      eligibilitySource,
       evidenceHash: stringField(eligibility, "evidenceHash"),
       verifiedAt: stringField(payload, "determinedAt"),
     },
@@ -327,27 +343,32 @@ async function expireEligibility(repository: UpstreamStateRepository, payload: R
 function availabilitySnapshots(itinerary: Record<string, unknown>, segmentRefs: readonly string[]): ReadonlyMap<string, StoredAvailability> {
   const bySegment = new Map<string, StoredAvailability>();
   for (const candidate of [...arrayOfObjects(itinerary.availabilitySnapshots), ...arrayOfObjects(itinerary.availabilityHint ? [itinerary.availabilityHint] : [])]) {
-    const segmentRef = stringField(candidate, "segmentRef") ?? stringField(candidate, "serviceSegmentRef") ?? (segmentRefs.length === 1 ? segmentRefs[0] : undefined);
+    const segmentRef = stringField(candidate, "segmentRef") ?? stringField(candidate, "serviceSegmentRef");
     if (!segmentRef) continue;
     const expiresAt = dateField(candidate, "expiresAt") ?? dateField(candidate, "validUntil");
     if (!expiresAt) continue;
-    const capturedAt = dateField(candidate, "capturedAt") ?? dateField(candidate, "updatedAt") ?? new Date();
+    const capturedAt = dateField(candidate, "capturedAt") ?? dateField(candidate, "updatedAt");
     const status = availabilityStatus(stringField(candidate, "status"));
+    const snapshotId = stringField(candidate, "snapshotId") ?? stringField(candidate, "availabilitySnapshotRef") ?? stringField(candidate, "availabilitySnapshotId");
+    const snapshotVersion = stringField(candidate, "snapshotVersion");
+    const sellable = booleanField(candidate, "sellable");
+    const confidence = availabilityConfidence(stringField(candidate, "confidence"));
+    if (!capturedAt || !status || !snapshotId || !snapshotVersion || sellable === undefined || !confidence) continue;
     bySegment.set(segmentRef, {
-      snapshotId: stringField(candidate, "snapshotId") ?? stringField(candidate, "availabilitySnapshotRef") ?? stringField(candidate, "availabilitySnapshotId") ?? `${segmentRef}:availability`,
-      snapshotVersion: stringField(candidate, "snapshotVersion") ?? "v1",
+      snapshotId,
+      snapshotVersion,
       capturedAt,
       expiresAt,
-      sellable: booleanField(candidate, "sellable") ?? status !== "UNAVAILABLE",
+      sellable,
       status,
-      confidence: mapStatusToConfidence(status, availabilityConfidence(stringField(candidate, "confidence"))),
+      confidence: mapStatusToConfidence(status, confidence),
     });
   }
   return bySegment;
 }
 
-function fareQuoteKey(channelId: string, travelerRefs: readonly string[]): string {
-  return `${channelId}:${travelerSetHash(travelerRefs)}`;
+function fareQuoteKey(inputHash: string, channelId: string, travelerRefs: readonly string[]): string {
+  return `${inputHash}:${channelId}:${travelerSetHash(travelerRefs)}`;
 }
 
 function travelerSetHash(travelerRefs: readonly string[]): string {
@@ -393,7 +414,7 @@ function moneyField(source: Record<string, unknown>, key: string): MoneyLike | u
   return currency && typeof minorUnits === "number" && Number.isFinite(minorUnits) ? { currency, minorUnits } : undefined;
 }
 
-function availabilityStatus(value: string | undefined): StoredAvailability["status"] {
+function availabilityStatus(value: string | undefined): StoredAvailability["status"] | undefined {
   switch (value) {
     case "AVAILABLE":
     case "LIMITED":
@@ -401,22 +422,22 @@ function availabilityStatus(value: string | undefined): StoredAvailability["stat
     case "UNAVAILABLE":
       return value;
     default:
-      return "AVAILABLE";
+      return undefined;
   }
 }
 
-function availabilityConfidence(value: string | undefined): AvailabilityConfidence {
+function availabilityConfidence(value: string | undefined): AvailabilityConfidence | undefined {
   switch (value) {
     case "confirmed-snapshot":
     case "low":
     case "estimated":
       return value;
     default:
-      return "estimated";
+      return undefined;
   }
 }
 
-function travelerType(value: string | undefined): TravelerType {
+function travelerType(value: string | undefined): TravelerType | undefined {
   switch (value) {
     case "ADULT":
     case "CHILD":
@@ -427,7 +448,7 @@ function travelerType(value: string | undefined): TravelerType {
     case "DISABLED":
       return value;
     default:
-      return "ADULT";
+      return undefined;
   }
 }
 
@@ -443,6 +464,9 @@ function transportMode(value: string | undefined): OfferItem["mode"] {
 
 function priceGuarantee(value: string | undefined): PriceGuaranteeLevel {
   switch (value) {
+    case "FIXED_UNTIL_EXPIRY":
+    case "FixedUntilExpiry":
+      return "FixedUntilExpiry";
     case "ESTIMATED_ONLY":
     case "EstimatedOnly":
       return "EstimatedOnly";

--- a/services/offer-management/src/bootstrap.ts
+++ b/services/offer-management/src/bootstrap.ts
@@ -1,10 +1,14 @@
+import { createRedisMessagingAdapters } from "./adapters/messaging/redis.js";
+import { CONSUMER_GROUP, SUBSCRIBED_STREAMS, consumerName } from "./adapters/messaging/stream-config.js";
 import { createApp, opentelemetryInstrumentationFromEnv, type InstrumentationHooks } from "./app.js";
+import { createUpstreamEventHandler, InMemoryUpstreamStateRepository } from "./application/upstream-state.js";
 
 export type BootstrapOptions = Readonly<{
   host?: string;
   port?: number;
   instrumentation?: InstrumentationHooks;
   redisUrl?: string;
+  instanceId?: string;
 }>;
 
 export function runtimeHost(options: Pick<BootstrapOptions, "host"> = {}): string {
@@ -28,7 +32,29 @@ export function runtimeRedisUrl(options: Pick<BootstrapOptions, "redisUrl"> = {}
 }
 
 export async function bootstrap(options: BootstrapOptions = {}) {
-  const app = createApp(options.instrumentation ?? opentelemetryInstrumentationFromEnv());
+  const messaging = await createRedisMessagingAdapters(runtimeRedisUrl(options));
+  const upstreamRepository = new InMemoryUpstreamStateRepository();
+  const app = createApp(options.instrumentation ?? opentelemetryInstrumentationFromEnv(), {
+    publisher: messaging.publisher,
+    upstreamRepository,
+  });
+
+  const abortController = new AbortController();
+  const subscription = messaging.subscriber.subscribe(
+    SUBSCRIBED_STREAMS,
+    CONSUMER_GROUP,
+    consumerName(options.instanceId ?? process.env.HOSTNAME),
+    createUpstreamEventHandler(upstreamRepository),
+    abortController.signal,
+  );
+  subscription.catch((error: unknown) => app.log.error({ err: error }, "offer-management event subscriber stopped"));
+
+  app.addHook("onClose", async () => {
+    abortController.abort();
+    messaging.subscriber.stop();
+    await messaging.close();
+  });
+
   await app.listen({ host: runtimeHost(options), port: runtimePort(options) });
   return app;
 }

--- a/services/offer-management/src/bootstrap.ts
+++ b/services/offer-management/src/bootstrap.ts
@@ -47,7 +47,21 @@ export async function bootstrap(options: BootstrapOptions = {}) {
     createUpstreamEventHandler(upstreamRepository),
     abortController.signal,
   );
-  subscription.catch((error: unknown) => app.log.error({ err: error }, "offer-management event subscriber stopped"));
+  const subscriptionFailed = new Promise<never>((_, reject) => {
+    subscription.catch((error: unknown) => {
+      app.log.error({ err: error }, "offer-management event subscriber stopped");
+      abortController.abort();
+      reject(error);
+      setImmediate(() => {
+        throw error;
+      });
+    });
+  });
+
+  await Promise.race([
+    messaging.subscriber.started(),
+    subscriptionFailed,
+  ]);
 
   app.addHook("onClose", async () => {
     abortController.abort();

--- a/services/offer-management/src/bootstrap.ts
+++ b/services/offer-management/src/bootstrap.ts
@@ -4,6 +4,7 @@ export type BootstrapOptions = Readonly<{
   host?: string;
   port?: number;
   instrumentation?: InstrumentationHooks;
+  redisUrl?: string;
 }>;
 
 export function runtimeHost(options: Pick<BootstrapOptions, "host"> = {}): string {
@@ -16,6 +17,14 @@ export function runtimePort(options: Pick<BootstrapOptions, "port"> = {}): numbe
   }
   const configured = Number.parseInt(process.env.PORT ?? "", 10);
   return Number.isFinite(configured) ? configured : 8080;
+}
+
+/**
+ * Resolve the Redis connection URL from options or the REDIS_URL environment
+ * variable. Falls back to the default local Redis.
+ */
+export function runtimeRedisUrl(options: Pick<BootstrapOptions, "redisUrl"> = {}): string {
+  return options.redisUrl ?? process.env.REDIS_URL ?? "redis://localhost:6379";
 }
 
 export async function bootstrap(options: BootstrapOptions = {}) {

--- a/services/offer-management/src/domain.ts
+++ b/services/offer-management/src/domain.ts
@@ -325,11 +325,11 @@ export class Offer {
     const offer = new Offer(snapshot);
     const event: OfferQuoted = deepFreeze({
       type: "OfferQuoted" as const,
-      eventId: `evt-${crypto.randomUUID()}`,
+      eventId: `evt-${uuidV7()}`,
       eventType: "OfferQuoted",
       schemaVersion: 1,
       occurredAt: new Date(command.quotedAt),
-      correlationId: `corr-${crypto.randomUUID()}`,
+      correlationId: `corr-${uuidV7()}`,
       producer: "offer-management",
       offerId: snapshot.offerId,
       offerVersion: snapshot.offerVersion,
@@ -393,11 +393,11 @@ export class Offer {
     }));
     const event: OfferExpired = deepFreeze({
       type: "OfferExpired" as const,
-      eventId: `evt-${crypto.randomUUID()}`,
+      eventId: `evt-${uuidV7()}`,
       eventType: "OfferExpired",
       schemaVersion: 1,
       occurredAt: new Date(at),
-      correlationId: `corr-${crypto.randomUUID()}`,
+      correlationId: `corr-${uuidV7()}`,
       producer: "offer-management",
       offerId: this.snapshot.offerId,
       offerVersion: this.snapshot.offerVersion,
@@ -660,4 +660,21 @@ function cloneForSnapshot<T>(value: T): T {
     return clone as T;
   }
   return value;
+}
+
+function uuidV7(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  const timestamp = BigInt(Date.now());
+
+  bytes[0] = Number((timestamp >> 40n) & 0xffn);
+  bytes[1] = Number((timestamp >> 32n) & 0xffn);
+  bytes[2] = Number((timestamp >> 24n) & 0xffn);
+  bytes[3] = Number((timestamp >> 16n) & 0xffn);
+  bytes[4] = Number((timestamp >> 8n) & 0xffn);
+  bytes[5] = Number(timestamp & 0xffn);
+  bytes[6] = (bytes[6] & 0x0f) | 0x70;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }

--- a/services/offer-management/src/index.ts
+++ b/services/offer-management/src/index.ts
@@ -3,7 +3,9 @@ export {
   health,
   metadata,
   opentelemetryInstrumentationFromEnv,
-  type ErrorEnvelope,
+  resetIdempotencyStore,
+  resetOfferStore,
+  type ErrorBody,
   type HealthStatus,
   type InstrumentationHooks,
   type ProbeStatus,
@@ -36,3 +38,20 @@ export {
   type ValidityWindow,
 } from "./domain.js";
 export { serviceProfile, type ServiceProfile } from "./profile.js";
+
+// Messaging ports
+export {
+  PublishFailed,
+  SubscribeFailed,
+  type EventEnvelope,
+  type EventHandler,
+  type EventPublisher,
+  type EventSubscriber,
+  type HandlerResult,
+} from "./ports/messaging.js";
+
+// Adapters (in-memory fakes for testing)
+export {
+  InMemoryEventPublisher,
+  InMemoryEventSubscriber,
+} from "./adapters/messaging/in-memory.js";

--- a/services/offer-management/src/index.ts
+++ b/services/offer-management/src/index.ts
@@ -15,7 +15,7 @@ export {
   type TraceResult,
   type TraceSpan,
 } from "./app.js";
-export { bootstrap, runtimeHost, runtimePort, type BootstrapOptions } from "./bootstrap.js";
+export { bootstrap, runtimeHost, runtimePort, runtimeRedisUrl, type BootstrapOptions } from "./bootstrap.js";
 export {
   DomainError,
   Offer,

--- a/services/offer-management/src/messaging.test.ts
+++ b/services/offer-management/src/messaging.test.ts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import { describe, it } from "node:test";
+
+import {
+  InMemoryEventPublisher,
+  InMemoryEventSubscriber,
+} from "./adapters/messaging/in-memory.js";
+import {
+  PublishFailed,
+  type EventEnvelope,
+  type EventHandler,
+} from "./ports/messaging.js";
+
+function makeEnvelope(overrides: Partial<EventEnvelope> = {}): EventEnvelope {
+  return {
+    eventId: `evt-${crypto.randomUUID()}`,
+    eventType: "OfferQuoted",
+    schemaVersion: 1,
+    producer: "offer-management",
+    correlationId: `corr-${crypto.randomUUID()}`,
+    occurredAt: new Date().toISOString(),
+    payload: {},
+    ...overrides,
+  };
+}
+
+describe("EventPublisher port — InMemoryEventPublisher", () => {
+  it("publishes an event and stores it in memory", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const envelope = makeEnvelope();
+
+    await publisher.publish(envelope);
+
+    assert.equal(publisher.published.length, 1);
+    assert.equal(publisher.published[0].eventId, envelope.eventId);
+  });
+
+  it("throws PublishFailed when failNext is set", async () => {
+    const publisher = new InMemoryEventPublisher();
+    publisher.failNext = true;
+
+    await assert.rejects(
+      () => publisher.publish(makeEnvelope()),
+      PublishFailed,
+    );
+  });
+
+  it("wraps events in a correct envelope with all required fields", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const eventId = `evt-${crypto.randomUUID()}`;
+    const correlationId = `corr-${crypto.randomUUID()}`;
+    const envelope = makeEnvelope({
+      eventId,
+      eventType: "OfferQuoted",
+      schemaVersion: 1,
+      producer: "offer-management",
+      correlationId,
+      occurredAt: "2026-07-05T10:30:00.000Z",
+      causationId: "cmd-123",
+      payload: {
+        offerId: "off-abc",
+        offerVersion: 1,
+        total: { currency: "CNY", minorUnits: 10400 },
+      },
+    });
+
+    await publisher.publish(envelope);
+
+    assert.equal(publisher.published.length, 1);
+    const saved = publisher.published[0];
+    assert.equal(saved.eventId, eventId);
+    assert.equal(saved.eventType, "OfferQuoted");
+    assert.equal(saved.schemaVersion, 1);
+    assert.equal(saved.producer, "offer-management");
+    assert.equal(saved.correlationId, correlationId);
+    assert.equal(saved.causationId, "cmd-123");
+    assert.equal(saved.occurredAt, "2026-07-05T10:30:00.000Z");
+    assert.deepEqual(saved.payload, {
+      offerId: "off-abc",
+      offerVersion: 1,
+      total: { currency: "CNY", minorUnits: 10400 },
+    });
+  });
+
+  it("supports findByProducer and findByEventType convenience methods", async () => {
+    const publisher = new InMemoryEventPublisher();
+
+    await publisher.publish(makeEnvelope({ eventType: "OfferQuoted", producer: "offer-management" }));
+    await publisher.publish(makeEnvelope({ eventType: "OfferExpired", producer: "offer-management" }));
+    await publisher.publish(makeEnvelope({ eventType: "OfferQuoted", producer: "other-service" }));
+
+    assert.equal(publisher.findByProducer("offer-management").length, 2);
+    assert.equal(publisher.findByProducer("other-service").length, 1);
+    assert.equal(publisher.findByEventType("OfferQuoted").length, 2);
+    assert.equal(publisher.findByEventType("OfferExpired").length, 1);
+  });
+});
+
+describe("EventSubscriber port — InMemoryEventSubscriber", () => {
+  it("calls the handler with received events", async () => {
+    const subscriber = new InMemoryEventSubscriber();
+    const received: EventEnvelope[] = [];
+    const handler: EventHandler = async (env) => {
+      received.push(env);
+      return "ack";
+    };
+
+    const signal = new AbortController().signal;
+    await subscriber.subscribe(["events:test"], "test-group", "test-consumer", handler, signal);
+
+    const envelope = makeEnvelope();
+    const result = await subscriber.simulateEvent(envelope);
+
+    assert.equal(result, "ack");
+    assert.equal(received.length, 1);
+    assert.equal(received[0].eventId, envelope.eventId);
+  });
+
+  it("deduplicates a duplicate eventId via handler returning ack for already-seen ids", async () => {
+    const subscriber = new InMemoryEventSubscriber();
+    const seen = new Set<string>();
+    const handler: EventHandler = async (env) => {
+      if (seen.has(env.eventId)) {
+        return "ack"; // already processed, ack and skip
+      }
+      seen.add(env.eventId);
+      return "ack";
+    };
+
+    const signal = new AbortController().signal;
+    await subscriber.subscribe(["events:test"], "test-group", "test-consumer", handler, signal);
+
+    const envelope = makeEnvelope();
+    const result1 = await subscriber.simulateEvent(envelope);
+    assert.equal(result1, "ack");
+    assert.equal(seen.size, 1);
+
+    // Same eventId again
+    const result2 = await subscriber.simulateEvent(envelope);
+    assert.equal(result2, "ack");
+    assert.equal(seen.size, 1); // should not have added again
+  });
+
+  it("returns retry for transient errors and dlq for fatal errors", async () => {
+    const subscriber = new InMemoryEventSubscriber();
+    let callCount = 0;
+    const handler: EventHandler = async () => {
+      callCount++;
+      if (callCount === 1) return "retry";
+      if (callCount === 2) return "dlq";
+      return "ack";
+    };
+
+    const signal = new AbortController().signal;
+    await subscriber.subscribe(["events:test"], "test-group", "test-consumer", handler, signal);
+
+    const envelope = makeEnvelope();
+
+    assert.equal(await subscriber.simulateEvent(envelope), "retry");
+    assert.equal(callCount, 1);
+
+    assert.equal(await subscriber.simulateEvent(envelope), "dlq");
+    assert.equal(callCount, 2);
+
+    assert.equal(await subscriber.simulateEvent(envelope), "ack");
+    assert.equal(callCount, 3);
+  });
+});

--- a/services/offer-management/src/messaging.test.ts
+++ b/services/offer-management/src/messaging.test.ts
@@ -6,6 +6,7 @@ import {
   InMemoryEventPublisher,
   InMemoryEventSubscriber,
 } from "./adapters/messaging/in-memory.js";
+import { RedisEventSubscriber } from "./adapters/messaging/subscriber.js";
 import {
   PublishFailed,
   type EventEnvelope,
@@ -167,3 +168,53 @@ describe("EventSubscriber port — InMemoryEventSubscriber", () => {
     assert.equal(callCount, 3);
   });
 });
+
+
+describe("RedisEventSubscriber recovery", () => {
+  it("uses Redis pending delivery counts for XAUTOCLAIM recovery DLQ decisions", async () => {
+    const envelope = makeEnvelope({ eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c222" });
+    const redis = new FakeRedisForRecovery("5-0", JSON.stringify(envelope), 5);
+    const subscriber = new RedisEventSubscriber(redis as never);
+
+    await (subscriber as unknown as { claimAndProcess: (stream: string, group: string, consumer: string, handler: EventHandler) => Promise<void> })
+      .claimAndProcess("events:fare-pricing", "offer-management", "offer-management-test", async () => {
+        throw new Error("handler should not run for poison message");
+      });
+
+    assert.deepEqual(redis.xpendingCalls, [["events:fare-pricing", "offer-management", "5-0", "5-0", 1]]);
+    assert.equal(redis.xaddCalls.length, 1);
+    assert.equal(redis.xaddCalls[0][0], "events:fare-pricing:dlq");
+    assert.deepEqual(redis.xackCalls, [["events:fare-pricing", "offer-management", "5-0"]]);
+  });
+});
+
+class FakeRedisForRecovery {
+  readonly xaddCalls: unknown[][] = [];
+  readonly xackCalls: unknown[][] = [];
+  readonly xpendingCalls: unknown[][] = [];
+
+  constructor(
+    private readonly entryId: string,
+    private readonly envelopeJson: string,
+    private readonly deliveryCount: number,
+  ) {}
+
+  async xautoclaim(): Promise<unknown[]> {
+    return ["0-0", [[this.entryId, ["envelope", this.envelopeJson]]]];
+  }
+
+  async xpending(...args: unknown[]): Promise<unknown[]> {
+    this.xpendingCalls.push(args);
+    return [[this.entryId, "offer-management-test", 60000, this.deliveryCount]];
+  }
+
+  async xadd(...args: unknown[]): Promise<string> {
+    this.xaddCalls.push(args);
+    return "6-0";
+  }
+
+  async xack(...args: unknown[]): Promise<number> {
+    this.xackCalls.push(args);
+    return 1;
+  }
+}

--- a/services/offer-management/src/messaging.test.ts
+++ b/services/offer-management/src/messaging.test.ts
@@ -107,7 +107,7 @@ describe("EventSubscriber port — InMemoryEventSubscriber", () => {
     };
 
     const signal = new AbortController().signal;
-    await subscriber.subscribe(["events:test"], "test-group", "test-consumer", handler, signal);
+    await subscriber.subscribe(["test-stream"], "test-group", "test-consumer", handler, signal);
 
     const envelope = makeEnvelope();
     const result = await subscriber.simulateEvent(envelope);
@@ -129,7 +129,7 @@ describe("EventSubscriber port — InMemoryEventSubscriber", () => {
     };
 
     const signal = new AbortController().signal;
-    await subscriber.subscribe(["events:test"], "test-group", "test-consumer", handler, signal);
+    await subscriber.subscribe(["test-stream"], "test-group", "test-consumer", handler, signal);
 
     const envelope = makeEnvelope();
     const result1 = await subscriber.simulateEvent(envelope);
@@ -153,7 +153,7 @@ describe("EventSubscriber port — InMemoryEventSubscriber", () => {
     };
 
     const signal = new AbortController().signal;
-    await subscriber.subscribe(["events:test"], "test-group", "test-consumer", handler, signal);
+    await subscriber.subscribe(["test-stream"], "test-group", "test-consumer", handler, signal);
 
     const envelope = makeEnvelope();
 

--- a/services/offer-management/src/messaging.test.ts
+++ b/services/offer-management/src/messaging.test.ts
@@ -7,6 +7,7 @@ import {
   InMemoryEventSubscriber,
 } from "./adapters/messaging/in-memory.js";
 import { RedisEventSubscriber } from "./adapters/messaging/subscriber.js";
+import { dlqStreamKey, streamKey } from "./adapters/messaging/stream-config.js";
 import {
   PublishFailed,
   type EventEnvelope,
@@ -15,15 +16,32 @@ import {
 
 function makeEnvelope(overrides: Partial<EventEnvelope> = {}): EventEnvelope {
   return {
-    eventId: `evt-${crypto.randomUUID()}`,
+    eventId: `evt-${uuidV7()}`,
     eventType: "OfferQuoted",
     schemaVersion: 1,
     producer: "offer-management",
-    correlationId: `corr-${crypto.randomUUID()}`,
+    correlationId: `corr-${uuidV7()}`,
     occurredAt: new Date().toISOString(),
     payload: {},
     ...overrides,
   };
+}
+
+function uuidV7(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  const timestamp = BigInt(Date.now());
+
+  bytes[0] = Number((timestamp >> 40n) & 0xffn);
+  bytes[1] = Number((timestamp >> 32n) & 0xffn);
+  bytes[2] = Number((timestamp >> 24n) & 0xffn);
+  bytes[3] = Number((timestamp >> 16n) & 0xffn);
+  bytes[4] = Number((timestamp >> 8n) & 0xffn);
+  bytes[5] = Number(timestamp & 0xffn);
+  bytes[6] = (bytes[6] & 0x0f) | 0x70;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
 describe("EventPublisher port — InMemoryEventPublisher", () => {
@@ -49,8 +67,8 @@ describe("EventPublisher port — InMemoryEventPublisher", () => {
 
   it("wraps events in a correct envelope with all required fields", async () => {
     const publisher = new InMemoryEventPublisher();
-    const eventId = `evt-${crypto.randomUUID()}`;
-    const correlationId = `corr-${crypto.randomUUID()}`;
+    const eventId = `evt-${uuidV7()}`;
+    const correlationId = `corr-${uuidV7()}`;
     const envelope = makeEnvelope({
       eventId,
       eventType: "OfferQuoted",
@@ -82,6 +100,55 @@ describe("EventPublisher port — InMemoryEventPublisher", () => {
       offerVersion: 1,
       total: { currency: "CNY", minorUnits: 10400 },
     });
+  });
+
+  it("serializes OfferQuoted payload using exactly the contract fields", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const payload = {
+      offerId: `off-${uuidV7()}`,
+      offerVersion: 1,
+      quoteRequestId: "quote-1",
+      accountId: "account-1",
+      channelId: "web",
+      itineraryId: "itin-456",
+      itineraryVersion: "itinerary-v1",
+      travelerSetHash: "tvl-001,tvl-002",
+      availabilitySnapshotRefs: ["availability-1"],
+      priceSnapshotRef: "price-1",
+      fareQuoteRefs: ["fq-1"],
+      ruleSnapshotRefs: ["rule-1"],
+      total: { currency: "CNY", minorUnits: 20000 },
+      expiresAt: "2026-07-05T10:30:00.000Z",
+      priceGuaranteeLevel: "FIXED_UNTIL_EXPIRY",
+      downstreamReference: {
+        offerId: `off-${uuidV7()}`,
+        offerVersion: 1,
+        priceSnapshotRef: "price-1",
+        ruleSnapshotRef: "rule-1",
+      },
+    };
+
+    await publisher.publish(makeEnvelope({ eventType: "OfferQuoted", payload }));
+
+    assert.deepEqual(Object.keys(publisher.published[0].payload).sort(), [
+      "accountId",
+      "availabilitySnapshotRefs",
+      "channelId",
+      "downstreamReference",
+      "expiresAt",
+      "fareQuoteRefs",
+      "itineraryId",
+      "itineraryVersion",
+      "offerId",
+      "offerVersion",
+      "priceGuaranteeLevel",
+      "priceSnapshotRef",
+      "quoteRequestId",
+      "ruleSnapshotRefs",
+      "total",
+      "travelerSetHash",
+    ].sort());
+    assert.equal(Object.hasOwn(publisher.published[0].payload, "boundaryProof"), false);
   });
 
   it("supports findByProducer and findByEventType convenience methods", async () => {
@@ -176,15 +243,18 @@ describe("RedisEventSubscriber recovery", () => {
     const redis = new FakeRedisForRecovery("5-0", JSON.stringify(envelope), 5);
     const subscriber = new RedisEventSubscriber(redis as never);
 
+    const sourceStream = streamKey("fare-pricing");
+    const group = "offer-management";
+
     await (subscriber as unknown as { claimAndProcess: (stream: string, group: string, consumer: string, handler: EventHandler) => Promise<void> })
-      .claimAndProcess("events:fare-pricing", "offer-management", "offer-management-test", async () => {
+      .claimAndProcess(sourceStream, group, "offer-management-test", async () => {
         throw new Error("handler should not run for poison message");
       });
 
-    assert.deepEqual(redis.xpendingCalls, [["events:fare-pricing", "offer-management", "5-0", "5-0", 1]]);
+    assert.deepEqual(redis.xpendingCalls, [[sourceStream, group, "5-0", "5-0", 1]]);
     assert.equal(redis.xaddCalls.length, 1);
-    assert.equal(redis.xaddCalls[0][0], "events:fare-pricing:dlq");
-    assert.deepEqual(redis.xackCalls, [["events:fare-pricing", "offer-management", "5-0"]]);
+    assert.equal(redis.xaddCalls[0][0], dlqStreamKey("fare-pricing"));
+    assert.deepEqual(redis.xackCalls, [[sourceStream, group, "5-0"]]);
   });
 });
 

--- a/services/offer-management/src/ports/messaging.ts
+++ b/services/offer-management/src/ports/messaging.ts
@@ -1,0 +1,78 @@
+// ---------------------------------------------------------------------------
+// EventEnvelope — shared envelope for all domain events
+// Per shared-primitives.md §1 and messaging.md Abstract Ports
+// ---------------------------------------------------------------------------
+
+export type EventEnvelope = Readonly<{
+  eventId: string;
+  eventType: string;
+  schemaVersion: number;
+  producer: string;
+  causationId?: string;
+  correlationId: string;
+  occurredAt: string;
+  payload: Record<string, unknown>;
+}>;
+
+// ---------------------------------------------------------------------------
+// EventPublisher port — application layer depends ONLY on this interface
+// ---------------------------------------------------------------------------
+
+export class PublishFailed extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = "PublishFailed";
+  }
+}
+
+export interface EventPublisher {
+  /**
+   * Publish a domain event to the event bus.
+   *
+   * - The implementation MUST determine the target stream from the `producer`
+   *   field of the envelope (stream = "events:<producer>").
+   * - The implementation MUST serialize the entire envelope as a single JSON
+   *   value in the "envelope" field of the Redis Stream entry.
+   * - The implementation MUST apply the retention policy (MAXLEN ~ 100000).
+   * - On transient failure, retry with exponential backoff (3 attempts).
+   * - On persistent failure, throw PublishFailed.
+   */
+  publish(envelope: EventEnvelope): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// EventSubscriber port — application layer depends ONLY on this interface
+// ---------------------------------------------------------------------------
+
+export class SubscribeFailed extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = "SubscribeFailed";
+  }
+}
+
+export type HandlerResult = "ack" | "retry" | "dlq";
+
+/**
+ * Event handler callback — returns a result indicating how the adapter
+ * should handle the message (ack, retry, or move to DLQ).
+ */
+export type EventHandler = (envelope: EventEnvelope) => Promise<HandlerResult>;
+
+export interface EventSubscriber {
+  /**
+   * Subscribe to one or more event streams as a consumer group member.
+   *
+   * The implementation runs in the background and calls the handler for each
+   * received message. The handler returns ack/retry/dlq to guide ack behaviour.
+   *
+   * Lifecycle: the subscriber runs until the provided AbortSignal is triggered.
+   */
+  subscribe(
+    streams: readonly string[],
+    group: string,
+    consumerName: string,
+    handler: EventHandler,
+    signal: AbortSignal,
+  ): Promise<void>;
+}

--- a/services/offer-management/src/ports/messaging.ts
+++ b/services/offer-management/src/ports/messaging.ts
@@ -30,7 +30,7 @@ export interface EventPublisher {
    * Publish a domain event to the event bus.
    *
    * - The implementation MUST determine the target stream from the `producer`
-   *   field of the envelope (stream = "events:<producer>").
+   *   field of the envelope.
    * - The implementation MUST serialize the entire envelope as a single JSON
    *   value in the "envelope" field of the Redis Stream entry.
    * - The implementation MUST apply the retention policy (MAXLEN ~ 100000).


### PR DESCRIPTION
Implements the HTTP API and Redis Streams event bus adapter for the offer-management service.

## Changes

1. **HTTP API** — POST /api/v1/offers (idempotent) and GET /api/v1/offers/:offerId
   - Canonical error body per docs/08-contracts/api/README.md
   - Idempotency-Key required on POST, replay returns original result
   - X-Correlation-Id propagation
   - Validation with proper error codes (VALIDATION_FAILED, IDEMPOTENCY_KEY_REUSED, NOT_FOUND)

2. **Messaging ports** — EventPublisher / EventSubscriber interfaces in src/ports/messaging.ts

3. **Redis Streams adapter** — src/adapters/messaging/ (ioredis only here)
   - Publisher: XADD with MAXLEN ~ 100000, exponential backoff retry
   - Subscriber: XREADGROUP, XACK, XAUTOCLAIM recovery, DLQ after 5 attempts
   - Stream config centralizes all stream-key strings

4. **In-memory fakes** for testing without live Redis

5. **Tests** — 29 tests covering all endpoints, validation, idempotency, messaging ports