### PR TITLE
REQ-038 payment HTTP API and event bus adapter

### DIFF
--- a/services/payment/pom.xml
+++ b/services/payment/pom.xml
@@ -27,6 +27,19 @@
       <version>1.46.0</version>
     </dependency>
     <dependency>
+      <groupId>io.lettuce</groupId>
+      <artifactId>lettuce-core</artifactId>
+      <version>6.4.2.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/services/payment/src/main/java/com/trainticket/payment/RequestContextFilter.java
+++ b/services/payment/src/main/java/com/trainticket/payment/RequestContextFilter.java
@@ -15,6 +15,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class RequestContextFilter extends OncePerRequestFilter {
     public static final String REQUEST_ID_HEADER = "X-Request-Id";
     public static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
+    public static final String REQUEST_ID_ATTRIBUTE = RequestContextFilter.class.getName() + ".requestId";
+    public static final String CORRELATION_ID_ATTRIBUTE = RequestContextFilter.class.getName() + ".correlationId";
 
     private final RuntimeTracer tracer;
 
@@ -37,6 +39,8 @@ public class RequestContextFilter extends OncePerRequestFilter {
             request.getRequestURI()
         );
 
+        request.setAttribute(REQUEST_ID_ATTRIBUTE, requestId);
+        request.setAttribute(CORRELATION_ID_ATTRIBUTE, correlationId);
         response.setHeader(REQUEST_ID_HEADER, requestId);
         response.setHeader(CORRELATION_ID_HEADER, correlationId);
         MDC.put("requestId", requestId);

--- a/services/payment/src/main/java/com/trainticket/payment/adapters/http/HttpModels.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/http/HttpModels.java
@@ -1,0 +1,57 @@
+package com.trainticket.payment.adapters.http;
+
+import java.time.Instant;
+import java.util.Map;
+
+record MoneyJson(String currency, Long minorUnits) {
+}
+
+record CreatePaymentIntentRequest(String businessRef, String purpose, MoneyJson amount, String payerRef) {
+}
+
+record PaymentIntentResponse(String paymentIntentId, String businessRef, MoneyJson amount, String status, Instant createdAt) {
+}
+
+record PaymentIntentDetailsResponse(
+    String paymentIntentId,
+    String businessRef,
+    String purpose,
+    MoneyJson amount,
+    String payerRef,
+    String status,
+    Instant createdAt,
+    Instant expiresAt,
+    MoneyJson authorizedAmount,
+    MoneyJson capturedAmount,
+    MoneyJson refundedAmount
+) {
+}
+
+record CancelPaymentIntentRequest(String reason) {
+}
+
+record CancelPaymentIntentResponse(String paymentIntentId, String status, Instant cancelledAt) {
+}
+
+record CapturePaymentResponse(String paymentIntentId, String status, MoneyJson capturedAmount, String channelTransactionId) {
+}
+
+record RequestRefundRequest(String paymentIntentId, MoneyJson amount, String reason, String businessCaseRef) {
+}
+
+record RefundResponse(String refundId, String paymentIntentId, MoneyJson amount, String status) {
+}
+
+record RefundDetailsResponse(
+    String refundId,
+    String paymentIntentId,
+    MoneyJson amount,
+    String status,
+    String reason,
+    String businessCaseRef,
+    String channelRefundTransactionId
+) {
+}
+
+record ErrorResponse(String code, String message, String correlationId, Map<String, Object> details) {
+}

--- a/services/payment/src/main/java/com/trainticket/payment/adapters/http/IdempotencyKeyReusedException.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/http/IdempotencyKeyReusedException.java
@@ -1,0 +1,7 @@
+package com.trainticket.payment.adapters.http;
+
+class IdempotencyKeyReusedException extends RuntimeException {
+    IdempotencyKeyReusedException(String message) {
+        super(message);
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/adapters/http/IdempotencyStore.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/http/IdempotencyStore.java
@@ -1,0 +1,38 @@
+package com.trainticket.payment.adapters.http;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+class IdempotencyStore {
+    private final Map<String, Entry> entries = new ConcurrentHashMap<>();
+
+    ResponseEntity<?> replayOrRecord(String method, String path, String idempotencyKey, Object requestBody, Supplier<ResponseEntity<?>> creator) {
+        String key = method + ":" + path + ":" + requireText(idempotencyKey, "idempotencyKey");
+        int requestHash = Objects.hashCode(requestBody);
+        Entry existing = entries.get(key);
+        if (existing != null) {
+            if (existing.requestHash != requestHash) {
+                throw new IdempotencyKeyReusedException("Idempotency-Key was reused with a different request body");
+            }
+            return existing.response;
+        }
+        ResponseEntity<?> response = creator.get();
+        entries.put(key, new Entry(requestHash, response));
+        return response;
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new ValidationException(name + " is required");
+        }
+        return value;
+    }
+
+    private record Entry(int requestHash, ResponseEntity<?> response) {
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/adapters/http/PaymentController.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/http/PaymentController.java
@@ -1,0 +1,117 @@
+package com.trainticket.payment.adapters.http;
+
+import com.trainticket.payment.RequestContextFilter;
+import com.trainticket.payment.application.PaymentCommandService;
+import com.trainticket.payment.domain.PaymentIntent;
+import com.trainticket.payment.domain.Refund;
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.util.Objects;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class PaymentController {
+    private final PaymentCommandService service;
+    private final IdempotencyStore idempotencyStore;
+
+    public PaymentController(PaymentCommandService service, IdempotencyStore idempotencyStore) {
+        this.service = Objects.requireNonNull(service, "service is required");
+        this.idempotencyStore = Objects.requireNonNull(idempotencyStore, "idempotencyStore is required");
+    }
+
+    @PostMapping("/payment-intents")
+    public ResponseEntity<?> createPaymentIntent(@RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey, @RequestBody(required = false) CreatePaymentIntentRequest request, HttpServletRequest httpRequest) {
+        requireIdempotencyKey(idempotencyKey);
+        validateCreate(request);
+        return idempotencyStore.replayOrRecord("POST", httpRequest.getRequestURI(), idempotencyKey, request, () -> {
+            PaymentIntent intent = service.createIntent(request.businessRef(), request.purpose(), PaymentHttpMapper.toMoney(request.amount()), request.payerRef(), idempotencyKey, correlationId(httpRequest));
+            return ResponseEntity.created(URI.create("/api/v1/payment-intents/" + intent.paymentIntentId())).body(PaymentHttpMapper.intentResponse(intent));
+        });
+    }
+
+    @PostMapping("/payment-intents/{paymentIntentId}/cancel")
+    public ResponseEntity<?> cancelPaymentIntent(@PathVariable String paymentIntentId, @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey, @RequestBody(required = false) CancelPaymentIntentRequest request, HttpServletRequest httpRequest) {
+        requireIdempotencyKey(idempotencyKey);
+        if (request == null || isBlank(request.reason())) {
+            throw new ValidationException("reason is required");
+        }
+        return idempotencyStore.replayOrRecord("POST", httpRequest.getRequestURI(), idempotencyKey, request, () -> ResponseEntity.ok(PaymentHttpMapper.cancelResponse(service.cancelIntent(paymentIntentId, request.reason(), idempotencyKey, correlationId(httpRequest)))));
+    }
+
+    @PostMapping("/payment-intents/{paymentIntentId}/capture")
+    public ResponseEntity<?> capturePayment(@PathVariable String paymentIntentId, @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey, HttpServletRequest httpRequest) {
+        requireIdempotencyKey(idempotencyKey);
+        return idempotencyStore.replayOrRecord("POST", httpRequest.getRequestURI(), idempotencyKey, "", () -> ResponseEntity.ok(PaymentHttpMapper.captureResponse(service.captureIntent(paymentIntentId, idempotencyKey, correlationId(httpRequest)))));
+    }
+
+    @PostMapping("/refunds")
+    public ResponseEntity<?> requestRefund(@RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey, @RequestBody(required = false) RequestRefundRequest request, HttpServletRequest httpRequest) {
+        requireIdempotencyKey(idempotencyKey);
+        validateRefund(request);
+        return idempotencyStore.replayOrRecord("POST", httpRequest.getRequestURI(), idempotencyKey, request, () -> {
+            Refund refund = service.requestRefund(request.paymentIntentId(), PaymentHttpMapper.toMoney(request.amount()), request.reason(), request.businessCaseRef(), idempotencyKey, correlationId(httpRequest));
+            return ResponseEntity.created(URI.create("/api/v1/refunds/" + refund.refundId())).body(PaymentHttpMapper.refundResponse(refund));
+        });
+    }
+
+    @GetMapping("/payment-intents/{paymentIntentId}")
+    public PaymentIntentDetailsResponse getPaymentIntent(@PathVariable String paymentIntentId) {
+        return PaymentHttpMapper.intentDetails(service.getIntent(paymentIntentId));
+    }
+
+    @GetMapping("/refunds/{refundId}")
+    public RefundDetailsResponse getRefund(@PathVariable String refundId) {
+        return PaymentHttpMapper.refundDetails(service.getRefund(refundId));
+    }
+
+    private static void validateCreate(CreatePaymentIntentRequest request) {
+        if (request == null) {
+            throw new ValidationException("request body is required");
+        }
+        requireText(request.businessRef(), "businessRef");
+        requireText(request.purpose(), "purpose");
+        PaymentHttpMapper.toMoney(request.amount());
+        requireText(request.payerRef(), "payerRef");
+    }
+
+    private static void validateRefund(RequestRefundRequest request) {
+        if (request == null) {
+            throw new ValidationException("request body is required");
+        }
+        requireText(request.paymentIntentId(), "paymentIntentId");
+        PaymentHttpMapper.toMoney(request.amount());
+        requireText(request.reason(), "reason");
+    }
+
+    private static void requireIdempotencyKey(String idempotencyKey) {
+        requireText(idempotencyKey, "Idempotency-Key");
+    }
+
+    private static String requireText(String value, String field) {
+        if (isBlank(value)) {
+            throw new ValidationException(field + " is required");
+        }
+        return value;
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private static String correlationId(HttpServletRequest request) {
+        Object attribute = request.getAttribute(RequestContextFilter.CORRELATION_ID_ATTRIBUTE);
+        if (attribute != null) {
+            return attribute.toString();
+        }
+        String header = request.getHeader(RequestContextFilter.CORRELATION_ID_HEADER);
+        return header == null ? "" : header;
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/adapters/http/PaymentExceptionHandler.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/http/PaymentExceptionHandler.java
@@ -1,0 +1,56 @@
+package com.trainticket.payment.adapters.http;
+
+import com.trainticket.payment.RequestContextFilter;
+import com.trainticket.payment.application.NotFoundException;
+import com.trainticket.payment.application.PublishFailedException;
+import com.trainticket.payment.domain.DomainRuleViolation;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class PaymentExceptionHandler {
+    @ExceptionHandler({ValidationException.class, HttpMessageNotReadableException.class, IllegalArgumentException.class})
+    ResponseEntity<ErrorResponse> validation(Exception exception, HttpServletRequest request) {
+        return error(HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", exception.getMessage(), request);
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    ResponseEntity<ErrorResponse> notFound(NotFoundException exception, HttpServletRequest request) {
+        return error(HttpStatus.NOT_FOUND, "NOT_FOUND", exception.getMessage(), request);
+    }
+
+    @ExceptionHandler(IdempotencyKeyReusedException.class)
+    ResponseEntity<ErrorResponse> idempotency(IdempotencyKeyReusedException exception, HttpServletRequest request) {
+        return error(HttpStatus.UNPROCESSABLE_ENTITY, "IDEMPOTENCY_KEY_REUSED", exception.getMessage(), request);
+    }
+
+    @ExceptionHandler(DomainRuleViolation.class)
+    ResponseEntity<ErrorResponse> domain(DomainRuleViolation exception, HttpServletRequest request) {
+        String code = exception.getMessage() != null && exception.getMessage().contains("cannot") ? "PRECONDITION_FAILED" : "DOMAIN_RULE_VIOLATION";
+        HttpStatus status = "PRECONDITION_FAILED".equals(code) ? HttpStatus.PRECONDITION_FAILED : HttpStatus.UNPROCESSABLE_ENTITY;
+        return error(status, code, exception.getMessage(), request);
+    }
+
+    @ExceptionHandler(PublishFailedException.class)
+    ResponseEntity<ErrorResponse> unavailable(PublishFailedException exception, HttpServletRequest request) {
+        return error(HttpStatus.SERVICE_UNAVAILABLE, "UNAVAILABLE", exception.getMessage(), request);
+    }
+
+    private static ResponseEntity<ErrorResponse> error(HttpStatus status, String code, String message, HttpServletRequest request) {
+        return ResponseEntity.status(status).body(new ErrorResponse(code, message, correlationId(request), Map.of()));
+    }
+
+    private static String correlationId(HttpServletRequest request) {
+        Object attribute = request.getAttribute(RequestContextFilter.CORRELATION_ID_ATTRIBUTE);
+        if (attribute != null) {
+            return attribute.toString();
+        }
+        String header = request.getHeader(RequestContextFilter.CORRELATION_ID_HEADER);
+        return header == null ? "" : header;
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/adapters/http/PaymentHttpMapper.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/http/PaymentHttpMapper.java
@@ -1,0 +1,83 @@
+package com.trainticket.payment.adapters.http;
+
+import com.trainticket.payment.domain.Money;
+import com.trainticket.payment.domain.PaymentEvent;
+import com.trainticket.payment.domain.PaymentIntent;
+import com.trainticket.payment.domain.PaymentIntentCreated;
+import com.trainticket.payment.domain.Refund;
+import java.time.Instant;
+
+final class PaymentHttpMapper {
+    private PaymentHttpMapper() {
+    }
+
+    static Money toMoney(MoneyJson json) {
+        if (json == null) {
+            throw new ValidationException("amount is required");
+        }
+        if (json.currency() == null || json.currency().isBlank()) {
+            throw new ValidationException("amount.currency is required");
+        }
+        if (json.minorUnits() == null) {
+            throw new ValidationException("amount.minorUnits is required");
+        }
+        return Money.fromMinorUnits(json.minorUnits(), json.currency());
+    }
+
+    static MoneyJson money(Money money) {
+        return new MoneyJson(money.currency().getCurrencyCode(), money.toMinorUnits());
+    }
+
+    static PaymentIntentResponse intentResponse(PaymentIntent intent) {
+        return new PaymentIntentResponse(intent.paymentIntentId(), intent.businessRef(), money(intent.amount()), intent.status().name(), createdAt(intent));
+    }
+
+    static PaymentIntentDetailsResponse intentDetails(PaymentIntent intent) {
+        return new PaymentIntentDetailsResponse(
+            intent.paymentIntentId(),
+            intent.businessRef(),
+            intent.purpose(),
+            money(intent.amount()),
+            intent.payerRef(),
+            intent.status().name(),
+            createdAt(intent),
+            intent.expiresAt(),
+            money(intent.authorizedAmount()),
+            money(intent.capturedAmount()),
+            money(intent.refundedAmount())
+        );
+    }
+
+    static CancelPaymentIntentResponse cancelResponse(PaymentIntent intent) {
+        return new CancelPaymentIntentResponse(intent.paymentIntentId(), intent.status().name(), lastEventAt(intent));
+    }
+
+    static CapturePaymentResponse captureResponse(PaymentIntent intent) {
+        return new CapturePaymentResponse(intent.paymentIntentId(), intent.status().name(), money(intent.capturedAmount()), lastChannelTransactionId(intent));
+    }
+
+    static RefundResponse refundResponse(Refund refund) {
+        return new RefundResponse(refund.refundId(), refund.paymentIntentId(), money(refund.amount()), refund.status().name());
+    }
+
+    static RefundDetailsResponse refundDetails(Refund refund) {
+        return new RefundDetailsResponse(refund.refundId(), refund.paymentIntentId(), money(refund.amount()), refund.status().name(), refund.reasonCode(), refund.sourceCaseRef(), refund.channelRefundTransactionId());
+    }
+
+    private static Instant createdAt(PaymentIntent intent) {
+        return intent.domainEvents().stream()
+            .filter(PaymentIntentCreated.class::isInstance)
+            .map(PaymentEvent::envelope)
+            .map(com.trainticket.payment.domain.EventEnvelope::occurredAt)
+            .findFirst()
+            .orElse(Instant.EPOCH);
+    }
+
+    private static Instant lastEventAt(PaymentIntent intent) {
+        return intent.domainEvents().getLast().envelope().occurredAt();
+    }
+
+    private static String lastChannelTransactionId(PaymentIntent intent) {
+        return intent.channelTransactionRefs().stream().sorted().reduce((first, second) -> second).orElse("").replaceFirst("^[^:]+:", "");
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/adapters/http/ValidationException.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/http/ValidationException.java
@@ -1,0 +1,7 @@
+package com.trainticket.payment.adapters.http;
+
+class ValidationException extends RuntimeException {
+    ValidationException(String message) {
+        super(message);
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/LettuceRedisStreamOperations.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/LettuceRedisStreamOperations.java
@@ -1,0 +1,80 @@
+package com.trainticket.payment.adapters.messaging;
+
+import io.lettuce.core.Consumer;
+import io.lettuce.core.Limit;
+import io.lettuce.core.Range;
+import io.lettuce.core.RedisBusyException;
+import io.lettuce.core.StreamMessage;
+import io.lettuce.core.XAddArgs;
+import io.lettuce.core.XAutoClaimArgs;
+import io.lettuce.core.XGroupCreateArgs;
+import io.lettuce.core.XReadArgs;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.models.stream.PendingMessage;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+final class LettuceRedisStreamOperations implements RedisStreamOperations {
+    private final StatefulRedisConnection<String, String> connection;
+
+    LettuceRedisStreamOperations(StatefulRedisConnection<String, String> connection) {
+        this.connection = Objects.requireNonNull(connection, "connection is required");
+    }
+
+    @Override
+    public void createGroup(String stream, String group) {
+        try {
+            connection.sync().xgroupCreate(XReadArgs.StreamOffset.from(stream, "$"), group, XGroupCreateArgs.Builder.mkstream());
+        } catch (RedisBusyException ignored) {
+            // Existing group is safe on restart.
+        }
+    }
+
+    @Override
+    public List<StreamEntry> readGroup(String stream, String group, String consumerName) {
+        return connection.sync()
+            .xreadgroup(Consumer.from(group, consumerName), XReadArgs.Builder.block(Duration.ofSeconds(2)).count(10), XReadArgs.StreamOffset.lastConsumed(stream))
+            .stream()
+            .map(LettuceRedisStreamOperations::toEntry)
+            .toList();
+    }
+
+    @Override
+    public List<StreamEntry> autoClaim(String stream, String group, String consumerName) {
+        return connection.sync()
+            .xautoclaim(stream, XAutoClaimArgs.Builder.xautoclaim(Consumer.from(group, consumerName), Duration.ofSeconds(60), "0-0").count(100))
+            .getMessages()
+            .stream()
+            .map(LettuceRedisStreamOperations::toEntry)
+            .toList();
+    }
+
+    @Override
+    public int deliveryCount(String stream, String group, String messageId) {
+        List<PendingMessage> messages = connection.sync().xpending(stream, group, Range.create(messageId, messageId), Limit.create(0, 1));
+        if (messages.isEmpty()) {
+            return 1;
+        }
+        long redeliveryCount = messages.getFirst().getRedeliveryCount();
+        if (redeliveryCount >= Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return (int) redeliveryCount;
+    }
+
+    @Override
+    public void ack(String stream, String group, String messageId) {
+        connection.sync().xack(stream, group, messageId);
+    }
+
+    @Override
+    public void moveToDlq(String stream, String envelopeJson) {
+        connection.sync().xadd(RedisStreamNames.dlqFor(stream), XAddArgs.Builder.maxlen(100_000).approximateTrimming(), Map.of("envelope", envelopeJson));
+    }
+
+    private static StreamEntry toEntry(StreamMessage<String, String> message) {
+        return new StreamEntry(message.getId(), message.getBody().get("envelope"));
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/PaymentSubscriptionRunner.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/PaymentSubscriptionRunner.java
@@ -1,0 +1,31 @@
+package com.trainticket.payment.adapters.messaging;
+
+import com.trainticket.payment.application.EventSubscriber;
+import com.trainticket.payment.application.PaymentInboundEventHandler;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "payment.messaging.enabled", havingValue = "true")
+public class PaymentSubscriptionRunner implements CommandLineRunner {
+    private final EventSubscriber subscriber;
+    private final PaymentInboundEventHandler handler;
+
+    public PaymentSubscriptionRunner(EventSubscriber subscriber, PaymentInboundEventHandler handler) {
+        this.subscriber = subscriber;
+        this.handler = handler;
+    }
+
+    @Override
+    public void run(String... args) {
+        subscriber.subscribe(
+            List.of(RedisStreamNames.BOOKING_ORCHESTRATION_STREAM, RedisStreamNames.POST_SALES_STREAM),
+            RedisStreamNames.PAYMENT_GROUP,
+            "payment-" + UUID.randomUUID(),
+            handler
+        );
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/RedisEventPublisher.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/RedisEventPublisher.java
@@ -1,0 +1,60 @@
+package com.trainticket.payment.adapters.messaging;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.payment.application.EventEnvelope;
+import com.trainticket.payment.application.EventPublisher;
+import com.trainticket.payment.application.PublishFailedException;
+import io.lettuce.core.XAddArgs;
+import io.lettuce.core.api.StatefulRedisConnection;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+
+public class RedisEventPublisher implements EventPublisher {
+    private static final int MAX_ATTEMPTS = 3;
+    private final StatefulRedisConnection<String, String> connection;
+    private final ObjectMapper objectMapper;
+
+    RedisEventPublisher(StatefulRedisConnection<String, String> connection, ObjectMapper objectMapper) {
+        this.connection = Objects.requireNonNull(connection, "connection is required");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper is required");
+    }
+
+    @Override
+    public void publish(EventEnvelope envelope) throws PublishFailedException {
+        String json = serialize(envelope);
+        String stream = RedisStreamNames.streamForProducer(envelope.producer());
+        RuntimeException last = null;
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            try {
+                connection.sync().xadd(stream, XAddArgs.Builder.maxlen(100_000).approximateTrimming(), Map.of("envelope", json));
+                return;
+            } catch (RuntimeException exception) {
+                last = exception;
+                backoff(attempt);
+            }
+        }
+        throw new PublishFailedException("event was not published", last);
+    }
+
+    private String serialize(EventEnvelope envelope) {
+        try {
+            return objectMapper.writeValueAsString(envelope);
+        } catch (JsonProcessingException exception) {
+            throw new PublishFailedException("event envelope could not be serialized", exception);
+        }
+    }
+
+    private static void backoff(int attempt) {
+        if (attempt >= MAX_ATTEMPTS) {
+            return;
+        }
+        try {
+            Thread.sleep(Duration.ofMillis(50L * attempt).toMillis());
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new PublishFailedException("publish retry interrupted", exception);
+        }
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/RedisEventSubscriber.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/RedisEventSubscriber.java
@@ -1,0 +1,122 @@
+package com.trainticket.payment.adapters.messaging;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.payment.application.EventEnvelope;
+import com.trainticket.payment.application.EventSubscriber;
+import com.trainticket.payment.application.HandlerResult;
+import com.trainticket.payment.application.SubscribeFailedException;
+import io.lettuce.core.Consumer;
+import io.lettuce.core.RedisBusyException;
+import io.lettuce.core.StreamMessage;
+import io.lettuce.core.XAddArgs;
+import io.lettuce.core.XAutoClaimArgs;
+import io.lettuce.core.XReadArgs;
+import io.lettuce.core.api.StatefulRedisConnection;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class RedisEventSubscriber implements EventSubscriber, AutoCloseable {
+    private static final int MAX_DELIVERY_ATTEMPTS = 5;
+    private final StatefulRedisConnection<String, String> connection;
+    private final ObjectMapper objectMapper;
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private final AtomicBoolean running = new AtomicBoolean();
+
+    RedisEventSubscriber(StatefulRedisConnection<String, String> connection, ObjectMapper objectMapper) {
+        this.connection = Objects.requireNonNull(connection, "connection is required");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper is required");
+    }
+
+    @Override
+    public void subscribe(List<String> streams, String group, String consumerName, EventHandler handler) throws SubscribeFailedException {
+        Objects.requireNonNull(streams, "streams are required");
+        if (streams.isEmpty()) {
+            throw new SubscribeFailedException("at least one stream is required", null);
+        }
+        createGroups(streams, group);
+        running.set(true);
+        executor.submit(() -> poll(streams, group, consumerName, handler));
+    }
+
+    private void createGroups(List<String> streams, String group) {
+        for (String stream : streams) {
+            try {
+                connection.sync().xgroupCreate(XReadArgs.StreamOffset.from(stream, "$"), group, io.lettuce.core.XGroupCreateArgs.Builder.mkstream());
+            } catch (RedisBusyException ignored) {
+                // Existing group is safe on restart.
+            } catch (RuntimeException exception) {
+                throw new SubscribeFailedException("consumer group could not be created", exception);
+            }
+        }
+    }
+
+    private void poll(List<String> streams, String group, String consumerName, EventHandler handler) {
+        while (running.get()) {
+            for (String stream : streams) {
+                recover(stream, group, consumerName, handler);
+                List<StreamMessage<String, String>> messages = connection.sync().xreadgroup(Consumer.from(group, consumerName), XReadArgs.Builder.block(Duration.ofSeconds(2)).count(10), XReadArgs.StreamOffset.lastConsumed(stream));
+                for (StreamMessage<String, String> message : messages) {
+                    handle(stream, group, message, handler, 1);
+                }
+            }
+        }
+    }
+
+    private void recover(String stream, String group, String consumerName, EventHandler handler) {
+        List<StreamMessage<String, String>> messages = connection.sync().xautoclaim(stream, XAutoClaimArgs.Builder.xautoclaim(Consumer.from(group, consumerName), Duration.ofSeconds(60), "0-0").count(100)).getMessages();
+        for (StreamMessage<String, String> message : messages) {
+            handle(stream, group, message, handler, MAX_DELIVERY_ATTEMPTS);
+        }
+    }
+
+    private void handle(String stream, String group, StreamMessage<String, String> message, EventHandler handler, int deliveryAttempts) {
+        String json = message.getBody().get("envelope");
+        if (json == null || deliveryAttempts >= MAX_DELIVERY_ATTEMPTS) {
+            moveToDlq(stream, json == null ? "{}" : json);
+            ack(stream, group, message.getId());
+            return;
+        }
+        EventEnvelope envelope = deserialize(json);
+        HandlerResult result = handler.handle(envelope);
+        if (result == HandlerResult.SUCCESS) {
+            ack(stream, group, message.getId());
+        } else if (result == HandlerResult.FATAL_FAILURE) {
+            moveToDlq(stream, json);
+            ack(stream, group, message.getId());
+        }
+    }
+
+    private EventEnvelope deserialize(String json) {
+        try {
+            return objectMapper.readValue(json, EventEnvelope.class);
+        } catch (JsonProcessingException exception) {
+            throw new SubscribeFailedException("event envelope could not be deserialized", exception);
+        }
+    }
+
+    private void ack(String stream, String group, String id) {
+        connection.sync().xack(stream, group, id);
+    }
+
+    private void moveToDlq(String stream, String json) {
+        connection.sync().xadd(RedisStreamNames.dlqFor(stream), XAddArgs.Builder.maxlen(100_000).approximateTrimming(), Map.of("envelope", json));
+    }
+
+    @Override
+    public void close() {
+        running.set(false);
+        executor.shutdown();
+        try {
+            executor.awaitTermination(5, TimeUnit.SECONDS);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/RedisEventSubscriber.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/RedisEventSubscriber.java
@@ -6,16 +6,7 @@ import com.trainticket.payment.application.EventEnvelope;
 import com.trainticket.payment.application.EventSubscriber;
 import com.trainticket.payment.application.HandlerResult;
 import com.trainticket.payment.application.SubscribeFailedException;
-import io.lettuce.core.Consumer;
-import io.lettuce.core.RedisBusyException;
-import io.lettuce.core.StreamMessage;
-import io.lettuce.core.XAddArgs;
-import io.lettuce.core.XAutoClaimArgs;
-import io.lettuce.core.XReadArgs;
-import io.lettuce.core.api.StatefulRedisConnection;
-import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -23,46 +14,49 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class RedisEventSubscriber implements EventSubscriber, AutoCloseable {
-    private static final int MAX_DELIVERY_ATTEMPTS = 5;
-    private final StatefulRedisConnection<String, String> connection;
+    static final int MAX_DELIVERY_ATTEMPTS = 5;
+
+    private final RedisStreamOperations streams;
     private final ObjectMapper objectMapper;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private final AtomicBoolean running = new AtomicBoolean();
 
-    RedisEventSubscriber(StatefulRedisConnection<String, String> connection, ObjectMapper objectMapper) {
-        this.connection = Objects.requireNonNull(connection, "connection is required");
+    RedisEventSubscriber(RedisStreamOperations streams, ObjectMapper objectMapper) {
+        this.streams = Objects.requireNonNull(streams, "streams are required");
         this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper is required");
     }
 
     @Override
-    public void subscribe(List<String> streams, String group, String consumerName, EventHandler handler) throws SubscribeFailedException {
-        Objects.requireNonNull(streams, "streams are required");
-        if (streams.isEmpty()) {
+    public void subscribe(List<String> streamNames, String group, String consumerName, EventHandler handler) throws SubscribeFailedException {
+        Objects.requireNonNull(streamNames, "streams are required");
+        Objects.requireNonNull(handler, "handler is required");
+        if (streamNames.isEmpty()) {
             throw new SubscribeFailedException("at least one stream is required", null);
         }
-        createGroups(streams, group);
+        createGroups(streamNames, group);
         running.set(true);
-        executor.submit(() -> poll(streams, group, consumerName, handler));
+        executor.submit(() -> poll(streamNames, group, consumerName, handler));
     }
 
-    private void createGroups(List<String> streams, String group) {
-        for (String stream : streams) {
+    void recoverOnce(String stream, String group, String consumerName, EventHandler handler) {
+        recover(stream, group, consumerName, handler);
+    }
+
+    private void createGroups(List<String> streamNames, String group) {
+        for (String stream : streamNames) {
             try {
-                connection.sync().xgroupCreate(XReadArgs.StreamOffset.from(stream, "$"), group, io.lettuce.core.XGroupCreateArgs.Builder.mkstream());
-            } catch (RedisBusyException ignored) {
-                // Existing group is safe on restart.
+                streams.createGroup(stream, group);
             } catch (RuntimeException exception) {
                 throw new SubscribeFailedException("consumer group could not be created", exception);
             }
         }
     }
 
-    private void poll(List<String> streams, String group, String consumerName, EventHandler handler) {
+    private void poll(List<String> streamNames, String group, String consumerName, EventHandler handler) {
         while (running.get()) {
-            for (String stream : streams) {
+            for (String stream : streamNames) {
                 recover(stream, group, consumerName, handler);
-                List<StreamMessage<String, String>> messages = connection.sync().xreadgroup(Consumer.from(group, consumerName), XReadArgs.Builder.block(Duration.ofSeconds(2)).count(10), XReadArgs.StreamOffset.lastConsumed(stream));
-                for (StreamMessage<String, String> message : messages) {
+                for (RedisStreamOperations.StreamEntry message : streams.readGroup(stream, group, consumerName)) {
                     handle(stream, group, message, handler, 1);
                 }
             }
@@ -70,26 +64,30 @@ public class RedisEventSubscriber implements EventSubscriber, AutoCloseable {
     }
 
     private void recover(String stream, String group, String consumerName, EventHandler handler) {
-        List<StreamMessage<String, String>> messages = connection.sync().xautoclaim(stream, XAutoClaimArgs.Builder.xautoclaim(Consumer.from(group, consumerName), Duration.ofSeconds(60), "0-0").count(100)).getMessages();
-        for (StreamMessage<String, String> message : messages) {
-            handle(stream, group, message, handler, MAX_DELIVERY_ATTEMPTS);
+        for (RedisStreamOperations.StreamEntry message : streams.autoClaim(stream, group, consumerName)) {
+            handle(stream, group, message, handler, streams.deliveryCount(stream, group, message.id()));
         }
     }
 
-    private void handle(String stream, String group, StreamMessage<String, String> message, EventHandler handler, int deliveryAttempts) {
-        String json = message.getBody().get("envelope");
-        if (json == null || deliveryAttempts >= MAX_DELIVERY_ATTEMPTS) {
-            moveToDlq(stream, json == null ? "{}" : json);
-            ack(stream, group, message.getId());
+    private void handle(String stream, String group, RedisStreamOperations.StreamEntry message, EventHandler handler, int deliveryAttempts) {
+        String json = message.envelopeJson();
+        if (json == null) {
+            streams.moveToDlq(stream, "{}");
+            streams.ack(stream, group, message.id());
+            return;
+        }
+        if (deliveryAttempts >= MAX_DELIVERY_ATTEMPTS) {
+            streams.moveToDlq(stream, json);
+            streams.ack(stream, group, message.id());
             return;
         }
         EventEnvelope envelope = deserialize(json);
         HandlerResult result = handler.handle(envelope);
         if (result == HandlerResult.SUCCESS) {
-            ack(stream, group, message.getId());
+            streams.ack(stream, group, message.id());
         } else if (result == HandlerResult.FATAL_FAILURE) {
-            moveToDlq(stream, json);
-            ack(stream, group, message.getId());
+            streams.moveToDlq(stream, json);
+            streams.ack(stream, group, message.id());
         }
     }
 
@@ -99,14 +97,6 @@ public class RedisEventSubscriber implements EventSubscriber, AutoCloseable {
         } catch (JsonProcessingException exception) {
             throw new SubscribeFailedException("event envelope could not be deserialized", exception);
         }
-    }
-
-    private void ack(String stream, String group, String id) {
-        connection.sync().xack(stream, group, id);
-    }
-
-    private void moveToDlq(String stream, String json) {
-        connection.sync().xadd(RedisStreamNames.dlqFor(stream), XAddArgs.Builder.maxlen(100_000).approximateTrimming(), Map.of("envelope", json));
     }
 
     @Override

--- a/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/RedisMessagingConfiguration.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/RedisMessagingConfiguration.java
@@ -1,0 +1,31 @@
+package com.trainticket.payment.adapters.messaging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisMessagingConfiguration {
+    @Bean(destroyMethod = "shutdown")
+    RedisClient paymentRedisClient(@Value("${REDIS_URL:redis://localhost:6379}") String redisUrl) {
+        return RedisClient.create(redisUrl);
+    }
+
+    @Bean(destroyMethod = "close")
+    StatefulRedisConnection<String, String> paymentRedisConnection(RedisClient paymentRedisClient) {
+        return paymentRedisClient.connect();
+    }
+
+    @Bean
+    RedisEventPublisher redisEventPublisher(StatefulRedisConnection<String, String> connection, ObjectMapper objectMapper) {
+        return new RedisEventPublisher(connection, objectMapper);
+    }
+
+    @Bean
+    RedisEventSubscriber redisEventSubscriber(StatefulRedisConnection<String, String> connection, ObjectMapper objectMapper) {
+        return new RedisEventSubscriber(connection, objectMapper);
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/RedisMessagingConfiguration.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/RedisMessagingConfiguration.java
@@ -25,7 +25,12 @@ public class RedisMessagingConfiguration {
     }
 
     @Bean
-    RedisEventSubscriber redisEventSubscriber(StatefulRedisConnection<String, String> connection, ObjectMapper objectMapper) {
-        return new RedisEventSubscriber(connection, objectMapper);
+    RedisStreamOperations redisStreamOperations(StatefulRedisConnection<String, String> connection) {
+        return new LettuceRedisStreamOperations(connection);
+    }
+
+    @Bean
+    RedisEventSubscriber redisEventSubscriber(RedisStreamOperations streams, ObjectMapper objectMapper) {
+        return new RedisEventSubscriber(streams, objectMapper);
     }
 }

--- a/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/RedisStreamNames.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/RedisStreamNames.java
@@ -1,0 +1,18 @@
+package com.trainticket.payment.adapters.messaging;
+
+final class RedisStreamNames {
+    static final String BOOKING_ORCHESTRATION_STREAM = "events:booking-orchestration";
+    static final String POST_SALES_STREAM = "events:post-sales";
+    static final String PAYMENT_GROUP = "payment";
+
+    private RedisStreamNames() {
+    }
+
+    static String streamForProducer(String producer) {
+        return "events:" + producer;
+    }
+
+    static String dlqFor(String stream) {
+        return stream + ":dlq";
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/RedisStreamOperations.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/RedisStreamOperations.java
@@ -1,0 +1,20 @@
+package com.trainticket.payment.adapters.messaging;
+
+import java.util.List;
+
+interface RedisStreamOperations {
+    void createGroup(String stream, String group);
+
+    List<StreamEntry> readGroup(String stream, String group, String consumerName);
+
+    List<StreamEntry> autoClaim(String stream, String group, String consumerName);
+
+    int deliveryCount(String stream, String group, String messageId);
+
+    void ack(String stream, String group, String messageId);
+
+    void moveToDlq(String stream, String envelopeJson);
+
+    record StreamEntry(String id, String envelopeJson) {
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/application/ApplicationConfiguration.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/ApplicationConfiguration.java
@@ -1,0 +1,13 @@
+package com.trainticket.payment.application;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ApplicationConfiguration {
+    @Bean
+    Clock clock() {
+        return Clock.systemUTC();
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/application/ConsumedEventDeduplicator.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/ConsumedEventDeduplicator.java
@@ -1,0 +1,14 @@
+package com.trainticket.payment.application;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ConsumedEventDeduplicator {
+    private final Set<String> processedEventIds = ConcurrentHashMap.newKeySet();
+
+    public boolean recordIfNew(String eventId) {
+        return processedEventIds.add(eventId);
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/application/ConsumedEventDeduplicator.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/ConsumedEventDeduplicator.java
@@ -8,6 +8,14 @@ import org.springframework.stereotype.Component;
 public class ConsumedEventDeduplicator {
     private final Set<String> processedEventIds = ConcurrentHashMap.newKeySet();
 
+    public boolean isProcessed(String eventId) {
+        return processedEventIds.contains(eventId);
+    }
+
+    public void recordProcessed(String eventId) {
+        processedEventIds.add(eventId);
+    }
+
     public boolean recordIfNew(String eventId) {
         return processedEventIds.add(eventId);
     }

--- a/services/payment/src/main/java/com/trainticket/payment/application/EventEnvelope.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/EventEnvelope.java
@@ -1,0 +1,35 @@
+package com.trainticket.payment.application;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record EventEnvelope(
+    String eventId,
+    String eventType,
+    Instant occurredAt,
+    String correlationId,
+    String causationId,
+    String producer,
+    int schemaVersion,
+    Object payload
+) {
+    public EventEnvelope {
+        eventId = requireText(eventId, "eventId");
+        eventType = requireText(eventType, "eventType");
+        Objects.requireNonNull(occurredAt, "occurredAt is required");
+        correlationId = requireText(correlationId, "correlationId");
+        causationId = requireText(causationId, "causationId");
+        producer = requireText(producer, "producer");
+        if (schemaVersion < 1) {
+            throw new IllegalArgumentException("schemaVersion must be positive");
+        }
+        Objects.requireNonNull(payload, "payload is required");
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/application/EventEnvelope.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/EventEnvelope.java
@@ -1,8 +1,10 @@
 package com.trainticket.payment.application;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.Instant;
 import java.util.Objects;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record EventEnvelope(
     String eventId,
     String eventType,
@@ -18,7 +20,9 @@ public record EventEnvelope(
         eventType = requireText(eventType, "eventType");
         Objects.requireNonNull(occurredAt, "occurredAt is required");
         correlationId = requireText(correlationId, "correlationId");
-        causationId = requireText(causationId, "causationId");
+        if (causationId != null && causationId.isBlank()) {
+            throw new IllegalArgumentException("causationId must not be blank when present");
+        }
         producer = requireText(producer, "producer");
         if (schemaVersion < 1) {
             throw new IllegalArgumentException("schemaVersion must be positive");

--- a/services/payment/src/main/java/com/trainticket/payment/application/EventEnvelopeMapper.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/EventEnvelopeMapper.java
@@ -1,0 +1,119 @@
+package com.trainticket.payment.application;
+
+import com.trainticket.payment.domain.ChannelCallbackReceived;
+import com.trainticket.payment.domain.DuplicateChannelCallbackDetected;
+import com.trainticket.payment.domain.LatePaymentDetected;
+import com.trainticket.payment.domain.Money;
+import com.trainticket.payment.domain.PaymentAuthorized;
+import com.trainticket.payment.domain.PaymentCaptured;
+import com.trainticket.payment.domain.PaymentEvent;
+import com.trainticket.payment.domain.PaymentFailed;
+import com.trainticket.payment.domain.PaymentIntentCancelled;
+import com.trainticket.payment.domain.PaymentIntentCreated;
+import com.trainticket.payment.domain.PaymentIntentExpired;
+import com.trainticket.payment.domain.RefundFailed;
+import com.trainticket.payment.domain.RefundRequested;
+import com.trainticket.payment.domain.RefundSettled;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class EventEnvelopeMapper {
+    private EventEnvelopeMapper() {
+    }
+
+    public static EventEnvelope fromDomainEvent(PaymentEvent event) {
+        com.trainticket.payment.domain.EventEnvelope envelope = event.envelope();
+        return new EventEnvelope(
+            envelope.eventId(),
+            envelope.eventType(),
+            envelope.occurredAt(),
+            envelope.correlationId(),
+            envelope.causationId(),
+            envelope.producer(),
+            envelope.schemaVersion(),
+            payload(event)
+        );
+    }
+
+    private static Map<String, Object> payload(PaymentEvent event) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        switch (event) {
+            case PaymentIntentCreated created -> {
+                payload.put("paymentIntentId", created.paymentIntentId());
+                payload.put("businessRef", created.businessRef());
+                payload.put("purpose", created.purpose());
+                payload.put("amount", money(created.amount()));
+                payload.put("payerRef", created.payerRef());
+                payload.put("idempotencyKey", created.idempotencyKey());
+                payload.put("createdAt", created.envelope().occurredAt());
+            }
+            case PaymentAuthorized authorized -> {
+                payload.put("paymentIntentId", authorized.paymentIntentId());
+                payload.put("authorizedAmount", money(authorized.authorizedAmount()));
+                payload.put("channel", authorized.channel());
+                payload.put("channelTransactionId", authorized.channelTransactionId());
+            }
+            case PaymentCaptured captured -> {
+                payload.put("paymentIntentId", captured.paymentIntentId());
+                payload.put("capturedAmount", money(captured.capturedAmount()));
+                payload.put("channel", captured.channel());
+                payload.put("channelTransactionId", captured.channelTransactionId());
+            }
+            case PaymentFailed failed -> {
+                payload.put("paymentIntentId", failed.paymentIntentId());
+                payload.put("reasonCode", failed.reasonCode());
+                payload.put("retryable", failed.retryable());
+            }
+            case PaymentIntentCancelled cancelled -> {
+                payload.put("paymentIntentId", cancelled.paymentIntentId());
+                payload.put("reason", cancelled.reason());
+            }
+            case PaymentIntentExpired expired -> payload.put("paymentIntentId", expired.paymentIntentId());
+            case RefundRequested requested -> {
+                payload.put("refundId", requested.refundId());
+                payload.put("paymentIntentId", requested.paymentIntentId());
+                payload.put("amount", money(requested.amount()));
+                payload.put("businessCaseRef", requested.sourceCaseRef());
+                payload.put("reason", requested.reasonCode());
+                payload.put("idempotencyKey", requested.idempotencyKey());
+            }
+            case RefundSettled settled -> {
+                payload.put("refundId", settled.refundId());
+                payload.put("paymentIntentId", settled.paymentIntentId());
+                payload.put("amount", money(settled.amount()));
+                payload.put("channelRefundTransactionId", settled.channelRefundTransactionId());
+            }
+            case RefundFailed failed -> {
+                payload.put("refundId", failed.refundId());
+                payload.put("paymentIntentId", failed.paymentIntentId());
+                payload.put("reasonCode", failed.reasonCode());
+                payload.put("retryable", failed.retryable());
+            }
+            case ChannelCallbackReceived received -> {
+                payload.put("callbackRecordId", received.callbackRecordId());
+                payload.put("channel", received.channel());
+                payload.put("callbackId", received.callbackId());
+                payload.put("payloadDigest", received.payloadDigest());
+                payload.put("processingStatus", received.processingStatus().name());
+            }
+            case DuplicateChannelCallbackDetected duplicate -> {
+                payload.put("callbackRecordId", duplicate.callbackRecordId());
+                payload.put("channel", duplicate.channel());
+                payload.put("callbackId", duplicate.callbackId());
+                payload.put("firstCallbackRecordId", duplicate.firstCallbackRecordId());
+            }
+            case LatePaymentDetected late -> {
+                payload.put("latePaymentCaseId", late.latePaymentCaseId());
+                payload.put("paymentIntentId", late.paymentIntentId());
+                payload.put("capturedAmount", money(late.capturedAmount()));
+                payload.put("channel", late.channel());
+                payload.put("channelTransactionId", late.channelTransactionId());
+            }
+        }
+        return payload;
+    }
+
+    public static Map<String, Object> money(Money money) {
+        return Map.of("currency", money.currency().getCurrencyCode(), "minorUnits", money.toMinorUnits());
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/application/EventEnvelopeMapper.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/EventEnvelopeMapper.java
@@ -86,8 +86,7 @@ public final class EventEnvelopeMapper {
             case RefundFailed failed -> {
                 payload.put("refundId", failed.refundId());
                 payload.put("paymentIntentId", failed.paymentIntentId());
-                payload.put("reasonCode", failed.reasonCode());
-                payload.put("retryable", failed.retryable());
+                payload.put("reason", failed.reason());
             }
             case ChannelCallbackReceived received -> {
                 payload.put("callbackRecordId", received.callbackRecordId());

--- a/services/payment/src/main/java/com/trainticket/payment/application/EventPublisher.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/EventPublisher.java
@@ -1,0 +1,5 @@
+package com.trainticket.payment.application;
+
+public interface EventPublisher {
+    void publish(EventEnvelope envelope) throws PublishFailedException;
+}

--- a/services/payment/src/main/java/com/trainticket/payment/application/EventSubscriber.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/EventSubscriber.java
@@ -1,0 +1,12 @@
+package com.trainticket.payment.application;
+
+import java.util.List;
+
+public interface EventSubscriber {
+    void subscribe(List<String> streams, String group, String consumerName, EventHandler handler) throws SubscribeFailedException;
+
+    @FunctionalInterface
+    interface EventHandler {
+        HandlerResult handle(EventEnvelope envelope);
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/application/HandlerResult.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/HandlerResult.java
@@ -1,0 +1,7 @@
+package com.trainticket.payment.application;
+
+public enum HandlerResult {
+    SUCCESS,
+    TRANSIENT_FAILURE,
+    FATAL_FAILURE
+}

--- a/services/payment/src/main/java/com/trainticket/payment/application/InboundEventPayload.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/InboundEventPayload.java
@@ -1,0 +1,105 @@
+package com.trainticket.payment.application;
+
+import com.trainticket.payment.domain.DomainRuleViolation;
+import com.trainticket.payment.domain.Money;
+import java.util.Map;
+
+final class InboundEventPayload {
+    private final Map<?, ?> payload;
+
+    private InboundEventPayload(Object payload) {
+        this.payload = asMap(payload, "payload");
+    }
+
+    static InboundEventPayload from(EventEnvelope envelope) {
+        return new InboundEventPayload(envelope.payload());
+    }
+
+    String requiredText(String field) {
+        Object value = payload.get(field);
+        if (!(value instanceof String text) || text.isBlank()) {
+            throw new DomainRuleViolation(field + " is required");
+        }
+        return text;
+    }
+
+    String optionalText(String field) {
+        Object value = payload.get(field);
+        if (value == null) {
+            return null;
+        }
+        if (!(value instanceof String text) || text.isBlank()) {
+            throw new DomainRuleViolation(field + " must be text when present");
+        }
+        return text;
+    }
+
+    Money requiredMoney(String field) {
+        Map<?, ?> money = asMap(payload.get(field), field);
+        Object currency = money.get("currency");
+        Object minorUnits = money.get("minorUnits");
+        if (!(currency instanceof String currencyCode) || currencyCode.isBlank()) {
+            throw new DomainRuleViolation(field + ".currency is required");
+        }
+        if (!(minorUnits instanceof Number number)) {
+            throw new DomainRuleViolation(field + ".minorUnits is required");
+        }
+        return Money.fromMinorUnits(number.longValue(), currencyCode);
+    }
+
+    Money moneyFromApprovedActions() {
+        Map<?, ?> approvedActions = asMap(payload.get("approvedActions"), "approvedActions");
+        for (String field : new String[] { "refundAmount", "amount" }) {
+            Object candidate = approvedActions.get(field);
+            if (candidate != null) {
+                return moneyFromObject(candidate, "approvedActions." + field);
+            }
+        }
+        Object refund = approvedActions.get("refund");
+        if (refund != null) {
+            Map<?, ?> refundAction = asMap(refund, "approvedActions.refund");
+            for (String field : new String[] { "amount", "refundAmount" }) {
+                Object candidate = refundAction.get(field);
+                if (candidate != null) {
+                    return moneyFromObject(candidate, "approvedActions.refund." + field);
+                }
+            }
+        }
+        throw new DomainRuleViolation("approvedActions refund amount is required");
+    }
+
+    String paymentIntentIdFromApprovedActions() {
+        Map<?, ?> approvedActions = asMap(payload.get("approvedActions"), "approvedActions");
+        Object value = approvedActions.get("paymentIntentId");
+        if (value == null && approvedActions.get("refund") != null) {
+            value = asMap(approvedActions.get("refund"), "approvedActions.refund").get("paymentIntentId");
+        }
+        if (!(value instanceof String text) || text.isBlank()) {
+            throw new DomainRuleViolation("approvedActions.paymentIntentId is required");
+        }
+        return text;
+    }
+
+    private static Money moneyFromObject(Object value, String field) {
+        Map<?, ?> money = asMap(value, field);
+        Object currency = money.get("currency");
+        Object minorUnits = money.get("minorUnits");
+        if (!(currency instanceof String currencyCode) || currencyCode.isBlank()) {
+            throw new DomainRuleViolation(field + ".currency is required");
+        }
+        if (!(minorUnits instanceof Number number)) {
+            throw new DomainRuleViolation(field + ".minorUnits is required");
+        }
+        return Money.fromMinorUnits(number.longValue(), currencyCode);
+    }
+
+    private static Map<?, ?> asMap(Object value, String field) {
+        if (value == null) {
+            throw new DomainRuleViolation(field + " is required");
+        }
+        if (!(value instanceof Map<?, ?> map)) {
+            throw new DomainRuleViolation(field + " must be an object");
+        }
+        return map;
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/application/NotFoundException.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.trainticket.payment.application;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/application/PaymentCommandService.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/PaymentCommandService.java
@@ -52,6 +52,14 @@ public class PaymentCommandService {
         return intent;
     }
 
+    public PaymentIntent authorizeIntent(String paymentIntentId, String idempotencyKey, String correlationId, String channelTransactionRef) {
+        PaymentIntent intent = getIntent(paymentIntentId);
+        int before = intent.domainEvents().size();
+        intent.authorize(intent.amount(), DEFAULT_CHANNEL, "auth-" + requireText(channelTransactionRef, "channelTransactionRef"), Instant.now(clock), commandId(idempotencyKey), commandId(idempotencyKey), correlationId);
+        publishNewEvents(intent.domainEvents(), before);
+        return intent;
+    }
+
     public Refund requestRefund(String paymentIntentId, Money amount, String reason, String businessCaseRef, String idempotencyKey, String correlationId) {
         PaymentIntent intent = getIntent(paymentIntentId);
         Refund refund = Refund.request(intent, amount, businessCaseRef == null || businessCaseRef.isBlank() ? "case-" + idempotencyKey : businessCaseRef, reason, idempotencyKey, Instant.now(clock), commandId(idempotencyKey), correlationId);

--- a/services/payment/src/main/java/com/trainticket/payment/application/PaymentCommandService.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/PaymentCommandService.java
@@ -22,10 +22,35 @@ public class PaymentCommandService {
     private final EventPublisher eventPublisher;
     private final Map<String, PaymentIntent> intents = new ConcurrentHashMap<>();
     private final Map<String, Refund> refunds = new ConcurrentHashMap<>();
+    private final Map<String, ReservationPaymentRequest> reservationPaymentRequests = new ConcurrentHashMap<>();
 
     public PaymentCommandService(Clock clock, EventPublisher eventPublisher) {
         this.clock = Objects.requireNonNull(clock, "clock is required");
         this.eventPublisher = Objects.requireNonNull(eventPublisher, "eventPublisher is required");
+    }
+
+    public ReservationPaymentRequest recordReservationPaymentRequest(
+        String eventId,
+        String segmentBookingId,
+        String journeyOrderId,
+        String segmentRef,
+        String travelerRef,
+        String idempotencyKey,
+        String correlationId,
+        Instant requestedAt
+    ) {
+        ReservationPaymentRequest request = new ReservationPaymentRequest(
+            eventId,
+            segmentBookingId,
+            journeyOrderId,
+            segmentRef,
+            travelerRef,
+            idempotencyKey,
+            correlationId,
+            requestedAt
+        );
+        reservationPaymentRequests.putIfAbsent(request.segmentBookingId(), request);
+        return reservationPaymentRequests.get(request.segmentBookingId());
     }
 
     public PaymentIntent createIntent(String businessRef, String purpose, Money amount, String payerRef, String idempotencyKey, String correlationId) {
@@ -66,6 +91,14 @@ public class PaymentCommandService {
         refunds.put(refund.refundId(), refund);
         publish(refund.domainEvents());
         return refund;
+    }
+
+    public ReservationPaymentRequest getReservationPaymentRequest(String segmentBookingId) {
+        ReservationPaymentRequest request = reservationPaymentRequests.get(requireText(segmentBookingId, "segmentBookingId"));
+        if (request == null) {
+            throw new NotFoundException("reservation payment request not found");
+        }
+        return request;
     }
 
     public PaymentIntent getIntent(String paymentIntentId) {

--- a/services/payment/src/main/java/com/trainticket/payment/application/PaymentCommandService.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/PaymentCommandService.java
@@ -1,0 +1,99 @@
+package com.trainticket.payment.application;
+
+import com.trainticket.payment.domain.DomainRuleViolation;
+import com.trainticket.payment.domain.Money;
+import com.trainticket.payment.domain.PaymentEvent;
+import com.trainticket.payment.domain.PaymentIntent;
+import com.trainticket.payment.domain.Refund;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PaymentCommandService {
+    private static final String DEFAULT_CHANNEL = "internal_payment_channel";
+
+    private final Clock clock;
+    private final EventPublisher eventPublisher;
+    private final Map<String, PaymentIntent> intents = new ConcurrentHashMap<>();
+    private final Map<String, Refund> refunds = new ConcurrentHashMap<>();
+
+    public PaymentCommandService(Clock clock, EventPublisher eventPublisher) {
+        this.clock = Objects.requireNonNull(clock, "clock is required");
+        this.eventPublisher = Objects.requireNonNull(eventPublisher, "eventPublisher is required");
+    }
+
+    public PaymentIntent createIntent(String businessRef, String purpose, Money amount, String payerRef, String idempotencyKey, String correlationId) {
+        Instant now = Instant.now(clock);
+        PaymentIntent intent = PaymentIntent.create(businessRef, purpose, amount, payerRef, now.plusSeconds(900), idempotencyKey, now, commandId(idempotencyKey), correlationId);
+        intents.put(intent.paymentIntentId(), intent);
+        publish(intent.domainEvents());
+        return intent;
+    }
+
+    public PaymentIntent cancelIntent(String paymentIntentId, String reason, String idempotencyKey, String correlationId) {
+        PaymentIntent intent = getIntent(paymentIntentId);
+        int before = intent.domainEvents().size();
+        intent.cancel(reason, Instant.now(clock), commandId(idempotencyKey), commandId(idempotencyKey), correlationId);
+        publishNewEvents(intent.domainEvents(), before);
+        return intent;
+    }
+
+    public PaymentIntent captureIntent(String paymentIntentId, String idempotencyKey, String correlationId) {
+        PaymentIntent intent = getIntent(paymentIntentId);
+        int before = intent.domainEvents().size();
+        intent.capture(intent.amount().subtract(intent.capturedAmount()), DEFAULT_CHANNEL, "txn-" + idempotencyKey, Instant.now(clock), commandId(idempotencyKey), commandId(idempotencyKey), correlationId);
+        publishNewEvents(intent.domainEvents(), before);
+        return intent;
+    }
+
+    public Refund requestRefund(String paymentIntentId, Money amount, String reason, String businessCaseRef, String idempotencyKey, String correlationId) {
+        PaymentIntent intent = getIntent(paymentIntentId);
+        Refund refund = Refund.request(intent, amount, businessCaseRef == null || businessCaseRef.isBlank() ? "case-" + idempotencyKey : businessCaseRef, reason, idempotencyKey, Instant.now(clock), commandId(idempotencyKey), correlationId);
+        refunds.put(refund.refundId(), refund);
+        publish(refund.domainEvents());
+        return refund;
+    }
+
+    public PaymentIntent getIntent(String paymentIntentId) {
+        PaymentIntent intent = intents.get(requireText(paymentIntentId, "paymentIntentId"));
+        if (intent == null) {
+            throw new NotFoundException("payment intent not found");
+        }
+        return intent;
+    }
+
+    public Refund getRefund(String refundId) {
+        Refund refund = refunds.get(requireText(refundId, "refundId"));
+        if (refund == null) {
+            throw new NotFoundException("refund not found");
+        }
+        return refund;
+    }
+
+    private void publishNewEvents(List<PaymentEvent> events, int previousSize) {
+        publish(new ArrayList<>(events.subList(previousSize, events.size())));
+    }
+
+    private void publish(List<PaymentEvent> events) {
+        for (PaymentEvent event : events) {
+            eventPublisher.publish(EventEnvelopeMapper.fromDomainEvent(event));
+        }
+    }
+
+    private static String commandId(String idempotencyKey) {
+        return "cmd-" + requireText(idempotencyKey, "idempotencyKey");
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/application/PaymentInboundEventHandler.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/PaymentInboundEventHandler.java
@@ -1,7 +1,6 @@
 package com.trainticket.payment.application;
 
 import com.trainticket.payment.domain.DomainRuleViolation;
-import com.trainticket.payment.domain.Money;
 import java.util.Objects;
 import org.springframework.stereotype.Component;
 
@@ -41,13 +40,16 @@ public class PaymentInboundEventHandler implements EventSubscriber.EventHandler 
 
     private void handleSegmentReservationRequested(EventEnvelope envelope) {
         InboundEventPayload payload = InboundEventPayload.from(envelope);
-        Money amount = payload.requiredMoney("amount");
-        String segmentBookingId = payload.requiredText("segmentBookingId");
-        String journeyOrderId = payload.requiredText("journeyOrderId");
-        String travelerRef = payload.requiredText("travelerRef");
-        String idempotencyKey = payload.requiredText("idempotencyKey");
-        String paymentIntentId = paymentCommands.createIntent(journeyOrderId, "purchase", amount, travelerRef, idempotencyKey, envelope.correlationId()).paymentIntentId();
-        paymentCommands.authorizeIntent(paymentIntentId, idempotencyKey + ":authorize", envelope.correlationId(), segmentBookingId);
+        paymentCommands.recordReservationPaymentRequest(
+            envelope.eventId(),
+            payload.requiredText("segmentBookingId"),
+            payload.requiredText("journeyOrderId"),
+            payload.requiredText("segmentRef"),
+            payload.requiredText("travelerRef"),
+            payload.requiredText("idempotencyKey"),
+            envelope.correlationId(),
+            envelope.occurredAt()
+        );
     }
 
     private void handlePostSalesApproved(EventEnvelope envelope) {

--- a/services/payment/src/main/java/com/trainticket/payment/application/PaymentInboundEventHandler.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/PaymentInboundEventHandler.java
@@ -1,0 +1,21 @@
+package com.trainticket.payment.application;
+
+import java.util.Objects;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PaymentInboundEventHandler implements EventSubscriber.EventHandler {
+    private final ConsumedEventDeduplicator deduplicator;
+
+    public PaymentInboundEventHandler(ConsumedEventDeduplicator deduplicator) {
+        this.deduplicator = Objects.requireNonNull(deduplicator, "deduplicator is required");
+    }
+
+    @Override
+    public HandlerResult handle(EventEnvelope envelope) {
+        if (!deduplicator.recordIfNew(envelope.eventId())) {
+            return HandlerResult.SUCCESS;
+        }
+        return HandlerResult.SUCCESS;
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/application/PaymentInboundEventHandler.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/PaymentInboundEventHandler.java
@@ -1,21 +1,66 @@
 package com.trainticket.payment.application;
 
+import com.trainticket.payment.domain.DomainRuleViolation;
+import com.trainticket.payment.domain.Money;
 import java.util.Objects;
 import org.springframework.stereotype.Component;
 
 @Component
 public class PaymentInboundEventHandler implements EventSubscriber.EventHandler {
     private final ConsumedEventDeduplicator deduplicator;
+    private final PaymentCommandService paymentCommands;
 
-    public PaymentInboundEventHandler(ConsumedEventDeduplicator deduplicator) {
+    public PaymentInboundEventHandler(ConsumedEventDeduplicator deduplicator, PaymentCommandService paymentCommands) {
         this.deduplicator = Objects.requireNonNull(deduplicator, "deduplicator is required");
+        this.paymentCommands = Objects.requireNonNull(paymentCommands, "paymentCommands are required");
     }
 
     @Override
     public HandlerResult handle(EventEnvelope envelope) {
-        if (!deduplicator.recordIfNew(envelope.eventId())) {
+        if (deduplicator.isProcessed(envelope.eventId())) {
             return HandlerResult.SUCCESS;
         }
-        return HandlerResult.SUCCESS;
+        try {
+            dispatch(envelope);
+            deduplicator.recordProcessed(envelope.eventId());
+            return HandlerResult.SUCCESS;
+        } catch (DomainRuleViolation | IllegalArgumentException exception) {
+            return HandlerResult.FATAL_FAILURE;
+        } catch (RuntimeException exception) {
+            return HandlerResult.TRANSIENT_FAILURE;
+        }
+    }
+
+    private void dispatch(EventEnvelope envelope) {
+        if ("SegmentReservationRequested".equals(envelope.eventType())) {
+            handleSegmentReservationRequested(envelope);
+        } else if ("PostSalesApproved".equals(envelope.eventType())) {
+            handlePostSalesApproved(envelope);
+        }
+    }
+
+    private void handleSegmentReservationRequested(EventEnvelope envelope) {
+        InboundEventPayload payload = InboundEventPayload.from(envelope);
+        Money amount = payload.requiredMoney("amount");
+        String segmentBookingId = payload.requiredText("segmentBookingId");
+        String journeyOrderId = payload.requiredText("journeyOrderId");
+        String travelerRef = payload.requiredText("travelerRef");
+        String idempotencyKey = payload.requiredText("idempotencyKey");
+        String paymentIntentId = paymentCommands.createIntent(journeyOrderId, "purchase", amount, travelerRef, idempotencyKey, envelope.correlationId()).paymentIntentId();
+        paymentCommands.authorizeIntent(paymentIntentId, idempotencyKey + ":authorize", envelope.correlationId(), segmentBookingId);
+    }
+
+    private void handlePostSalesApproved(EventEnvelope envelope) {
+        InboundEventPayload payload = InboundEventPayload.from(envelope);
+        String caseId = payload.requiredText("caseId");
+        String reason = payload.optionalText("reason");
+        paymentCommands.requestRefund(
+            payload.paymentIntentIdFromApprovedActions(),
+            payload.moneyFromApprovedActions(),
+            reason == null ? "post-sales-approved" : reason,
+            caseId,
+            caseId,
+            envelope.correlationId()
+        );
     }
 }

--- a/services/payment/src/main/java/com/trainticket/payment/application/PublishFailedException.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/PublishFailedException.java
@@ -1,0 +1,7 @@
+package com.trainticket.payment.application;
+
+public class PublishFailedException extends RuntimeException {
+    public PublishFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/application/ReservationPaymentRequest.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/ReservationPaymentRequest.java
@@ -1,0 +1,33 @@
+package com.trainticket.payment.application;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record ReservationPaymentRequest(
+    String eventId,
+    String segmentBookingId,
+    String journeyOrderId,
+    String segmentRef,
+    String travelerRef,
+    String idempotencyKey,
+    String correlationId,
+    Instant requestedAt
+) {
+    public ReservationPaymentRequest {
+        eventId = requireText(eventId, "eventId");
+        segmentBookingId = requireText(segmentBookingId, "segmentBookingId");
+        journeyOrderId = requireText(journeyOrderId, "journeyOrderId");
+        segmentRef = requireText(segmentRef, "segmentRef");
+        travelerRef = requireText(travelerRef, "travelerRef");
+        idempotencyKey = requireText(idempotencyKey, "idempotencyKey");
+        correlationId = requireText(correlationId, "correlationId");
+        Objects.requireNonNull(requestedAt, "requestedAt is required");
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/application/SubscribeFailedException.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/SubscribeFailedException.java
@@ -1,0 +1,7 @@
+package com.trainticket.payment.application;
+
+public class SubscribeFailedException extends RuntimeException {
+    public SubscribeFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/services/payment/src/main/java/com/trainticket/payment/domain/PaymentIntent.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/PaymentIntent.java
@@ -64,7 +64,7 @@ public final class PaymentIntent {
         if (!Objects.requireNonNull(expiresAt, "expiresAt is required").isAfter(Objects.requireNonNull(occurredAt, "occurredAt is required"))) {
             throw new DomainRuleViolation("payment intent expiry must be in the future");
         }
-        PaymentIntent intent = new PaymentIntent(UUID.randomUUID().toString(), businessRef, purpose, amount, payerRef, expiresAt, idempotencyKey);
+        PaymentIntent intent = new PaymentIntent("pi-" + UUID.randomUUID(), businessRef, purpose, amount, payerRef, expiresAt, idempotencyKey);
         intent.domainEvents.add(new PaymentIntentCreated(
             EventEnvelope.create("PaymentIntentCreated", occurredAt, sourceCommandId, correlationId, "payment"),
             intent.paymentIntentId, intent.businessRef, intent.purpose, intent.amount, intent.payerRef, intent.idempotencyKey

--- a/services/payment/src/main/java/com/trainticket/payment/domain/Refund.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/Refund.java
@@ -115,7 +115,7 @@ public final class Refund {
         status = retryable ? RefundStatus.FAILED : RefundStatus.MANUAL_REVIEW_REQUIRED;
         domainEvents.add(new RefundFailed(
             EventEnvelope.create("RefundFailed", occurredAt, causationId, correlationId, "payment"),
-            refundId, paymentIntentId, requireText(reasonCode, "reasonCode"), retryable
+            refundId, paymentIntentId, requireText(reasonCode, "reasonCode")
         ));
     }
 

--- a/services/payment/src/main/java/com/trainticket/payment/domain/Refund.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/Refund.java
@@ -49,7 +49,7 @@ public final class Refund {
         if (amount.isGreaterThan(capturedIntent.refundableBalance())) {
             throw new DomainRuleViolation("refund amount cannot exceed captured-and-not-refunded balance");
         }
-        Refund refund = new Refund(UUID.randomUUID().toString(), capturedIntent.paymentIntentId(), amount, sourceCaseRef, reasonCode, idempotencyKey);
+        Refund refund = new Refund("rf-" + UUID.randomUUID(), capturedIntent.paymentIntentId(), amount, sourceCaseRef, reasonCode, idempotencyKey);
         refund.domainEvents.add(new RefundRequested(
             EventEnvelope.create("RefundRequested", occurredAt, sourceCommandId, correlationId, "payment"),
             refund.refundId, refund.paymentIntentId, refund.amount, refund.sourceCaseRef, refund.reasonCode, refund.idempotencyKey

--- a/services/payment/src/main/java/com/trainticket/payment/domain/RefundFailed.java
+++ b/services/payment/src/main/java/com/trainticket/payment/domain/RefundFailed.java
@@ -4,6 +4,5 @@ public record RefundFailed(
     EventEnvelope envelope,
     String refundId,
     String paymentIntentId,
-    String reasonCode,
-    boolean retryable
+    String reason
 ) implements PaymentEvent {}

--- a/services/payment/src/test/java/com/trainticket/payment/adapters/http/PaymentControllerTest.java
+++ b/services/payment/src/test/java/com/trainticket/payment/adapters/http/PaymentControllerTest.java
@@ -1,0 +1,131 @@
+package com.trainticket.payment.adapters.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.trainticket.payment.RequestContextFilter;
+import com.trainticket.payment.application.PaymentCommandService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class PaymentControllerTest {
+    private PaymentController controller;
+    private PaymentExceptionHandler exceptionHandler;
+
+    @BeforeEach
+    void setUp() {
+        PaymentCommandService service = new PaymentCommandService(Clock.fixed(Instant.parse("2026-07-05T10:30:00Z"), ZoneOffset.UTC), envelope -> { });
+        controller = new PaymentController(service, new IdempotencyStore());
+        exceptionHandler = new PaymentExceptionHandler();
+    }
+
+    @Test
+    void createPaymentIntentHappyPath() {
+        ResponseEntity<?> response = createIntent("idem-create-1", "ord-1");
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        PaymentIntentResponse body = (PaymentIntentResponse) response.getBody();
+        assertNotNull(body);
+        assertTrue(body.paymentIntentId().startsWith("pi-"));
+        assertEquals("ord-1", body.businessRef());
+        assertEquals("CNY", body.amount().currency());
+        assertEquals(35000L, body.amount().minorUnits());
+        assertEquals("CREATED", body.status());
+        assertEquals("2026-07-05T10:30:00Z", body.createdAt().toString());
+    }
+
+    @Test
+    void cancelPaymentIntentHappyPath() {
+        String id = ((PaymentIntentResponse) createIntent("idem-create-cancel", "ord-cancel").getBody()).paymentIntentId();
+        ResponseEntity<?> response = controller.cancelPaymentIntent(id, "idem-cancel-1", new CancelPaymentIntentRequest("customer changed mind"), request("/api/v1/payment-intents/" + id + "/cancel"));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        CancelPaymentIntentResponse body = (CancelPaymentIntentResponse) response.getBody();
+        assertEquals(id, body.paymentIntentId());
+        assertEquals("CANCELLED", body.status());
+        assertNotNull(body.cancelledAt());
+    }
+
+    @Test
+    void capturePaymentHappyPath() {
+        String id = ((PaymentIntentResponse) createIntent("idem-create-capture", "ord-capture").getBody()).paymentIntentId();
+        ResponseEntity<?> response = controller.capturePayment(id, "idem-capture-1", request("/api/v1/payment-intents/" + id + "/capture"));
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        CapturePaymentResponse body = (CapturePaymentResponse) response.getBody();
+        assertEquals(id, body.paymentIntentId());
+        assertEquals("CAPTURED", body.status());
+        assertEquals(35000L, body.capturedAmount().minorUnits());
+        assertEquals("txn-idem-capture-1", body.channelTransactionId());
+    }
+
+    @Test
+    void requestRefundHappyPath() {
+        String id = ((PaymentIntentResponse) createIntent("idem-create-refund", "ord-refund").getBody()).paymentIntentId();
+        controller.capturePayment(id, "idem-capture-refund", request("/api/v1/payment-intents/" + id + "/capture"));
+        ResponseEntity<?> response = controller.requestRefund("idem-refund-1", new RequestRefundRequest(id, new MoneyJson("CNY", 10000L), "ticket refund", "ps-1"), request("/api/v1/refunds"));
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        RefundResponse body = (RefundResponse) response.getBody();
+        assertTrue(body.refundId().startsWith("rf-"));
+        assertEquals(id, body.paymentIntentId());
+        assertEquals(10000L, body.amount().minorUnits());
+        assertEquals("REQUESTED", body.status());
+    }
+
+    @Test
+    void getPaymentIntentHappyPath() {
+        String id = ((PaymentIntentResponse) createIntent("idem-create-get", "ord-get").getBody()).paymentIntentId();
+        PaymentIntentDetailsResponse body = controller.getPaymentIntent(id);
+        assertEquals(id, body.paymentIntentId());
+        assertEquals("purchase", body.purpose());
+        assertNotNull(body.expiresAt());
+    }
+
+    @Test
+    void getRefundHappyPath() {
+        String id = ((PaymentIntentResponse) createIntent("idem-create-get-refund", "ord-get-refund").getBody()).paymentIntentId();
+        controller.capturePayment(id, "idem-capture-get-refund", request("/api/v1/payment-intents/" + id + "/capture"));
+        String refundId = ((RefundResponse) controller.requestRefund("idem-refund-get", new RequestRefundRequest(id, new MoneyJson("CNY", 10000L), "ticket refund", null), request("/api/v1/refunds")).getBody()).refundId();
+        RefundDetailsResponse body = controller.getRefund(refundId);
+        assertEquals(refundId, body.refundId());
+        assertEquals("case-idem-refund-get", body.businessCaseRef());
+    }
+
+    @Test
+    void validationFailureReturnsCanonicalBody() {
+        MockHttpServletRequest request = request("/api/v1/payment-intents");
+        request.removeHeader(RequestContextFilter.CORRELATION_ID_HEADER);
+        request.addHeader(RequestContextFilter.CORRELATION_ID_HEADER, "corr-invalid");
+        try {
+            controller.createPaymentIntent("idem-invalid", new CreatePaymentIntentRequest("ord-1", null, null, null), request);
+        } catch (ValidationException exception) {
+            ResponseEntity<ErrorResponse> response = exceptionHandler.validation(exception, request);
+            assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+            assertEquals("VALIDATION_FAILED", response.getBody().code());
+            assertEquals("corr-invalid", response.getBody().correlationId());
+            assertTrue(response.getBody().details().isEmpty());
+        }
+    }
+
+    @Test
+    void idempotentReplayReturnsOriginalResult() {
+        CreatePaymentIntentRequest body = new CreatePaymentIntentRequest("ord-replay", "purchase", new MoneyJson("CNY", 12345L), "acct-1");
+        ResponseEntity<?> first = controller.createPaymentIntent("idem-replay", body, request("/api/v1/payment-intents"));
+        ResponseEntity<?> second = controller.createPaymentIntent("idem-replay", body, request("/api/v1/payment-intents"));
+        assertEquals(first, second);
+    }
+
+    private ResponseEntity<?> createIntent(String key, String businessRef) {
+        return controller.createPaymentIntent(key, new CreatePaymentIntentRequest(businessRef, "purchase", new MoneyJson("CNY", 35000L), "acct-1"), request("/api/v1/payment-intents"));
+    }
+
+    private MockHttpServletRequest request(String uri) {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", uri);
+        request.addHeader(RequestContextFilter.CORRELATION_ID_HEADER, "corr-test");
+        return request;
+    }
+}

--- a/services/payment/src/test/java/com/trainticket/payment/adapters/messaging/RedisEventSubscriberTest.java
+++ b/services/payment/src/test/java/com/trainticket/payment/adapters/messaging/RedisEventSubscriberTest.java
@@ -1,0 +1,88 @@
+package com.trainticket.payment.adapters.messaging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.trainticket.payment.application.EventEnvelope;
+import com.trainticket.payment.application.HandlerResult;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class RedisEventSubscriberTest {
+    @Test
+    void recoveredMessageUsesRealPelDeliveryCountBeforeDlq() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        FakeRedisStreamOperations streams = new FakeRedisStreamOperations(objectMapper.writeValueAsString(envelope()));
+        RedisEventSubscriber subscriber = new RedisEventSubscriber(streams, objectMapper);
+
+        streams.deliveryCount = 4;
+        subscriber.recoverOnce("events:booking-orchestration", "payment", "payment-test", ignored -> HandlerResult.TRANSIENT_FAILURE);
+        assertEquals(1, streams.handledAttempts);
+        assertEquals(0, streams.dlqEnvelopes.size());
+        assertEquals(0, streams.ackedIds.size());
+
+        streams.deliveryCount = 5;
+        subscriber.recoverOnce("events:booking-orchestration", "payment", "payment-test", ignored -> HandlerResult.TRANSIENT_FAILURE);
+        assertEquals(1, streams.dlqEnvelopes.size());
+        assertEquals(List.of("1-0"), streams.ackedIds);
+    }
+
+    private static EventEnvelope envelope() {
+        return new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-0284-5c26e8b0c222",
+            "SegmentReservationRequested",
+            Instant.parse("2026-07-05T10:30:00Z"),
+            "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c444",
+            "evt-0194f2e0-7b3e-7610-0284-5c26e8b0c111",
+            "booking-orchestration",
+            1,
+            Map.of("segmentBookingId", "sb-1", "journeyOrderId", "ord-1", "travelerRef", "trav-1", "idempotencyKey", "idem-1", "amount", Map.of("currency", "CNY", "minorUnits", 100L))
+        );
+    }
+
+    private static final class FakeRedisStreamOperations implements RedisStreamOperations {
+        private final String envelopeJson;
+        private int deliveryCount;
+        private int handledAttempts;
+        private final List<String> ackedIds = new ArrayList<>();
+        private final List<String> dlqEnvelopes = new ArrayList<>();
+
+        private FakeRedisStreamOperations(String envelopeJson) {
+            this.envelopeJson = envelopeJson;
+        }
+
+        @Override
+        public void createGroup(String stream, String group) {
+        }
+
+        @Override
+        public List<StreamEntry> readGroup(String stream, String group, String consumerName) {
+            return List.of();
+        }
+
+        @Override
+        public List<StreamEntry> autoClaim(String stream, String group, String consumerName) {
+            return List.of(new StreamEntry("1-0", envelopeJson));
+        }
+
+        @Override
+        public int deliveryCount(String stream, String group, String messageId) {
+            handledAttempts++;
+            return deliveryCount;
+        }
+
+        @Override
+        public void ack(String stream, String group, String messageId) {
+            ackedIds.add(messageId);
+        }
+
+        @Override
+        public void moveToDlq(String stream, String envelopeJson) {
+            dlqEnvelopes.add(envelopeJson);
+        }
+    }
+}

--- a/services/payment/src/test/java/com/trainticket/payment/adapters/messaging/RedisEventSubscriberTest.java
+++ b/services/payment/src/test/java/com/trainticket/payment/adapters/messaging/RedisEventSubscriberTest.java
@@ -1,6 +1,7 @@
 package com.trainticket.payment.adapters.messaging;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -31,6 +32,38 @@ class RedisEventSubscriberTest {
         assertEquals(List.of("1-0"), streams.ackedIds);
     }
 
+    @Test
+    void deserializesEnvelopeWithoutOptionalCausationId() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        String json = """
+            {
+              "eventId":"evt-0194f2e0-7b3e-7610-0284-5c26e8b0c333",
+              "eventType":"SegmentReservationRequested",
+              "occurredAt":"2026-07-05T10:30:00Z",
+              "correlationId":"corr-0194f2e0-7b3e-7610-0284-5c26e8b0c444",
+              "producer":"booking-orchestration",
+              "schemaVersion":1,
+              "payload":{
+                "segmentBookingId":"sb-1",
+                "journeyOrderId":"ord-1",
+                "segmentRef":"seg-1",
+                "travelerRef":"trav-1",
+                "idempotencyKey":"idem-1"
+              }
+            }
+            """;
+        FakeRedisStreamOperations streams = new FakeRedisStreamOperations(json);
+        RedisEventSubscriber subscriber = new RedisEventSubscriber(streams, objectMapper);
+
+        subscriber.recoverOnce("events:booking-orchestration", "payment", "payment-test", envelope -> {
+            assertNull(envelope.causationId());
+            return HandlerResult.SUCCESS;
+        });
+
+        assertEquals(List.of("1-0"), streams.ackedIds);
+        assertEquals(0, streams.dlqEnvelopes.size());
+    }
+
     private static EventEnvelope envelope() {
         return new EventEnvelope(
             "evt-0194f2e0-7b3e-7610-0284-5c26e8b0c222",
@@ -40,7 +73,7 @@ class RedisEventSubscriberTest {
             "evt-0194f2e0-7b3e-7610-0284-5c26e8b0c111",
             "booking-orchestration",
             1,
-            Map.of("segmentBookingId", "sb-1", "journeyOrderId", "ord-1", "travelerRef", "trav-1", "idempotencyKey", "idem-1", "amount", Map.of("currency", "CNY", "minorUnits", 100L))
+            Map.of("segmentBookingId", "sb-1", "journeyOrderId", "ord-1", "segmentRef", "seg-1", "travelerRef", "trav-1", "idempotencyKey", "idem-1")
         );
     }
 

--- a/services/payment/src/test/java/com/trainticket/payment/application/FakeEventPublisher.java
+++ b/services/payment/src/test/java/com/trainticket/payment/application/FakeEventPublisher.java
@@ -1,0 +1,17 @@
+package com.trainticket.payment.application;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FakeEventPublisher implements EventPublisher {
+    private final List<EventEnvelope> published = new ArrayList<>();
+
+    @Override
+    public void publish(EventEnvelope envelope) {
+        published.add(envelope);
+    }
+
+    public List<EventEnvelope> published() {
+        return List.copyOf(published);
+    }
+}

--- a/services/payment/src/test/java/com/trainticket/payment/application/FakeEventSubscriber.java
+++ b/services/payment/src/test/java/com/trainticket/payment/application/FakeEventSubscriber.java
@@ -1,0 +1,16 @@
+package com.trainticket.payment.application;
+
+import java.util.List;
+
+public class FakeEventSubscriber implements EventSubscriber {
+    private EventHandler handler;
+
+    @Override
+    public void subscribe(List<String> streams, String group, String consumerName, EventHandler handler) {
+        this.handler = handler;
+    }
+
+    public HandlerResult emit(EventEnvelope envelope) {
+        return handler.handle(envelope);
+    }
+}

--- a/services/payment/src/test/java/com/trainticket/payment/application/PaymentMessagingApplicationTest.java
+++ b/services/payment/src/test/java/com/trainticket/payment/application/PaymentMessagingApplicationTest.java
@@ -32,13 +32,78 @@ class PaymentMessagingApplicationTest {
 
     @Test
     void subscriberDeduplicatesDuplicateEventIds() {
-        ConsumedEventDeduplicator deduplicator = new ConsumedEventDeduplicator();
-        PaymentInboundEventHandler handler = new PaymentInboundEventHandler(deduplicator);
+        FakeEventPublisher publisher = new FakeEventPublisher();
+        PaymentInboundEventHandler handler = new PaymentInboundEventHandler(
+            new ConsumedEventDeduplicator(),
+            new PaymentCommandService(Clock.fixed(Instant.parse("2026-07-05T10:30:00Z"), ZoneOffset.UTC), publisher)
+        );
         FakeEventSubscriber subscriber = new FakeEventSubscriber();
         subscriber.subscribe(List.of("ignored"), "payment", "payment-test", handler);
-        EventEnvelope envelope = new EventEnvelope("evt-1", "PostSalesApproved", Instant.parse("2026-07-05T10:30:00Z"), "corr-1", "cause-1", "post-sales", 1, Map.of("x", "y"));
+        EventEnvelope envelope = segmentReservationRequested("evt-1", "idem-1");
 
         assertEquals(HandlerResult.SUCCESS, subscriber.emit(envelope));
         assertEquals(HandlerResult.SUCCESS, subscriber.emit(envelope));
+        assertEquals(2, publisher.published().size());
+    }
+
+    @Test
+    void segmentReservationRequestedCreatesAndAuthorizesPaymentIntent() {
+        FakeEventPublisher publisher = new FakeEventPublisher();
+        PaymentInboundEventHandler handler = new PaymentInboundEventHandler(
+            new ConsumedEventDeduplicator(),
+            new PaymentCommandService(Clock.fixed(Instant.parse("2026-07-05T10:30:00Z"), ZoneOffset.UTC), publisher)
+        );
+
+        assertEquals(HandlerResult.SUCCESS, handler.handle(segmentReservationRequested("evt-segment", "idem-segment")));
+
+        assertEquals("PaymentIntentCreated", publisher.published().get(0).eventType());
+        assertEquals("PaymentAuthorized", publisher.published().get(1).eventType());
+    }
+
+    @Test
+    void postSalesApprovedRequestsRefundThroughDomain() {
+        FakeEventPublisher publisher = new FakeEventPublisher();
+        PaymentCommandService commands = new PaymentCommandService(Clock.fixed(Instant.parse("2026-07-05T10:30:00Z"), ZoneOffset.UTC), publisher);
+        String paymentIntentId = commands.createIntent("ord-refund", "purchase", Money.fromMinorUnits(1000, "CNY"), "trav-1", "idem-create", "corr-create").paymentIntentId();
+        commands.captureIntent(paymentIntentId, "idem-capture", "corr-create");
+        PaymentInboundEventHandler handler = new PaymentInboundEventHandler(new ConsumedEventDeduplicator(), commands);
+
+        EventEnvelope approved = new EventEnvelope(
+            "evt-refund",
+            "PostSalesApproved",
+            Instant.parse("2026-07-05T10:31:00Z"),
+            "corr-refund",
+            "evt-post-sales",
+            "post-sales",
+            1,
+            Map.of(
+                "caseId", "case-1",
+                "orderId", "ord-refund",
+                "approvedActions", Map.of("paymentIntentId", paymentIntentId, "refundAmount", Map.of("currency", "CNY", "minorUnits", 500L))
+            )
+        );
+
+        assertEquals(HandlerResult.SUCCESS, handler.handle(approved));
+        assertEquals("RefundRequested", publisher.published().getLast().eventType());
+    }
+
+    private static EventEnvelope segmentReservationRequested(String eventId, String idempotencyKey) {
+        return new EventEnvelope(
+            eventId,
+            "SegmentReservationRequested",
+            Instant.parse("2026-07-05T10:30:00Z"),
+            "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c444",
+            "evt-0194f2e0-7b3e-7610-0284-5c26e8b0c111",
+            "booking-orchestration",
+            1,
+            Map.of(
+                "segmentBookingId", "sb-1",
+                "journeyOrderId", "ord-1",
+                "segmentRef", "seg-1",
+                "travelerRef", "trav-1",
+                "idempotencyKey", idempotencyKey,
+                "amount", Map.of("currency", "CNY", "minorUnits", 35000L)
+            )
+        );
     }
 }

--- a/services/payment/src/test/java/com/trainticket/payment/application/PaymentMessagingApplicationTest.java
+++ b/services/payment/src/test/java/com/trainticket/payment/application/PaymentMessagingApplicationTest.java
@@ -1,0 +1,44 @@
+package com.trainticket.payment.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import com.trainticket.payment.domain.Money;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PaymentMessagingApplicationTest {
+    @Test
+    void publisherWrapsDomainEventsInContractEnvelope() {
+        FakeEventPublisher publisher = new FakeEventPublisher();
+        PaymentCommandService service = new PaymentCommandService(Clock.fixed(Instant.parse("2026-07-05T10:30:00Z"), ZoneOffset.UTC), publisher);
+
+        service.createIntent("ord-123", "purchase", Money.fromMinorUnits(35000, "CNY"), "acct-1", "0194f2e0-7b3e-7610-0284-5c26e8b0c555", "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c444");
+
+        EventEnvelope envelope = publisher.published().getFirst();
+        assertEquals("PaymentIntentCreated", envelope.eventType());
+        assertEquals("payment", envelope.producer());
+        assertEquals(1, envelope.schemaVersion());
+        assertEquals("corr-0194f2e0-7b3e-7610-0284-5c26e8b0c444", envelope.correlationId());
+        assertEquals("cmd-0194f2e0-7b3e-7610-0284-5c26e8b0c555", envelope.causationId());
+        assertEquals("2026-07-05T10:30:00Z", envelope.occurredAt().toString());
+        Map<?, ?> payload = assertInstanceOf(Map.class, envelope.payload());
+        assertEquals(Map.of("currency", "CNY", "minorUnits", 35000L), payload.get("amount"));
+    }
+
+    @Test
+    void subscriberDeduplicatesDuplicateEventIds() {
+        ConsumedEventDeduplicator deduplicator = new ConsumedEventDeduplicator();
+        PaymentInboundEventHandler handler = new PaymentInboundEventHandler(deduplicator);
+        FakeEventSubscriber subscriber = new FakeEventSubscriber();
+        subscriber.subscribe(List.of("ignored"), "payment", "payment-test", handler);
+        EventEnvelope envelope = new EventEnvelope("evt-1", "PostSalesApproved", Instant.parse("2026-07-05T10:30:00Z"), "corr-1", "cause-1", "post-sales", 1, Map.of("x", "y"));
+
+        assertEquals(HandlerResult.SUCCESS, subscriber.emit(envelope));
+        assertEquals(HandlerResult.SUCCESS, subscriber.emit(envelope));
+    }
+}

--- a/services/payment/src/test/java/com/trainticket/payment/application/PaymentMessagingApplicationTest.java
+++ b/services/payment/src/test/java/com/trainticket/payment/application/PaymentMessagingApplicationTest.java
@@ -2,6 +2,7 @@ package com.trainticket.payment.application;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.trainticket.payment.domain.Money;
 import java.time.Clock;
@@ -43,21 +44,24 @@ class PaymentMessagingApplicationTest {
 
         assertEquals(HandlerResult.SUCCESS, subscriber.emit(envelope));
         assertEquals(HandlerResult.SUCCESS, subscriber.emit(envelope));
-        assertEquals(2, publisher.published().size());
+        assertEquals(0, publisher.published().size());
     }
 
     @Test
-    void segmentReservationRequestedCreatesAndAuthorizesPaymentIntent() {
+    void segmentReservationRequestedRecordsConformantRequestWithoutInventingMoney() {
         FakeEventPublisher publisher = new FakeEventPublisher();
-        PaymentInboundEventHandler handler = new PaymentInboundEventHandler(
-            new ConsumedEventDeduplicator(),
-            new PaymentCommandService(Clock.fixed(Instant.parse("2026-07-05T10:30:00Z"), ZoneOffset.UTC), publisher)
-        );
+        PaymentCommandService commands = new PaymentCommandService(Clock.fixed(Instant.parse("2026-07-05T10:30:00Z"), ZoneOffset.UTC), publisher);
+        PaymentInboundEventHandler handler = new PaymentInboundEventHandler(new ConsumedEventDeduplicator(), commands);
 
         assertEquals(HandlerResult.SUCCESS, handler.handle(segmentReservationRequested("evt-segment", "idem-segment")));
 
-        assertEquals("PaymentIntentCreated", publisher.published().get(0).eventType());
-        assertEquals("PaymentAuthorized", publisher.published().get(1).eventType());
+        ReservationPaymentRequest request = commands.getReservationPaymentRequest("sb-1");
+        assertEquals("evt-segment", request.eventId());
+        assertEquals("ord-1", request.journeyOrderId());
+        assertEquals("seg-1", request.segmentRef());
+        assertEquals("trav-1", request.travelerRef());
+        assertEquals("idem-segment", request.idempotencyKey());
+        assertTrue(publisher.published().isEmpty());
     }
 
     @Test
@@ -101,8 +105,7 @@ class PaymentMessagingApplicationTest {
                 "journeyOrderId", "ord-1",
                 "segmentRef", "seg-1",
                 "travelerRef", "trav-1",
-                "idempotencyKey", idempotencyKey,
-                "amount", Map.of("currency", "CNY", "minorUnits", 35000L)
+                "idempotencyKey", idempotencyKey
             )
         );
     }

--- a/services/payment/src/test/java/com/trainticket/payment/application/PaymentMessagingApplicationTest.java
+++ b/services/payment/src/test/java/com/trainticket/payment/application/PaymentMessagingApplicationTest.java
@@ -91,6 +91,32 @@ class PaymentMessagingApplicationTest {
         assertEquals("RefundRequested", publisher.published().getLast().eventType());
     }
 
+    @Test
+    void mapsRefundFailedPayloadToContractShape() {
+        EventEnvelope envelope = EventEnvelopeMapper.fromDomainEvent(new com.trainticket.payment.domain.RefundFailed(
+            com.trainticket.payment.domain.EventEnvelope.create(
+                "RefundFailed",
+                Instant.parse("2026-07-05T10:32:00Z"),
+                "evt-0194f2e0-7b3e-7610-0284-5c26e8b0c111",
+                "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c444",
+                "payment"
+            ),
+            "rf-0194f2e0-7b3e-7610-0284-5c26e8b0c333",
+            "pi-0194f2e0-7b3e-7610-0284-5c26e8b0c222",
+            "ACCOUNT_CLOSED"
+        ));
+
+        assertEquals("RefundFailed", envelope.eventType());
+        assertEquals(
+            Map.of(
+                "refundId", "rf-0194f2e0-7b3e-7610-0284-5c26e8b0c333",
+                "paymentIntentId", "pi-0194f2e0-7b3e-7610-0284-5c26e8b0c222",
+                "reason", "ACCOUNT_CLOSED"
+            ),
+            envelope.payload()
+        );
+    }
+
     private static EventEnvelope segmentReservationRequested(String eventId, String idempotencyKey) {
         return new EventEnvelope(
             eventId,

--- a/services/payment/src/test/java/com/trainticket/payment/domain/RefundDomainTest.java
+++ b/services/payment/src/test/java/com/trainticket/payment/domain/RefundDomainTest.java
@@ -53,7 +53,7 @@ class RefundDomainTest {
         refund.fail("ACCOUNT_CLOSED", false, NOW.plusSeconds(45), "FailRefund", "channel-refund-callback", "corr-refund");
         assertEquals(RefundStatus.MANUAL_REVIEW_REQUIRED, refund.status());
         RefundFailed finalFailure = assertInstanceOf(RefundFailed.class, refund.domainEvents().get(2));
-        assertEquals("ACCOUNT_CLOSED", finalFailure.reasonCode());
+        assertEquals("ACCOUNT_CLOSED", finalFailure.reason());
     }
 
     private static PaymentIntent capturedIntent() {


### PR DESCRIPTION
## Summary\n- Add payment HTTP API endpoints with idempotency, canonical errors, correlation propagation, and contract Money/ID shapes\n- Add application EventPublisher/EventSubscriber ports plus Redis Streams adapter under adapters/messaging\n- Add endpoint and messaging tests using in-memory fakes\n\n## Validation\n- cd services/payment && mvn -q test\n- grep -R 'lettuce\|RedisClient' -n services/payment/src/main/java | grep -v adapters\n- make check