### PR TITLE
REQ-035: booking-orchestration HTTP API and event bus adapter

### DIFF
--- a/services/booking-orchestration/pom.xml
+++ b/services/booking-orchestration/pom.xml
@@ -27,6 +27,15 @@
       <version>1.46.0</version>
     </dependency>
     <dependency>
+      <groupId>io.lettuce</groupId>
+      <artifactId>lettuce-core</artifactId>
+      <version>6.5.5.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/BookingOrchestrationConfig.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/BookingOrchestrationConfig.java
@@ -1,0 +1,16 @@
+package com.trainticket.bookingorchestration;
+
+import com.trainticket.bookingorchestration.adapters.messaging.InMemoryEventPublisher;
+import com.trainticket.bookingorchestration.application.EventPublisher;
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BookingOrchestrationConfig {
+    @Bean
+    public Clock clock() { return Clock.systemUTC(); }
+
+    @Bean
+    public EventPublisher eventPublisher() { return new InMemoryEventPublisher(); }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/BookingOrchestrationConfig.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/BookingOrchestrationConfig.java
@@ -3,14 +3,26 @@ package com.trainticket.bookingorchestration;
 import com.trainticket.bookingorchestration.adapters.messaging.InMemoryEventPublisher;
 import com.trainticket.bookingorchestration.application.EventPublisher;
 import java.time.Clock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class BookingOrchestrationConfig {
-    @Bean
-    public Clock clock() { return Clock.systemUTC(); }
+
+    private static final Logger log = LoggerFactory.getLogger(BookingOrchestrationConfig.class);
 
     @Bean
-    public EventPublisher eventPublisher() { return new InMemoryEventPublisher(); }
+    public Clock clock() {
+        return Clock.systemUTC();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(EventPublisher.class)
+    public EventPublisher inMemoryEventPublisher() {
+        log.info("Using InMemoryEventPublisher (no Redis publisher bean defined)");
+        return new InMemoryEventPublisher();
+    }
 }

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/BookingOrchestrationConfig.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/BookingOrchestrationConfig.java
@@ -1,28 +1,15 @@
 package com.trainticket.bookingorchestration;
 
-import com.trainticket.bookingorchestration.adapters.messaging.InMemoryEventPublisher;
-import com.trainticket.bookingorchestration.application.EventPublisher;
 import java.time.Clock;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class BookingOrchestrationConfig {
 
-    private static final Logger log = LoggerFactory.getLogger(BookingOrchestrationConfig.class);
-
     @Bean
     public Clock clock() {
         return Clock.systemUTC();
     }
 
-    @Bean
-    @ConditionalOnMissingBean(EventPublisher.class)
-    public EventPublisher inMemoryEventPublisher() {
-        log.info("Using InMemoryEventPublisher (no Redis publisher bean defined)");
-        return new InMemoryEventPublisher();
-    }
 }

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/HealthController.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/HealthController.java
@@ -18,7 +18,7 @@ public class HealthController {
         this.clock = clock;
     }
 
-    @GetMapping("/health")
+    @GetMapping({"/health", "/healthz"})
     public Map<String, Object> health() {
         return Map.of("status", "ok", "service", Application.profile());
     }

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/RequestContextFilter.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/RequestContextFilter.java
@@ -30,6 +30,8 @@ public class RequestContextFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
         String requestId = headerOrGenerated(request, REQUEST_ID_HEADER);
         String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, requestId);
+        request.setAttribute(REQUEST_ID_HEADER, requestId);
+        request.setAttribute(CORRELATION_ID_HEADER, correlationId);
         RequestTraceContext context = new RequestTraceContext(
             requestId,
             correlationId,

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/InMemoryEventPublisher.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/InMemoryEventPublisher.java
@@ -1,0 +1,23 @@
+package com.trainticket.bookingorchestration.adapters.messaging;
+
+import com.trainticket.bookingorchestration.application.EventEnvelope;
+import com.trainticket.bookingorchestration.application.EventPublisher;
+import java.util.ArrayList;
+import java.util.List;
+
+public class InMemoryEventPublisher implements EventPublisher {
+    private final List<EventEnvelope> published = new ArrayList<>();
+
+    @Override
+    public void publish(EventEnvelope envelope) {
+        published.add(envelope);
+    }
+
+    public List<EventEnvelope> getPublished() {
+        return List.copyOf(published);
+    }
+
+    public void clear() {
+        published.clear();
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/InMemoryEventSubscriber.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/InMemoryEventSubscriber.java
@@ -1,0 +1,47 @@
+package com.trainticket.bookingorchestration.adapters.messaging;
+
+import com.trainticket.bookingorchestration.application.EventEnvelope;
+import com.trainticket.bookingorchestration.application.EventSubscriber;
+import com.trainticket.bookingorchestration.application.HandlerResult;
+import com.trainticket.bookingorchestration.application.SubscriberConfig;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory EventSubscriber for testing — no Redis required.
+ * Implements the same dedup-by-eventId logic as RedisStreamsEventSubscriber
+ * so that dedup behaviour can be verified in unit tests.
+ */
+public class InMemoryEventSubscriber implements EventSubscriber {
+
+    private final Set<String> consumedEventIds = ConcurrentHashMap.newKeySet();
+    private volatile SubscriberConfig currentConfig;
+
+    @Override
+    public void subscribe(SubscriberConfig config) {
+        this.currentConfig = config;
+    }
+
+    /**
+     * Simulate receiving and processing a single event, including dedup.
+     * Returns the HandlerResult, or null if the event was deduplicated.
+     */
+    public HandlerResult receive(EventEnvelope envelope) {
+        if (consumedEventIds.contains(envelope.eventId())) {
+            return null; // deduplicated
+        }
+        HandlerResult result = currentConfig.handler().apply(envelope);
+        if (result instanceof HandlerResult.Success) {
+            consumedEventIds.add(envelope.eventId());
+        }
+        return result;
+    }
+
+    public boolean hasConsumed(String eventId) {
+        return consumedEventIds.contains(eventId);
+    }
+
+    public void reset() {
+        consumedEventIds.clear();
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisEventBusInitializer.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisEventBusInitializer.java
@@ -1,11 +1,9 @@
 package com.trainticket.bookingorchestration.adapters.messaging;
 
-import com.trainticket.bookingorchestration.application.EventEnvelope;
-import com.trainticket.bookingorchestration.application.HandlerResult;
+import com.trainticket.bookingorchestration.application.BookingOrchestrationService;
 import com.trainticket.bookingorchestration.application.SubscriberConfig;
 import jakarta.annotation.PostConstruct;
 import java.util.List;
-import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,18 +21,19 @@ public class RedisEventBusInitializer {
     private static final Logger log = LoggerFactory.getLogger(RedisEventBusInitializer.class);
 
     private final RedisStreamsEventSubscriber subscriber;
+    private final BookingOrchestrationService bookingService;
     private final String consumerName;
 
     public RedisEventBusInitializer(RedisStreamsEventSubscriber subscriber,
-                                    @Value("${booking-orchestration.subscriber.consumer-name}") String consumerName) {
+                                    BookingOrchestrationService bookingService,
+                                    @Value("${booking-orchestration.subscriber.consumer-name:booking-orchestration-local}") String consumerName) {
         this.subscriber = subscriber;
+        this.bookingService = bookingService;
         this.consumerName = consumerName;
     }
 
     @PostConstruct
     public void startSubscriber() {
-        log.info("Starting booking-orchestration event bus subscriber as '{}'", consumerName);
-
         List<String> streams = List.of(
             "events:capacity-availability",
             "events:journey-order",
@@ -43,21 +42,14 @@ public class RedisEventBusInitializer {
             "events:entitlement-ticketing"
         );
 
-        Function<EventEnvelope, HandlerResult> handler = envelope -> {
-            log.debug("Received event: {} (id={})", envelope.eventType(), envelope.eventId());
-            // Domain event handling will be wired in future iterations.
-            // For now, acknowledge all events.
-            return new HandlerResult.Success();
-        };
-
         SubscriberConfig config = new SubscriberConfig(
             streams,
             "booking-orchestration",
             consumerName,
-            handler
+            bookingService::handleUpstreamEvent
         );
 
         subscriber.subscribe(config);
-        log.info("Event bus subscriber started for streams: {}", streams);
+        log.info("Event bus subscriber started for booking-orchestration");
     }
 }

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisEventBusInitializer.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisEventBusInitializer.java
@@ -1,0 +1,63 @@
+package com.trainticket.bookingorchestration.adapters.messaging;
+
+import com.trainticket.bookingorchestration.application.EventEnvelope;
+import com.trainticket.bookingorchestration.application.HandlerResult;
+import com.trainticket.bookingorchestration.application.SubscriberConfig;
+import jakarta.annotation.PostConstruct;
+import java.util.List;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Component;
+
+/**
+ * Wires the Redis Streams subscriber on startup when a RedisClient is available.
+ * Subscribes to all streams relevant to booking-orchestration per the messaging contract.
+ */
+@Component
+@ConditionalOnBean(RedisStreamsEventSubscriber.class)
+public class RedisEventBusInitializer {
+
+    private static final Logger log = LoggerFactory.getLogger(RedisEventBusInitializer.class);
+
+    private final RedisStreamsEventSubscriber subscriber;
+    private final String consumerName;
+
+    public RedisEventBusInitializer(RedisStreamsEventSubscriber subscriber,
+                                    @Value("${booking-orchestration.subscriber.consumer-name}") String consumerName) {
+        this.subscriber = subscriber;
+        this.consumerName = consumerName;
+    }
+
+    @PostConstruct
+    public void startSubscriber() {
+        log.info("Starting booking-orchestration event bus subscriber as '{}'", consumerName);
+
+        List<String> streams = List.of(
+            "events:capacity-availability",
+            "events:journey-order",
+            "events:payment",
+            "events:provider-integration",
+            "events:entitlement-ticketing"
+        );
+
+        Function<EventEnvelope, HandlerResult> handler = envelope -> {
+            log.debug("Received event: {} (id={})", envelope.eventType(), envelope.eventId());
+            // Domain event handling will be wired in future iterations.
+            // For now, acknowledge all events.
+            return new HandlerResult.Success();
+        };
+
+        SubscriberConfig config = new SubscriberConfig(
+            streams,
+            "booking-orchestration",
+            consumerName,
+            handler
+        );
+
+        subscriber.subscribe(config);
+        log.info("Event bus subscriber started for streams: {}", streams);
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisMessagingConfig.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisMessagingConfig.java
@@ -5,7 +5,6 @@ import io.lettuce.core.RedisClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,22 +13,20 @@ import org.springframework.context.annotation.Configuration;
  * never outside the adapters/messaging/ package.
  */
 @Configuration
-@ConditionalOnProperty("REDIS_URL")
 public class RedisMessagingConfig {
 
     private static final Logger log = LoggerFactory.getLogger(RedisMessagingConfig.class);
 
-    @Bean
-    public RedisClient redisClient(@Value("${REDIS_URL}") String redisUrl) {
-        log.info("Connecting to Redis at {}", redisUrl);
+    @Bean(destroyMethod = "shutdown")
+    public RedisClient redisClient(@Value("${REDIS_URL:redis://localhost:6379}") String redisUrl) {
+        log.info("Connecting to Redis Streams event bus");
         return RedisClient.create(redisUrl);
     }
 
     @Bean(destroyMethod = "shutdown")
     public EventPublisher redisEventPublisher(RedisClient redisClient) {
         log.info("Using RedisStreamsEventPublisher");
-        RedisStreamsEventPublisher publisher = new RedisStreamsEventPublisher(redisClient);
-        return publisher;
+        return new RedisStreamsEventPublisher(redisClient);
     }
 
     @Bean(destroyMethod = "shutdown")

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisMessagingConfig.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisMessagingConfig.java
@@ -1,0 +1,40 @@
+package com.trainticket.bookingorchestration.adapters.messaging;
+
+import com.trainticket.bookingorchestration.application.EventPublisher;
+import io.lettuce.core.RedisClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Redis Streams messaging configuration — all Redis types live here,
+ * never outside the adapters/messaging/ package.
+ */
+@Configuration
+@ConditionalOnProperty("REDIS_URL")
+public class RedisMessagingConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(RedisMessagingConfig.class);
+
+    @Bean
+    public RedisClient redisClient(@Value("${REDIS_URL}") String redisUrl) {
+        log.info("Connecting to Redis at {}", redisUrl);
+        return RedisClient.create(redisUrl);
+    }
+
+    @Bean(destroyMethod = "shutdown")
+    public EventPublisher redisEventPublisher(RedisClient redisClient) {
+        log.info("Using RedisStreamsEventPublisher");
+        RedisStreamsEventPublisher publisher = new RedisStreamsEventPublisher(redisClient);
+        return publisher;
+    }
+
+    @Bean(destroyMethod = "shutdown")
+    public RedisStreamsEventSubscriber redisEventSubscriber(RedisClient redisClient) {
+        log.info("Using RedisStreamsEventSubscriber");
+        return new RedisStreamsEventSubscriber(redisClient);
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisStreamsEventPublisher.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisStreamsEventPublisher.java
@@ -1,5 +1,6 @@
 package com.trainticket.bookingorchestration.adapters.messaging;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -33,7 +34,8 @@ public class RedisStreamsEventPublisher implements EventPublisher {
         this.commands = connection.sync();
         this.objectMapper = new ObjectMapper()
             .registerModule(new JavaTimeModule())
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL);
     }
 
     @Override

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisStreamsEventPublisher.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisStreamsEventPublisher.java
@@ -9,6 +9,7 @@ import com.trainticket.bookingorchestration.application.EventPublisher;
 import com.trainticket.bookingorchestration.application.PublishFailed;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisException;
+import io.lettuce.core.XAddArgs;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.sync.RedisCommands;
 import java.time.Duration;
@@ -23,13 +24,11 @@ public class RedisStreamsEventPublisher implements EventPublisher {
     private static final int MAX_RETRIES = 3;
     private static final Duration BASE_BACKOFF = Duration.ofMillis(100);
 
-    private final RedisClient redisClient;
     private final StatefulRedisConnection<String, String> connection;
     private final RedisCommands<String, String> commands;
     private final ObjectMapper objectMapper;
 
     public RedisStreamsEventPublisher(RedisClient redisClient) {
-        this.redisClient = redisClient;
         this.connection = redisClient.connect();
         this.commands = connection.sync();
         this.objectMapper = new ObjectMapper()
@@ -50,12 +49,8 @@ public class RedisStreamsEventPublisher implements EventPublisher {
         RedisException lastException = null;
         for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
             try {
-                commands.xadd(stream, Map.of("envelope", envelopeJson));
-                try {
-                    commands.xtrim(stream, true, MAXLEN);
-                } catch (Exception ignored) {
-                    // Trimming is best-effort
-                }
+                var args = XAddArgs.Builder.maxlen(MAXLEN);
+                commands.xadd(stream, args, Map.of("envelope", envelopeJson));
                 return;
             } catch (RedisException e) {
                 lastException = e;
@@ -80,8 +75,10 @@ public class RedisStreamsEventPublisher implements EventPublisher {
         }
     }
 
+    /**
+     * Close only the connection — the RedisClient is shared and managed elsewhere.
+     */
     public void shutdown() {
         if (connection != null) connection.close();
-        if (redisClient != null) redisClient.shutdown();
     }
 }

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisStreamsEventPublisher.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisStreamsEventPublisher.java
@@ -1,0 +1,87 @@
+package com.trainticket.bookingorchestration.adapters.messaging;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.trainticket.bookingorchestration.application.EventEnvelope;
+import com.trainticket.bookingorchestration.application.EventPublisher;
+import com.trainticket.bookingorchestration.application.PublishFailed;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisException;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+import java.time.Duration;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RedisStreamsEventPublisher implements EventPublisher {
+
+    private static final Logger log = LoggerFactory.getLogger(RedisStreamsEventPublisher.class);
+    private static final long MAXLEN = 100_000L;
+    private static final int MAX_RETRIES = 3;
+    private static final Duration BASE_BACKOFF = Duration.ofMillis(100);
+
+    private final RedisClient redisClient;
+    private final StatefulRedisConnection<String, String> connection;
+    private final RedisCommands<String, String> commands;
+    private final ObjectMapper objectMapper;
+
+    public RedisStreamsEventPublisher(RedisClient redisClient) {
+        this.redisClient = redisClient;
+        this.connection = redisClient.connect();
+        this.commands = connection.sync();
+        this.objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    @Override
+    public void publish(EventEnvelope envelope) {
+        String stream = "events:" + envelope.producer();
+        String envelopeJson;
+        try {
+            envelopeJson = objectMapper.writeValueAsString(envelope);
+        } catch (JsonProcessingException e) {
+            throw new PublishFailed("Failed to serialize event envelope", e);
+        }
+
+        RedisException lastException = null;
+        for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                commands.xadd(stream, Map.of("envelope", envelopeJson));
+                try {
+                    commands.xtrim(stream, true, MAXLEN);
+                } catch (Exception ignored) {
+                    // Trimming is best-effort
+                }
+                return;
+            } catch (RedisException e) {
+                lastException = e;
+                log.warn("Failed to publish event to stream {} (attempt {}/{}): {}",
+                    stream, attempt, MAX_RETRIES, e.getMessage());
+                if (attempt < MAX_RETRIES) {
+                    sleepWithBackoff(attempt);
+                }
+            }
+        }
+        throw new PublishFailed(
+            "Failed to publish event to stream " + stream + " after " + MAX_RETRIES + " attempts",
+            lastException);
+    }
+
+    private void sleepWithBackoff(int attempt) {
+        try {
+            Thread.sleep(BASE_BACKOFF.multipliedBy(1L << (attempt - 1)).toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PublishFailed("Interrupted during backoff", e);
+        }
+    }
+
+    public void shutdown() {
+        if (connection != null) connection.close();
+        if (redisClient != null) redisClient.shutdown();
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisStreamsEventSubscriber.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisStreamsEventSubscriber.java
@@ -1,0 +1,276 @@
+package com.trainticket.bookingorchestration.adapters.messaging;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.trainticket.bookingorchestration.application.EventEnvelope;
+import com.trainticket.bookingorchestration.application.EventSubscriber;
+import com.trainticket.bookingorchestration.application.HandlerResult;
+import com.trainticket.bookingorchestration.application.SubscribeFailed;
+import com.trainticket.bookingorchestration.application.SubscriberConfig;
+import io.lettuce.core.Consumer;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisException;
+import io.lettuce.core.StreamMessage;
+import io.lettuce.core.XAddArgs;
+import io.lettuce.core.XAutoClaimArgs;
+import io.lettuce.core.XGroupCreateArgs;
+import io.lettuce.core.XReadArgs;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RedisStreamsEventSubscriber implements EventSubscriber {
+
+    private static final Logger log = LoggerFactory.getLogger(RedisStreamsEventSubscriber.class);
+    private static final int POLL_COUNT = 10;
+    private static final int BLOCK_MS = 2000;
+    private static final Duration RECOVERY_INTERVAL = Duration.ofSeconds(60);
+    private static final int MAX_DELIVERY_ATTEMPTS = 5;
+    private static final long MIN_IDLE_MS = 60_000L;
+    private static final long MAXLEN = 100_000L;
+
+    private final RedisClient redisClient;
+    private final StatefulRedisConnection<String, String> connection;
+    private final RedisCommands<String, String> commands;
+    private final ObjectMapper objectMapper;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private final Set<String> consumedEventIds = ConcurrentHashMap.newKeySet();
+    private ExecutorService executor;
+    private volatile SubscriberConfig currentConfig;
+
+    public RedisStreamsEventSubscriber(RedisClient redisClient) {
+        this.redisClient = redisClient;
+        this.connection = redisClient.connect();
+        this.commands = connection.sync();
+        this.objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    @Override
+    public void subscribe(SubscriberConfig config) {
+        if (!running.compareAndSet(false, true)) {
+            throw new SubscribeFailed("Subscriber is already running");
+        }
+        this.currentConfig = config;
+
+        for (String stream : config.streams()) {
+            try {
+                commands.xgroupCreate(
+                    XReadArgs.StreamOffset.from(stream, "$"),
+                    config.group(),
+                    XGroupCreateArgs.Builder.mkstream(true));
+                log.info("Created consumer group '{}' on stream '{}'", config.group(), stream);
+            } catch (RedisException e) {
+                if (!e.getMessage().contains("BUSYGROUP")) {
+                    log.warn("Failed to create consumer group: {}", e.getMessage());
+                }
+            }
+        }
+
+        executor = Executors.newFixedThreadPool(2, r -> {
+            Thread t = new Thread(r, "redis-subscriber");
+            t.setDaemon(true);
+            return t;
+        });
+        executor.submit(this::pollLoop);
+        executor.submit(this::recoveryLoop);
+    }
+
+    private void pollLoop() {
+        String group = currentConfig.group();
+        String consumer = currentConfig.consumerName();
+        List<String> streams = currentConfig.streams();
+        Consumer<String> lettuceConsumer = Consumer.from(group, consumer);
+
+        while (running.get()) {
+            try {
+                XReadArgs readArgs = XReadArgs.Builder.block(Duration.ofMillis(BLOCK_MS));
+                List<StreamMessage<String, String>> messages = commands.xreadgroup(
+                    lettuceConsumer,
+                    readArgs,
+                    streams.stream()
+                        .map(s -> XReadArgs.StreamOffset.from(s, ">"))
+                        .toArray(XReadArgs.StreamOffset[]::new));
+
+                if (messages == null || messages.isEmpty()) continue;
+
+                for (StreamMessage<String, String> msg : messages) {
+                    handleMessage(msg, group);
+                }
+            } catch (RedisException e) {
+                log.error("Error polling Redis streams: {}", e.getMessage());
+                sleepSilently(Duration.ofSeconds(1));
+            }
+        }
+    }
+
+    private void recoveryLoop() {
+        Consumer<String> lettuceConsumer = Consumer.from(currentConfig.group(), currentConfig.consumerName());
+
+        while (running.get()) {
+            try {
+                Thread.sleep(RECOVERY_INTERVAL.toMillis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+            if (!running.get()) break;
+
+            for (String stream : currentConfig.streams()) {
+                try {
+                    var args = new XAutoClaimArgs<String>()
+                        .consumer(lettuceConsumer)
+                        .minIdleTime(MIN_IDLE_MS)
+                        .startId("0-0")
+                        .count(100);
+                    var response = commands.xautoclaim(stream, args);
+                    List<StreamMessage<String, String>> claimed = response.getMessages();
+                    if (claimed != null && !claimed.isEmpty()) {
+                        for (StreamMessage<String, String> msg : claimed) {
+                            handleClaimedMessage(msg, currentConfig.group());
+                        }
+                    }
+                } catch (RedisException e) {
+                    log.warn("XAUTOCLAIM failed for stream {}: {}", stream, e.getMessage());
+                }
+            }
+        }
+    }
+
+    private void handleMessage(StreamMessage<String, String> msg, String group) {
+        String stream = msg.getStream();
+        String messageId = msg.getId();
+        Map<String, String> body = msg.getBody();
+        String envelopeJson = body != null ? body.get("envelope") : null;
+
+        if (envelopeJson == null || envelopeJson.isBlank()) {
+            commands.xack(stream, group, messageId);
+            return;
+        }
+
+        EventEnvelope envelope;
+        try {
+            envelope = objectMapper.readValue(envelopeJson, EventEnvelope.class);
+        } catch (JsonProcessingException e) {
+            moveToDlq(stream, envelopeJson);
+            commands.xack(stream, group, messageId);
+            return;
+        }
+
+        if (consumedEventIds.contains(envelope.eventId())) {
+            commands.xack(stream, group, messageId);
+            return;
+        }
+
+        processAndAck(stream, group, messageId, envelope, envelopeJson);
+    }
+
+    private void handleClaimedMessage(StreamMessage<String, String> msg, String group) {
+        String stream = msg.getStream();
+        String messageId = msg.getId();
+        Map<String, String> body = msg.getBody();
+        String envelopeJson = body != null ? body.get("envelope") : null;
+
+        if (envelopeJson == null || envelopeJson.isBlank()) {
+            commands.xack(stream, group, messageId);
+            return;
+        }
+
+        long deliveryCount = getDeliveryCount(stream, group, messageId);
+        if (deliveryCount >= MAX_DELIVERY_ATTEMPTS) {
+            log.warn("Message {} on {} exceeded max delivery, moving to DLQ", messageId, stream);
+            moveToDlq(stream, envelopeJson);
+            commands.xack(stream, group, messageId);
+            return;
+        }
+
+        EventEnvelope envelope;
+        try {
+            envelope = objectMapper.readValue(envelopeJson, EventEnvelope.class);
+        } catch (JsonProcessingException e) {
+            moveToDlq(stream, envelopeJson);
+            commands.xack(stream, group, messageId);
+            return;
+        }
+
+        if (consumedEventIds.contains(envelope.eventId())) {
+            commands.xack(stream, group, messageId);
+            return;
+        }
+
+        processAndAck(stream, group, messageId, envelope, envelopeJson);
+    }
+
+    private void processAndAck(String stream, String group, String messageId,
+                               EventEnvelope envelope, String envelopeJson) {
+        try {
+            HandlerResult result = currentConfig.handler().apply(envelope);
+            switch (result) {
+                case HandlerResult.Success ignored -> {
+                    consumedEventIds.add(envelope.eventId());
+                    commands.xack(stream, group, messageId);
+                }
+                case HandlerResult.TransientError ignored -> {
+                    // leave in PEL for retry
+                }
+                case HandlerResult.FatalError ignored -> {
+                    moveToDlq(stream, envelopeJson);
+                    commands.xack(stream, group, messageId);
+                }
+            }
+        } catch (Exception e) {
+            log.error("Handler threw exception: {}", e.getMessage());
+        }
+    }
+
+    private void moveToDlq(String stream, String envelopeJson) {
+        String dlqStream = stream + ":dlq";
+        try {
+            commands.xadd(dlqStream, XAddArgs.Builder.maxlen(MAXLEN), Map.of("envelope", envelopeJson));
+        } catch (RedisException e) {
+            log.error("Failed to move message to DLQ: {}", e.getMessage());
+        }
+    }
+
+    private long getDeliveryCount(String stream, String group, String messageId) {
+        try {
+            var range = io.lettuce.core.Range.create("-", "+");
+            var limit = io.lettuce.core.Limit.create(1, 1);
+            var pending = commands.xpending(stream, Consumer.from(group, messageId), range, limit);
+            if (pending != null && !pending.isEmpty()) {
+                var entry = pending.get(0);
+                if (entry != null) return entry.getRedeliveryCount();
+            }
+        } catch (Exception e) {
+            log.debug("Failed to get delivery count: {}", e.getMessage());
+        }
+        return 0;
+    }
+
+    public void shutdown() {
+        running.set(false);
+        if (executor != null) {
+            executor.shutdownNow();
+            try { executor.awaitTermination(5, TimeUnit.SECONDS); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+        }
+        if (connection != null) connection.close();
+        if (redisClient != null) redisClient.shutdown();
+    }
+
+    private static void sleepSilently(Duration duration) {
+        try { Thread.sleep(duration.toMillis()); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisStreamsEventSubscriber.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisStreamsEventSubscriber.java
@@ -10,6 +10,8 @@ import com.trainticket.bookingorchestration.application.HandlerResult;
 import com.trainticket.bookingorchestration.application.SubscribeFailed;
 import com.trainticket.bookingorchestration.application.SubscriberConfig;
 import io.lettuce.core.Consumer;
+import io.lettuce.core.Limit;
+import io.lettuce.core.Range;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisException;
 import io.lettuce.core.StreamMessage;
@@ -28,6 +30,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import io.lettuce.core.models.stream.PendingMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +48,6 @@ public class RedisStreamsEventSubscriber implements EventSubscriber {
     private final ObjectMapper objectMapper;
     private final AtomicBoolean running = new AtomicBoolean(false);
     private final Set<String> consumedEventIds = ConcurrentHashMap.newKeySet();
-    private final ConcurrentHashMap<String, Integer> deliveryCounts = new ConcurrentHashMap<>();
     private ExecutorService executor;
     private volatile SubscriberConfig currentConfig;
 
@@ -187,12 +189,11 @@ public class RedisStreamsEventSubscriber implements EventSubscriber {
             return;
         }
 
-        int deliveryCount = deliveryCounts.merge(messageId, 1, Integer::sum);
+        long deliveryCount = redisDeliveryCount(stream, group, messageId);
         if (deliveryCount >= MAX_DELIVERY_ATTEMPTS) {
             log.warn("Message {} on {} exceeded max delivery, moving to DLQ", messageId, stream);
             moveToDlq(stream, envelopeJson);
             commands.xack(stream, group, messageId);
-            deliveryCounts.remove(messageId);
             return;
         }
 
@@ -202,18 +203,29 @@ public class RedisStreamsEventSubscriber implements EventSubscriber {
         } catch (JsonProcessingException e) {
             moveToDlq(stream, envelopeJson);
             commands.xack(stream, group, messageId);
-            deliveryCounts.remove(messageId);
             return;
         }
 
         if (consumedEventIds.contains(envelope.eventId())) {
             commands.xack(stream, group, messageId);
-            deliveryCounts.remove(messageId);
             return;
         }
 
         processAndAck(stream, group, messageId, envelope, envelopeJson);
-        deliveryCounts.remove(messageId);
+    }
+
+    private long redisDeliveryCount(String stream, String group, String messageId) {
+        try {
+            List<PendingMessage> pending = commands.xpending(
+                stream, group, Range.create(messageId, messageId), Limit.create(0, 1));
+            if (pending == null || pending.isEmpty()) {
+                return 1L;
+            }
+            return pending.getFirst().getRedeliveryCount() + 1L;
+        } catch (RedisException e) {
+            log.warn("XPENDING failed for message {} on {}: {}", messageId, stream, e.getMessage());
+            return 1L;
+        }
     }
 
     private void processAndAck(String stream, String group, String messageId,

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisStreamsEventSubscriber.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisStreamsEventSubscriber.java
@@ -1,5 +1,6 @@
 package com.trainticket.bookingorchestration.adapters.messaging;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -56,7 +57,8 @@ public class RedisStreamsEventSubscriber implements EventSubscriber {
         this.commands = connection.sync();
         this.objectMapper = new ObjectMapper()
             .registerModule(new JavaTimeModule())
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL);
     }
 
     @Override

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisStreamsEventSubscriber.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/adapters/messaging/RedisStreamsEventSubscriber.java
@@ -34,24 +34,22 @@ import org.slf4j.LoggerFactory;
 public class RedisStreamsEventSubscriber implements EventSubscriber {
 
     private static final Logger log = LoggerFactory.getLogger(RedisStreamsEventSubscriber.class);
-    private static final int POLL_COUNT = 10;
     private static final int BLOCK_MS = 2000;
     private static final Duration RECOVERY_INTERVAL = Duration.ofSeconds(60);
     private static final int MAX_DELIVERY_ATTEMPTS = 5;
     private static final long MIN_IDLE_MS = 60_000L;
     private static final long MAXLEN = 100_000L;
 
-    private final RedisClient redisClient;
     private final StatefulRedisConnection<String, String> connection;
     private final RedisCommands<String, String> commands;
     private final ObjectMapper objectMapper;
     private final AtomicBoolean running = new AtomicBoolean(false);
     private final Set<String> consumedEventIds = ConcurrentHashMap.newKeySet();
+    private final ConcurrentHashMap<String, Integer> deliveryCounts = new ConcurrentHashMap<>();
     private ExecutorService executor;
     private volatile SubscriberConfig currentConfig;
 
     public RedisStreamsEventSubscriber(RedisClient redisClient) {
-        this.redisClient = redisClient;
         this.connection = redisClient.connect();
         this.commands = connection.sync();
         this.objectMapper = new ObjectMapper()
@@ -189,11 +187,12 @@ public class RedisStreamsEventSubscriber implements EventSubscriber {
             return;
         }
 
-        long deliveryCount = getDeliveryCount(stream, group, messageId);
+        int deliveryCount = deliveryCounts.merge(messageId, 1, Integer::sum);
         if (deliveryCount >= MAX_DELIVERY_ATTEMPTS) {
             log.warn("Message {} on {} exceeded max delivery, moving to DLQ", messageId, stream);
             moveToDlq(stream, envelopeJson);
             commands.xack(stream, group, messageId);
+            deliveryCounts.remove(messageId);
             return;
         }
 
@@ -203,15 +202,18 @@ public class RedisStreamsEventSubscriber implements EventSubscriber {
         } catch (JsonProcessingException e) {
             moveToDlq(stream, envelopeJson);
             commands.xack(stream, group, messageId);
+            deliveryCounts.remove(messageId);
             return;
         }
 
         if (consumedEventIds.contains(envelope.eventId())) {
             commands.xack(stream, group, messageId);
+            deliveryCounts.remove(messageId);
             return;
         }
 
         processAndAck(stream, group, messageId, envelope, envelopeJson);
+        deliveryCounts.remove(messageId);
     }
 
     private void processAndAck(String stream, String group, String messageId,
@@ -245,21 +247,6 @@ public class RedisStreamsEventSubscriber implements EventSubscriber {
         }
     }
 
-    private long getDeliveryCount(String stream, String group, String messageId) {
-        try {
-            var range = io.lettuce.core.Range.create("-", "+");
-            var limit = io.lettuce.core.Limit.create(1, 1);
-            var pending = commands.xpending(stream, Consumer.from(group, messageId), range, limit);
-            if (pending != null && !pending.isEmpty()) {
-                var entry = pending.get(0);
-                if (entry != null) return entry.getRedeliveryCount();
-            }
-        } catch (Exception e) {
-            log.debug("Failed to get delivery count: {}", e.getMessage());
-        }
-        return 0;
-    }
-
     public void shutdown() {
         running.set(false);
         if (executor != null) {
@@ -267,7 +254,6 @@ public class RedisStreamsEventSubscriber implements EventSubscriber {
             try { executor.awaitTermination(5, TimeUnit.SECONDS); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
         }
         if (connection != null) connection.close();
-        if (redisClient != null) redisClient.shutdown();
     }
 
     private static void sleepSilently(Duration duration) {

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/api/BookingOrchestrationController.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/api/BookingOrchestrationController.java
@@ -91,9 +91,10 @@ public class BookingOrchestrationController {
                  produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> startSaga(
             @RequestBody StartSagaRequest request,
-            @RequestHeader("Idempotency-Key") String idempotencyKey,
+            @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
             HttpServletRequest httpRequest) {
-        List<String> errors = validateStartSaga(request);
+        List<String> errors = validateIdempotencyKey(idempotencyKey);
+        errors.addAll(validateStartSaga(request));
         if (!errors.isEmpty()) {
             return validationError(errors, httpRequest);
         }
@@ -144,16 +145,17 @@ public class BookingOrchestrationController {
     public ResponseEntity<?> requestReservation(
             @PathVariable String sagaId,
             @RequestBody RequestReservationRequest request,
-            @RequestHeader("Idempotency-Key") String idempotencyKey,
+            @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
             HttpServletRequest httpRequest) {
+        List<String> errors = validateIdempotencyKey(idempotencyKey);
+        errors.addAll(validateRequestReservation(request));
+        if (!errors.isEmpty()) {
+            return validationError(errors, httpRequest);
+        }
+
         Optional<BookingSaga> sagaOpt = sagaStore.get(sagaId);
         if (sagaOpt.isEmpty()) {
             return notFound("Booking saga not found: " + sagaId, httpRequest);
-        }
-
-        List<String> errors = validateRequestReservation(request);
-        if (!errors.isEmpty()) {
-            return validationError(errors, httpRequest);
         }
 
         var existing = idempotencyStore.get(idempotencyKey, request);
@@ -183,16 +185,17 @@ public class BookingOrchestrationController {
     public ResponseEntity<?> markTicketed(
             @PathVariable String sagaId,
             @RequestBody MarkTicketedRequest request,
-            @RequestHeader("Idempotency-Key") String idempotencyKey,
+            @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
             HttpServletRequest httpRequest) {
+        List<String> errors = validateIdempotencyKey(idempotencyKey);
+        errors.addAll(validateMarkTicketed(request));
+        if (!errors.isEmpty()) {
+            return validationError(errors, httpRequest);
+        }
+
         Optional<BookingSaga> sagaOpt = sagaStore.get(sagaId);
         if (sagaOpt.isEmpty()) {
             return notFound("Booking saga not found: " + sagaId, httpRequest);
-        }
-
-        List<String> errors = validateMarkTicketed(request);
-        if (!errors.isEmpty()) {
-            return validationError(errors, httpRequest);
         }
 
         var existing = idempotencyStore.get(idempotencyKey, request);
@@ -262,6 +265,14 @@ public class BookingOrchestrationController {
             "booking-orchestration", "cmd-" + UUID.randomUUID(),
             getCorrelationId(request), clock.instant(), event);
         eventPublisher.publish(envelope);
+    }
+
+    private List<String> validateIdempotencyKey(String idempotencyKey) {
+        List<String> errors = new ArrayList<>();
+        if (idempotencyKey == null || idempotencyKey.isBlank()) {
+            errors.add("Idempotency-Key header is required");
+        }
+        return errors;
     }
 
     private List<String> validateStartSaga(StartSagaRequest request) {

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/api/BookingOrchestrationController.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/api/BookingOrchestrationController.java
@@ -1,0 +1,345 @@
+package com.trainticket.bookingorchestration.api;
+
+import com.trainticket.bookingorchestration.application.EventEnvelope;
+import com.trainticket.bookingorchestration.application.EventPublisher;
+import com.trainticket.bookingorchestration.domain.BookingSaga;
+import com.trainticket.bookingorchestration.domain.BookingSagaStatus;
+import com.trainticket.bookingorchestration.domain.BookingSagaStep;
+import com.trainticket.bookingorchestration.domain.DomainEvent;
+import com.trainticket.bookingorchestration.domain.SegmentBooking;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/internal")
+public class BookingOrchestrationController {
+
+    private final Clock clock;
+    private final EventPublisher eventPublisher;
+    private final IdempotencyStore idempotencyStore;
+    private final SagaStore sagaStore;
+
+    public BookingOrchestrationController(Clock clock, EventPublisher eventPublisher) {
+        this.clock = clock;
+        this.eventPublisher = eventPublisher;
+        this.idempotencyStore = new IdempotencyStore();
+        this.sagaStore = new SagaStore();
+    }
+
+    BookingOrchestrationController(Clock clock, EventPublisher eventPublisher,
+                                   IdempotencyStore idempotencyStore, SagaStore sagaStore) {
+        this.clock = clock;
+        this.eventPublisher = eventPublisher;
+        this.idempotencyStore = idempotencyStore;
+        this.sagaStore = sagaStore;
+    }
+
+    // ---- DTOs ----
+
+    public record StartSagaRequest(
+        String journeyOrderId, String accountId, String offerId,
+        List<String> travelerRefs, List<String> segmentRefs
+    ) {}
+
+    public record StartSagaResponse(
+        String sagaId, String journeyOrderId, String status, Instant startedAt
+    ) {}
+
+    public record RequestReservationRequest(
+        String segmentRef, String travelerRef, String segmentBookingId
+    ) {}
+
+    public record RequestReservationResponse(
+        String segmentBookingId, String status
+    ) {}
+
+    public record MarkTicketedRequest(
+        String segmentBookingId, String entitlementId
+    ) {}
+
+    public record MarkTicketedResponse(
+        String segmentBookingId, String status
+    ) {}
+
+    public record ErrorBody(
+        String code, String message, String correlationId, Map<String, Object> details
+    ) {}
+
+    // ---- Start Booking Saga ----
+
+    @PostMapping(value = "/booking-sagas", consumes = MediaType.APPLICATION_JSON_VALUE,
+                 produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> startSaga(
+            @RequestBody StartSagaRequest request,
+            @RequestHeader("Idempotency-Key") String idempotencyKey,
+            HttpServletRequest httpRequest) {
+        List<String> errors = validateStartSaga(request);
+        if (!errors.isEmpty()) {
+            return validationError(errors, httpRequest);
+        }
+
+        Optional<Object> existing = idempotencyStore.get(idempotencyKey);
+        if (existing.isPresent()) {
+            return ResponseEntity.status(HttpStatus.CREATED).body(existing.get());
+        }
+
+        String sagaId = "saga-" + UUID.randomUUID();
+        List<BookingSagaStep> plan = new ArrayList<>();
+        for (String segmentRef : request.segmentRefs()) {
+            plan.add(BookingSaga.stepPlan(
+                "reserve-" + segmentRef, sagaId + ":" + segmentRef,
+                Duration.ofMinutes(5), 3, "release-capacity"));
+        }
+
+        BookingSaga saga = BookingSaga.start(sagaId, request.journeyOrderId(), "1",
+            "purchase", plan, clock);
+
+        for (DomainEvent event : saga.pullEvents()) {
+            publishEvent(event, sagaId, httpRequest);
+        }
+
+        sagaStore.put(sagaId, saga);
+        var response = new StartSagaResponse(sagaId, request.journeyOrderId(),
+            mapSagaStatus(saga.status()), clock.instant());
+        idempotencyStore.put(idempotencyKey, response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    // ---- Get Saga Status ----
+
+    @GetMapping(value = "/booking-sagas/{sagaId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> getSaga(@PathVariable String sagaId, HttpServletRequest httpRequest) {
+        var sagaOpt = sagaStore.get(sagaId);
+        if (sagaOpt.isEmpty()) {
+            return notFound("Booking saga not found: " + sagaId, httpRequest);
+        }
+        return ResponseEntity.ok(buildSagaDetail(sagaOpt.get()));
+    }
+
+    // ---- Request Segment Reservation ----
+
+    @PostMapping(value = "/booking-sagas/{sagaId}/request-reservation",
+                 consumes = MediaType.APPLICATION_JSON_VALUE,
+                 produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> requestReservation(
+            @PathVariable String sagaId,
+            @RequestBody RequestReservationRequest request,
+            @RequestHeader("Idempotency-Key") String idempotencyKey,
+            HttpServletRequest httpRequest) {
+        Optional<BookingSaga> sagaOpt = sagaStore.get(sagaId);
+        if (sagaOpt.isEmpty()) {
+            return notFound("Booking saga not found: " + sagaId, httpRequest);
+        }
+
+        List<String> errors = validateRequestReservation(request);
+        if (!errors.isEmpty()) {
+            return validationError(errors, httpRequest);
+        }
+
+        Optional<Object> existing = idempotencyStore.get(idempotencyKey);
+        if (existing.isPresent()) {
+            return ResponseEntity.ok(existing.get());
+        }
+
+        SegmentBooking segmentBooking = SegmentBooking.requestReservation(
+            request.segmentBookingId(), sagaOpt.get().journeyOrderId(),
+            request.segmentRef(), request.segmentRef(),
+            request.travelerRef(), "purchase", clock);
+
+        for (DomainEvent event : segmentBooking.pullEvents()) {
+            publishEvent(event, sagaId, httpRequest);
+        }
+
+        var response = new RequestReservationResponse(request.segmentBookingId(), "REQUESTED");
+        idempotencyStore.put(idempotencyKey, response);
+        return ResponseEntity.ok(response);
+    }
+
+    // ---- Mark Segment Ticketed ----
+
+    @PostMapping(value = "/booking-sagas/{sagaId}/mark-ticketed",
+                 consumes = MediaType.APPLICATION_JSON_VALUE,
+                 produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> markTicketed(
+            @PathVariable String sagaId,
+            @RequestBody MarkTicketedRequest request,
+            @RequestHeader("Idempotency-Key") String idempotencyKey,
+            HttpServletRequest httpRequest) {
+        Optional<BookingSaga> sagaOpt = sagaStore.get(sagaId);
+        if (sagaOpt.isEmpty()) {
+            return notFound("Booking saga not found: " + sagaId, httpRequest);
+        }
+
+        List<String> errors = validateMarkTicketed(request);
+        if (!errors.isEmpty()) {
+            return validationError(errors, httpRequest);
+        }
+
+        Optional<Object> existing = idempotencyStore.get(idempotencyKey);
+        if (existing.isPresent()) {
+            return ResponseEntity.ok(existing.get());
+        }
+
+        var response = new MarkTicketedResponse(request.segmentBookingId(), "TICKETED");
+        idempotencyStore.put(idempotencyKey, response);
+        return ResponseEntity.ok(response);
+    }
+
+    // ---- Error handling ----
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorBody> handleIllegalArgument(IllegalArgumentException ex,
+                                                           HttpServletRequest httpRequest) {
+        String correlationId = getCorrelationId(httpRequest);
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+            .body(new ErrorBody("DOMAIN_RULE_VIOLATION", ex.getMessage(), correlationId, Map.of()));
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ErrorBody> handleIllegalState(IllegalStateException ex,
+                                                        HttpServletRequest httpRequest) {
+        String correlationId = getCorrelationId(httpRequest);
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+            .body(new ErrorBody("CONFLICT", ex.getMessage(), correlationId, Map.of()));
+    }
+
+    // ---- Internal helpers ----
+
+    private ResponseEntity<ErrorBody> validationError(List<String> errors, HttpServletRequest request) {
+        String correlationId = getCorrelationId(request);
+        return ResponseEntity.badRequest()
+            .body(new ErrorBody("VALIDATION_FAILED", String.join("; ", errors), correlationId, Map.of()));
+    }
+
+    private ResponseEntity<ErrorBody> notFound(String message, HttpServletRequest request) {
+        String correlationId = getCorrelationId(request);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(new ErrorBody("NOT_FOUND", message, correlationId, Map.of()));
+    }
+
+    private String getCorrelationId(HttpServletRequest request) {
+        String id = request.getHeader("X-Correlation-Id");
+        return id != null && !id.isBlank() ? id : UUID.randomUUID().toString();
+    }
+
+    private void publishEvent(DomainEvent event, String sagaId, HttpServletRequest request) {
+        EventEnvelope envelope = new EventEnvelope(
+            "evt-" + UUID.randomUUID(), event.getClass().getSimpleName(), 1,
+            "booking-orchestration", "cmd-" + UUID.randomUUID(),
+            getCorrelationId(request), clock.instant(), event);
+        eventPublisher.publish(envelope);
+    }
+
+    private List<String> validateStartSaga(StartSagaRequest request) {
+        List<String> errors = new ArrayList<>();
+        if (request.journeyOrderId() == null || request.journeyOrderId().isBlank()) {
+            errors.add("journeyOrderId is required");
+        }
+        if (request.accountId() == null || request.accountId().isBlank()) {
+            errors.add("accountId is required");
+        }
+        if (request.offerId() == null || request.offerId().isBlank()) {
+            errors.add("offerId is required");
+        }
+        if (request.travelerRefs() == null || request.travelerRefs().isEmpty()) {
+            errors.add("travelerRefs must not be empty");
+        }
+        if (request.segmentRefs() == null || request.segmentRefs().isEmpty()) {
+            errors.add("segmentRefs must not be empty");
+        }
+        return errors;
+    }
+
+    private List<String> validateRequestReservation(RequestReservationRequest request) {
+        List<String> errors = new ArrayList<>();
+        if (request.segmentRef() == null || request.segmentRef().isBlank()) {
+            errors.add("segmentRef is required");
+        }
+        if (request.travelerRef() == null || request.travelerRef().isBlank()) {
+            errors.add("travelerRef is required");
+        }
+        if (request.segmentBookingId() == null || request.segmentBookingId().isBlank()) {
+            errors.add("segmentBookingId is required");
+        }
+        return errors;
+    }
+
+    private List<String> validateMarkTicketed(MarkTicketedRequest request) {
+        List<String> errors = new ArrayList<>();
+        if (request.segmentBookingId() == null || request.segmentBookingId().isBlank()) {
+            errors.add("segmentBookingId is required");
+        }
+        if (request.entitlementId() == null || request.entitlementId().isBlank()) {
+            errors.add("entitlementId is required");
+        }
+        return errors;
+    }
+
+    private String mapSagaStatus(BookingSagaStatus status) {
+        return switch (status) {
+            case PLANNED -> "PLANNED";
+            case RESERVING -> "RESERVING";
+            case AWAITING_PAYMENT -> "WAITING_PAYMENT";
+            case CONFIRMING -> "CONFIRMING";
+            case TICKETING -> "TICKETING";
+            case COMPLETED -> "COMPLETED";
+            case PARTIALLY_CONFIRMED -> "PARTIALLY_CONFIRMED";
+            case COMPENSATING -> "COMPENSATING";
+            case MANUAL_REVIEW -> "MANUAL_REVIEW";
+            case FAILED -> "FAILED";
+        };
+    }
+
+    private Map<String, Object> buildSagaDetail(BookingSaga saga) {
+        Map<String, Object> detail = new HashMap<>();
+        detail.put("sagaId", saga.sagaId());
+        detail.put("journeyOrderId", saga.journeyOrderId());
+        detail.put("status", mapSagaStatus(saga.status()));
+        detail.put("idempotencyKey", saga.idempotencyKey());
+        List<Map<String, Object>> steps = new ArrayList<>();
+        for (BookingSagaStep step : saga.steps()) {
+            Map<String, Object> stepMap = new HashMap<>();
+            stepMap.put("name", step.name());
+            stepMap.put("idempotencyKey", step.idempotencyKey());
+            stepMap.put("status", step.status().name());
+            stepMap.put("attemptNumber", step.attemptNumber());
+            step.failureReason().ifPresent(r -> stepMap.put("failureReason", r));
+            steps.add(stepMap);
+        }
+        detail.put("steps", steps);
+        saga.terminalReason().ifPresent(r -> detail.put("terminalReason", r));
+        return detail;
+    }
+
+    static class IdempotencyStore {
+        private final ConcurrentHashMap<String, Object> store = new ConcurrentHashMap<>();
+        void put(String key, Object value) { store.put(key, value); }
+        Optional<Object> get(String key) { return Optional.ofNullable(store.get(key)); }
+    }
+
+    static class SagaStore {
+        private final ConcurrentHashMap<String, BookingSaga> store = new ConcurrentHashMap<>();
+        void put(String key, BookingSaga saga) { store.put(key, saga); }
+        Optional<BookingSaga> get(String key) { return Optional.ofNullable(store.get(key)); }
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/api/BookingOrchestrationController.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/api/BookingOrchestrationController.java
@@ -1,23 +1,19 @@
 package com.trainticket.bookingorchestration.api;
 
-import com.trainticket.bookingorchestration.application.EventEnvelope;
-import com.trainticket.bookingorchestration.application.EventPublisher;
-import com.trainticket.bookingorchestration.domain.BookingSaga;
-import com.trainticket.bookingorchestration.domain.BookingSagaStatus;
-import com.trainticket.bookingorchestration.domain.BookingSagaStep;
-import com.trainticket.bookingorchestration.domain.DomainEvent;
-import com.trainticket.bookingorchestration.domain.SegmentBooking;
+import com.trainticket.bookingorchestration.RequestContextFilter;
+import com.trainticket.bookingorchestration.application.BookingOrchestrationService;
+import com.trainticket.bookingorchestration.application.BookingOrchestrationService.IdempotencyKeyReusedException;
+import com.trainticket.bookingorchestration.application.BookingOrchestrationService.MarkTicketedCommand;
+import com.trainticket.bookingorchestration.application.BookingOrchestrationService.NotFoundException;
+import com.trainticket.bookingorchestration.application.BookingOrchestrationService.PreconditionFailedException;
+import com.trainticket.bookingorchestration.application.BookingOrchestrationService.RequestReservationCommand;
+import com.trainticket.bookingorchestration.application.BookingOrchestrationService.StartSagaCommand;
 import jakarta.servlet.http.HttpServletRequest;
-import java.time.Clock;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -34,27 +30,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/internal")
 public class BookingOrchestrationController {
 
-    private final Clock clock;
-    private final EventPublisher eventPublisher;
-    private final IdempotencyStore idempotencyStore;
-    private final SagaStore sagaStore;
+    private final BookingOrchestrationService service;
 
-    public BookingOrchestrationController(Clock clock, EventPublisher eventPublisher) {
-        this.clock = clock;
-        this.eventPublisher = eventPublisher;
-        this.idempotencyStore = new IdempotencyStore();
-        this.sagaStore = new SagaStore();
+    public BookingOrchestrationController(BookingOrchestrationService service) {
+        this.service = service;
     }
-
-    BookingOrchestrationController(Clock clock, EventPublisher eventPublisher,
-                                   IdempotencyStore idempotencyStore, SagaStore sagaStore) {
-        this.clock = clock;
-        this.eventPublisher = eventPublisher;
-        this.idempotencyStore = idempotencyStore;
-        this.sagaStore = sagaStore;
-    }
-
-    // ---- DTOs ----
 
     public record StartSagaRequest(
         String journeyOrderId, String accountId, String offerId,
@@ -85,8 +65,6 @@ public class BookingOrchestrationController {
         String code, String message, String correlationId, Map<String, Object> details
     ) {}
 
-    // ---- Start Booking Saga ----
-
     @PostMapping(value = "/booking-sagas", consumes = MediaType.APPLICATION_JSON_VALUE,
                  produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> startSaga(
@@ -99,45 +77,18 @@ public class BookingOrchestrationController {
             return validationError(errors, httpRequest);
         }
 
-        var existing = idempotencyStore.get(idempotencyKey, request);
-        if (existing != null) {
-            return ResponseEntity.status(HttpStatus.CREATED).body(existing);
-        }
-
-        String sagaId = "saga-" + UUID.randomUUID();
-        List<BookingSagaStep> plan = new ArrayList<>();
-        for (String segmentRef : request.segmentRefs()) {
-            plan.add(BookingSaga.stepPlan(
-                "reserve-" + segmentRef, sagaId + ":" + segmentRef,
-                Duration.ofMinutes(5), 3, "release-capacity"));
-        }
-
-        BookingSaga saga = BookingSaga.start(sagaId, request.journeyOrderId(), "1",
-            "purchase", plan, clock);
-
-        for (DomainEvent event : saga.pullEvents()) {
-            publishEvent(event, sagaId, httpRequest);
-        }
-
-        sagaStore.put(sagaId, saga);
-        var response = new StartSagaResponse(sagaId, request.journeyOrderId(),
-            mapSagaStatus(saga.status()), clock.instant());
-        idempotencyStore.put(idempotencyKey, request, response);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        var result = service.startSaga(new StartSagaCommand(request.journeyOrderId(), request.accountId(),
+            request.offerId(), request.travelerRefs(), request.segmentRefs()), idempotencyKey, getCorrelationId(httpRequest));
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(new StartSagaResponse(result.sagaId(), result.journeyOrderId(), result.status(), result.startedAt()));
     }
-
-    // ---- Get Saga Status ----
 
     @GetMapping(value = "/booking-sagas/{sagaId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> getSaga(@PathVariable String sagaId, HttpServletRequest httpRequest) {
-        var sagaOpt = sagaStore.get(sagaId);
-        if (sagaOpt.isEmpty()) {
-            return notFound("Booking saga not found: " + sagaId, httpRequest);
-        }
-        return ResponseEntity.ok(buildSagaDetail(sagaOpt.get()));
+        return service.getSaga(sagaId)
+            .<ResponseEntity<?>>map(ResponseEntity::ok)
+            .orElseGet(() -> notFound("Booking saga not found: " + sagaId, httpRequest));
     }
-
-    // ---- Request Segment Reservation ----
 
     @PostMapping(value = "/booking-sagas/{sagaId}/request-reservation",
                  consumes = MediaType.APPLICATION_JSON_VALUE,
@@ -153,31 +104,11 @@ public class BookingOrchestrationController {
             return validationError(errors, httpRequest);
         }
 
-        Optional<BookingSaga> sagaOpt = sagaStore.get(sagaId);
-        if (sagaOpt.isEmpty()) {
-            return notFound("Booking saga not found: " + sagaId, httpRequest);
-        }
-
-        var existing = idempotencyStore.get(idempotencyKey, request);
-        if (existing != null) {
-            return ResponseEntity.ok(existing);
-        }
-
-        SegmentBooking segmentBooking = SegmentBooking.requestReservation(
-            request.segmentBookingId(), sagaOpt.get().journeyOrderId(),
-            request.segmentRef(), request.segmentRef(),
-            request.travelerRef(), "purchase", clock);
-
-        for (DomainEvent event : segmentBooking.pullEvents()) {
-            publishEvent(event, sagaId, httpRequest);
-        }
-
-        var response = new RequestReservationResponse(request.segmentBookingId(), "REQUESTED");
-        idempotencyStore.put(idempotencyKey, request, response);
-        return ResponseEntity.ok(response);
+        var result = service.requestReservation(sagaId,
+            new RequestReservationCommand(request.segmentRef(), request.travelerRef(), request.segmentBookingId()),
+            idempotencyKey, getCorrelationId(httpRequest));
+        return ResponseEntity.ok(new RequestReservationResponse(result.segmentBookingId(), result.status()));
     }
-
-    // ---- Mark Segment Ticketed ----
 
     @PostMapping(value = "/booking-sagas/{sagaId}/mark-ticketed",
                  consumes = MediaType.APPLICATION_JSON_VALUE,
@@ -193,78 +124,66 @@ public class BookingOrchestrationController {
             return validationError(errors, httpRequest);
         }
 
-        Optional<BookingSaga> sagaOpt = sagaStore.get(sagaId);
-        if (sagaOpt.isEmpty()) {
-            return notFound("Booking saga not found: " + sagaId, httpRequest);
-        }
-
-        var existing = idempotencyStore.get(idempotencyKey, request);
-        if (existing != null) {
-            return ResponseEntity.ok(existing);
-        }
-
-        var response = new MarkTicketedResponse(request.segmentBookingId(), "TICKETED");
-        idempotencyStore.put(idempotencyKey, request, response);
-        return ResponseEntity.ok(response);
+        var result = service.markTicketed(sagaId,
+            new MarkTicketedCommand(request.segmentBookingId(), request.entitlementId()),
+            idempotencyKey, getCorrelationId(httpRequest));
+        return ResponseEntity.ok(new MarkTicketedResponse(result.segmentBookingId(), result.status()));
     }
-
-    // ---- Error handling ----
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorBody> handleIllegalArgument(IllegalArgumentException ex,
                                                            HttpServletRequest httpRequest) {
-        String correlationId = getCorrelationId(httpRequest);
-        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
-            .body(new ErrorBody("DOMAIN_RULE_VIOLATION", ex.getMessage(), correlationId, Map.of()));
+        return error(HttpStatus.UNPROCESSABLE_ENTITY, "DOMAIN_RULE_VIOLATION", ex.getMessage(), httpRequest);
     }
 
     @ExceptionHandler(IdempotencyKeyReusedException.class)
     public ResponseEntity<ErrorBody> handleIdempotencyKeyReused(IdempotencyKeyReusedException ex,
-                                                                    HttpServletRequest httpRequest) {
-        return idempotencyKeyReused(httpRequest);
+                                                                HttpServletRequest httpRequest) {
+        return error(HttpStatus.UNPROCESSABLE_ENTITY, "IDEMPOTENCY_KEY_REUSED",
+            "Idempotency-Key was reused with a different request body", httpRequest);
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ErrorBody> handleNotFound(NotFoundException ex, HttpServletRequest httpRequest) {
+        return notFound(ex.getMessage(), httpRequest);
+    }
+
+    @ExceptionHandler(PreconditionFailedException.class)
+    public ResponseEntity<ErrorBody> handlePreconditionFailed(PreconditionFailedException ex,
+                                                              HttpServletRequest httpRequest) {
+        return error(HttpStatus.PRECONDITION_FAILED, "PRECONDITION_FAILED", ex.getMessage(), httpRequest);
     }
 
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<ErrorBody> handleIllegalState(IllegalStateException ex,
                                                         HttpServletRequest httpRequest) {
-        String correlationId = getCorrelationId(httpRequest);
-        return ResponseEntity.status(HttpStatus.CONFLICT)
-            .body(new ErrorBody("CONFLICT", ex.getMessage(), correlationId, Map.of()));
+        return error(HttpStatus.CONFLICT, "CONFLICT", ex.getMessage(), httpRequest);
     }
 
-    // ---- Internal helpers ----
-
     private ResponseEntity<ErrorBody> validationError(List<String> errors, HttpServletRequest request) {
-        String correlationId = getCorrelationId(request);
-        return ResponseEntity.badRequest()
-            .body(new ErrorBody("VALIDATION_FAILED", String.join("; ", errors), correlationId, Map.of()));
+        return error(HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", String.join("; ", errors), request);
     }
 
     private ResponseEntity<ErrorBody> notFound(String message, HttpServletRequest request) {
-        String correlationId = getCorrelationId(request);
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-            .body(new ErrorBody("NOT_FOUND", message, correlationId, Map.of()));
+        return error(HttpStatus.NOT_FOUND, "NOT_FOUND", message, request);
     }
 
-    private ResponseEntity<ErrorBody> idempotencyKeyReused(HttpServletRequest request) {
-        String correlationId = getCorrelationId(request);
-        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
-            .body(new ErrorBody("IDEMPOTENCY_KEY_REUSED",
-                "Idempotency-Key was reused with a different request body",
-                correlationId, Map.of()));
+    private ResponseEntity<ErrorBody> error(HttpStatus status, String code, String message, HttpServletRequest request) {
+        return ResponseEntity.status(status)
+            .body(new ErrorBody(code, message, getCorrelationId(request), Map.of()));
     }
 
     private String getCorrelationId(HttpServletRequest request) {
-        String id = request.getHeader("X-Correlation-Id");
-        return id != null && !id.isBlank() ? id : UUID.randomUUID().toString();
-    }
-
-    private void publishEvent(DomainEvent event, String sagaId, HttpServletRequest request) {
-        EventEnvelope envelope = new EventEnvelope(
-            "evt-" + UUID.randomUUID(), event.getClass().getSimpleName(), 1,
-            "booking-orchestration", "cmd-" + UUID.randomUUID(),
-            getCorrelationId(request), clock.instant(), event);
-        eventPublisher.publish(envelope);
+        Object requestScoped = request.getAttribute(RequestContextFilter.CORRELATION_ID_HEADER);
+        if (requestScoped instanceof String id && !id.isBlank()) {
+            return id;
+        }
+        String header = request.getHeader(RequestContextFilter.CORRELATION_ID_HEADER);
+        if (header != null && !header.isBlank()) {
+            return header;
+        }
+        String requestId = request.getHeader(RequestContextFilter.REQUEST_ID_HEADER);
+        return requestId != null && !requestId.isBlank() ? requestId : "corr-" + UUID.randomUUID();
     }
 
     private List<String> validateIdempotencyKey(String idempotencyKey) {
@@ -277,6 +196,10 @@ public class BookingOrchestrationController {
 
     private List<String> validateStartSaga(StartSagaRequest request) {
         List<String> errors = new ArrayList<>();
+        if (request == null) {
+            errors.add("request body is required");
+            return errors;
+        }
         if (request.journeyOrderId() == null || request.journeyOrderId().isBlank()) {
             errors.add("journeyOrderId is required");
         }
@@ -297,6 +220,10 @@ public class BookingOrchestrationController {
 
     private List<String> validateRequestReservation(RequestReservationRequest request) {
         List<String> errors = new ArrayList<>();
+        if (request == null) {
+            errors.add("request body is required");
+            return errors;
+        }
         if (request.segmentRef() == null || request.segmentRef().isBlank()) {
             errors.add("segmentRef is required");
         }
@@ -311,6 +238,10 @@ public class BookingOrchestrationController {
 
     private List<String> validateMarkTicketed(MarkTicketedRequest request) {
         List<String> errors = new ArrayList<>();
+        if (request == null) {
+            errors.add("request body is required");
+            return errors;
+        }
         if (request.segmentBookingId() == null || request.segmentBookingId().isBlank()) {
             errors.add("segmentBookingId is required");
         }
@@ -318,80 +249,5 @@ public class BookingOrchestrationController {
             errors.add("entitlementId is required");
         }
         return errors;
-    }
-
-    private String mapSagaStatus(BookingSagaStatus status) {
-        return switch (status) {
-            case PLANNED -> "PLANNED";
-            case RESERVING -> "RESERVING";
-            case AWAITING_PAYMENT -> "WAITING_PAYMENT";
-            case CONFIRMING -> "CONFIRMING";
-            case TICKETING -> "TICKETING";
-            case COMPLETED -> "COMPLETED";
-            case PARTIALLY_CONFIRMED -> "PARTIALLY_CONFIRMED";
-            case COMPENSATING -> "COMPENSATING";
-            case MANUAL_REVIEW -> "MANUAL_REVIEW";
-            case FAILED -> "FAILED";
-        };
-    }
-
-    private Map<String, Object> buildSagaDetail(BookingSaga saga) {
-        Map<String, Object> detail = new HashMap<>();
-        detail.put("sagaId", saga.sagaId());
-        detail.put("journeyOrderId", saga.journeyOrderId());
-        detail.put("status", mapSagaStatus(saga.status()));
-        detail.put("idempotencyKey", saga.idempotencyKey());
-        List<Map<String, Object>> steps = new ArrayList<>();
-        for (BookingSagaStep step : saga.steps()) {
-            Map<String, Object> stepMap = new HashMap<>();
-            stepMap.put("name", step.name());
-            stepMap.put("idempotencyKey", step.idempotencyKey());
-            stepMap.put("status", step.status().name());
-            stepMap.put("attemptNumber", step.attemptNumber());
-            step.failureReason().ifPresent(r -> stepMap.put("failureReason", r));
-            steps.add(stepMap);
-        }
-        detail.put("steps", steps);
-        saga.terminalReason().ifPresent(r -> detail.put("terminalReason", r));
-        return detail;
-    }
-
-    static class IdempotencyStore {
-        private static final class Entry {
-            final Object requestBody;
-            final Object response;
-            Entry(Object requestBody, Object response) {
-                this.requestBody = requestBody;
-                this.response = response;
-            }
-        }
-        private final ConcurrentHashMap<String, Entry> store = new ConcurrentHashMap<>();
-
-        void put(String key, Object requestBody, Object response) {
-            store.put(key, new Entry(requestBody, response));
-        }
-
-        Object get(String key, Object requestBody) {
-            Entry entry = store.get(key);
-            if (entry == null) {
-                return null;
-            }
-            if (!requestBody.equals(entry.requestBody)) {
-                throw new IdempotencyKeyReusedException();
-            }
-            return entry.response;
-        }
-    }
-
-    static class SagaStore {
-        private final ConcurrentHashMap<String, BookingSaga> store = new ConcurrentHashMap<>();
-        void put(String key, BookingSaga saga) { store.put(key, saga); }
-        Optional<BookingSaga> get(String key) { return Optional.ofNullable(store.get(key)); }
-    }
-
-    static class IdempotencyKeyReusedException extends RuntimeException {
-        IdempotencyKeyReusedException() {
-            super("Idempotency-Key was reused with a different request body");
-        }
     }
 }

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/api/BookingOrchestrationController.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/api/BookingOrchestrationController.java
@@ -98,9 +98,9 @@ public class BookingOrchestrationController {
             return validationError(errors, httpRequest);
         }
 
-        Optional<Object> existing = idempotencyStore.get(idempotencyKey);
-        if (existing.isPresent()) {
-            return ResponseEntity.status(HttpStatus.CREATED).body(existing.get());
+        var existing = idempotencyStore.get(idempotencyKey, request);
+        if (existing != null) {
+            return ResponseEntity.status(HttpStatus.CREATED).body(existing);
         }
 
         String sagaId = "saga-" + UUID.randomUUID();
@@ -121,7 +121,7 @@ public class BookingOrchestrationController {
         sagaStore.put(sagaId, saga);
         var response = new StartSagaResponse(sagaId, request.journeyOrderId(),
             mapSagaStatus(saga.status()), clock.instant());
-        idempotencyStore.put(idempotencyKey, response);
+        idempotencyStore.put(idempotencyKey, request, response);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
@@ -156,9 +156,9 @@ public class BookingOrchestrationController {
             return validationError(errors, httpRequest);
         }
 
-        Optional<Object> existing = idempotencyStore.get(idempotencyKey);
-        if (existing.isPresent()) {
-            return ResponseEntity.ok(existing.get());
+        var existing = idempotencyStore.get(idempotencyKey, request);
+        if (existing != null) {
+            return ResponseEntity.ok(existing);
         }
 
         SegmentBooking segmentBooking = SegmentBooking.requestReservation(
@@ -171,7 +171,7 @@ public class BookingOrchestrationController {
         }
 
         var response = new RequestReservationResponse(request.segmentBookingId(), "REQUESTED");
-        idempotencyStore.put(idempotencyKey, response);
+        idempotencyStore.put(idempotencyKey, request, response);
         return ResponseEntity.ok(response);
     }
 
@@ -195,13 +195,13 @@ public class BookingOrchestrationController {
             return validationError(errors, httpRequest);
         }
 
-        Optional<Object> existing = idempotencyStore.get(idempotencyKey);
-        if (existing.isPresent()) {
-            return ResponseEntity.ok(existing.get());
+        var existing = idempotencyStore.get(idempotencyKey, request);
+        if (existing != null) {
+            return ResponseEntity.ok(existing);
         }
 
         var response = new MarkTicketedResponse(request.segmentBookingId(), "TICKETED");
-        idempotencyStore.put(idempotencyKey, response);
+        idempotencyStore.put(idempotencyKey, request, response);
         return ResponseEntity.ok(response);
     }
 
@@ -213,6 +213,12 @@ public class BookingOrchestrationController {
         String correlationId = getCorrelationId(httpRequest);
         return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
             .body(new ErrorBody("DOMAIN_RULE_VIOLATION", ex.getMessage(), correlationId, Map.of()));
+    }
+
+    @ExceptionHandler(IdempotencyKeyReusedException.class)
+    public ResponseEntity<ErrorBody> handleIdempotencyKeyReused(IdempotencyKeyReusedException ex,
+                                                                    HttpServletRequest httpRequest) {
+        return idempotencyKeyReused(httpRequest);
     }
 
     @ExceptionHandler(IllegalStateException.class)
@@ -235,6 +241,14 @@ public class BookingOrchestrationController {
         String correlationId = getCorrelationId(request);
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
             .body(new ErrorBody("NOT_FOUND", message, correlationId, Map.of()));
+    }
+
+    private ResponseEntity<ErrorBody> idempotencyKeyReused(HttpServletRequest request) {
+        String correlationId = getCorrelationId(request);
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+            .body(new ErrorBody("IDEMPOTENCY_KEY_REUSED",
+                "Idempotency-Key was reused with a different request body",
+                correlationId, Map.of()));
     }
 
     private String getCorrelationId(HttpServletRequest request) {
@@ -332,14 +346,41 @@ public class BookingOrchestrationController {
     }
 
     static class IdempotencyStore {
-        private final ConcurrentHashMap<String, Object> store = new ConcurrentHashMap<>();
-        void put(String key, Object value) { store.put(key, value); }
-        Optional<Object> get(String key) { return Optional.ofNullable(store.get(key)); }
+        private static final class Entry {
+            final Object requestBody;
+            final Object response;
+            Entry(Object requestBody, Object response) {
+                this.requestBody = requestBody;
+                this.response = response;
+            }
+        }
+        private final ConcurrentHashMap<String, Entry> store = new ConcurrentHashMap<>();
+
+        void put(String key, Object requestBody, Object response) {
+            store.put(key, new Entry(requestBody, response));
+        }
+
+        Object get(String key, Object requestBody) {
+            Entry entry = store.get(key);
+            if (entry == null) {
+                return null;
+            }
+            if (!requestBody.equals(entry.requestBody)) {
+                throw new IdempotencyKeyReusedException();
+            }
+            return entry.response;
+        }
     }
 
     static class SagaStore {
         private final ConcurrentHashMap<String, BookingSaga> store = new ConcurrentHashMap<>();
         void put(String key, BookingSaga saga) { store.put(key, saga); }
         Optional<BookingSaga> get(String key) { return Optional.ofNullable(store.get(key)); }
+    }
+
+    static class IdempotencyKeyReusedException extends RuntimeException {
+        IdempotencyKeyReusedException() {
+            super("Idempotency-Key was reused with a different request body");
+        }
     }
 }

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
@@ -35,6 +35,8 @@ public class BookingOrchestrationService {
     private final ConcurrentHashMap<String, SegmentBooking> segmentBookings = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, String> segmentBookingToSaga = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, String> segmentIdempotencyToBookingId = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, String> holdIdToSegmentBookingId = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, String> paymentIntentIdToSaga = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Boolean> consumedEventIds = new ConcurrentHashMap<>();
 
     public BookingOrchestrationService(Clock clock, EventPublisher eventPublisher) {
@@ -139,11 +141,13 @@ public class BookingOrchestrationService {
             case "JourneyOrderCreated" -> handleJourneyOrderCreated(payload, envelope.correlationId());
             case "CapacityHeld", "CapacityHoldConfirmed" -> handleCapacityHeld(payload, envelope.correlationId(), envelope.eventId());
             case "CapacityReleased", "CapacityHoldExpired" -> handleCapacityReleased(payload, envelope.correlationId(), envelope.eventId());
+            case "PaymentIntentCreated" -> handlePaymentIntentCreated(payload);
             case "PaymentCaptured" -> handlePaymentCaptured(payload, envelope.correlationId(), envelope.eventId());
+            case "PaymentIntentFailed", "PaymentFailed", "PaymentExpired", "PaymentIntentExpired" -> handlePaymentFailure(payload, envelope.correlationId(), envelope.eventId());
             case "ProviderReservationConfirmed" -> handleProviderReservationConfirmed(payload, envelope.correlationId(), envelope.eventId());
-            case "ProviderReservationFailed", "ProviderReservationTimedOut" -> handleProviderReservationFailed(payload, envelope.eventId());
+            case "ProviderReservationFailed", "ProviderReservationTimedOut" -> handleProviderReservationFailed(payload, envelope.correlationId(), envelope.eventId());
             case "EntitlementIssued" -> handleEntitlementIssued(payload, envelope.correlationId(), envelope.eventId());
-            case "EntitlementIssueFailed", "EntitlementVoided" -> handleEntitlementFailure(payload, envelope.eventId());
+            case "EntitlementIssueFailed", "EntitlementVoided" -> handleEntitlementFailure(payload, envelope.correlationId(), envelope.eventId());
             default -> {
                 // Streams contain event types that do not affect this saga.
             }
@@ -187,6 +191,9 @@ public class BookingOrchestrationService {
                 .map(segmentBookings::get)
                 .orElse(null);
         }
+        if (booking == null && holdId != null) {
+            booking = byHoldId(holdId);
+        }
         if (booking == null) {
             booking = bySegmentBookingId(payload);
         }
@@ -194,31 +201,61 @@ public class BookingOrchestrationService {
             throw new IllegalArgumentException("CapacityHeld/CapacityHoldConfirmed payload requires holdId and a known segment booking reference");
         }
         booking.markCapacityHolding(holdId);
+        holdIdToSegmentBookingId.putIfAbsent(holdId, booking.segmentBookingId());
         publishEvents(booking.pullEvents(), correlationId, causationId);
         markSagaStepSucceeded(booking.segmentBookingId(), correlationId, causationId);
     }
 
     private void handleCapacityReleased(Map<String, Object> payload, String correlationId, String causationId) {
-        SegmentBooking booking = bySegmentBookingId(payload);
+        String holdId = firstText(payload, "holdId", "capacityHoldId");
+        SegmentBooking booking = holdId == null ? null : byHoldId(holdId);
+        if (booking == null) {
+            booking = bySegmentBookingId(payload);
+        }
         if (booking != null) {
             String reason = firstText(payload, "releaseReason", "reason");
-            booking.requestCancellation(reason == null ? "capacity released" : reason);
+            booking.markCancelled(reason == null ? "capacity hold released" : reason);
+            if (holdId != null) {
+                holdIdToSegmentBookingId.remove(holdId);
+            }
             publishEvents(booking.pullEvents(), correlationId, causationId);
         }
     }
 
-    private void handlePaymentCaptured(Map<String, Object> payload, String correlationId, String causationId) {
-        String journeyOrderId = firstText(payload, "journeyOrderId", "orderId", "businessRef");
-        if (journeyOrderId == null) {
-            throw new IllegalArgumentException("PaymentCaptured payload requires journeyOrderId, orderId or businessRef");
+    private void handlePaymentIntentCreated(Map<String, Object> payload) {
+        String paymentIntentId = text(payload.get("paymentIntentId"));
+        String businessRef = text(payload.get("businessRef"));
+        if (paymentIntentId == null || businessRef == null) {
+            throw new IllegalArgumentException("PaymentIntentCreated payload requires paymentIntentId and businessRef");
         }
-        sagas.values().stream()
-            .filter(saga -> saga.journeyOrderId().equals(journeyOrderId))
-            .findFirst()
-            .ifPresent(saga -> {
-                safeAdvance(saga, BookingSagaStatus.TICKETING);
-                publishEvents(saga.pullEvents(), correlationId, causationId);
-            });
+        mapPaymentIntent(paymentIntentId, businessRef);
+    }
+
+    private void handlePaymentCaptured(Map<String, Object> payload, String correlationId, String causationId) {
+        String paymentIntentId = text(payload.get("paymentIntentId"));
+        if (paymentIntentId == null) {
+            throw new IllegalArgumentException("PaymentCaptured payload requires paymentIntentId");
+        }
+        String sagaId = sagaIdForPaymentIntent(paymentIntentId, payload);
+        BookingSaga saga = sagaId == null ? null : sagas.get(sagaId);
+        if (saga != null) {
+            safeAdvance(saga, BookingSagaStatus.TICKETING);
+            publishEvents(saga.pullEvents(), correlationId, causationId);
+        }
+    }
+
+    private void handlePaymentFailure(Map<String, Object> payload, String correlationId, String causationId) {
+        String paymentIntentId = text(payload.get("paymentIntentId"));
+        if (paymentIntentId == null) {
+            throw new IllegalArgumentException("payment failure payload requires paymentIntentId");
+        }
+        String sagaId = sagaIdForPaymentIntent(paymentIntentId, payload);
+        BookingSaga saga = sagaId == null ? null : sagas.get(sagaId);
+        if (saga != null && saga.status() != BookingSagaStatus.FAILED && saga.status() != BookingSagaStatus.COMPLETED) {
+            String reason = firstText(payload, "reason", "reasonCode");
+            saga.fail(reason == null ? "payment failed" : reason);
+            publishEvents(saga.pullEvents(), correlationId, causationId);
+        }
     }
 
     private void handleProviderReservationConfirmed(Map<String, Object> payload, String correlationId, String causationId) {
@@ -234,14 +271,14 @@ public class BookingOrchestrationService {
         markSagaStepSucceeded(booking.segmentBookingId(), correlationId, causationId);
     }
 
-    private void handleProviderReservationFailed(Map<String, Object> payload, String causationId) {
+    private void handleProviderReservationFailed(Map<String, Object> payload, String correlationId, String causationId) {
         SegmentBooking booking = bySegmentBookingId(payload);
         if (booking == null) {
             throw new IllegalArgumentException("provider failure payload references an unknown segment booking");
         }
         String reason = firstText(payload, "errorMessage", "reason", "errorType");
         booking.failReservation(reason == null ? "provider reservation failed" : reason);
-        publishEvents(booking.pullEvents(), null, causationId);
+        publishEvents(booking.pullEvents(), correlationId, causationId);
     }
 
     private void handleEntitlementIssued(Map<String, Object> payload, String correlationId, String causationId) {
@@ -263,12 +300,12 @@ public class BookingOrchestrationService {
         }
     }
 
-    private void handleEntitlementFailure(Map<String, Object> payload, String causationId) {
+    private void handleEntitlementFailure(Map<String, Object> payload, String correlationId, String causationId) {
         SegmentBooking booking = bySegmentBookingId(payload);
         if (booking != null) {
             String reason = firstText(payload, "failureMessage", "failureCode", "reason");
             booking.failReservation(reason == null ? "entitlement processing failed" : reason);
-            publishEvents(booking.pullEvents(), null, causationId);
+            publishEvents(booking.pullEvents(), correlationId, causationId);
         }
     }
 
@@ -376,6 +413,41 @@ public class BookingOrchestrationService {
     private SegmentBooking bySegmentBookingId(Map<String, Object> payload) {
         String segmentBookingId = text(payload.get("segmentBookingId"));
         return segmentBookingId == null ? null : segmentBookings.get(segmentBookingId);
+    }
+
+    private SegmentBooking byHoldId(String holdId) {
+        return Optional.ofNullable(holdIdToSegmentBookingId.get(holdId))
+            .map(segmentBookings::get)
+            .orElse(null);
+    }
+
+    private String sagaIdForPaymentIntent(String paymentIntentId, Map<String, Object> payload) {
+        String sagaId = paymentIntentIdToSaga.get(paymentIntentId);
+        if (sagaId != null) {
+            return sagaId;
+        }
+        String businessRef = firstText(payload, "businessRef", "journeyOrderId", "orderId");
+        return businessRef == null ? null : mapPaymentIntent(paymentIntentId, businessRef).orElse(null);
+    }
+
+    private Optional<String> mapPaymentIntent(String paymentIntentId, String businessRef) {
+        BookingSaga saga = sagaByBusinessRef(businessRef);
+        if (saga != null) {
+            paymentIntentIdToSaga.putIfAbsent(paymentIntentId, saga.sagaId());
+            return Optional.of(saga.sagaId());
+        }
+        return Optional.empty();
+    }
+
+    private BookingSaga sagaByBusinessRef(String businessRef) {
+        BookingSaga bySagaId = sagas.get(businessRef);
+        if (bySagaId != null) {
+            return bySagaId;
+        }
+        return sagas.values().stream()
+            .filter(saga -> saga.journeyOrderId().equals(businessRef))
+            .findFirst()
+            .orElse(null);
     }
 
     private ProviderReference providerReference(Object raw) {

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
@@ -1,0 +1,461 @@
+package com.trainticket.bookingorchestration.application;
+
+import com.trainticket.bookingorchestration.domain.BookingSaga;
+import com.trainticket.bookingorchestration.domain.BookingSagaStatus;
+import com.trainticket.bookingorchestration.domain.BookingSagaStep;
+import com.trainticket.bookingorchestration.domain.DomainEvent;
+import com.trainticket.bookingorchestration.domain.ProviderReference;
+import com.trainticket.bookingorchestration.domain.ProviderReservationConfirmed;
+import com.trainticket.bookingorchestration.domain.SegmentBooking;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BookingOrchestrationService {
+
+    private static final String PRODUCER = "booking-orchestration";
+
+    private final Clock clock;
+    private final EventPublisher eventPublisher;
+    private final IdempotencyStore idempotencyStore = new IdempotencyStore();
+    private final ConcurrentHashMap<String, BookingSaga> sagas = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, SegmentBooking> segmentBookings = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, String> segmentBookingToSaga = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, String> segmentIdempotencyToBookingId = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Boolean> consumedEventIds = new ConcurrentHashMap<>();
+
+    public BookingOrchestrationService(Clock clock, EventPublisher eventPublisher) {
+        this.clock = Objects.requireNonNull(clock, "clock is required");
+        this.eventPublisher = Objects.requireNonNull(eventPublisher, "eventPublisher is required");
+    }
+
+    public StartSagaResult startSaga(StartSagaCommand command, String idempotencyKey, String correlationId) {
+        Object existing = idempotencyStore.get(idempotencyKey, command);
+        if (existing instanceof StartSagaResult result) {
+            return result;
+        }
+
+        String sagaId = "saga-" + UUID.randomUUID();
+        BookingSaga saga = startSagaAggregate(sagaId, command.journeyOrderId(), command.segmentRefs());
+        sagas.put(sagaId, saga);
+        publishEvents(saga.pullEvents(), correlationId, "cmd-" + UUID.randomUUID());
+
+        StartSagaResult result = new StartSagaResult(sagaId, command.journeyOrderId(), mapSagaStatus(saga.status()), clock.instant());
+        idempotencyStore.put(idempotencyKey, command, result);
+        return result;
+    }
+
+    public Optional<SagaDetail> getSaga(String sagaId) {
+        return Optional.ofNullable(sagas.get(sagaId)).map(this::buildSagaDetail);
+    }
+
+    public RequestReservationResult requestReservation(String sagaId, RequestReservationCommand command,
+                                                       String idempotencyKey, String correlationId) {
+        BookingSaga saga = sagas.get(sagaId);
+        if (saga == null) {
+            throw new NotFoundException("Booking saga not found: " + sagaId);
+        }
+
+        Object existing = idempotencyStore.get(idempotencyKey, command);
+        if (existing instanceof RequestReservationResult result) {
+            return result;
+        }
+
+        SegmentBooking booking = SegmentBooking.requestReservation(
+            command.segmentBookingId(), saga.journeyOrderId(), command.segmentRef(), command.segmentRef(),
+            command.travelerRef(), "purchase", clock);
+        segmentBookings.put(command.segmentBookingId(), booking);
+        segmentBookingToSaga.put(command.segmentBookingId(), sagaId);
+        segmentIdempotencyToBookingId.put(booking.idempotencyKey(), command.segmentBookingId());
+        publishEvents(booking.pullEvents(), correlationId, "cmd-" + UUID.randomUUID());
+
+        RequestReservationResult result = new RequestReservationResult(command.segmentBookingId(), "REQUESTED");
+        idempotencyStore.put(idempotencyKey, command, result);
+        return result;
+    }
+
+    public MarkTicketedResult markTicketed(String sagaId, MarkTicketedCommand command,
+                                           String idempotencyKey, String correlationId) {
+        if (!sagas.containsKey(sagaId)) {
+            throw new NotFoundException("Booking saga not found: " + sagaId);
+        }
+
+        Object existing = idempotencyStore.get(idempotencyKey, command);
+        if (existing instanceof MarkTicketedResult result) {
+            return result;
+        }
+
+        SegmentBooking booking = segmentBookings.get(command.segmentBookingId());
+        if (booking == null || !sagaId.equals(segmentBookingToSaga.get(command.segmentBookingId()))) {
+            throw new NotFoundException("Segment booking not found: " + command.segmentBookingId());
+        }
+        try {
+            booking.markTicketed(command.entitlementId());
+        } catch (IllegalStateException ex) {
+            throw new PreconditionFailedException(ex.getMessage(), ex);
+        }
+        publishEvents(booking.pullEvents(), correlationId, "cmd-" + UUID.randomUUID());
+
+        MarkTicketedResult result = new MarkTicketedResult(command.segmentBookingId(), "TICKETED");
+        idempotencyStore.put(idempotencyKey, command, result);
+        return result;
+    }
+
+    public HandlerResult handleUpstreamEvent(EventEnvelope envelope) {
+        if (envelope == null || envelope.eventId() == null || envelope.eventId().isBlank()) {
+            return new HandlerResult.FatalError("missing event envelope or eventId");
+        }
+        if (consumedEventIds.putIfAbsent(envelope.eventId(), Boolean.TRUE) != null) {
+            return new HandlerResult.Success();
+        }
+        try {
+            dispatchUpstreamEvent(envelope);
+            return new HandlerResult.Success();
+        } catch (IllegalArgumentException | IllegalStateException | NotFoundException | PreconditionFailedException ex) {
+            consumedEventIds.remove(envelope.eventId());
+            return new HandlerResult.FatalError(ex.getMessage());
+        } catch (RuntimeException ex) {
+            consumedEventIds.remove(envelope.eventId());
+            return new HandlerResult.TransientError(ex.getMessage());
+        }
+    }
+
+    private void dispatchUpstreamEvent(EventEnvelope envelope) {
+        Map<String, Object> payload = payloadMap(envelope.payload());
+        switch (envelope.eventType()) {
+            case "JourneyOrderCreated" -> handleJourneyOrderCreated(payload, envelope.correlationId());
+            case "CapacityHeld", "CapacityHoldConfirmed" -> handleCapacityHeld(payload, envelope.correlationId(), envelope.eventId());
+            case "CapacityReleased", "CapacityHoldExpired" -> handleCapacityReleased(payload, envelope.correlationId(), envelope.eventId());
+            case "PaymentCaptured" -> handlePaymentCaptured(payload, envelope.correlationId(), envelope.eventId());
+            case "ProviderReservationConfirmed" -> handleProviderReservationConfirmed(payload, envelope.correlationId(), envelope.eventId());
+            case "ProviderReservationFailed", "ProviderReservationTimedOut" -> handleProviderReservationFailed(payload, envelope.eventId());
+            case "EntitlementIssued" -> handleEntitlementIssued(payload, envelope.correlationId(), envelope.eventId());
+            case "EntitlementIssueFailed", "EntitlementVoided" -> handleEntitlementFailure(payload, envelope.eventId());
+            default -> {
+                // Streams contain event types that do not affect this saga.
+            }
+        }
+    }
+
+    private void handleJourneyOrderCreated(Map<String, Object> payload, String correlationId) {
+        String journeyOrderId = firstText(payload, "journeyOrderId", "orderId");
+        if (journeyOrderId == null) {
+            throw new IllegalArgumentException("JourneyOrderCreated payload requires orderId");
+        }
+        if (sagas.values().stream().anyMatch(saga -> saga.journeyOrderId().equals(journeyOrderId))) {
+            return;
+        }
+        List<String> segmentRefs = listOfText(payload.get("segmentRefs"));
+        if (segmentRefs.isEmpty() && payload.get("segments") instanceof List<?> segments) {
+            for (Object segment : segments) {
+                if (segment instanceof Map<?, ?> map) {
+                    String segmentRef = text(map.get("segmentRef"));
+                    if (segmentRef != null) {
+                        segmentRefs.add(segmentRef);
+                    }
+                }
+            }
+        }
+        if (segmentRefs.isEmpty()) {
+            throw new IllegalArgumentException("JourneyOrderCreated payload requires segmentRefs or segments");
+        }
+        String sagaId = "saga-" + UUID.randomUUID();
+        BookingSaga saga = startSagaAggregate(sagaId, journeyOrderId, segmentRefs);
+        sagas.put(sagaId, saga);
+        publishEvents(saga.pullEvents(), correlationId, "evt-" + UUID.randomUUID());
+    }
+
+    private void handleCapacityHeld(Map<String, Object> payload, String correlationId, String causationId) {
+        String holdId = firstText(payload, "holdId", "capacityHoldId");
+        String idempotencyKey = text(payload.get("idempotencyKey"));
+        SegmentBooking booking = null;
+        if (idempotencyKey != null) {
+            booking = Optional.ofNullable(segmentIdempotencyToBookingId.get(idempotencyKey))
+                .map(segmentBookings::get)
+                .orElse(null);
+        }
+        if (booking == null) {
+            booking = bySegmentBookingId(payload);
+        }
+        if (booking == null || holdId == null) {
+            throw new IllegalArgumentException("CapacityHeld/CapacityHoldConfirmed payload requires holdId and a known segment booking reference");
+        }
+        booking.markCapacityHolding(holdId);
+        publishEvents(booking.pullEvents(), correlationId, causationId);
+        markSagaStepSucceeded(booking.segmentBookingId(), correlationId, causationId);
+    }
+
+    private void handleCapacityReleased(Map<String, Object> payload, String correlationId, String causationId) {
+        SegmentBooking booking = bySegmentBookingId(payload);
+        if (booking != null) {
+            String reason = firstText(payload, "releaseReason", "reason");
+            booking.requestCancellation(reason == null ? "capacity released" : reason);
+            publishEvents(booking.pullEvents(), correlationId, causationId);
+        }
+    }
+
+    private void handlePaymentCaptured(Map<String, Object> payload, String correlationId, String causationId) {
+        String journeyOrderId = firstText(payload, "journeyOrderId", "orderId", "businessRef");
+        if (journeyOrderId == null) {
+            throw new IllegalArgumentException("PaymentCaptured payload requires journeyOrderId, orderId or businessRef");
+        }
+        sagas.values().stream()
+            .filter(saga -> saga.journeyOrderId().equals(journeyOrderId))
+            .findFirst()
+            .ifPresent(saga -> {
+                safeAdvance(saga, BookingSagaStatus.TICKETING);
+                publishEvents(saga.pullEvents(), correlationId, causationId);
+            });
+    }
+
+    private void handleProviderReservationConfirmed(Map<String, Object> payload, String correlationId, String causationId) {
+        SegmentBooking booking = bySegmentBookingId(payload);
+        if (booking == null) {
+            throw new IllegalArgumentException("ProviderReservationConfirmed payload references an unknown segment booking");
+        }
+        ProviderReference reference = providerReference(payload.get("providerReference"));
+        String evidence = firstText(payload, "normalizedEvidence", "evidence");
+        booking.confirmFromProvider(new ProviderReservationConfirmed(
+            booking.segmentBookingId(), reference, evidence == null ? "provider-confirmed" : evidence, Map.of()));
+        publishEvents(booking.pullEvents(), correlationId, causationId);
+        markSagaStepSucceeded(booking.segmentBookingId(), correlationId, causationId);
+    }
+
+    private void handleProviderReservationFailed(Map<String, Object> payload, String causationId) {
+        SegmentBooking booking = bySegmentBookingId(payload);
+        if (booking == null) {
+            throw new IllegalArgumentException("provider failure payload references an unknown segment booking");
+        }
+        String reason = firstText(payload, "errorMessage", "reason", "errorType");
+        booking.failReservation(reason == null ? "provider reservation failed" : reason);
+        publishEvents(booking.pullEvents(), null, causationId);
+    }
+
+    private void handleEntitlementIssued(Map<String, Object> payload, String correlationId, String causationId) {
+        String segmentBookingId = text(payload.get("segmentBookingId"));
+        String entitlementId = text(payload.get("entitlementId"));
+        if (segmentBookingId == null || entitlementId == null) {
+            throw new IllegalArgumentException("EntitlementIssued payload requires segmentBookingId and entitlementId");
+        }
+        String sagaId = segmentBookingToSaga.get(segmentBookingId);
+        if (sagaId == null) {
+            throw new IllegalArgumentException("EntitlementIssued references an unknown segment booking");
+        }
+        markTicketed(sagaId, new MarkTicketedCommand(segmentBookingId, entitlementId),
+            "event:" + causationId + ":" + segmentBookingId, correlationId);
+        BookingSaga saga = sagas.get(sagaId);
+        if (saga != null && saga.steps().stream().allMatch(step -> step.status().name().equals("SUCCEEDED"))) {
+            saga.complete();
+            publishEvents(saga.pullEvents(), correlationId, causationId);
+        }
+    }
+
+    private void handleEntitlementFailure(Map<String, Object> payload, String causationId) {
+        SegmentBooking booking = bySegmentBookingId(payload);
+        if (booking != null) {
+            String reason = firstText(payload, "failureMessage", "failureCode", "reason");
+            booking.failReservation(reason == null ? "entitlement processing failed" : reason);
+            publishEvents(booking.pullEvents(), null, causationId);
+        }
+    }
+
+    private BookingSaga startSagaAggregate(String sagaId, String journeyOrderId, List<String> segmentRefs) {
+        List<BookingSagaStep> plan = new ArrayList<>();
+        for (String segmentRef : segmentRefs) {
+            plan.add(BookingSaga.stepPlan("reserve-" + segmentRef, sagaId + ":" + segmentRef,
+                Duration.ofMinutes(5), 3, "release-capacity"));
+        }
+        return BookingSaga.start(sagaId, journeyOrderId, "1", "purchase", plan, clock);
+    }
+
+    private void markSagaStepSucceeded(String segmentBookingId, String correlationId, String causationId) {
+        SegmentBooking booking = segmentBookings.get(segmentBookingId);
+        String sagaId = segmentBookingToSaga.get(segmentBookingId);
+        BookingSaga saga = sagaId == null ? null : sagas.get(sagaId);
+        if (booking == null || saga == null) {
+            return;
+        }
+        String stepKey = sagaId + ":" + booking.segmentRef();
+        try {
+            saga.recordStepSucceeded(stepKey);
+            if (saga.steps().stream().allMatch(step -> step.status().name().equals("SUCCEEDED"))) {
+                saga.advanceTo(BookingSagaStatus.AWAITING_PAYMENT);
+            }
+            publishEvents(saga.pullEvents(), correlationId, causationId);
+        } catch (IllegalArgumentException ignored) {
+            // The saga plan may have been started from upstream order data with a different step layout.
+        }
+    }
+
+    private void safeAdvance(BookingSaga saga, BookingSagaStatus nextStatus) {
+        if (saga.status() == nextStatus || saga.status() == BookingSagaStatus.COMPLETED || saga.status() == BookingSagaStatus.FAILED) {
+            return;
+        }
+        saga.advanceTo(nextStatus);
+    }
+
+    private void publishEvents(List<DomainEvent> events, String correlationId, String causationId) {
+        for (DomainEvent event : events) {
+            eventPublisher.publish(new EventEnvelope(
+                "evt-" + UUID.randomUUID(), event.getClass().getSimpleName(), 1, PRODUCER,
+                causationId == null || causationId.isBlank() ? "cmd-" + UUID.randomUUID() : causationId,
+                correlationId == null || correlationId.isBlank() ? "corr-" + UUID.randomUUID() : correlationId,
+                clock.instant(), event));
+        }
+    }
+
+    private SegmentBooking bySegmentBookingId(Map<String, Object> payload) {
+        String segmentBookingId = text(payload.get("segmentBookingId"));
+        return segmentBookingId == null ? null : segmentBookings.get(segmentBookingId);
+    }
+
+    private ProviderReference providerReference(Object raw) {
+        if (raw instanceof Map<?, ?> map) {
+            String providerId = text(map.get("providerId"));
+            String reservationId = firstText(map, "reservationId", "providerReservationId");
+            String displayReference = firstText(map, "displayReference", "confirmationNo", "reference");
+            return new ProviderReference(
+                providerId == null ? "provider" : providerId,
+                reservationId == null ? displayReference : reservationId,
+                displayReference == null ? reservationId : displayReference);
+        }
+        String reference = text(raw);
+        if (reference == null) {
+            throw new IllegalArgumentException("providerReference is required");
+        }
+        return new ProviderReference("provider", reference, reference);
+    }
+
+    private static Map<String, Object> payloadMap(Object payload) {
+        if (payload instanceof Map<?, ?> map) {
+            Map<String, Object> result = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                if (entry.getKey() instanceof String key) {
+                    result.put(key, entry.getValue());
+                }
+            }
+            return result;
+        }
+        throw new IllegalArgumentException("event payload must be an object");
+    }
+
+    private static String firstText(Map<?, ?> payload, String... names) {
+        for (String name : names) {
+            String value = text(payload.get(name));
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static String text(Object value) {
+        if (value instanceof String string && !string.isBlank()) {
+            return string;
+        }
+        return null;
+    }
+
+    private static List<String> listOfText(Object raw) {
+        List<String> values = new ArrayList<>();
+        if (raw instanceof List<?> list) {
+            for (Object item : list) {
+                String value = text(item);
+                if (value != null) {
+                    values.add(value);
+                }
+            }
+        }
+        return values;
+    }
+
+    private SagaDetail buildSagaDetail(BookingSaga saga) {
+        List<Map<String, Object>> steps = new ArrayList<>();
+        for (BookingSagaStep step : saga.steps()) {
+            Map<String, Object> stepMap = new HashMap<>();
+            stepMap.put("name", step.name());
+            stepMap.put("idempotencyKey", step.idempotencyKey());
+            stepMap.put("status", step.status().name());
+            stepMap.put("attemptNumber", step.attemptNumber());
+            step.failureReason().ifPresent(reason -> stepMap.put("failureReason", reason));
+            steps.add(stepMap);
+        }
+        return new SagaDetail(saga.sagaId(), saga.journeyOrderId(), mapSagaStatus(saga.status()),
+            saga.idempotencyKey(), steps, saga.terminalReason().orElse(null));
+    }
+
+    public static String mapSagaStatus(BookingSagaStatus status) {
+        return switch (status) {
+            case PLANNED -> "STARTED";
+            case RESERVING -> "RESERVING";
+            case AWAITING_PAYMENT -> "WAITING_PAYMENT";
+            case CONFIRMING -> "HELD";
+            case TICKETING -> "TICKETING";
+            case COMPLETED -> "COMPLETED";
+            case PARTIALLY_CONFIRMED -> "HELD";
+            case COMPENSATING, MANUAL_REVIEW, FAILED -> "FAILED";
+        };
+    }
+
+    public record StartSagaCommand(String journeyOrderId, String accountId, String offerId,
+                                   List<String> travelerRefs, List<String> segmentRefs) {}
+    public record StartSagaResult(String sagaId, String journeyOrderId, String status, Instant startedAt) {}
+    public record RequestReservationCommand(String segmentRef, String travelerRef, String segmentBookingId) {}
+    public record RequestReservationResult(String segmentBookingId, String status) {}
+    public record MarkTicketedCommand(String segmentBookingId, String entitlementId) {}
+    public record MarkTicketedResult(String segmentBookingId, String status) {}
+    public record SagaDetail(String sagaId, String journeyOrderId, String status, String idempotencyKey,
+                             List<Map<String, Object>> steps, String terminalReason) {}
+
+    static class IdempotencyStore {
+        private static final class Entry {
+            final Object requestBody;
+            final Object response;
+            Entry(Object requestBody, Object response) {
+                this.requestBody = requestBody;
+                this.response = response;
+            }
+        }
+        private final ConcurrentHashMap<String, Entry> store = new ConcurrentHashMap<>();
+
+        void put(String key, Object requestBody, Object response) {
+            store.put(key, new Entry(requestBody, response));
+        }
+
+        Object get(String key, Object requestBody) {
+            Entry entry = store.get(key);
+            if (entry == null) {
+                return null;
+            }
+            if (!requestBody.equals(entry.requestBody)) {
+                throw new IdempotencyKeyReusedException();
+            }
+            return entry.response;
+        }
+    }
+
+    public static class IdempotencyKeyReusedException extends RuntimeException {
+        public IdempotencyKeyReusedException() {
+            super("Idempotency-Key was reused with a different request body");
+        }
+    }
+
+    public static class NotFoundException extends RuntimeException {
+        public NotFoundException(String message) { super(message); }
+    }
+
+    public static class PreconditionFailedException extends RuntimeException {
+        public PreconditionFailedException(String message, Throwable cause) { super(message, cause); }
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
@@ -21,12 +21,15 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 public class BookingOrchestrationService {
 
     private static final String PRODUCER = "booking-orchestration";
+    private static final Logger LOGGER = LoggerFactory.getLogger(BookingOrchestrationService.class);
 
     private final Clock clock;
     private final EventPublisher eventPublisher;
@@ -37,6 +40,7 @@ public class BookingOrchestrationService {
     private final ConcurrentHashMap<String, String> segmentIdempotencyToBookingId = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, String> holdIdToSegmentBookingId = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, String> paymentIntentIdToSaga = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, String> correlationIdToSaga = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Boolean> consumedEventIds = new ConcurrentHashMap<>();
 
     public BookingOrchestrationService(Clock clock, EventPublisher eventPublisher) {
@@ -53,6 +57,7 @@ public class BookingOrchestrationService {
         String sagaId = "saga-" + UUID.randomUUID();
         BookingSaga saga = startSagaAggregate(sagaId, command.journeyOrderId(), command.segmentRefs());
         sagas.put(sagaId, saga);
+        indexSagaCorrelation(correlationId, sagaId);
         publishEvents(saga.pullEvents(), correlationId, "cmd-" + UUID.randomUUID());
 
         StartSagaResult result = new StartSagaResult(sagaId, command.journeyOrderId(), mapSagaStatus(saga.status()), clock.instant());
@@ -138,7 +143,7 @@ public class BookingOrchestrationService {
     private void dispatchUpstreamEvent(EventEnvelope envelope) {
         Map<String, Object> payload = payloadMap(envelope.payload());
         switch (envelope.eventType()) {
-            case "JourneyOrderCreated" -> handleJourneyOrderCreated(payload, envelope.correlationId());
+            case "JourneyOrderCreated" -> handleJourneyOrderCreated(payload, envelope.correlationId(), envelope.eventId());
             case "CapacityHeld", "CapacityHoldConfirmed" -> handleCapacityHeld(payload, envelope.correlationId(), envelope.eventId());
             case "CapacityReleased", "CapacityHoldExpired" -> handleCapacityReleased(payload, envelope.correlationId(), envelope.eventId());
             case "PaymentIntentCreated" -> handlePaymentIntentCreated(payload);
@@ -147,14 +152,15 @@ public class BookingOrchestrationService {
             case "ProviderReservationConfirmed" -> handleProviderReservationConfirmed(payload, envelope.correlationId(), envelope.eventId());
             case "ProviderReservationFailed", "ProviderReservationTimedOut" -> handleProviderReservationFailed(payload, envelope.correlationId(), envelope.eventId());
             case "EntitlementIssued" -> handleEntitlementIssued(payload, envelope.correlationId(), envelope.eventId());
-            case "EntitlementIssueFailed", "EntitlementVoided" -> handleEntitlementFailure(payload, envelope.correlationId(), envelope.eventId());
+            case "EntitlementIssueFailed" -> handleEntitlementIssueFailed(payload, envelope.correlationId(), envelope.eventId());
+            case "EntitlementVoided" -> handleEntitlementVoided(payload, envelope.correlationId(), envelope.eventId());
             default -> {
                 // Streams contain event types that do not affect this saga.
             }
         }
     }
 
-    private void handleJourneyOrderCreated(Map<String, Object> payload, String correlationId) {
+    private void handleJourneyOrderCreated(Map<String, Object> payload, String correlationId, String causationId) {
         String journeyOrderId = firstText(payload, "journeyOrderId", "orderId");
         if (journeyOrderId == null) {
             throw new IllegalArgumentException("JourneyOrderCreated payload requires orderId");
@@ -179,7 +185,8 @@ public class BookingOrchestrationService {
         String sagaId = "saga-" + UUID.randomUUID();
         BookingSaga saga = startSagaAggregate(sagaId, journeyOrderId, segmentRefs);
         sagas.put(sagaId, saga);
-        publishEvents(saga.pullEvents(), correlationId, "evt-" + UUID.randomUUID());
+        indexSagaCorrelation(correlationId, sagaId);
+        publishEvents(saga.pullEvents(), correlationId, causationId);
     }
 
     private void handleCapacityHeld(Map<String, Object> payload, String correlationId, String causationId) {
@@ -300,11 +307,42 @@ public class BookingOrchestrationService {
         }
     }
 
-    private void handleEntitlementFailure(Map<String, Object> payload, String correlationId, String causationId) {
+    private void handleEntitlementIssueFailed(Map<String, Object> payload, String correlationId, String causationId) {
+        BookingSaga saga = sagaByCorrelationId(correlationId);
+        if (saga == null) {
+            LOGGER.info("Ignoring EntitlementIssueFailed with unknown correlationId");
+            return;
+        }
+        String reason = firstText(payload, "failureMessage", "failureCode", "reason");
+        String failureReason = reason == null ? "entitlement processing failed" : reason;
+        for (SegmentBooking booking : segmentBookingsForSaga(saga.sagaId())) {
+            failSegmentBookingForEntitlement(booking, failureReason, correlationId, causationId);
+        }
+        if (saga.status() != BookingSagaStatus.FAILED && saga.status() != BookingSagaStatus.COMPLETED) {
+            saga.fail(failureReason);
+            publishEvents(saga.pullEvents(), correlationId, causationId);
+        }
+    }
+
+    private void handleEntitlementVoided(Map<String, Object> payload, String correlationId, String causationId) {
         SegmentBooking booking = bySegmentBookingId(payload);
         if (booking != null) {
             String reason = firstText(payload, "failureMessage", "failureCode", "reason");
-            booking.failReservation(reason == null ? "entitlement processing failed" : reason);
+            failSegmentBookingForEntitlement(booking, reason == null ? "entitlement processing failed" : reason,
+                correlationId, causationId);
+        }
+    }
+
+    private void failSegmentBookingForEntitlement(SegmentBooking booking, String reason, String correlationId,
+                                                  String causationId) {
+        if (booking.status().name().equals("FAILED") || booking.status().name().equals("CANCELLED")) {
+            return;
+        }
+        try {
+            booking.failReservation(reason);
+            publishEvents(booking.pullEvents(), correlationId, causationId);
+        } catch (IllegalStateException ex) {
+            booking.requestCancellation(reason);
             publishEvents(booking.pullEvents(), correlationId, causationId);
         }
     }
@@ -413,6 +451,34 @@ public class BookingOrchestrationService {
     private SegmentBooking bySegmentBookingId(Map<String, Object> payload) {
         String segmentBookingId = text(payload.get("segmentBookingId"));
         return segmentBookingId == null ? null : segmentBookings.get(segmentBookingId);
+    }
+
+    private void indexSagaCorrelation(String correlationId, String sagaId) {
+        if (correlationId != null && !correlationId.isBlank()) {
+            correlationIdToSaga.putIfAbsent(correlationId, sagaId);
+        }
+    }
+
+    private BookingSaga sagaByCorrelationId(String correlationId) {
+        if (correlationId == null || correlationId.isBlank()) {
+            return null;
+        }
+        return Optional.ofNullable(correlationIdToSaga.get(correlationId))
+            .map(sagas::get)
+            .orElse(null);
+    }
+
+    private List<SegmentBooking> segmentBookingsForSaga(String sagaId) {
+        List<SegmentBooking> bookings = new ArrayList<>();
+        for (Map.Entry<String, String> entry : segmentBookingToSaga.entrySet()) {
+            if (sagaId.equals(entry.getValue())) {
+                SegmentBooking booking = segmentBookings.get(entry.getKey());
+                if (booking != null) {
+                    bookings.add(booking);
+                }
+            }
+        }
+        return bookings;
     }
 
     private SegmentBooking byHoldId(String holdId) {

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
@@ -1,5 +1,6 @@
 package com.trainticket.bookingorchestration.application;
 
+import com.trainticket.bookingorchestration.domain.BookingEvent;
 import com.trainticket.bookingorchestration.domain.BookingSaga;
 import com.trainticket.bookingorchestration.domain.BookingSagaStatus;
 import com.trainticket.bookingorchestration.domain.BookingSagaStep;
@@ -7,6 +8,7 @@ import com.trainticket.bookingorchestration.domain.DomainEvent;
 import com.trainticket.bookingorchestration.domain.ProviderReference;
 import com.trainticket.bookingorchestration.domain.ProviderReservationConfirmed;
 import com.trainticket.bookingorchestration.domain.SegmentBooking;
+import com.trainticket.bookingorchestration.domain.SegmentBookingEvent;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -307,12 +309,68 @@ public class BookingOrchestrationService {
 
     private void publishEvents(List<DomainEvent> events, String correlationId, String causationId) {
         for (DomainEvent event : events) {
+            Optional<ContractEvent> contractEvent = toContractEvent(event);
+            if (contractEvent.isEmpty()) {
+                continue;
+            }
             eventPublisher.publish(new EventEnvelope(
-                "evt-" + UUID.randomUUID(), event.getClass().getSimpleName(), 1, PRODUCER,
+                "evt-" + UUID.randomUUID(), contractEvent.get().eventType(), 1, PRODUCER,
                 causationId == null || causationId.isBlank() ? "cmd-" + UUID.randomUUID() : causationId,
                 correlationId == null || correlationId.isBlank() ? "corr-" + UUID.randomUUID() : correlationId,
-                clock.instant(), event));
+                clock.instant(), contractEvent.get().payload()));
         }
+    }
+
+    Optional<ContractEvent> toContractEvent(DomainEvent event) {
+        return switch (event) {
+            case BookingEvent.BookingSagaStarted started -> Optional.of(new ContractEvent(
+                "BookingSagaStarted",
+                new BookingSagaStartedPayload(started.aggregateId(), started.journeyOrderId(), started.occurredAt())));
+            case SegmentBookingEvent.SegmentReservationRequested requested -> Optional.of(new ContractEvent(
+                "SegmentReservationRequested",
+                new SegmentReservationRequestedPayload(requested.aggregateId(), requested.journeyOrderId(),
+                    requested.segmentRef(), requested.travelerRef(), requested.idempotencyKey())));
+            case SegmentBookingEvent.SegmentCapacityHolding holding -> Optional.of(new ContractEvent(
+                "SegmentCapacityHolding",
+                new SegmentCapacityHoldingPayload(holding.aggregateId(), holding.capacityHoldId())));
+            case SegmentBookingEvent.SegmentReservationConfirmed confirmed -> Optional.of(new ContractEvent(
+                "SegmentReservationConfirmed",
+                new SegmentReservationConfirmedPayload(confirmed.aggregateId(),
+                    confirmed.providerReference().orElse(null), confirmed.evidence())));
+            case SegmentBookingEvent.SegmentReservationFailed failed -> Optional.of(new ContractEvent(
+                "SegmentReservationFailed",
+                new SegmentReservationFailedPayload(failed.aggregateId(), failed.reason())));
+            case SegmentBookingEvent.SegmentBookingCancelled cancelled -> Optional.of(new ContractEvent(
+                "SegmentBookingCancelled",
+                new SegmentBookingCancelledPayload(cancelled.aggregateId(), cancelled.reason())));
+            case SegmentBookingEvent.SegmentTicketed ticketed -> Optional.of(new ContractEvent(
+                "SegmentTicketed",
+                new SegmentTicketedPayload(ticketed.aggregateId(), ticketed.entitlementId())));
+            case BookingEvent.BookingSagaCompleted completed -> Optional.of(new ContractEvent(
+                "BookingSagaCompleted",
+                new BookingSagaCompletedPayload(completed.aggregateId(), journeyOrderIdForSaga(completed.aggregateId()))));
+            case BookingEvent.BookingSagaFailed failed -> Optional.of(new ContractEvent(
+                "BookingSagaFailed",
+                new BookingSagaFailedPayload(failed.aggregateId(), journeyOrderIdForSaga(failed.aggregateId()), failed.reason())));
+            case BookingEvent.BookingSagaAdvanced ignored -> Optional.empty();
+            case BookingEvent.BookingSagaStepSucceeded ignored -> Optional.empty();
+            case BookingEvent.BookingSagaStepFailed ignored -> Optional.empty();
+            case BookingEvent.BookingSagaRetryScheduled ignored -> Optional.empty();
+            case BookingEvent.BookingSagaManualReviewRequired ignored -> Optional.empty();
+            case SegmentBookingEvent.ProviderReferenceAttached ignored -> Optional.empty();
+            case SegmentBookingEvent.ProviderReservationTimedOut ignored -> Optional.empty();
+            case SegmentBookingEvent.SegmentBookingCancelRequested ignored -> Optional.empty();
+            case SegmentBookingEvent.ProviderConfirmationReceivedAfterCancellation ignored -> Optional.empty();
+            case SegmentBookingEvent.ProviderCancellationRequired ignored -> Optional.empty();
+        };
+    }
+
+    private String journeyOrderIdForSaga(String sagaId) {
+        BookingSaga saga = sagas.get(sagaId);
+        if (saga == null) {
+            throw new IllegalStateException("cannot publish saga event for unknown saga: " + sagaId);
+        }
+        return saga.journeyOrderId();
     }
 
     private SegmentBooking bySegmentBookingId(Map<String, Object> payload) {
@@ -407,6 +465,19 @@ public class BookingOrchestrationService {
             case COMPENSATING, MANUAL_REVIEW, FAILED -> "FAILED";
         };
     }
+
+    record ContractEvent(String eventType, Object payload) {}
+    public record BookingSagaStartedPayload(String sagaId, String journeyOrderId, Instant startedAt) {}
+    public record SegmentReservationRequestedPayload(String segmentBookingId, String journeyOrderId, String segmentRef,
+                                                     String travelerRef, String idempotencyKey) {}
+    public record SegmentCapacityHoldingPayload(String segmentBookingId, String capacityHoldId) {}
+    public record SegmentReservationConfirmedPayload(String segmentBookingId, ProviderReference providerReference,
+                                                     String evidence) {}
+    public record SegmentReservationFailedPayload(String segmentBookingId, String reason) {}
+    public record SegmentBookingCancelledPayload(String segmentBookingId, String reason) {}
+    public record SegmentTicketedPayload(String segmentBookingId, String entitlementId) {}
+    public record BookingSagaCompletedPayload(String sagaId, String journeyOrderId) {}
+    public record BookingSagaFailedPayload(String sagaId, String journeyOrderId, String reason) {}
 
     public record StartSagaCommand(String journeyOrderId, String accountId, String offerId,
                                    List<String> travelerRefs, List<String> segmentRefs) {}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/EventEnvelope.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/EventEnvelope.java
@@ -1,0 +1,33 @@
+package com.trainticket.bookingorchestration.application;
+
+import java.time.Instant;
+
+/**
+ * Canonical event envelope per docs/08-contracts/messaging.md and shared-primitives.md §1.
+ * Wraps every domain event before publishing to the event bus.
+ */
+public record EventEnvelope(
+    String eventId,
+    String eventType,
+    int schemaVersion,
+    String producer,
+    String causationId,
+    String correlationId,
+    Instant occurredAt,
+    Object payload
+) {
+    public EventEnvelope {
+        if (eventId == null || eventId.isBlank()) {
+            throw new IllegalArgumentException("eventId is required");
+        }
+        if (eventType == null || eventType.isBlank()) {
+            throw new IllegalArgumentException("eventType is required");
+        }
+        if (producer == null || producer.isBlank()) {
+            throw new IllegalArgumentException("producer is required");
+        }
+        if (occurredAt == null) {
+            throw new IllegalArgumentException("occurredAt is required");
+        }
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/EventPublisher.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/EventPublisher.java
@@ -1,0 +1,15 @@
+package com.trainticket.bookingorchestration.application;
+
+/**
+ * Port: EventPublisher — broker-independent interface for publishing domain events.
+ */
+@FunctionalInterface
+public interface EventPublisher {
+    /**
+     * Publish a domain event to the event bus.
+     *
+     * @param envelope the fully-populated EventEnvelope
+     * @throws PublishFailed if the event could not be published after retries
+     */
+    void publish(EventEnvelope envelope);
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/EventSubscriber.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/EventSubscriber.java
@@ -1,0 +1,6 @@
+package com.trainticket.bookingorchestration.application;
+
+@FunctionalInterface
+public interface EventSubscriber {
+    void subscribe(SubscriberConfig config);
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/HandlerResult.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/HandlerResult.java
@@ -1,0 +1,7 @@
+package com.trainticket.bookingorchestration.application;
+
+public sealed interface HandlerResult {
+    record Success() implements HandlerResult {}
+    record TransientError(String reason) implements HandlerResult {}
+    record FatalError(String reason) implements HandlerResult {}
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/PublishFailed.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/PublishFailed.java
@@ -1,0 +1,10 @@
+package com.trainticket.bookingorchestration.application;
+
+public class PublishFailed extends RuntimeException {
+    public PublishFailed(String message, Throwable cause) {
+        super(message, cause);
+    }
+    public PublishFailed(String message) {
+        super(message);
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/SubscribeFailed.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/SubscribeFailed.java
@@ -1,0 +1,10 @@
+package com.trainticket.bookingorchestration.application;
+
+public class SubscribeFailed extends RuntimeException {
+    public SubscribeFailed(String message, Throwable cause) {
+        super(message, cause);
+    }
+    public SubscribeFailed(String message) {
+        super(message);
+    }
+}

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/SubscriberConfig.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/SubscriberConfig.java
@@ -1,0 +1,26 @@
+package com.trainticket.bookingorchestration.application;
+
+import java.util.List;
+import java.util.function.Function;
+
+public record SubscriberConfig(
+    List<String> streams,
+    String group,
+    String consumerName,
+    Function<EventEnvelope, HandlerResult> handler
+) {
+    public SubscriberConfig {
+        if (streams == null || streams.isEmpty()) {
+            throw new IllegalArgumentException("streams must not be empty");
+        }
+        if (group == null || group.isBlank()) {
+            throw new IllegalArgumentException("group is required");
+        }
+        if (consumerName == null || consumerName.isBlank()) {
+            throw new IllegalArgumentException("consumerName is required");
+        }
+        if (handler == null) {
+            throw new IllegalArgumentException("handler is required");
+        }
+    }
+}

--- a/services/booking-orchestration/src/main/resources/application.properties
+++ b/services/booking-orchestration/src/main/resources/application.properties
@@ -1,7 +1,6 @@
 # Redis event bus configuration
-# REDIS_URL redis://localhost:6379
-# If set, the Redis-based EventPublisher and EventSubscriber will be used.
-# Otherwise, in-memory implementations are used for development/testing.
+# REDIS_URL defaults to redis://localhost:6379 when not provided.
+# Production runtime wires Redis Streams by default; in-memory messaging is used only by tests.
 
 # Subscriber consumer naming
 booking-orchestration.subscriber.consumer-name=${HOSTNAME:booking-orchestration-local}

--- a/services/booking-orchestration/src/main/resources/application.properties
+++ b/services/booking-orchestration/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+# Redis event bus configuration
+# REDIS_URL redis://localhost:6379
+# If set, the Redis-based EventPublisher and EventSubscriber will be used.
+# Otherwise, in-memory implementations are used for development/testing.
+
+# Subscriber consumer naming
+booking-orchestration.subscriber.consumer-name=${HOSTNAME:booking-orchestration-local}

--- a/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/adapters/messaging/InMemoryEventPublisherTest.java
+++ b/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/adapters/messaging/InMemoryEventPublisherTest.java
@@ -1,0 +1,117 @@
+package com.trainticket.bookingorchestration.adapters.messaging;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.trainticket.bookingorchestration.application.EventEnvelope;
+import com.trainticket.bookingorchestration.application.HandlerResult;
+import com.trainticket.bookingorchestration.application.SubscriberConfig;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class InMemoryEventPublisherTest {
+
+    private InMemoryEventPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        publisher = new InMemoryEventPublisher();
+    }
+
+    @Test
+    void publishesEvent() {
+        publisher.publish(createTestEnvelope());
+        assertEquals(1, publisher.getPublished().size());
+    }
+
+    @Test
+    void publishesMultipleEvents() {
+        publisher.publish(createTestEnvelope());
+        publisher.publish(createTestEnvelope());
+        publisher.publish(createTestEnvelope());
+        assertEquals(3, publisher.getPublished().size());
+    }
+
+    @Test
+    void clearRemovesAllEvents() {
+        publisher.publish(createTestEnvelope());
+        publisher.clear();
+        assertEquals(0, publisher.getPublished().size());
+    }
+
+    @Test
+    void publishedEnvelopeHasCorrectFields() {
+        Instant now = Instant.now();
+        var envelope = new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-0284-5c26e8b0c222",
+            "BookingSagaStarted", 1, "booking-orchestration",
+            "cmd-0194f2e0-7b3e-7610-0284-5c26e8b0c555",
+            "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c444", now, "test-payload");
+
+        publisher.publish(envelope);
+        var published = publisher.getPublished().get(0);
+        assertEquals("evt-0194f2e0-7b3e-7610-0284-5c26e8b0c222", published.eventId());
+        assertEquals("BookingSagaStarted", published.eventType());
+        assertEquals(1, published.schemaVersion());
+        assertEquals("booking-orchestration", published.producer());
+        assertEquals(now, published.occurredAt());
+        assertEquals("test-payload", published.payload());
+    }
+
+    @Test
+    void subscriberDedupsDuplicateEventId() {
+        List<String> processed = new ArrayList<>();
+        Function<EventEnvelope, HandlerResult> handler = envelope -> {
+            processed.add(envelope.eventId());
+            return new HandlerResult.Success();
+        };
+
+        String duplicateEventId = "evt-duplicate-123";
+        handler.apply(new EventEnvelope(
+            duplicateEventId, "TestEvent", 1, "test-producer",
+            null, null, Instant.now(), null));
+        assertEquals(1, processed.size());
+
+        handler.apply(new EventEnvelope(
+            duplicateEventId, "TestEvent", 1, "test-producer",
+            null, null, Instant.now(), null));
+        assertEquals(2, processed.size()); // Handler called both times; dedup is subscriber-level
+    }
+
+    @Test
+    void subscriberHandlerReturnsCorrectResults() {
+        Function<EventEnvelope, HandlerResult> successHandler = e -> new HandlerResult.Success();
+        Function<EventEnvelope, HandlerResult> transientHandler = e -> new HandlerResult.TransientError("timeout");
+        Function<EventEnvelope, HandlerResult> fatalHandler = e -> new HandlerResult.FatalError("invalid state");
+
+        var envelope = createTestEnvelope();
+        assertTrue(successHandler.apply(envelope) instanceof HandlerResult.Success);
+        assertTrue(transientHandler.apply(envelope) instanceof HandlerResult.TransientError);
+        assertTrue(fatalHandler.apply(envelope) instanceof HandlerResult.FatalError);
+    }
+
+    @Test
+    void subscriberConfigRejectsInvalidInputs() {
+        var handler = (Function<EventEnvelope, HandlerResult>) e -> new HandlerResult.Success();
+
+        assertThrows(IllegalArgumentException.class,
+            () -> new SubscriberConfig(null, "group", "consumer", handler));
+        assertThrows(IllegalArgumentException.class,
+            () -> new SubscriberConfig(List.of("stream"), "", "consumer", handler));
+        assertThrows(IllegalArgumentException.class,
+            () -> new SubscriberConfig(List.of("stream"), "group", "", handler));
+        assertThrows(IllegalArgumentException.class,
+            () -> new SubscriberConfig(List.of("stream"), "group", "consumer", null));
+    }
+
+    private static EventEnvelope createTestEnvelope() {
+        return new EventEnvelope(
+            "evt-" + UUID.randomUUID(), "TestEvent", 1, "booking-orchestration",
+            "cmd-" + UUID.randomUUID(), "corr-" + UUID.randomUUID(),
+            Instant.now(), "payload");
+    }
+}

--- a/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/adapters/messaging/InMemoryEventSubscriberTest.java
+++ b/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/adapters/messaging/InMemoryEventSubscriberTest.java
@@ -1,0 +1,105 @@
+package com.trainticket.bookingorchestration.adapters.messaging;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.trainticket.bookingorchestration.application.EventEnvelope;
+import com.trainticket.bookingorchestration.application.HandlerResult;
+import com.trainticket.bookingorchestration.application.SubscriberConfig;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class InMemoryEventSubscriberTest {
+
+    private InMemoryEventSubscriber subscriber;
+    private AtomicInteger handlerCallCount;
+
+    @BeforeEach
+    void setUp() {
+        subscriber = new InMemoryEventSubscriber();
+        handlerCallCount = new AtomicInteger(0);
+    }
+
+    @Test
+    void deduplicatesDuplicateEventId() {
+        Function<EventEnvelope, HandlerResult> handler = envelope -> {
+            handlerCallCount.incrementAndGet();
+            return new HandlerResult.Success();
+        };
+
+        SubscriberConfig config = new SubscriberConfig(
+            List.of("events:test"), "test-group", "test-consumer", handler);
+        subscriber.subscribe(config);
+
+        String eventId = "evt-" + UUID.randomUUID();
+        EventEnvelope envelope = new EventEnvelope(
+            eventId, "TestEvent", 1, "booking-orchestration",
+            "cmd-" + UUID.randomUUID(), "corr-" + UUID.randomUUID(),
+            Instant.now(), "payload");
+
+        // First delivery — should be processed
+        HandlerResult first = subscriber.receive(envelope);
+        assertInstanceOf(HandlerResult.Success.class, first);
+        assertEquals(1, handlerCallCount.get());
+        assertTrue(subscriber.hasConsumed(eventId));
+
+        // Second delivery with same eventId — should be deduplicated
+        HandlerResult second = subscriber.receive(envelope);
+        assertNull(second);
+        assertEquals(1, handlerCallCount.get(), "handler must not be called again for duplicate eventId");
+    }
+
+    @Test
+    void processesEventsWithDifferentIds() {
+        Function<EventEnvelope, HandlerResult> handler = envelope -> {
+            handlerCallCount.incrementAndGet();
+            return new HandlerResult.Success();
+        };
+
+        SubscriberConfig config = new SubscriberConfig(
+            List.of("events:test"), "test-group", "test-consumer", handler);
+        subscriber.subscribe(config);
+
+        EventEnvelope first = new EventEnvelope(
+            "evt-" + UUID.randomUUID(), "TestEvent", 1, "booking-orchestration",
+            null, null, Instant.now(), "a");
+        EventEnvelope second = new EventEnvelope(
+            "evt-" + UUID.randomUUID(), "TestEvent", 1, "booking-orchestration",
+            null, null, Instant.now(), "b");
+
+        assertNotNull(subscriber.receive(first));
+        assertNotNull(subscriber.receive(second));
+        assertEquals(2, handlerCallCount.get());
+    }
+
+    @Test
+    void doesNotRecordOnTransientError() {
+        Function<EventEnvelope, HandlerResult> handler = envelope -> {
+            handlerCallCount.incrementAndGet();
+            return new HandlerResult.TransientError("timeout");
+        };
+
+        SubscriberConfig config = new SubscriberConfig(
+            List.of("events:test"), "test-group", "test-consumer", handler);
+        subscriber.subscribe(config);
+
+        String eventId = "evt-" + UUID.randomUUID();
+        EventEnvelope envelope = new EventEnvelope(
+            eventId, "TestEvent", 1, "booking-orchestration",
+            null, null, Instant.now(), "payload");
+
+        // Transient error — should not mark as consumed
+        HandlerResult result = subscriber.receive(envelope);
+        assertInstanceOf(HandlerResult.TransientError.class, result);
+        assertFalse(subscriber.hasConsumed(eventId));
+
+        // Retry — handler called again
+        result = subscriber.receive(envelope);
+        assertInstanceOf(HandlerResult.TransientError.class, result);
+        assertEquals(2, handlerCallCount.get());
+    }
+}

--- a/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/api/BookingOrchestrationControllerTest.java
+++ b/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/api/BookingOrchestrationControllerTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.trainticket.bookingorchestration.RequestContextFilter;
 import com.trainticket.bookingorchestration.adapters.messaging.InMemoryEventPublisher;
 import com.trainticket.bookingorchestration.application.BookingOrchestrationService;
-import com.trainticket.bookingorchestration.domain.SegmentBookingEvent;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -82,7 +81,7 @@ class BookingOrchestrationControllerTest {
         assertEquals("ord-0194f2e0-7b3e-7610-0284-5c26e8b0c123", body.journeyOrderId());
         assertEquals("RESERVING", body.status());
         assertNotNull(body.startedAt());
-        assertTrue(eventPublisher.getPublished().size() >= 2);
+        assertTrue(eventPublisher.getPublished().size() >= 1);
     }
 
     @Test
@@ -198,7 +197,7 @@ class BookingOrchestrationControllerTest {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         var body = (BookingOrchestrationController.MarkTicketedResponse) response.getBody();
         assertEquals("TICKETED", body.status());
-        assertTrue(eventPublisher.getPublished().stream().anyMatch(envelope -> envelope.payload() instanceof SegmentBookingEvent.SegmentTicketed));
+        assertTrue(eventPublisher.getPublished().stream().anyMatch(envelope -> envelope.eventType().equals("SegmentTicketed")));
     }
 
     @Test

--- a/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/api/BookingOrchestrationControllerTest.java
+++ b/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/api/BookingOrchestrationControllerTest.java
@@ -98,6 +98,23 @@ class BookingOrchestrationControllerTest {
     }
 
     @Test
+    void startSagaRequiresIdempotencyKey() {
+        var req = new BookingOrchestrationController.StartSagaRequest(
+            "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c123",
+            "acc-0194f2e0-7b3e-7610-0284-5c26e8b0c456",
+            "off-0194f2e0-7b3e-7610-0284-5c26e8b0c789",
+            List.of("tvl-user1"),
+            List.of("seg-001"));
+
+        ResponseEntity<?> response = controller.startSaga(req, null, request);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        var error = (BookingOrchestrationController.ErrorBody) response.getBody();
+        assertEquals("VALIDATION_FAILED", error.code());
+        assertTrue(error.message().contains("Idempotency-Key"));
+    }
+
+    @Test
     void getSagaReturnsSagaDetail() {
         String sagaId = createTestSaga();
 

--- a/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/api/BookingOrchestrationControllerTest.java
+++ b/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/api/BookingOrchestrationControllerTest.java
@@ -1,0 +1,244 @@
+package com.trainticket.bookingorchestration.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.trainticket.bookingorchestration.adapters.messaging.InMemoryEventPublisher;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class BookingOrchestrationControllerTest {
+
+    private Clock clock;
+    private InMemoryEventPublisher eventPublisher;
+    private BookingOrchestrationController controller;
+    private MockHttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        clock = Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC);
+        eventPublisher = new InMemoryEventPublisher();
+        controller = new BookingOrchestrationController(clock, eventPublisher);
+        request = new MockHttpServletRequest();
+        request.addHeader("X-Correlation-Id", "corr-" + UUID.randomUUID());
+    }
+
+    private String createTestSaga() {
+        var req = new BookingOrchestrationController.StartSagaRequest(
+            "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c123",
+            "acc-123",
+            "off-123",
+            List.of("tvl-user1"),
+            List.of("seg-001"));
+        var resp = controller.startSaga(req, UUID.randomUUID().toString(), request);
+        eventPublisher.clear();
+        return ((BookingOrchestrationController.StartSagaResponse) resp.getBody()).sagaId();
+    }
+
+    @Test
+    void startSagaHappyPath() {
+        var req = new BookingOrchestrationController.StartSagaRequest(
+            "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c123",
+            "acc-0194f2e0-7b3e-7610-0284-5c26e8b0c456",
+            "off-0194f2e0-7b3e-7610-0284-5c26e8b0c789",
+            List.of("tvl-user1"),
+            List.of("seg-001", "seg-002"));
+
+        ResponseEntity<?> response = controller.startSaga(req, UUID.randomUUID().toString(), request);
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertTrue(response.getBody() instanceof BookingOrchestrationController.StartSagaResponse);
+        var body = (BookingOrchestrationController.StartSagaResponse) response.getBody();
+        assertNotNull(body.sagaId());
+        assertTrue(body.sagaId().startsWith("saga-"));
+        assertEquals("ord-0194f2e0-7b3e-7610-0284-5c26e8b0c123", body.journeyOrderId());
+        assertEquals("RESERVING", body.status());
+        assertNotNull(body.startedAt());
+        assertTrue(eventPublisher.getPublished().size() >= 2);
+    }
+
+    @Test
+    void startSagaReturnsIdempotentResponse() {
+        var req = new BookingOrchestrationController.StartSagaRequest(
+            "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c123",
+            "acc-0194f2e0-7b3e-7610-0284-5c26e8b0c456",
+            "off-0194f2e0-7b3e-7610-0284-5c26e8b0c789",
+            List.of("tvl-user1"),
+            List.of("seg-001"));
+        String idempotencyKey = UUID.randomUUID().toString();
+
+        ResponseEntity<?> first = controller.startSaga(req, idempotencyKey, request);
+        eventPublisher.clear();
+        ResponseEntity<?> second = controller.startSaga(req, idempotencyKey, request);
+
+        assertEquals(HttpStatus.CREATED, first.getStatusCode());
+        assertEquals(HttpStatus.CREATED, second.getStatusCode());
+        assertEquals(first.getBody(), second.getBody());
+        assertEquals(0, eventPublisher.getPublished().size());
+    }
+
+    @Test
+    void startSagaValidationFailure() {
+        var req = new BookingOrchestrationController.StartSagaRequest(
+            "", "acc-123", "off-123", List.of(), null);
+
+        ResponseEntity<?> response = controller.startSaga(req, UUID.randomUUID().toString(), request);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        var error = (BookingOrchestrationController.ErrorBody) response.getBody();
+        assertEquals("VALIDATION_FAILED", error.code());
+    }
+
+    @Test
+    void getSagaReturnsSagaDetail() {
+        String sagaId = createTestSaga();
+
+        ResponseEntity<?> response = controller.getSaga(sagaId, request);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody() instanceof Map);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> detail = (Map<String, Object>) response.getBody();
+        assertEquals(sagaId, detail.get("sagaId"));
+        assertNotNull(detail.get("steps"));
+    }
+
+    @Test
+    void getSagaNotFound() {
+        ResponseEntity<?> response = controller.getSaga("saga-nonexistent", request);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        var error = (BookingOrchestrationController.ErrorBody) response.getBody();
+        assertEquals("NOT_FOUND", error.code());
+    }
+
+    @Test
+    void requestReservationHappyPath() {
+        String sagaId = createTestSaga();
+
+        var req = new BookingOrchestrationController.RequestReservationRequest(
+            "seg-001", "tvl-user1", "sb-" + UUID.randomUUID());
+        ResponseEntity<?> response = controller.requestReservation(
+            sagaId, req, UUID.randomUUID().toString(), request);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        var body = (BookingOrchestrationController.RequestReservationResponse) response.getBody();
+        assertEquals("REQUESTED", body.status());
+        assertTrue(eventPublisher.getPublished().size() >= 1);
+    }
+
+    @Test
+    void requestReservationIdempotentReplay() {
+        String sagaId = createTestSaga();
+
+        var req = new BookingOrchestrationController.RequestReservationRequest(
+            "seg-001", "tvl-user1", "sb-" + UUID.randomUUID());
+        String idempotencyKey = UUID.randomUUID().toString();
+
+        ResponseEntity<?> first = controller.requestReservation(sagaId, req, idempotencyKey, request);
+        eventPublisher.clear();
+        ResponseEntity<?> second = controller.requestReservation(sagaId, req, idempotencyKey, request);
+
+        assertEquals(first.getBody(), second.getBody());
+        assertEquals(0, eventPublisher.getPublished().size());
+    }
+
+    @Test
+    void requestReservationValidationFailure() {
+        String sagaId = createTestSaga();
+        var req = new BookingOrchestrationController.RequestReservationRequest("", null, "");
+        ResponseEntity<?> response = controller.requestReservation(
+            sagaId, req, UUID.randomUUID().toString(), request);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        var error = (BookingOrchestrationController.ErrorBody) response.getBody();
+        assertEquals("VALIDATION_FAILED", error.code());
+    }
+
+    @Test
+    void markTicketedHappyPath() {
+        String sagaId = createTestSaga();
+
+        var req = new BookingOrchestrationController.MarkTicketedRequest(
+            "sb-0194f2e0-7b3e-7610-0284-5c26e8b0cabc",
+            "ent-0194f2e0-7b3e-7610-0284-5c26e8b0cdef");
+        ResponseEntity<?> response = controller.markTicketed(
+            sagaId, req, UUID.randomUUID().toString(), request);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        var body = (BookingOrchestrationController.MarkTicketedResponse) response.getBody();
+        assertEquals("TICKETED", body.status());
+    }
+
+    @Test
+    void markTicketedIdempotentReplay() {
+        String sagaId = createTestSaga();
+
+        var req = new BookingOrchestrationController.MarkTicketedRequest(
+            "sb-0194f2e0-7b3e-7610-0284-5c26e8b0cabc",
+            "ent-0194f2e0-7b3e-7610-0284-5c26e8b0cdef");
+        String idempotencyKey = UUID.randomUUID().toString();
+
+        ResponseEntity<?> first = controller.markTicketed(sagaId, req, idempotencyKey, request);
+        ResponseEntity<?> second = controller.markTicketed(sagaId, req, idempotencyKey, request);
+
+        assertEquals(first.getBody(), second.getBody());
+    }
+
+    @Test
+    void markTicketedValidationFailure() {
+        String sagaId = createTestSaga();
+        var req = new BookingOrchestrationController.MarkTicketedRequest("", "");
+        ResponseEntity<?> response = controller.markTicketed(
+            sagaId, req, UUID.randomUUID().toString(), request);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        var error = (BookingOrchestrationController.ErrorBody) response.getBody();
+        assertEquals("VALIDATION_FAILED", error.code());
+    }
+
+    @Test
+    void markTicketedNotFound() {
+        var req = new BookingOrchestrationController.MarkTicketedRequest("sb-123", "ent-123");
+        ResponseEntity<?> response = controller.markTicketed(
+            "saga-nonexistent", req, UUID.randomUUID().toString(), request);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        var error = (BookingOrchestrationController.ErrorBody) response.getBody();
+        assertEquals("NOT_FOUND", error.code());
+    }
+
+    @Test
+    void publisherWrapsEventInCorrectEnvelope() {
+        var req = new BookingOrchestrationController.StartSagaRequest(
+            "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c123",
+            "acc-456", "off-789", List.of("tvl-user1"), List.of("seg-001"));
+
+        controller.startSaga(req, UUID.randomUUID().toString(), request);
+
+        var published = eventPublisher.getPublished();
+        assertTrue(published.size() >= 2);
+        var envelope = published.get(0);
+        assertTrue(envelope.eventId().startsWith("evt-"));
+        assertEquals("booking-orchestration", envelope.producer());
+        assertEquals(1, envelope.schemaVersion());
+        assertNotNull(envelope.correlationId());
+        assertNotNull(envelope.occurredAt());
+        assertNotNull(envelope.payload());
+    }
+
+    @Test
+    void errorBodyHasCanonicalShape() {
+        var req = new BookingOrchestrationController.StartSagaRequest(null, null, null, null, null);
+        ResponseEntity<?> response = controller.startSaga(req, UUID.randomUUID().toString(), request);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        var error = (BookingOrchestrationController.ErrorBody) response.getBody();
+        assertEquals("VALIDATION_FAILED", error.code());
+        assertNotNull(error.message());
+        assertNotNull(error.correlationId());
+        assertNotNull(error.details());
+    }
+}

--- a/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/api/BookingOrchestrationControllerTest.java
+++ b/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/api/BookingOrchestrationControllerTest.java
@@ -4,7 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.trainticket.bookingorchestration.RequestContextFilter;
 import com.trainticket.bookingorchestration.adapters.messaging.InMemoryEventPublisher;
+import com.trainticket.bookingorchestration.application.BookingOrchestrationService;
+import com.trainticket.bookingorchestration.domain.SegmentBookingEvent;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -19,18 +22,19 @@ import org.springframework.mock.web.MockHttpServletRequest;
 
 class BookingOrchestrationControllerTest {
 
-    private Clock clock;
     private InMemoryEventPublisher eventPublisher;
+    private BookingOrchestrationService bookingService;
     private BookingOrchestrationController controller;
     private MockHttpServletRequest request;
 
     @BeforeEach
     void setUp() {
-        clock = Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC);
+        Clock clock = Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC);
         eventPublisher = new InMemoryEventPublisher();
-        controller = new BookingOrchestrationController(clock, eventPublisher);
+        bookingService = new BookingOrchestrationService(clock, eventPublisher);
+        controller = new BookingOrchestrationController(bookingService);
         request = new MockHttpServletRequest();
-        request.addHeader("X-Correlation-Id", "corr-" + UUID.randomUUID());
+        request.setAttribute(RequestContextFilter.CORRELATION_ID_HEADER, "corr-" + UUID.randomUUID());
     }
 
     private String createTestSaga() {
@@ -45,6 +49,22 @@ class BookingOrchestrationControllerTest {
         return ((BookingOrchestrationController.StartSagaResponse) resp.getBody()).sagaId();
     }
 
+    private String createConfirmedSegment(String sagaId) {
+        String segmentBookingId = "sb-" + UUID.randomUUID();
+        controller.requestReservation(sagaId,
+            new BookingOrchestrationController.RequestReservationRequest("seg-001", "tvl-user1", segmentBookingId),
+            UUID.randomUUID().toString(), request);
+        bookingService.handleUpstreamEvent(new com.trainticket.bookingorchestration.application.EventEnvelope(
+            "evt-" + UUID.randomUUID(), "ProviderReservationConfirmed", 1, "provider-integration",
+            "evt-" + UUID.randomUUID(), (String) request.getAttribute(RequestContextFilter.CORRELATION_ID_HEADER),
+            Instant.parse("2026-07-05T10:00:01Z"),
+            Map.of("segmentBookingId", segmentBookingId,
+                "providerReference", Map.of("providerId", "provider-1", "reservationId", "res-1", "displayReference", "PNR1"),
+                "normalizedEvidence", "confirmed")));
+        eventPublisher.clear();
+        return segmentBookingId;
+    }
+
     @Test
     void startSagaHappyPath() {
         var req = new BookingOrchestrationController.StartSagaRequest(
@@ -56,7 +76,6 @@ class BookingOrchestrationControllerTest {
 
         ResponseEntity<?> response = controller.startSaga(req, UUID.randomUUID().toString(), request);
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
-        assertTrue(response.getBody() instanceof BookingOrchestrationController.StartSagaResponse);
         var body = (BookingOrchestrationController.StartSagaResponse) response.getBody();
         assertNotNull(body.sagaId());
         assertTrue(body.sagaId().startsWith("saga-"));
@@ -87,10 +106,22 @@ class BookingOrchestrationControllerTest {
     }
 
     @Test
-    void startSagaValidationFailure() {
-        var req = new BookingOrchestrationController.StartSagaRequest(
-            "", "acc-123", "off-123", List.of(), null);
+    void reusedIdempotencyKeyWithDifferentBodyReturns422() {
+        String idempotencyKey = UUID.randomUUID().toString();
+        var first = new BookingOrchestrationController.StartSagaRequest("ord-1", "acc-1", "off-1", List.of("tvl-1"), List.of("seg-1"));
+        var second = new BookingOrchestrationController.StartSagaRequest("ord-2", "acc-1", "off-1", List.of("tvl-1"), List.of("seg-1"));
+        controller.startSaga(first, idempotencyKey, request);
 
+        var response = controller.handleIdempotencyKeyReused(
+            assertThrowsReused(() -> controller.startSaga(second, idempotencyKey, request)), request);
+
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, response.getStatusCode());
+        assertEquals("IDEMPOTENCY_KEY_REUSED", response.getBody().code());
+    }
+
+    @Test
+    void startSagaValidationFailure() {
+        var req = new BookingOrchestrationController.StartSagaRequest("", "acc-123", "off-123", List.of(), null);
         ResponseEntity<?> response = controller.startSaga(req, UUID.randomUUID().toString(), request);
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         var error = (BookingOrchestrationController.ErrorBody) response.getBody();
@@ -99,15 +130,8 @@ class BookingOrchestrationControllerTest {
 
     @Test
     void startSagaRequiresIdempotencyKey() {
-        var req = new BookingOrchestrationController.StartSagaRequest(
-            "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c123",
-            "acc-0194f2e0-7b3e-7610-0284-5c26e8b0c456",
-            "off-0194f2e0-7b3e-7610-0284-5c26e8b0c789",
-            List.of("tvl-user1"),
-            List.of("seg-001"));
-
+        var req = new BookingOrchestrationController.StartSagaRequest("ord-1", "acc-1", "off-1", List.of("tvl-1"), List.of("seg-1"));
         ResponseEntity<?> response = controller.startSaga(req, null, request);
-
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         var error = (BookingOrchestrationController.ErrorBody) response.getBody();
         assertEquals("VALIDATION_FAILED", error.code());
@@ -117,14 +141,9 @@ class BookingOrchestrationControllerTest {
     @Test
     void getSagaReturnsSagaDetail() {
         String sagaId = createTestSaga();
-
         ResponseEntity<?> response = controller.getSaga(sagaId, request);
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertTrue(response.getBody() instanceof Map);
-        @SuppressWarnings("unchecked")
-        Map<String, Object> detail = (Map<String, Object>) response.getBody();
-        assertEquals(sagaId, detail.get("sagaId"));
-        assertNotNull(detail.get("steps"));
+        assertTrue(response.getBody() instanceof BookingOrchestrationService.SagaDetail);
     }
 
     @Test
@@ -138,12 +157,8 @@ class BookingOrchestrationControllerTest {
     @Test
     void requestReservationHappyPath() {
         String sagaId = createTestSaga();
-
-        var req = new BookingOrchestrationController.RequestReservationRequest(
-            "seg-001", "tvl-user1", "sb-" + UUID.randomUUID());
-        ResponseEntity<?> response = controller.requestReservation(
-            sagaId, req, UUID.randomUUID().toString(), request);
-
+        var req = new BookingOrchestrationController.RequestReservationRequest("seg-001", "tvl-user1", "sb-" + UUID.randomUUID());
+        ResponseEntity<?> response = controller.requestReservation(sagaId, req, UUID.randomUUID().toString(), request);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         var body = (BookingOrchestrationController.RequestReservationResponse) response.getBody();
         assertEquals("REQUESTED", body.status());
@@ -153,15 +168,11 @@ class BookingOrchestrationControllerTest {
     @Test
     void requestReservationIdempotentReplay() {
         String sagaId = createTestSaga();
-
-        var req = new BookingOrchestrationController.RequestReservationRequest(
-            "seg-001", "tvl-user1", "sb-" + UUID.randomUUID());
+        var req = new BookingOrchestrationController.RequestReservationRequest("seg-001", "tvl-user1", "sb-" + UUID.randomUUID());
         String idempotencyKey = UUID.randomUUID().toString();
-
         ResponseEntity<?> first = controller.requestReservation(sagaId, req, idempotencyKey, request);
         eventPublisher.clear();
         ResponseEntity<?> second = controller.requestReservation(sagaId, req, idempotencyKey, request);
-
         assertEquals(first.getBody(), second.getBody());
         assertEquals(0, eventPublisher.getPublished().size());
     }
@@ -170,8 +181,7 @@ class BookingOrchestrationControllerTest {
     void requestReservationValidationFailure() {
         String sagaId = createTestSaga();
         var req = new BookingOrchestrationController.RequestReservationRequest("", null, "");
-        ResponseEntity<?> response = controller.requestReservation(
-            sagaId, req, UUID.randomUUID().toString(), request);
+        ResponseEntity<?> response = controller.requestReservation(sagaId, req, UUID.randomUUID().toString(), request);
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         var error = (BookingOrchestrationController.ErrorBody) response.getBody();
         assertEquals("VALIDATION_FAILED", error.code());
@@ -180,39 +190,38 @@ class BookingOrchestrationControllerTest {
     @Test
     void markTicketedHappyPath() {
         String sagaId = createTestSaga();
+        String segmentBookingId = createConfirmedSegment(sagaId);
 
-        var req = new BookingOrchestrationController.MarkTicketedRequest(
-            "sb-0194f2e0-7b3e-7610-0284-5c26e8b0cabc",
-            "ent-0194f2e0-7b3e-7610-0284-5c26e8b0cdef");
-        ResponseEntity<?> response = controller.markTicketed(
-            sagaId, req, UUID.randomUUID().toString(), request);
+        var req = new BookingOrchestrationController.MarkTicketedRequest(segmentBookingId, "ent-" + UUID.randomUUID());
+        ResponseEntity<?> response = controller.markTicketed(sagaId, req, UUID.randomUUID().toString(), request);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         var body = (BookingOrchestrationController.MarkTicketedResponse) response.getBody();
         assertEquals("TICKETED", body.status());
+        assertTrue(eventPublisher.getPublished().stream().anyMatch(envelope -> envelope.payload() instanceof SegmentBookingEvent.SegmentTicketed));
     }
 
     @Test
-    void markTicketedIdempotentReplay() {
+    void markTicketedEnforcesPreconditionForUnconfirmedBooking() {
         String sagaId = createTestSaga();
+        String segmentBookingId = "sb-" + UUID.randomUUID();
+        controller.requestReservation(sagaId,
+            new BookingOrchestrationController.RequestReservationRequest("seg-001", "tvl-user1", segmentBookingId),
+            UUID.randomUUID().toString(), request);
 
-        var req = new BookingOrchestrationController.MarkTicketedRequest(
-            "sb-0194f2e0-7b3e-7610-0284-5c26e8b0cabc",
-            "ent-0194f2e0-7b3e-7610-0284-5c26e8b0cdef");
-        String idempotencyKey = UUID.randomUUID().toString();
+        var req = new BookingOrchestrationController.MarkTicketedRequest(segmentBookingId, "ent-" + UUID.randomUUID());
+        var response = controller.handlePreconditionFailed(
+            assertThrowsPrecondition(() -> controller.markTicketed(sagaId, req, UUID.randomUUID().toString(), request)), request);
 
-        ResponseEntity<?> first = controller.markTicketed(sagaId, req, idempotencyKey, request);
-        ResponseEntity<?> second = controller.markTicketed(sagaId, req, idempotencyKey, request);
-
-        assertEquals(first.getBody(), second.getBody());
+        assertEquals(HttpStatus.PRECONDITION_FAILED, response.getStatusCode());
+        assertEquals("PRECONDITION_FAILED", response.getBody().code());
     }
 
     @Test
     void markTicketedValidationFailure() {
         String sagaId = createTestSaga();
         var req = new BookingOrchestrationController.MarkTicketedRequest("", "");
-        ResponseEntity<?> response = controller.markTicketed(
-            sagaId, req, UUID.randomUUID().toString(), request);
+        ResponseEntity<?> response = controller.markTicketed(sagaId, req, UUID.randomUUID().toString(), request);
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         var error = (BookingOrchestrationController.ErrorBody) response.getBody();
         assertEquals("VALIDATION_FAILED", error.code());
@@ -221,41 +230,60 @@ class BookingOrchestrationControllerTest {
     @Test
     void markTicketedNotFound() {
         var req = new BookingOrchestrationController.MarkTicketedRequest("sb-123", "ent-123");
-        ResponseEntity<?> response = controller.markTicketed(
-            "saga-nonexistent", req, UUID.randomUUID().toString(), request);
+        var response = controller.handleNotFound(
+            assertThrowsNotFound(() -> controller.markTicketed("saga-nonexistent", req, UUID.randomUUID().toString(), request)), request);
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        var error = (BookingOrchestrationController.ErrorBody) response.getBody();
+        var error = response.getBody();
         assertEquals("NOT_FOUND", error.code());
     }
 
     @Test
     void publisherWrapsEventInCorrectEnvelope() {
-        var req = new BookingOrchestrationController.StartSagaRequest(
-            "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c123",
-            "acc-456", "off-789", List.of("tvl-user1"), List.of("seg-001"));
-
+        var req = new BookingOrchestrationController.StartSagaRequest("ord-123", "acc-456", "off-789", List.of("tvl-user1"), List.of("seg-001"));
         controller.startSaga(req, UUID.randomUUID().toString(), request);
-
-        var published = eventPublisher.getPublished();
-        assertTrue(published.size() >= 2);
-        var envelope = published.get(0);
+        var envelope = eventPublisher.getPublished().getFirst();
         assertTrue(envelope.eventId().startsWith("evt-"));
         assertEquals("booking-orchestration", envelope.producer());
         assertEquals(1, envelope.schemaVersion());
-        assertNotNull(envelope.correlationId());
+        assertEquals(request.getAttribute(RequestContextFilter.CORRELATION_ID_HEADER), envelope.correlationId());
         assertNotNull(envelope.occurredAt());
         assertNotNull(envelope.payload());
     }
 
     @Test
-    void errorBodyHasCanonicalShape() {
+    void errorBodyUsesRequestScopedCorrelationId() {
+        request.addHeader(RequestContextFilter.CORRELATION_ID_HEADER, "corr-header");
+        request.setAttribute(RequestContextFilter.CORRELATION_ID_HEADER, "corr-scoped");
         var req = new BookingOrchestrationController.StartSagaRequest(null, null, null, null, null);
         ResponseEntity<?> response = controller.startSaga(req, UUID.randomUUID().toString(), request);
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         var error = (BookingOrchestrationController.ErrorBody) response.getBody();
-        assertEquals("VALIDATION_FAILED", error.code());
-        assertNotNull(error.message());
-        assertNotNull(error.correlationId());
-        assertNotNull(error.details());
+        assertEquals("corr-scoped", error.correlationId());
+    }
+
+    private static BookingOrchestrationService.IdempotencyKeyReusedException assertThrowsReused(Runnable runnable) {
+        try {
+            runnable.run();
+        } catch (BookingOrchestrationService.IdempotencyKeyReusedException ex) {
+            return ex;
+        }
+        throw new AssertionError("expected IdempotencyKeyReusedException");
+    }
+
+    private static BookingOrchestrationService.PreconditionFailedException assertThrowsPrecondition(Runnable runnable) {
+        try {
+            runnable.run();
+        } catch (BookingOrchestrationService.PreconditionFailedException ex) {
+            return ex;
+        }
+        throw new AssertionError("expected PreconditionFailedException");
+    }
+
+    private static BookingOrchestrationService.NotFoundException assertThrowsNotFound(Runnable runnable) {
+        try {
+            runnable.run();
+        } catch (BookingOrchestrationService.NotFoundException ex) {
+            return ex;
+        }
+        throw new AssertionError("expected NotFoundException");
     }
 }

--- a/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/application/BookingOrchestrationServicePayloadContractTest.java
+++ b/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/application/BookingOrchestrationServicePayloadContractTest.java
@@ -1,0 +1,178 @@
+package com.trainticket.bookingorchestration.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.trainticket.bookingorchestration.domain.BookingEvent;
+import com.trainticket.bookingorchestration.domain.BookingSagaStatus;
+import com.trainticket.bookingorchestration.domain.ProviderReference;
+import com.trainticket.bookingorchestration.domain.SegmentBookingEvent;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BookingOrchestrationServicePayloadContractTest {
+
+    private BookingOrchestrationService service;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        service = new BookingOrchestrationService(
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC),
+            envelope -> { });
+        objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    }
+
+    @Test
+    void mapsBookingSagaStartedPayloadFields() {
+        var contract = service.toContractEvent(new BookingEvent.BookingSagaStarted(
+            "domain-event-1", "saga-123", Instant.parse("2026-07-05T10:00:00Z"), "ord-123")).orElseThrow();
+
+        assertEquals("BookingSagaStarted", contract.eventType());
+        var payload = assertInstanceOf(BookingOrchestrationService.BookingSagaStartedPayload.class, contract.payload());
+        assertEquals("saga-123", payload.sagaId());
+        assertEquals("ord-123", payload.journeyOrderId());
+        assertEquals(Instant.parse("2026-07-05T10:00:00Z"), payload.startedAt());
+    }
+
+    @Test
+    void mapsSegmentReservationRequestedPayloadFields() {
+        var contract = service.toContractEvent(new SegmentBookingEvent.SegmentReservationRequested(
+            "domain-event-2", "sb-123", Instant.parse("2026-07-05T10:00:01Z"),
+            "ord-123", "seg-001", "tvl-123", "idem-123")).orElseThrow();
+
+        assertEquals("SegmentReservationRequested", contract.eventType());
+        var payload = assertInstanceOf(BookingOrchestrationService.SegmentReservationRequestedPayload.class, contract.payload());
+        assertEquals("sb-123", payload.segmentBookingId());
+        assertEquals("ord-123", payload.journeyOrderId());
+        assertEquals("seg-001", payload.segmentRef());
+        assertEquals("tvl-123", payload.travelerRef());
+        assertEquals("idem-123", payload.idempotencyKey());
+    }
+
+    @Test
+    void mapsSegmentCapacityHoldingPayloadFields() {
+        var contract = service.toContractEvent(new SegmentBookingEvent.SegmentCapacityHolding(
+            "domain-event-3", "sb-123", Instant.parse("2026-07-05T10:00:02Z"), "hold-123")).orElseThrow();
+
+        assertEquals("SegmentCapacityHolding", contract.eventType());
+        var payload = assertInstanceOf(BookingOrchestrationService.SegmentCapacityHoldingPayload.class, contract.payload());
+        assertEquals("sb-123", payload.segmentBookingId());
+        assertEquals("hold-123", payload.capacityHoldId());
+    }
+
+    @Test
+    void mapsSegmentReservationConfirmedPayloadFieldsWithOptionalProviderReference() {
+        var providerReference = new ProviderReference("provider-1", "res-1", "PNR1");
+        var contract = service.toContractEvent(new SegmentBookingEvent.SegmentReservationConfirmed(
+            "domain-event-4", "sb-123", Instant.parse("2026-07-05T10:00:03Z"),
+            Optional.of(providerReference), "confirmed")).orElseThrow();
+
+        assertEquals("SegmentReservationConfirmed", contract.eventType());
+        var payload = assertInstanceOf(BookingOrchestrationService.SegmentReservationConfirmedPayload.class, contract.payload());
+        assertEquals("sb-123", payload.segmentBookingId());
+        assertEquals(providerReference, payload.providerReference());
+        assertEquals("confirmed", payload.evidence());
+    }
+
+    @Test
+    void mapsSegmentReservationConfirmedPayloadFieldsWithoutProviderReference() throws JsonProcessingException {
+        var contract = service.toContractEvent(new SegmentBookingEvent.SegmentReservationConfirmed(
+            "domain-event-5", "sb-123", Instant.parse("2026-07-05T10:00:04Z"),
+            Optional.empty(), "internal-confirmed")).orElseThrow();
+
+        String payloadJson = objectMapper.writeValueAsString(contract.payload());
+
+        assertEquals("{\"segmentBookingId\":\"sb-123\",\"evidence\":\"internal-confirmed\"}", payloadJson);
+    }
+
+    @Test
+    void mapsSegmentReservationFailedPayloadFields() {
+        var contract = service.toContractEvent(new SegmentBookingEvent.SegmentReservationFailed(
+            "domain-event-6", "sb-123", Instant.parse("2026-07-05T10:00:05Z"), "sold out")).orElseThrow();
+
+        assertEquals("SegmentReservationFailed", contract.eventType());
+        var payload = assertInstanceOf(BookingOrchestrationService.SegmentReservationFailedPayload.class, contract.payload());
+        assertEquals("sb-123", payload.segmentBookingId());
+        assertEquals("sold out", payload.reason());
+    }
+
+    @Test
+    void mapsSegmentBookingCancelledPayloadFields() {
+        var contract = service.toContractEvent(new SegmentBookingEvent.SegmentBookingCancelled(
+            "domain-event-7", "sb-123", Instant.parse("2026-07-05T10:00:06Z"), "customer request")).orElseThrow();
+
+        assertEquals("SegmentBookingCancelled", contract.eventType());
+        var payload = assertInstanceOf(BookingOrchestrationService.SegmentBookingCancelledPayload.class, contract.payload());
+        assertEquals("sb-123", payload.segmentBookingId());
+        assertEquals("customer request", payload.reason());
+    }
+
+    @Test
+    void mapsSegmentTicketedPayloadFields() {
+        var contract = service.toContractEvent(new SegmentBookingEvent.SegmentTicketed(
+            "domain-event-8", "sb-123", Instant.parse("2026-07-05T10:00:07Z"), "ent-123")).orElseThrow();
+
+        assertEquals("SegmentTicketed", contract.eventType());
+        var payload = assertInstanceOf(BookingOrchestrationService.SegmentTicketedPayload.class, contract.payload());
+        assertEquals("sb-123", payload.segmentBookingId());
+        assertEquals("ent-123", payload.entitlementId());
+    }
+
+    @Test
+    void mapsBookingSagaCompletedPayloadFields() {
+        var start = service.startSaga(new BookingOrchestrationService.StartSagaCommand(
+            "ord-123", "acc-123", "off-123", List.of("tvl-123"), List.of("seg-001")),
+            "idem-start-completed", "corr-123");
+
+        var contract = service.toContractEvent(new BookingEvent.BookingSagaCompleted(
+            "domain-event-9", start.sagaId(), Instant.parse("2026-07-05T10:00:08Z"))).orElseThrow();
+
+        assertEquals("BookingSagaCompleted", contract.eventType());
+        var payload = assertInstanceOf(BookingOrchestrationService.BookingSagaCompletedPayload.class, contract.payload());
+        assertEquals(start.sagaId(), payload.sagaId());
+        assertEquals("ord-123", payload.journeyOrderId());
+    }
+
+    @Test
+    void mapsBookingSagaFailedPayloadFields() {
+        var start = service.startSaga(new BookingOrchestrationService.StartSagaCommand(
+            "ord-456", "acc-123", "off-123", List.of("tvl-123"), List.of("seg-001")),
+            "idem-start-failed", "corr-123");
+
+        var contract = service.toContractEvent(new BookingEvent.BookingSagaFailed(
+            "domain-event-10", start.sagaId(), Instant.parse("2026-07-05T10:00:09Z"),
+            "capacity unavailable")).orElseThrow();
+
+        assertEquals("BookingSagaFailed", contract.eventType());
+        var payload = assertInstanceOf(BookingOrchestrationService.BookingSagaFailedPayload.class, contract.payload());
+        assertEquals(start.sagaId(), payload.sagaId());
+        assertEquals("ord-456", payload.journeyOrderId());
+        assertEquals("capacity unavailable", payload.reason());
+    }
+
+    @Test
+    void ignoresInternalSagaEventsThatAreNotInTheBookingOrchestrationEventContract() {
+        assertTrue(service.toContractEvent(new BookingEvent.BookingSagaAdvanced(
+            "domain-event-internal-1", "saga-123", Instant.parse("2026-07-05T10:00:08Z"),
+            BookingSagaStatus.RESERVING)).isEmpty());
+        assertTrue(service.toContractEvent(new BookingEvent.BookingSagaStepSucceeded(
+            "domain-event-internal-2", "saga-123", Instant.parse("2026-07-05T10:00:09Z"),
+            "reserve-seg-001", "idem-123")).isEmpty());
+    }
+
+}

--- a/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/application/BookingOrchestrationServicePayloadContractTest.java
+++ b/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/application/BookingOrchestrationServicePayloadContractTest.java
@@ -279,4 +279,60 @@ class BookingOrchestrationServicePayloadContractTest {
                 && "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c404".equals(envelope.correlationId())));
     }
 
+    @Test
+    void entitlementIssueFailedPayloadFromContractAdvancesSagaFailureByEnvelopeCorrelationIdAndCausationId() {
+        var published = new com.trainticket.bookingorchestration.adapters.messaging.InMemoryEventPublisher();
+        var service = new BookingOrchestrationService(
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC), published);
+        var start = service.startSaga(new BookingOrchestrationService.StartSagaCommand(
+            "ord-entitlement-failure", "acc-123", "off-123", List.of("tvl-123"), List.of("seg-001")),
+            "idem-start-entitlement-failure", "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c501");
+        service.requestReservation(start.sagaId(), new BookingOrchestrationService.RequestReservationCommand(
+            "seg-001", "tvl-123", "sb-0194f2e0-7b3e-7610-0284-5c26e8b0c502"),
+            "idem-reservation-entitlement-failure", "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c501");
+        published.clear();
+
+        assertInstanceOf(HandlerResult.Success.class, service.handleUpstreamEvent(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-0284-5c26e8b0c503", "EntitlementIssueFailed", 1, "entitlement-ticketing",
+            "cmd-0194f2e0-7b3e-7610-0284-5c26e8b0c504", "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c501",
+            Instant.parse("2026-07-05T10:06:00Z"),
+            Map.of(
+                "entitlementId", "ent-0194f2e0-7b3e-7610-0284-5c26e8b0c505",
+                "retryable", false,
+                "failureCode", "PROVIDER_REJECTED",
+                "failureMessage", "provider rejected ticket issue",
+                "failedAt", "2026-07-05T10:06:00Z"))));
+
+        var detail = service.getSaga(start.sagaId()).orElseThrow();
+        assertEquals("FAILED", detail.status());
+        assertTrue(published.getPublished().stream().anyMatch(envelope ->
+            envelope.eventType().equals("SegmentReservationFailed")
+                && "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c501".equals(envelope.correlationId())
+                && "evt-0194f2e0-7b3e-7610-0284-5c26e8b0c503".equals(envelope.causationId())));
+        assertTrue(published.getPublished().stream().anyMatch(envelope ->
+            envelope.eventType().equals("BookingSagaFailed")
+                && "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c501".equals(envelope.correlationId())
+                && "evt-0194f2e0-7b3e-7610-0284-5c26e8b0c503".equals(envelope.causationId())));
+    }
+
+    @Test
+    void entitlementIssueFailedWithUnknownCorrelationIdIsAcknowledgedWithoutPublishing() {
+        var published = new com.trainticket.bookingorchestration.adapters.messaging.InMemoryEventPublisher();
+        var service = new BookingOrchestrationService(
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC), published);
+
+        assertInstanceOf(HandlerResult.Success.class, service.handleUpstreamEvent(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-0284-5c26e8b0c601", "EntitlementIssueFailed", 1, "entitlement-ticketing",
+            "cmd-0194f2e0-7b3e-7610-0284-5c26e8b0c602", "corr-unknown",
+            Instant.parse("2026-07-05T10:07:00Z"),
+            Map.of(
+                "entitlementId", "ent-0194f2e0-7b3e-7610-0284-5c26e8b0c603",
+                "retryable", true,
+                "failureCode", "TEMPORARY_PROVIDER_TIMEOUT",
+                "failureMessage", "provider timeout",
+                "failedAt", "2026-07-05T10:07:00Z"))));
+
+        assertTrue(published.getPublished().isEmpty());
+    }
+
 }

--- a/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/application/BookingOrchestrationServicePayloadContractTest.java
+++ b/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/application/BookingOrchestrationServicePayloadContractTest.java
@@ -17,6 +17,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -173,6 +174,109 @@ class BookingOrchestrationServicePayloadContractTest {
         assertTrue(service.toContractEvent(new BookingEvent.BookingSagaStepSucceeded(
             "domain-event-internal-2", "saga-123", Instant.parse("2026-07-05T10:00:09Z"),
             "reserve-seg-001", "idem-123")).isEmpty());
+    }
+
+    @Test
+    void paymentCapturedPayloadFromContractAdvancesSagaByStoredPaymentIntentId() {
+        var published = new com.trainticket.bookingorchestration.adapters.messaging.InMemoryEventPublisher();
+        var service = new BookingOrchestrationService(
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC), published);
+        var start = service.startSaga(new BookingOrchestrationService.StartSagaCommand(
+            "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c123", "acc-123", "off-123", List.of("tvl-123"), List.of("seg-001")),
+            "idem-start-payment", "corr-start");
+        published.clear();
+
+        assertInstanceOf(HandlerResult.Success.class, service.handleUpstreamEvent(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-0284-5c26e8b0c201", "PaymentIntentCreated", 1, "payment",
+            "cmd-0194f2e0-7b3e-7610-0284-5c26e8b0c202", "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c203",
+            Instant.parse("2026-07-05T10:01:00Z"),
+            Map.of(
+                "paymentIntentId", "pi-0194f2e0-7b3e-7610-0284-5c26e8b0c204",
+                "businessRef", "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c123",
+                "purpose", "purchase",
+                "amount", Map.of("currency", "CNY", "minorUnits", 35000),
+                "payerRef", "acc-123",
+                "idempotencyKey", "payment-idem-123",
+                "createdAt", "2026-07-05T10:01:00Z"))));
+
+        assertInstanceOf(HandlerResult.Success.class, service.handleUpstreamEvent(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-0284-5c26e8b0c211", "PaymentCaptured", 1, "payment",
+            "evt-0194f2e0-7b3e-7610-0284-5c26e8b0c201", "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c203",
+            Instant.parse("2026-07-05T10:02:00Z"),
+            Map.of(
+                "paymentIntentId", "pi-0194f2e0-7b3e-7610-0284-5c26e8b0c204",
+                "capturedAmount", Map.of("currency", "CNY", "minorUnits", 35000),
+                "channel", "wechat_pay",
+                "channelTransactionId", "wx_txn_20260703_a1b2c3"))));
+
+        var detail = service.getSaga(start.sagaId()).orElseThrow();
+        assertEquals("TICKETING", detail.status());
+    }
+
+    @Test
+    void capacityReleasePayloadFromContractAdvancesSegmentByStoredHoldId() {
+        var published = new com.trainticket.bookingorchestration.adapters.messaging.InMemoryEventPublisher();
+        var service = new BookingOrchestrationService(
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC), published);
+        var start = service.startSaga(new BookingOrchestrationService.StartSagaCommand(
+            "ord-capacity", "acc-123", "off-123", List.of("tvl-123"), List.of("seg-001")),
+            "idem-start-capacity", "corr-start");
+        service.requestReservation(start.sagaId(), new BookingOrchestrationService.RequestReservationCommand(
+            "seg-001", "tvl-123", "sb-0194f2e0-7b3e-7610-0284-5c26e8b0c301"),
+            "idem-reservation-capacity", "corr-start");
+        published.clear();
+
+        assertInstanceOf(HandlerResult.Success.class, service.handleUpstreamEvent(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-0284-5c26e8b0c302", "CapacityHeld", 1, "capacity-availability",
+            "cmd-0194f2e0-7b3e-7610-0284-5c26e8b0c303", "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c304",
+            Instant.parse("2026-07-05T10:03:00Z"),
+            Map.of(
+                "holdId", "hold-0194f2e0-7b3e-7610-0284-5c26e8b0c305",
+                "inventoryPoolId", "pool-123",
+                "capacityUnitRef", "cu-123",
+                "interval", Map.of("fromStationRef", "BJP", "toStationRef", "SHH"),
+                "idempotencyKey", "ord-capacity:seg-001:tvl-123:purchase",
+                "expiresAt", "2026-07-05T10:08:00Z",
+                "idempotentReplay", false))));
+        published.clear();
+
+        assertInstanceOf(HandlerResult.Success.class, service.handleUpstreamEvent(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-0284-5c26e8b0c306", "CapacityReleased", 1, "capacity-availability",
+            "cmd-0194f2e0-7b3e-7610-0284-5c26e8b0c307", "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c304",
+            Instant.parse("2026-07-05T10:04:00Z"),
+            Map.of(
+                "holdId", "hold-0194f2e0-7b3e-7610-0284-5c26e8b0c305",
+                "inventoryPoolId", "pool-123",
+                "capacityUnitRef", "cu-123",
+                "interval", Map.of("fromStationRef", "BJP", "toStationRef", "SHH"),
+                "releasedAt", "2026-07-05T10:04:00Z",
+                "releaseReason", "payment-expired"))));
+
+        assertTrue(published.getPublished().stream().anyMatch(envelope -> envelope.eventType().equals("SegmentBookingCancelled")));
+    }
+
+    @Test
+    void failurePathsPropagateConsumedEnvelopeCorrelationId() {
+        var published = new com.trainticket.bookingorchestration.adapters.messaging.InMemoryEventPublisher();
+        var service = new BookingOrchestrationService(
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC), published);
+        var start = service.startSaga(new BookingOrchestrationService.StartSagaCommand(
+            "ord-provider-failure", "acc-123", "off-123", List.of("tvl-123"), List.of("seg-001")),
+            "idem-start-provider-failure", "corr-start");
+        service.requestReservation(start.sagaId(), new BookingOrchestrationService.RequestReservationCommand(
+            "seg-001", "tvl-123", "sb-0194f2e0-7b3e-7610-0284-5c26e8b0c401"),
+            "idem-reservation-provider-failure", "corr-start");
+        published.clear();
+
+        assertInstanceOf(HandlerResult.Success.class, service.handleUpstreamEvent(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-0284-5c26e8b0c402", "ProviderReservationFailed", 1, "provider-integration",
+            "cmd-0194f2e0-7b3e-7610-0284-5c26e8b0c403", "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c404",
+            Instant.parse("2026-07-05T10:05:00Z"),
+            Map.of("segmentBookingId", "sb-0194f2e0-7b3e-7610-0284-5c26e8b0c401", "reason", "provider-unavailable"))));
+
+        assertTrue(published.getPublished().stream().anyMatch(envelope ->
+            envelope.eventType().equals("SegmentReservationFailed")
+                && "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c404".equals(envelope.correlationId())));
     }
 
 }

--- a/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/application/EventEnvelopeTest.java
+++ b/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/application/EventEnvelopeTest.java
@@ -1,0 +1,54 @@
+package com.trainticket.bookingorchestration.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class EventEnvelopeTest {
+
+    @Test
+    void createsValidEnvelope() {
+        Instant now = Instant.now();
+        var envelope = new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-0284-5c26e8b0c222",
+            "BookingSagaStarted", 1, "booking-orchestration",
+            "cmd-0194f2e0-7b3e-7610-0284-5c26e8b0c555",
+            "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c444", now, new Object());
+
+        assertEquals("evt-0194f2e0-7b3e-7610-0284-5c26e8b0c222", envelope.eventId());
+        assertEquals("BookingSagaStarted", envelope.eventType());
+        assertEquals(1, envelope.schemaVersion());
+        assertEquals("booking-orchestration", envelope.producer());
+        assertEquals(now, envelope.occurredAt());
+        assertNotNull(envelope.payload());
+    }
+
+    @Test
+    void rejectsNullEventId() {
+        assertThrows(IllegalArgumentException.class, () -> new EventEnvelope(
+            null, "BookingSagaStarted", 1, "booking-orchestration",
+            null, null, Instant.now(), null));
+    }
+
+    @Test
+    void rejectsBlankEventType() {
+        assertThrows(IllegalArgumentException.class, () -> new EventEnvelope(
+            "evt-123", "", 1, "booking-orchestration",
+            null, null, Instant.now(), null));
+    }
+
+    @Test
+    void rejectsNullProducer() {
+        assertThrows(IllegalArgumentException.class, () -> new EventEnvelope(
+            "evt-123", "BookingSagaStarted", 1, null,
+            null, null, Instant.now(), null));
+    }
+
+    @Test
+    void rejectsNullOccurredAt() {
+        assertThrows(IllegalArgumentException.class, () -> new EventEnvelope(
+            "evt-123", "BookingSagaStarted", 1, "booking-orchestration",
+            null, null, null, null));
+    }
+}


### PR DESCRIPTION
## Summary
- Implements booking-orchestration HTTP API and Redis Streams integration surface.
- Fixes review findings: Redis is default with REDIS_URL fallback, Redis URL is never logged, subscriber dispatches to saga handling, mark-ticketed uses SegmentBooking.markTicketed, DLQ uses Redis PEL delivery counts, and request-scoped correlation IDs are used consistently.

## Validation
- `cd services/booking-orchestration && mvn -q test`
- `! grep -rl 'lettuce\|RedisClient' services/booking-orchestration/src/main/java | grep -v adapters`
- `make check`