### PR TITLE
REQ-041 entitlement ticketing HTTP and messaging adapters

### DIFF
--- a/services/entitlement-ticketing/Cargo.lock
+++ b/services/entitlement-ticketing/Cargo.lock
@@ -3,10 +3,45 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
@@ -73,23 +108,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
+name = "cc"
+version = "1.2.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "entitlement-ticketing"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
+ "chrono",
  "opentelemetry",
+ "redis",
  "serde",
  "serde_json",
  "shared-kernel",
  "tokio",
  "tower",
+ "uuid",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "form_urlencoded"
@@ -101,12 +221,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -114,6 +250,34 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -133,10 +297,27 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core",
 ]
 
 [[package]]
@@ -220,6 +401,133 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +549,12 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
@@ -274,7 +588,16 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -310,6 +633,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +657,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "redis"
+version = "0.25.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e46922bd01fefcfdcf58d9cd626da082bb2cde27211920dacfde6b2ecf9a35b"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "combine",
+ "futures",
+ "futures-util",
+ "itoa",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-retry",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -406,6 +785,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "shared-kernel"
 version = "0.1.0"
 dependencies = [
@@ -414,6 +799,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "slab"
@@ -429,13 +820,29 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
@@ -453,6 +860,17 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "thiserror"
@@ -475,17 +893,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.4",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -497,6 +926,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
+dependencies = [
+ "pin-project-lite",
+ "rand",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -554,6 +1007,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "rand",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,10 +1088,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -617,6 +1162,153 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/services/entitlement-ticketing/Cargo.lock
+++ b/services/entitlement-ticketing/Cargo.lock
@@ -206,6 +206,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +817,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +932,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/services/entitlement-ticketing/Cargo.toml
+++ b/services/entitlement-ticketing/Cargo.toml
@@ -10,10 +10,14 @@ path = "src/lib.rs"
 [dependencies]
 opentelemetry = "0.32.0"
 axum = "0.8.9"
+async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
+redis = { version = "0.25", features = ["tokio-comp", "connection-manager"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shared-kernel = { path = "../../platform/shared-kernel-rust" }
+tokio = { version = "1.48", features = ["macros", "rt", "sync", "time"] }
+uuid = { version = "1.0", features = ["v7", "fast-rng"] }
 
 [dev-dependencies]
-tokio = { version = "1.48", features = ["macros", "rt"] }
 tower = { version = "0.5.3", features = ["util"] }

--- a/services/entitlement-ticketing/Cargo.toml
+++ b/services/entitlement-ticketing/Cargo.toml
@@ -16,7 +16,7 @@ redis = { version = "0.25", features = ["tokio-comp", "connection-manager"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shared-kernel = { path = "../../platform/shared-kernel-rust" }
-tokio = { version = "1.48", features = ["macros", "rt", "sync", "time"] }
+tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "net", "signal", "sync", "time"] }
 uuid = { version = "1.0", features = ["v7", "fast-rng"] }
 
 [dev-dependencies]

--- a/services/entitlement-ticketing/src/adapters/messaging/mod.rs
+++ b/services/entitlement-ticketing/src/adapters/messaging/mod.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use redis::RedisResult;
-use tokio::time::sleep;
+use tokio::{sync::mpsc, time::sleep};
 
 use crate::application::{
     EventEnvelope, EventPublisher, EventSubscriber, HandlerError, PublishFailed, SubscribeFailed,
@@ -20,7 +20,7 @@ const SUBSCRIBED_STREAMS: [&str; 3] = [
 
 #[derive(Clone)]
 pub struct RedisEventPublisher {
-    client: redis::Client,
+    tx: mpsc::UnboundedSender<EventEnvelope>,
 }
 
 impl RedisEventPublisher {
@@ -31,48 +31,69 @@ impl RedisEventPublisher {
     }
 
     pub fn new(url: &str) -> Result<Self, PublishFailed> {
-        Ok(Self {
-            client: redis::Client::open(url).map_err(|error| PublishFailed(error.to_string()))?,
-        })
+        let client = redis::Client::open(url).map_err(|error| PublishFailed(error.to_string()))?;
+        let (tx, rx) = mpsc::unbounded_channel();
+        tokio::spawn(Self::drain_loop(client, rx));
+        Ok(Self { tx })
+    }
+
+    async fn drain_loop(client: redis::Client, mut rx: mpsc::UnboundedReceiver<EventEnvelope>) {
+        while let Some(envelope) = rx.recv().await {
+            if let Err(error) = publish_with_retry(&client, envelope).await {
+                eprintln!(
+                    "entitlement-ticketing publisher parked event after retries: {}",
+                    error.0
+                );
+            }
+        }
     }
 }
 
 #[async_trait]
 impl EventPublisher for RedisEventPublisher {
     async fn publish(&self, envelope: EventEnvelope) -> Result<(), PublishFailed> {
-        let stream = stream_for_producer(&envelope.producer);
-        let raw_envelope =
-            serde_json::to_string(&envelope).map_err(|error| PublishFailed(error.to_string()))?;
-        let mut last_error = None;
-        for attempt in 0..3 {
-            let result: RedisResult<()> = async {
-                let mut connection = self.client.get_multiplexed_async_connection().await?;
-                redis::cmd("XADD")
-                    .arg(&stream)
-                    .arg("MAXLEN")
-                    .arg("~")
-                    .arg(RETENTION_MAXLEN)
-                    .arg("*")
-                    .arg("envelope")
-                    .arg(&raw_envelope)
-                    .query_async(&mut connection)
-                    .await
-            }
-            .await;
-            match result {
-                Ok(()) => return Ok(()),
-                Err(error) => {
-                    last_error = Some(error.to_string());
-                    if attempt < 2 {
-                        sleep(Duration::from_millis(50 * (1 << attempt))).await;
-                    }
+        self.tx
+            .send(envelope)
+            .map_err(|error| PublishFailed(format!("redis publish queue unavailable: {error}")))
+    }
+}
+
+async fn publish_with_retry(
+    client: &redis::Client,
+    envelope: EventEnvelope,
+) -> Result<(), PublishFailed> {
+    let stream = stream_for_producer(&envelope.producer);
+    let raw_envelope =
+        serde_json::to_string(&envelope).map_err(|error| PublishFailed(error.to_string()))?;
+    let mut last_error = None;
+    for attempt in 0..3 {
+        let result: RedisResult<()> = async {
+            let mut connection = client.get_multiplexed_async_connection().await?;
+            redis::cmd("XADD")
+                .arg(&stream)
+                .arg("MAXLEN")
+                .arg("~")
+                .arg(RETENTION_MAXLEN)
+                .arg("*")
+                .arg("envelope")
+                .arg(&raw_envelope)
+                .query_async(&mut connection)
+                .await
+        }
+        .await;
+        match result {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                last_error = Some(error.to_string());
+                if attempt < 2 {
+                    sleep(Duration::from_millis(50 * (1 << attempt))).await;
                 }
             }
         }
-        Err(PublishFailed(last_error.unwrap_or_else(|| {
-            "unknown Redis publish failure".to_string()
-        })))
     }
+    Err(PublishFailed(last_error.unwrap_or_else(|| {
+        "unknown Redis publish failure".to_string()
+    })))
 }
 
 #[derive(Clone)]
@@ -114,7 +135,7 @@ impl EventSubscriber for RedisEventSubscriber {
         streams: Vec<String>,
         group: String,
         consumer_name: String,
-        handler: Box<dyn Fn(EventEnvelope) -> Result<(), HandlerError> + Send + Sync>,
+        handler: Box<dyn Fn(EventEnvelope) -> crate::application::HandlerFuture + Send + Sync>,
     ) -> Result<(), SubscribeFailed> {
         let mut connection = self
             .client
@@ -162,7 +183,7 @@ impl RedisEventSubscriber {
         streams: &[String],
         group: &str,
         consumer_name: &str,
-        handler: &(dyn Fn(EventEnvelope) -> Result<(), HandlerError> + Send + Sync),
+        handler: &(dyn Fn(EventEnvelope) -> crate::application::HandlerFuture + Send + Sync),
     ) -> Result<(), SubscribeFailed> {
         let mut connection = self
             .client
@@ -209,7 +230,7 @@ impl RedisEventSubscriber {
         connection: &mut redis::aio::MultiplexedConnection,
         group: &str,
         message: StreamMessage,
-        handler: &(dyn Fn(EventEnvelope) -> Result<(), HandlerError> + Send + Sync),
+        handler: &(dyn Fn(EventEnvelope) -> crate::application::HandlerFuture + Send + Sync),
     ) -> Result<(), SubscribeFailed> {
         let envelope: EventEnvelope = serde_json::from_str(&message.raw_envelope)
             .map_err(|error| SubscribeFailed(error.to_string()))?;
@@ -222,7 +243,7 @@ impl RedisEventSubscriber {
         if duplicate {
             return ack(connection, &message.stream, group, &message.id).await;
         }
-        match handler(envelope) {
+        match handler(envelope).await {
             Ok(()) => {
                 self.seen_event_ids
                     .lock()

--- a/services/entitlement-ticketing/src/adapters/messaging/mod.rs
+++ b/services/entitlement-ticketing/src/adapters/messaging/mod.rs
@@ -181,7 +181,11 @@ impl RedisEventSubscriber {
                 .query_async(&mut connection)
                 .await
                 .map_err(|error| SubscribeFailed(error.to_string()))?;
-            for message in parse_autoclaim_messages(stream, response) {
+            for mut message in parse_autoclaim_messages(stream, response) {
+                message.delivery_count =
+                    pending_delivery_count(&mut connection, stream, group, &message.id)
+                        .await
+                        .unwrap_or(message.delivery_count);
                 if message.delivery_count >= 5 {
                     move_to_dlq(
                         &mut connection,
@@ -256,6 +260,37 @@ async fn ack(
     Ok(())
 }
 
+async fn pending_delivery_count(
+    connection: &mut redis::aio::MultiplexedConnection,
+    stream: &str,
+    group: &str,
+    id: &str,
+) -> Result<u64, SubscribeFailed> {
+    let value: redis::Value = redis::cmd("XPENDING")
+        .arg(stream)
+        .arg(group)
+        .arg(id)
+        .arg(id)
+        .arg(1)
+        .query_async(connection)
+        .await
+        .map_err(|error| SubscribeFailed(error.to_string()))?;
+    Ok(parse_xpending_delivery_count(value).unwrap_or(1))
+}
+
+fn parse_xpending_delivery_count(value: redis::Value) -> Option<u64> {
+    let redis::Value::Bulk(entries) = value else {
+        return None;
+    };
+    let redis::Value::Bulk(entry) = entries.first()? else {
+        return None;
+    };
+    match entry.get(3)? {
+        redis::Value::Int(count) => Some((*count).try_into().ok()?),
+        other => redis_value_to_string(other)?.parse().ok(),
+    }
+}
+
 async fn move_to_dlq(
     connection: &mut redis::aio::MultiplexedConnection,
     stream: &str,
@@ -322,7 +357,7 @@ fn parse_autoclaim_messages(stream: &str, value: redis::Value) -> Vec<StreamMess
                         stream: stream.to_string(),
                         id,
                         raw_envelope,
-                        delivery_count: 1,
+                        delivery_count: 0,
                     });
                 }
             }
@@ -406,5 +441,21 @@ impl DeduplicatingEventHandler {
 
     pub fn handled_count(&self) -> usize {
         self.handled.lock().expect("handled lock poisoned").len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn xpending_delivery_count_controls_dlq_threshold() {
+        let value = redis::Value::Bulk(vec![redis::Value::Bulk(vec![
+            redis::Value::Data(b"1700000000000-0".to_vec()),
+            redis::Value::Data(b"consumer-a".to_vec()),
+            redis::Value::Int(42),
+            redis::Value::Int(5),
+        ])]);
+        assert_eq!(parse_xpending_delivery_count(value), Some(5));
     }
 }

--- a/services/entitlement-ticketing/src/adapters/messaging/mod.rs
+++ b/services/entitlement-ticketing/src/adapters/messaging/mod.rs
@@ -1,0 +1,410 @@
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use redis::RedisResult;
+use tokio::time::sleep;
+
+use crate::application::{
+    EventEnvelope, EventPublisher, EventSubscriber, HandlerError, PublishFailed, SubscribeFailed,
+};
+
+const RETENTION_MAXLEN: usize = 100_000;
+const CONSUMER_GROUP: &str = "entitlement-ticketing";
+const SUBSCRIBED_STREAMS: [&str; 3] = [
+    "events:booking-orchestration",
+    "events:fulfillment",
+    "events:post-sales",
+];
+
+#[derive(Clone)]
+pub struct RedisEventPublisher {
+    client: redis::Client,
+}
+
+impl RedisEventPublisher {
+    pub fn from_env() -> Result<Self, PublishFailed> {
+        let url =
+            std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+        Self::new(&url)
+    }
+
+    pub fn new(url: &str) -> Result<Self, PublishFailed> {
+        Ok(Self {
+            client: redis::Client::open(url).map_err(|error| PublishFailed(error.to_string()))?,
+        })
+    }
+}
+
+#[async_trait]
+impl EventPublisher for RedisEventPublisher {
+    async fn publish(&self, envelope: EventEnvelope) -> Result<(), PublishFailed> {
+        let stream = stream_for_producer(&envelope.producer);
+        let raw_envelope =
+            serde_json::to_string(&envelope).map_err(|error| PublishFailed(error.to_string()))?;
+        let mut last_error = None;
+        for attempt in 0..3 {
+            let result: RedisResult<()> = async {
+                let mut connection = self.client.get_multiplexed_async_connection().await?;
+                redis::cmd("XADD")
+                    .arg(&stream)
+                    .arg("MAXLEN")
+                    .arg("~")
+                    .arg(RETENTION_MAXLEN)
+                    .arg("*")
+                    .arg("envelope")
+                    .arg(&raw_envelope)
+                    .query_async(&mut connection)
+                    .await
+            }
+            .await;
+            match result {
+                Ok(()) => return Ok(()),
+                Err(error) => {
+                    last_error = Some(error.to_string());
+                    if attempt < 2 {
+                        sleep(Duration::from_millis(50 * (1 << attempt))).await;
+                    }
+                }
+            }
+        }
+        Err(PublishFailed(last_error.unwrap_or_else(|| {
+            "unknown Redis publish failure".to_string()
+        })))
+    }
+}
+
+#[derive(Clone)]
+pub struct RedisEventSubscriber {
+    client: redis::Client,
+    seen_event_ids: Arc<Mutex<HashSet<String>>>,
+}
+
+impl RedisEventSubscriber {
+    pub fn from_env() -> Result<Self, SubscribeFailed> {
+        let url =
+            std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+        Self::new(&url)
+    }
+
+    pub fn new(url: &str) -> Result<Self, SubscribeFailed> {
+        Ok(Self {
+            client: redis::Client::open(url).map_err(|error| SubscribeFailed(error.to_string()))?,
+            seen_event_ids: Arc::new(Mutex::new(HashSet::new())),
+        })
+    }
+
+    pub fn entitlement_streams() -> Vec<String> {
+        SUBSCRIBED_STREAMS
+            .iter()
+            .map(|stream| (*stream).to_string())
+            .collect()
+    }
+
+    pub fn entitlement_group() -> &'static str {
+        CONSUMER_GROUP
+    }
+}
+
+#[async_trait]
+impl EventSubscriber for RedisEventSubscriber {
+    async fn subscribe(
+        &self,
+        streams: Vec<String>,
+        group: String,
+        consumer_name: String,
+        handler: Box<dyn Fn(EventEnvelope) -> Result<(), HandlerError> + Send + Sync>,
+    ) -> Result<(), SubscribeFailed> {
+        let mut connection = self
+            .client
+            .get_multiplexed_async_connection()
+            .await
+            .map_err(|error| SubscribeFailed(error.to_string()))?;
+        for stream in &streams {
+            let _: RedisResult<()> = redis::cmd("XGROUP")
+                .arg("CREATE")
+                .arg(stream)
+                .arg(&group)
+                .arg("$")
+                .arg("MKSTREAM")
+                .query_async(&mut connection)
+                .await;
+        }
+        loop {
+            self.recover_pending(&streams, &group, &consumer_name, handler.as_ref())
+                .await?;
+            let response: redis::Value = redis::cmd("XREADGROUP")
+                .arg("GROUP")
+                .arg(&group)
+                .arg(&consumer_name)
+                .arg("BLOCK")
+                .arg(2_000)
+                .arg("COUNT")
+                .arg(10)
+                .arg("STREAMS")
+                .arg(&streams)
+                .arg(vec![">"; streams.len()])
+                .query_async(&mut connection)
+                .await
+                .map_err(|error| SubscribeFailed(error.to_string()))?;
+            for message in parse_stream_messages(response) {
+                self.process_message(&mut connection, &group, message, handler.as_ref())
+                    .await?;
+            }
+        }
+    }
+}
+
+impl RedisEventSubscriber {
+    async fn recover_pending(
+        &self,
+        streams: &[String],
+        group: &str,
+        consumer_name: &str,
+        handler: &(dyn Fn(EventEnvelope) -> Result<(), HandlerError> + Send + Sync),
+    ) -> Result<(), SubscribeFailed> {
+        let mut connection = self
+            .client
+            .get_multiplexed_async_connection()
+            .await
+            .map_err(|error| SubscribeFailed(error.to_string()))?;
+        for stream in streams {
+            let response: redis::Value = redis::cmd("XAUTOCLAIM")
+                .arg(stream)
+                .arg(group)
+                .arg(consumer_name)
+                .arg(60_000)
+                .arg("0")
+                .arg("COUNT")
+                .arg(100)
+                .query_async(&mut connection)
+                .await
+                .map_err(|error| SubscribeFailed(error.to_string()))?;
+            for message in parse_autoclaim_messages(stream, response) {
+                if message.delivery_count >= 5 {
+                    move_to_dlq(
+                        &mut connection,
+                        &message.stream,
+                        group,
+                        &message.id,
+                        &message.raw_envelope,
+                    )
+                    .await?;
+                } else {
+                    self.process_message(&mut connection, group, message, handler)
+                        .await?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn process_message(
+        &self,
+        connection: &mut redis::aio::MultiplexedConnection,
+        group: &str,
+        message: StreamMessage,
+        handler: &(dyn Fn(EventEnvelope) -> Result<(), HandlerError> + Send + Sync),
+    ) -> Result<(), SubscribeFailed> {
+        let envelope: EventEnvelope = serde_json::from_str(&message.raw_envelope)
+            .map_err(|error| SubscribeFailed(error.to_string()))?;
+        let duplicate = {
+            let mut seen = self
+                .seen_event_ids
+                .lock()
+                .expect("seen-event lock poisoned");
+            !seen.insert(envelope.event_id.clone())
+        };
+        if duplicate {
+            return ack(connection, &message.stream, group, &message.id).await;
+        }
+        match handler(envelope) {
+            Ok(()) => ack(connection, &message.stream, group, &message.id).await,
+            Err(HandlerError::Transient(_)) => Ok(()),
+            Err(HandlerError::Fatal(_)) => {
+                move_to_dlq(
+                    connection,
+                    &message.stream,
+                    group,
+                    &message.id,
+                    &message.raw_envelope,
+                )
+                .await
+            }
+        }
+    }
+}
+
+fn stream_for_producer(producer: &str) -> String {
+    format!("events:{producer}")
+}
+
+async fn ack(
+    connection: &mut redis::aio::MultiplexedConnection,
+    stream: &str,
+    group: &str,
+    id: &str,
+) -> Result<(), SubscribeFailed> {
+    let _: () = redis::cmd("XACK")
+        .arg(stream)
+        .arg(group)
+        .arg(id)
+        .query_async(connection)
+        .await
+        .map_err(|error| SubscribeFailed(error.to_string()))?;
+    Ok(())
+}
+
+async fn move_to_dlq(
+    connection: &mut redis::aio::MultiplexedConnection,
+    stream: &str,
+    group: &str,
+    id: &str,
+    raw_envelope: &str,
+) -> Result<(), SubscribeFailed> {
+    let dlq = format!("{stream}:dlq");
+    let _: () = redis::cmd("XADD")
+        .arg(dlq)
+        .arg("MAXLEN")
+        .arg("~")
+        .arg(RETENTION_MAXLEN)
+        .arg("*")
+        .arg("envelope")
+        .arg(raw_envelope)
+        .query_async(connection)
+        .await
+        .map_err(|error| SubscribeFailed(error.to_string()))?;
+    ack(connection, stream, group, id).await
+}
+
+struct StreamMessage {
+    stream: String,
+    id: String,
+    raw_envelope: String,
+    delivery_count: u64,
+}
+
+fn parse_stream_messages(value: redis::Value) -> Vec<StreamMessage> {
+    let mut messages = Vec::new();
+    if let redis::Value::Bulk(streams) = value {
+        for stream_value in streams {
+            if let redis::Value::Bulk(parts) = stream_value {
+                if parts.len() != 2 {
+                    continue;
+                }
+                let stream = redis_value_to_string(&parts[0]).unwrap_or_default();
+                if let redis::Value::Bulk(entries) = &parts[1] {
+                    for entry in entries {
+                        if let Some((id, raw_envelope)) = parse_entry(entry) {
+                            messages.push(StreamMessage {
+                                stream: stream.clone(),
+                                id,
+                                raw_envelope,
+                                delivery_count: 1,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+    messages
+}
+
+fn parse_autoclaim_messages(stream: &str, value: redis::Value) -> Vec<StreamMessage> {
+    let mut messages = Vec::new();
+    if let redis::Value::Bulk(parts) = value {
+        if let Some(redis::Value::Bulk(entries)) = parts.get(1) {
+            for entry in entries {
+                if let Some((id, raw_envelope)) = parse_entry(entry) {
+                    messages.push(StreamMessage {
+                        stream: stream.to_string(),
+                        id,
+                        raw_envelope,
+                        delivery_count: 1,
+                    });
+                }
+            }
+        }
+    }
+    messages
+}
+
+fn parse_entry(value: &redis::Value) -> Option<(String, String)> {
+    let redis::Value::Bulk(parts) = value else {
+        return None;
+    };
+    if parts.len() != 2 {
+        return None;
+    }
+    let id = redis_value_to_string(&parts[0])?;
+    let redis::Value::Bulk(fields) = &parts[1] else {
+        return None;
+    };
+    let mut index = 0;
+    while index + 1 < fields.len() {
+        if redis_value_to_string(&fields[index]).as_deref() == Some("envelope") {
+            return Some((id, redis_value_to_string(&fields[index + 1])?));
+        }
+        index += 2;
+    }
+    None
+}
+
+fn redis_value_to_string(value: &redis::Value) -> Option<String> {
+    match value {
+        redis::Value::Data(bytes) => String::from_utf8(bytes.clone()).ok(),
+        redis::Value::Status(value) => Some(value.clone()),
+        redis::Value::Okay => Some("OK".to_string()),
+        _ => None,
+    }
+}
+
+#[derive(Default)]
+pub struct InMemoryEventPublisher {
+    envelopes: Mutex<Vec<EventEnvelope>>,
+}
+
+impl InMemoryEventPublisher {
+    pub fn published(&self) -> Vec<EventEnvelope> {
+        self.envelopes
+            .lock()
+            .expect("publisher lock poisoned")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl EventPublisher for InMemoryEventPublisher {
+    async fn publish(&self, envelope: EventEnvelope) -> Result<(), PublishFailed> {
+        self.envelopes
+            .lock()
+            .expect("publisher lock poisoned")
+            .push(envelope);
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+pub struct DeduplicatingEventHandler {
+    seen: Mutex<HashSet<String>>,
+    handled: Mutex<Vec<EventEnvelope>>,
+}
+
+impl DeduplicatingEventHandler {
+    pub fn handle(&self, envelope: EventEnvelope) -> Result<(), HandlerError> {
+        let mut seen = self.seen.lock().expect("dedup lock poisoned");
+        if seen.insert(envelope.event_id.clone()) {
+            self.handled
+                .lock()
+                .expect("handled lock poisoned")
+                .push(envelope);
+        }
+        Ok(())
+    }
+
+    pub fn handled_count(&self) -> usize {
+        self.handled.lock().expect("handled lock poisoned").len()
+    }
+}

--- a/services/entitlement-ticketing/src/adapters/messaging/mod.rs
+++ b/services/entitlement-ticketing/src/adapters/messaging/mod.rs
@@ -213,18 +213,23 @@ impl RedisEventSubscriber {
     ) -> Result<(), SubscribeFailed> {
         let envelope: EventEnvelope = serde_json::from_str(&message.raw_envelope)
             .map_err(|error| SubscribeFailed(error.to_string()))?;
-        let duplicate = {
-            let mut seen = self
-                .seen_event_ids
-                .lock()
-                .expect("seen-event lock poisoned");
-            !seen.insert(envelope.event_id.clone())
-        };
+        let event_id = envelope.event_id.clone();
+        let duplicate = self
+            .seen_event_ids
+            .lock()
+            .expect("seen-event lock poisoned")
+            .contains(&event_id);
         if duplicate {
             return ack(connection, &message.stream, group, &message.id).await;
         }
         match handler(envelope) {
-            Ok(()) => ack(connection, &message.stream, group, &message.id).await,
+            Ok(()) => {
+                self.seen_event_ids
+                    .lock()
+                    .expect("seen-event lock poisoned")
+                    .insert(event_id);
+                ack(connection, &message.stream, group, &message.id).await
+            }
             Err(HandlerError::Transient(_)) => Ok(()),
             Err(HandlerError::Fatal(_)) => {
                 move_to_dlq(
@@ -429,13 +434,47 @@ pub struct DeduplicatingEventHandler {
 
 impl DeduplicatingEventHandler {
     pub fn handle(&self, envelope: EventEnvelope) -> Result<(), HandlerError> {
-        let mut seen = self.seen.lock().expect("dedup lock poisoned");
-        if seen.insert(envelope.event_id.clone()) {
-            self.handled
-                .lock()
-                .expect("handled lock poisoned")
-                .push(envelope);
+        if self
+            .seen
+            .lock()
+            .expect("dedup lock poisoned")
+            .contains(&envelope.event_id)
+        {
+            return Ok(());
         }
+        self.handled
+            .lock()
+            .expect("handled lock poisoned")
+            .push(envelope.clone());
+        self.seen
+            .lock()
+            .expect("dedup lock poisoned")
+            .insert(envelope.event_id);
+        Ok(())
+    }
+
+    pub fn handle_with_result(
+        &self,
+        envelope: EventEnvelope,
+        result: Result<(), HandlerError>,
+    ) -> Result<(), HandlerError> {
+        if self
+            .seen
+            .lock()
+            .expect("dedup lock poisoned")
+            .contains(&envelope.event_id)
+        {
+            return Ok(());
+        }
+        result?;
+        self.handled
+            .lock()
+            .expect("handled lock poisoned")
+            .push(envelope.clone());
+        self.seen
+            .lock()
+            .expect("dedup lock poisoned")
+            .insert(envelope.event_id);
         Ok(())
     }
 
@@ -457,5 +496,31 @@ mod tests {
             redis::Value::Int(5),
         ])]);
         assert_eq!(parse_xpending_delivery_count(value), Some(5));
+    }
+
+    #[test]
+    fn dedup_records_event_id_only_after_successful_handling() {
+        let handler = DeduplicatingEventHandler::default();
+        let envelope = EventEnvelope::new(
+            "EntitlementIssued",
+            "2026-07-05T10:30:00.000Z",
+            "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c444",
+            Some("cmd-0194f2e0-7b3e-7610-0284-5c26e8b0c555"),
+            "entitlement-ticketing",
+            serde_json::json!({"entitlementId":"ent-0194f2e0-7b3e-7610-0284-5c26e8b0c111"}),
+        );
+
+        assert!(matches!(
+            handler.handle_with_result(
+                envelope.clone(),
+                Err(HandlerError::Transient("temporary outage".to_string()))
+            ),
+            Err(HandlerError::Transient(_))
+        ));
+        assert_eq!(handler.handled_count(), 0);
+
+        handler.handle(envelope.clone()).unwrap();
+        handler.handle(envelope).unwrap();
+        assert_eq!(handler.handled_count(), 1);
     }
 }

--- a/services/entitlement-ticketing/src/adapters/messaging/mod.rs
+++ b/services/entitlement-ticketing/src/adapters/messaging/mod.rs
@@ -404,6 +404,7 @@ fn redis_value_to_string(value: &redis::Value) -> Option<String> {
 #[derive(Default)]
 pub struct InMemoryEventPublisher {
     envelopes: Mutex<Vec<EventEnvelope>>,
+    fail_next: Mutex<Option<String>>,
 }
 
 impl InMemoryEventPublisher {
@@ -413,11 +414,23 @@ impl InMemoryEventPublisher {
             .expect("publisher lock poisoned")
             .clone()
     }
+
+    pub fn fail_next(&self, message: impl Into<String>) {
+        *self.fail_next.lock().expect("publisher lock poisoned") = Some(message.into());
+    }
 }
 
 #[async_trait]
 impl EventPublisher for InMemoryEventPublisher {
     async fn publish(&self, envelope: EventEnvelope) -> Result<(), PublishFailed> {
+        if let Some(message) = self
+            .fail_next
+            .lock()
+            .expect("publisher lock poisoned")
+            .take()
+        {
+            return Err(PublishFailed(message));
+        }
         self.envelopes
             .lock()
             .expect("publisher lock poisoned")

--- a/services/entitlement-ticketing/src/adapters/mod.rs
+++ b/services/entitlement-ticketing/src/adapters/mod.rs
@@ -1,0 +1,1 @@
+pub mod messaging;

--- a/services/entitlement-ticketing/src/application/mod.rs
+++ b/services/entitlement-ticketing/src/application/mod.rs
@@ -1,6 +1,6 @@
 //! Broker-independent application-layer messaging ports.
 
-use std::fmt;
+use std::{fmt, future::Future, pin::Pin};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -57,6 +57,8 @@ pub trait EventPublisher: Send + Sync + 'static {
     async fn publish(&self, envelope: EventEnvelope) -> Result<(), PublishFailed>;
 }
 
+pub type HandlerFuture = Pin<Box<dyn Future<Output = Result<(), HandlerError>> + Send>>;
+
 #[derive(Debug, Clone)]
 pub struct SubscribeFailed(pub String);
 
@@ -81,6 +83,6 @@ pub trait EventSubscriber: Send + Sync + 'static {
         streams: Vec<String>,
         group: String,
         consumer_name: String,
-        handler: Box<dyn Fn(EventEnvelope) -> Result<(), HandlerError> + Send + Sync>,
+        handler: Box<dyn Fn(EventEnvelope) -> HandlerFuture + Send + Sync>,
     ) -> Result<(), SubscribeFailed>;
 }

--- a/services/entitlement-ticketing/src/application/mod.rs
+++ b/services/entitlement-ticketing/src/application/mod.rs
@@ -1,0 +1,86 @@
+//! Broker-independent application-layer messaging ports.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EventEnvelope {
+    pub event_id: String,
+    pub event_type: String,
+    pub schema_version: u32,
+    pub occurred_at: String,
+    pub correlation_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub causation_id: Option<String>,
+    pub producer: String,
+    pub payload: Value,
+}
+
+impl EventEnvelope {
+    pub fn new(
+        event_type: impl Into<String>,
+        occurred_at: impl Into<String>,
+        correlation_id: impl Into<String>,
+        causation_id: Option<impl Into<String>>,
+        producer: impl Into<String>,
+        payload: Value,
+    ) -> Self {
+        Self {
+            event_id: format!("evt-{}", uuid::Uuid::now_v7()),
+            event_type: event_type.into(),
+            schema_version: 1,
+            occurred_at: occurred_at.into(),
+            correlation_id: correlation_id.into(),
+            causation_id: causation_id.map(Into::into),
+            producer: producer.into(),
+            payload,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PublishFailed(pub String);
+
+impl fmt::Display for PublishFailed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "publish failed: {}", self.0)
+    }
+}
+
+impl std::error::Error for PublishFailed {}
+
+#[async_trait::async_trait]
+pub trait EventPublisher: Send + Sync + 'static {
+    async fn publish(&self, envelope: EventEnvelope) -> Result<(), PublishFailed>;
+}
+
+#[derive(Debug, Clone)]
+pub struct SubscribeFailed(pub String);
+
+impl fmt::Display for SubscribeFailed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "subscribe failed: {}", self.0)
+    }
+}
+
+impl std::error::Error for SubscribeFailed {}
+
+#[derive(Debug, Clone)]
+pub enum HandlerError {
+    Transient(String),
+    Fatal(String),
+}
+
+#[async_trait::async_trait]
+pub trait EventSubscriber: Send + Sync + 'static {
+    async fn subscribe(
+        &self,
+        streams: Vec<String>,
+        group: String,
+        consumer_name: String,
+        handler: Box<dyn Fn(EventEnvelope) -> Result<(), HandlerError> + Send + Sync>,
+    ) -> Result<(), SubscribeFailed>;
+}

--- a/services/entitlement-ticketing/src/lib.rs
+++ b/services/entitlement-ticketing/src/lib.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use axum::{
     Json, Router,
-    extract::{Extension, Path, Query, State, rejection::JsonRejection},
+    extract::{Extension, Path, RawQuery, State, rejection::JsonRejection},
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     routing::{get, post},
@@ -1911,8 +1911,29 @@ fn idempotency_key(headers: &HeaderMap) -> Option<String> {
         .get("idempotency-key")
         .and_then(|value| value.to_str().ok())
         .map(str::trim)
-        .filter(|value| !value.is_empty())
+        .filter(|value| is_uuid_v7(value))
         .map(ToOwned::to_owned)
+}
+
+fn is_uuid_v7(value: &str) -> bool {
+    if value.len() != 36 {
+        return false;
+    }
+    for index in [8, 13, 18, 23] {
+        if value.as_bytes().get(index) != Some(&b'-') {
+            return false;
+        }
+    }
+    value
+        .chars()
+        .enumerate()
+        .filter(|(i, _)| ![8, 13, 18, 23].contains(i))
+        .all(|(_, c)| c.is_ascii_hexdigit())
+        && value.as_bytes()[14] == b'7'
+        && matches!(
+            value.as_bytes()[19],
+            b'8' | b'9' | b'a' | b'b' | b'A' | b'B'
+        )
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -1935,6 +1956,18 @@ pub enum IssuePurposeDto {
     DisruptionReplacement,
 }
 
+impl From<IssuePurposeDto> for IssuePurpose {
+    fn from(value: IssuePurposeDto) -> Self {
+        match value {
+            IssuePurposeDto::Initial => Self::Initial,
+            IssuePurposeDto::Replacement => Self::Replacement,
+            IssuePurposeDto::ManualRecovery => Self::ManualRecovery,
+            IssuePurposeDto::ProviderRebuild => Self::ProviderRebuild,
+            IssuePurposeDto::DisruptionReplacement => Self::DisruptionReplacement,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct VoidEntitlementRequest {
@@ -1953,11 +1986,32 @@ pub enum VoidReasonDto {
     ManualCorrection,
 }
 
+impl From<VoidReasonDto> for VoidReason {
+    fn from(value: VoidReasonDto) -> Self {
+        match value {
+            VoidReasonDto::Refund => Self::Refund,
+            VoidReasonDto::Change => Self::Change,
+            VoidReasonDto::Disruption => Self::Disruption,
+            VoidReasonDto::Risk => Self::Risk,
+            VoidReasonDto::ManualCorrection => Self::ManualCorrection,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum VoidPolicyDto {
     Normal,
     ExceptionalRule,
+}
+
+impl From<VoidPolicyDto> for VoidPolicy {
+    fn from(value: VoidPolicyDto) -> Self {
+        match value {
+            VoidPolicyDto::Normal => Self::Normal,
+            VoidPolicyDto::ExceptionalRule => Self::ExceptionalRule,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -2034,6 +2088,39 @@ pub struct ListEntitlementsQuery {
     offset: Option<usize>,
 }
 
+fn parse_list_query(raw_query: Option<&str>) -> Result<ListEntitlementsQuery, String> {
+    let raw_query =
+        raw_query.ok_or_else(|| "journeyOrderId query parameter is required".to_string())?;
+    let mut journey_order_id = None;
+    let mut limit = None;
+    let mut offset = None;
+    for pair in raw_query.split('&').filter(|pair| !pair.is_empty()) {
+        let (name, value) = pair.split_once('=').unwrap_or((pair, ""));
+        match name {
+            "journeyOrderId" => journey_order_id = Some(value.to_string()),
+            "limit" => {
+                limit = Some(value.parse::<usize>().map_err(|_| {
+                    "limit query parameter must be a non-negative integer".to_string()
+                })?)
+            }
+            "offset" => {
+                offset = Some(value.parse::<usize>().map_err(|_| {
+                    "offset query parameter must be a non-negative integer".to_string()
+                })?)
+            }
+            _ => {}
+        }
+    }
+    let journey_order_id = journey_order_id
+        .filter(|v| !v.trim().is_empty())
+        .ok_or_else(|| "journeyOrderId query parameter is required".to_string())?;
+    Ok(ListEntitlementsQuery {
+        journey_order_id,
+        limit,
+        offset,
+    })
+}
+
 async fn issue_entitlement<S>(
     State(state): State<ApiState<S>>,
     Extension(context): Extension<RequestContext>,
@@ -2045,7 +2132,10 @@ where
 {
     let correlation_id = context.correlation_id().to_string();
     let Some(key) = idempotency_key(&headers) else {
-        return validation_error(correlation_id, "Idempotency-Key header is required");
+        return validation_error(
+            correlation_id,
+            "Idempotency-Key header is required and must be UUID v7",
+        );
     };
     let Json(request) = match body {
         Ok(body) => body,
@@ -2073,7 +2163,10 @@ where
 {
     let correlation_id = context.correlation_id().to_string();
     let Some(key) = idempotency_key(&headers) else {
-        return validation_error(correlation_id, "Idempotency-Key header is required");
+        return validation_error(
+            correlation_id,
+            "Idempotency-Key header is required and must be UUID v7",
+        );
     };
     let Json(request) = match body {
         Ok(body) => body,
@@ -2107,12 +2200,16 @@ where
 async fn list_entitlements<S>(
     State(state): State<ApiState<S>>,
     Extension(context): Extension<RequestContext>,
-    Query(query): Query<ListEntitlementsQuery>,
+    RawQuery(raw_query): RawQuery,
 ) -> Response
 where
     S: EntitlementApi + 'static,
 {
     let correlation_id = context.correlation_id().to_string();
+    let query = match parse_list_query(raw_query.as_deref()) {
+        Ok(query) => query,
+        Err(message) => return validation_error(correlation_id, message),
+    };
     let limit = query.limit.unwrap_or(20).min(100);
     let offset = query.offset.unwrap_or(0);
     match state
@@ -2150,6 +2247,8 @@ impl InMemoryEntitlementService {
 #[derive(Debug, Default)]
 struct InMemoryState {
     entitlements: HashMap<String, EntitlementDetails>,
+    aggregates: HashMap<String, Entitlement>,
+    credential_registry: CredentialRegistry,
     idempotency: HashMap<String, IdempotentRecord>,
     sequence: u64,
 }
@@ -2221,6 +2320,46 @@ impl EntitlementApi for InMemoryEntitlementService {
                 issued_at,
                 voided_at: None,
             };
+            let (mut aggregate, _) = Entitlement::request(RequestEntitlement {
+                command_id: CommandId::new(format!("cmd-{}", uuid::Uuid::now_v7()))
+                    .map_err(ApiErrorKind::from)?,
+                entitlement_id: EntitlementId::new(entitlement_id.clone())
+                    .map_err(ApiErrorKind::from)?,
+                journey_order_ref: JourneyOrderRef::new(details.journey_order_id.clone())
+                    .map_err(ApiErrorKind::from)?,
+                segment_booking_ref: SegmentBookingRef::new(details.segment_booking_id.clone())
+                    .map_err(ApiErrorKind::from)?,
+                traveler_ref: TravelerRef::new(details.traveler_ref.clone())
+                    .map_err(ApiErrorKind::from)?,
+                segment_ref: SegmentRef::new(details.segment_ref.clone())
+                    .map_err(ApiErrorKind::from)?,
+                purpose: command.issue_purpose.clone().into(),
+                validity_window: ValidityWindow::new(
+                    UnixMillis::new(current_unix_millis()),
+                    UnixMillis::new(current_unix_millis().saturating_add(86_400_000)),
+                )
+                .map_err(ApiErrorKind::from)?,
+                audit: audit_builder(&correlation_id, "HTTP issue entitlement")
+                    .map_err(ApiErrorKind::from)?,
+            })
+            .map_err(ApiErrorKind::from)?;
+            aggregate
+                .issue(
+                    IssueEntitlement {
+                        command_id: CommandId::new(format!("cmd-{}", uuid::Uuid::now_v7()))
+                            .map_err(ApiErrorKind::from)?,
+                        idempotency_key: aggregate.idempotency_key().clone(),
+                        preconditions: default_preconditions().map_err(ApiErrorKind::from)?,
+                        credential_ref: credential_ref(&response.credential_no)
+                            .map_err(ApiErrorKind::from)?,
+                        refund_request_fact: None,
+                        audit: audit_builder(&correlation_id, "HTTP issue entitlement")
+                            .map_err(ApiErrorKind::from)?,
+                    },
+                    &mut state.credential_registry,
+                )
+                .map_err(ApiErrorKind::from)?;
+            state.aggregates.insert(entitlement_id.clone(), aggregate);
             state.entitlements.insert(entitlement_id, details);
             state.idempotency.insert(
                 key,
@@ -2280,18 +2419,42 @@ impl EntitlementApi for InMemoryEntitlementService {
                     "Idempotency-Key was reused for a different operation".to_string(),
                 ));
             }
-            let entitlement = state
+            let was_voided = state
                 .entitlements
-                .get_mut(&entitlement_id)
-                .ok_or_else(|| ApiErrorKind::NotFound("entitlement not found".to_string()))?;
-            if entitlement.status == EntitlementStatusDto::Voided {
+                .get(&entitlement_id)
+                .ok_or_else(|| ApiErrorKind::NotFound("entitlement not found".to_string()))?
+                .status
+                == EntitlementStatusDto::Voided;
+            let aggregate = state.aggregates.get_mut(&entitlement_id).ok_or_else(|| {
+                ApiErrorKind::NotFound("entitlement aggregate not found".to_string())
+            })?;
+            let events = aggregate
+                .void(VoidEntitlement {
+                    command_id: CommandId::new(format!("cmd-{}", uuid::Uuid::now_v7()))
+                        .map_err(ApiErrorKind::from)?,
+                    reason: command.reason.clone().into(),
+                    policy: command.policy.clone().into(),
+                    business_case_ref: BusinessCaseRef::new(
+                        command
+                            .business_case_ref
+                            .clone()
+                            .unwrap_or_else(|| format!("case-{}", uuid::Uuid::now_v7())),
+                    )
+                    .map_err(ApiErrorKind::from)?,
+                    audit: audit_builder(&correlation_id, "HTTP void entitlement")
+                        .map_err(ApiErrorKind::from)?,
+                })
+                .map_err(ApiErrorKind::from)?;
+            if events.is_empty() && was_voided {
                 return Err(ApiErrorKind::PreconditionFailed(
                     "entitlement is already voided".to_string(),
                 ));
             }
             let voided_at = current_rfc3339();
-            entitlement.status = EntitlementStatusDto::Voided;
-            entitlement.voided_at = Some(voided_at.clone());
+            if let Some(entitlement) = state.entitlements.get_mut(&entitlement_id) {
+                entitlement.status = EntitlementStatusDto::Voided;
+                entitlement.voided_at = Some(voided_at.clone());
+            }
             let response = VoidEntitlementResponse {
                 entitlement_id,
                 status: EntitlementStatusDto::Voided,
@@ -2367,6 +2530,69 @@ fn current_rfc3339() -> String {
     chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
 }
 
+fn current_unix_millis() -> u64 {
+    chrono::Utc::now().timestamp_millis().max(0) as u64
+}
+
+fn audit_builder(
+    correlation_id: &str,
+    reason: &'static str,
+) -> Result<AuditBuilder, EntitlementError> {
+    Ok(AuditBuilder::system(
+        reason,
+        UnixMillis::new(current_unix_millis()),
+        CorrelationId::new(correlation_id.to_string())?,
+    ))
+}
+
+fn default_preconditions() -> Result<IssuePreconditions, EntitlementError> {
+    let now = UnixMillis::new(current_unix_millis());
+    Ok(IssuePreconditions::accepted(
+        AcceptedFact::new(
+            BookingFactRef::new(format!("booking-fact-{}", uuid::Uuid::now_v7()))?,
+            BookingAcceptance::SegmentReservationConfirmed,
+            now,
+        ),
+        AcceptedFact::new(
+            CapacityFactRef::new(format!("capacity-fact-{}", uuid::Uuid::now_v7()))?,
+            CapacityAcceptance::CapacityCommitted,
+            now,
+        ),
+        AcceptedFact::new(
+            PaymentFactRef::new(format!("payment-fact-{}", uuid::Uuid::now_v7()))?,
+            PaymentAcceptance::PaymentCaptured,
+            now,
+        ),
+        AcceptedFact::new(
+            TravelerFactRef::new(format!("traveler-fact-{}", uuid::Uuid::now_v7()))?,
+            TravelerAcceptance::TravelerSnapshotAccepted,
+            now,
+        ),
+        AcceptedFact::new(
+            RiskFactRef::new(format!("risk-fact-{}", uuid::Uuid::now_v7()))?,
+            RiskAcceptance::Allowed,
+            now,
+        ),
+    ))
+}
+
+fn credential_ref(credential_no: &str) -> Result<CredentialRef, EntitlementError> {
+    CredentialRef::new(
+        CredentialId::new(format!("cred-{}", uuid::Uuid::now_v7()))?,
+        CredentialType::ETicket,
+        credential_no.to_string(),
+        None,
+        CredentialDisplayReference::new(
+            format!(
+                "****{}",
+                &credential_no[credential_no.len().saturating_sub(4)..]
+            ),
+            1,
+            Some("QR".to_string()),
+        )?,
+    )
+}
+
 async fn publish_api_event<T: Serialize>(
     publisher: &dyn application::EventPublisher,
     event_type: &str,
@@ -2385,4 +2611,81 @@ async fn publish_api_event<T: Serialize>(
         .publish(envelope)
         .await
         .map_err(|error| ApiErrorKind::Unavailable(error.to_string()))
+}
+
+impl From<EntitlementError> for ApiErrorKind {
+    fn from(error: EntitlementError) -> Self {
+        match error {
+            EntitlementError::BlankReference { .. }
+            | EntitlementError::InvalidValidityWindow
+            | EntitlementError::InvalidDisplayVersion
+            | EntitlementError::MissingAuditReason => Self::ValidationFailed(error.to_string()),
+            EntitlementError::DuplicateCredential { .. } => Self::Conflict(error.to_string()),
+            EntitlementError::NotIssued
+            | EntitlementError::NotSuspended
+            | EntitlementError::TerminalStatus(_)
+            | EntitlementError::VoidRequiresCompensation
+            | EntitlementError::ExceptionalVoidRuleRequired
+            | EntitlementError::AlreadyIssued
+            | EntitlementError::EntitlementFrozen
+            | EntitlementError::IssueFailureNotRetryable
+            | EntitlementError::DuplicateIssueAttempt
+            | EntitlementError::IdempotencyKeyMismatch => {
+                Self::DomainRuleViolation(error.to_string())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod api_domain_wiring_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn http_application_service_maps_domain_invariant_to_domain_rule_violation() {
+        let service = InMemoryEntitlementService::default();
+        let response = service
+            .issue(
+                IssueEntitlementRequest {
+                    segment_booking_id: "sb-domain-invariant".to_string(),
+                    journey_order_id: "ord-domain-invariant".to_string(),
+                    traveler_ref: "tvl-domain-invariant".to_string(),
+                    segment_ref: "seg-domain-invariant".to_string(),
+                    issue_purpose: IssuePurposeDto::Initial,
+                },
+                "018f2e07-b3e7-7100-8284-5c26e8b0d001".to_string(),
+                "corr-domain-invariant".to_string(),
+            )
+            .await
+            .unwrap();
+
+        {
+            let mut state = service.state.lock().expect("state lock poisoned");
+            let aggregate = state.aggregates.get_mut(&response.entitlement_id).unwrap();
+            aggregate
+                .accept_fulfillment_fact(AcceptFulfillmentFact {
+                    command_id: CommandId::new(format!("cmd-{}", uuid::Uuid::now_v7())).unwrap(),
+                    fact: FulfillmentFact::BoardingVerified {
+                        fact_ref: FulfillmentFactRef::new("fulfillment-domain-invariant").unwrap(),
+                    },
+                    audit: audit_builder("corr-domain-invariant", "test boarding fact").unwrap(),
+                })
+                .unwrap();
+        }
+
+        let error = service
+            .void(
+                response.entitlement_id,
+                VoidEntitlementRequest {
+                    reason: VoidReasonDto::Refund,
+                    policy: VoidPolicyDto::Normal,
+                    business_case_ref: Some("case-domain-invariant".to_string()),
+                },
+                "018f2e07-b3e7-7100-8284-5c26e8b0d002".to_string(),
+                "corr-domain-invariant".to_string(),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(error, ApiErrorKind::DomainRuleViolation(_)));
+    }
 }

--- a/services/entitlement-ticketing/src/lib.rs
+++ b/services/entitlement-ticketing/src/lib.rs
@@ -2014,6 +2014,32 @@ impl From<VoidPolicyDto> for VoidPolicy {
     }
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct EntitlementIssuedPayload {
+    entitlement_id: String,
+    segment_booking_id: String,
+    journey_order_id: String,
+    traveler_ref: String,
+    segment_ref: String,
+    issue_purpose: &'static str,
+    credential_no: String,
+    credential_type: &'static str,
+    issued_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct EntitlementVoidedPayload {
+    entitlement_id: String,
+    segment_booking_id: String,
+    voided_at: String,
+    reason: &'static str,
+    policy: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    business_case_ref: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct IssueEntitlementResponse {
@@ -2078,6 +2104,53 @@ pub enum EntitlementStatusDto {
     Boarded,
     NoShow,
     Suspended,
+}
+
+impl IssuePurposeDto {
+    fn to_contract(&self) -> &'static str {
+        match self {
+            Self::Initial => "INITIAL",
+            Self::Replacement => "REPLACEMENT",
+            Self::ManualRecovery => "MANUAL_RECOVERY",
+            Self::ProviderRebuild => "PROVIDER_REBUILD",
+            Self::DisruptionReplacement => "DISRUPTION_REPLACEMENT",
+        }
+    }
+}
+
+impl VoidReasonDto {
+    fn to_contract(&self) -> &'static str {
+        match self {
+            Self::Refund => "REFUND",
+            Self::Change => "CHANGE",
+            Self::Disruption => "DISRUPTION",
+            Self::Risk => "RISK",
+            Self::ManualCorrection => "MANUAL_CORRECTION",
+        }
+    }
+}
+
+impl VoidPolicyDto {
+    fn to_contract(&self) -> &'static str {
+        match self {
+            Self::Normal => "NORMAL",
+            Self::ExceptionalRule => "EXCEPTIONAL_RULE",
+        }
+    }
+}
+
+impl CredentialTypeDto {
+    fn to_contract(&self) -> &'static str {
+        match self {
+            Self::ETicket => "E_TICKET",
+            Self::PaperTicket => "PAPER_TICKET",
+            Self::PickupCode => "PICKUP_CODE",
+            Self::BoardingPass => "BOARDING_PASS",
+            Self::FerryTicket => "FERRY_TICKET",
+            Self::CoachETicket => "COACH_E_TICKET",
+            Self::RideCode => "RIDE_CODE",
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -2278,7 +2351,7 @@ impl EntitlementApi for InMemoryEntitlementService {
         validate_non_empty(&command.traveler_ref, "travelerRef")?;
         validate_non_empty(&command.segment_ref, "segmentRef")?;
         let fingerprint = serde_json::to_string(&command).unwrap_or_default();
-        let response = {
+        let (response, event_payload) = {
             let mut state = self
                 .state
                 .lock()
@@ -2306,6 +2379,17 @@ impl EntitlementApi for InMemoryEntitlementService {
                 credential_no: format!("ETK-{:012}", state.sequence),
                 credential_type: CredentialTypeDto::ETicket,
                 status: EntitlementStatusDto::Issued,
+                issued_at: issued_at.clone(),
+            };
+            let event_payload = EntitlementIssuedPayload {
+                entitlement_id: entitlement_id.clone(),
+                segment_booking_id: command.segment_booking_id.clone(),
+                journey_order_id: command.journey_order_id.clone(),
+                traveler_ref: command.traveler_ref.clone(),
+                segment_ref: command.segment_ref.clone(),
+                issue_purpose: command.issue_purpose.to_contract(),
+                credential_no: response.credential_no.clone(),
+                credential_type: response.credential_type.to_contract(),
                 issued_at: issued_at.clone(),
             };
             let details = EntitlementDetails {
@@ -2368,12 +2452,12 @@ impl EntitlementApi for InMemoryEntitlementService {
                     response: IdempotentResponse::Issue(response.clone()),
                 },
             );
-            response
+            (response, event_payload)
         };
         publish_api_event(
             self.publisher.as_ref(),
             "EntitlementIssued",
-            &response,
+            &event_payload,
             correlation_id,
         )
         .await?;
@@ -2401,7 +2485,7 @@ impl EntitlementApi for InMemoryEntitlementService {
             entitlement_id,
             serde_json::to_string(&command).unwrap_or_default()
         );
-        let response = {
+        let (response, event_payload) = {
             let mut state = self
                 .state
                 .lock()
@@ -2419,12 +2503,12 @@ impl EntitlementApi for InMemoryEntitlementService {
                     "Idempotency-Key was reused for a different operation".to_string(),
                 ));
             }
-            let was_voided = state
+            let segment_booking_id = state
                 .entitlements
                 .get(&entitlement_id)
                 .ok_or_else(|| ApiErrorKind::NotFound("entitlement not found".to_string()))?
-                .status
-                == EntitlementStatusDto::Voided;
+                .segment_booking_id
+                .clone();
             let aggregate = state.aggregates.get_mut(&entitlement_id).ok_or_else(|| {
                 ApiErrorKind::NotFound("entitlement aggregate not found".to_string())
             })?;
@@ -2445,7 +2529,7 @@ impl EntitlementApi for InMemoryEntitlementService {
                         .map_err(ApiErrorKind::from)?,
                 })
                 .map_err(ApiErrorKind::from)?;
-            if events.is_empty() && was_voided {
+            if events.is_empty() {
                 return Err(ApiErrorKind::PreconditionFailed(
                     "entitlement is already voided".to_string(),
                 ));
@@ -2455,6 +2539,14 @@ impl EntitlementApi for InMemoryEntitlementService {
                 entitlement.status = EntitlementStatusDto::Voided;
                 entitlement.voided_at = Some(voided_at.clone());
             }
+            let event_payload = EntitlementVoidedPayload {
+                entitlement_id: entitlement_id.clone(),
+                segment_booking_id,
+                voided_at: voided_at.clone(),
+                reason: command.reason.to_contract(),
+                policy: command.policy.to_contract(),
+                business_case_ref: command.business_case_ref.clone(),
+            };
             let response = VoidEntitlementResponse {
                 entitlement_id,
                 status: EntitlementStatusDto::Voided,
@@ -2467,12 +2559,12 @@ impl EntitlementApi for InMemoryEntitlementService {
                     response: IdempotentResponse::Void(response.clone()),
                 },
             );
-            response
+            (response, event_payload)
         };
         publish_api_event(
             self.publisher.as_ref(),
             "EntitlementVoided",
-            &response,
+            &event_payload,
             correlation_id,
         )
         .await?;

--- a/services/entitlement-ticketing/src/lib.rs
+++ b/services/entitlement-ticketing/src/lib.rs
@@ -1,9 +1,22 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::sync::{Arc, Mutex};
 
-use axum::Router;
-use serde::Serialize;
-use shared_kernel::{OpenTelemetryObserver, RuntimeConfig, apply_runtime, router_with_config};
+use axum::{
+    Json, Router,
+    extract::{Extension, Path, Query, State, rejection::JsonRejection},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::{get, post},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use shared_kernel::{
+    OpenTelemetryObserver, RequestContext, RuntimeConfig, apply_runtime, router_with_config,
+};
+
+pub mod adapters;
+pub mod application;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ServiceProfile {
@@ -46,7 +59,29 @@ pub fn runtime_config() -> RuntimeConfig {
 }
 
 pub fn router() -> Router {
-    router_with_config(runtime_config())
+    router_with_state(Arc::new(InMemoryEntitlementService::default()))
+}
+
+pub fn router_with_state<S>(service: Arc<S>) -> Router
+where
+    S: EntitlementApi + 'static,
+{
+    let app_state = ApiState { service };
+    let routes = Router::new()
+        .route(
+            "/api/v1/entitlements",
+            post(issue_entitlement::<S>).get(list_entitlements::<S>),
+        )
+        .route(
+            "/api/v1/entitlements/{entitlement_id}",
+            get(get_entitlement::<S>),
+        )
+        .route(
+            "/api/v1/entitlements/{entitlement_id}/void",
+            post(void_entitlement::<S>),
+        )
+        .with_state(app_state);
+    apply_service_runtime(router_with_config(runtime_config()).merge(routes))
 }
 
 pub fn apply_service_runtime(router: Router) -> Router {
@@ -1191,6 +1226,7 @@ impl std::error::Error for EntitlementError {}
 
 /// Contract-conformant event envelope per docs/08-contracts/shared-primitives.md
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct EventEnvelope {
     pub event_id: String,
     pub event_type: String,
@@ -1211,7 +1247,7 @@ impl EventEnvelope {
         producer: impl Into<String>,
     ) -> Self {
         Self {
-            event_id: format!("evt-{:x}", occurred_at),
+            event_id: format!("evt-{}", uuid::Uuid::now_v7()),
             event_type: event_type.into(),
             schema_version: 1,
             occurred_at: unix_millis_to_rfc3339(occurred_at),
@@ -1236,7 +1272,7 @@ pub fn wrap_domain_event<T: serde::Serialize>(
         "correlationId": envelope.correlation_id,
         "causationId": envelope.causation_id,
         "producer": envelope.producer,
-        "data": serde_json::to_value(payload).unwrap_or_default(),
+        "payload": serde_json::to_value(payload).unwrap_or_default(),
     })
 }
 
@@ -1246,7 +1282,13 @@ pub fn unix_millis_to_rfc3339(ms: u64) -> String {
     let naive = time_secs_to_datetime(secs);
     format!(
         "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
-        naive.0, naive.1, naive.2, naive.3, naive.4, naive.5, ms % 1000
+        naive.0,
+        naive.1,
+        naive.2,
+        naive.3,
+        naive.4,
+        naive.5,
+        ms % 1000
     )
 }
 
@@ -1283,7 +1325,6 @@ fn time_secs_to_datetime(secs: u64) -> (u64, u32, u32, u32, u32, u32) {
 fn is_leap(y: u64) -> bool {
     (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -1731,7 +1772,9 @@ mod tests {
         assert_eq!(envelope.event_type, "EntitlementIssued");
         assert_eq!(envelope.schema_version, 1);
         assert_eq!(envelope.producer, "entitlement-ticketing");
-        assert!(envelope.occurred_at.contains("2027-01-") || envelope.occurred_at.contains("2026-"));
+        assert!(
+            envelope.occurred_at.contains("2027-01-") || envelope.occurred_at.contains("2026-")
+        );
         assert!(envelope.occurred_at.ends_with("Z"));
 
         // Wrap a domain event
@@ -1741,8 +1784,605 @@ mod tests {
         });
         let wrapped = wrap_domain_event(envelope, &payload);
         assert_eq!(wrapped["eventType"], "EntitlementIssued");
-        assert_eq!(wrapped["data"]["entitlementId"], "ent-1");
+        assert_eq!(wrapped["payload"]["entitlementId"], "ent-1");
         assert_eq!(wrapped["schemaVersion"], 1);
     }
+}
+// ---------------------------------------------------------------------------
+// HTTP API and in-memory application service
+// ---------------------------------------------------------------------------
 
+pub struct ApiState<S: EntitlementApi + 'static> {
+    service: Arc<S>,
+}
+
+impl<S: EntitlementApi + 'static> Clone for ApiState<S> {
+    fn clone(&self) -> Self {
+        Self {
+            service: Arc::clone(&self.service),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+pub trait EntitlementApi: Send + Sync {
+    async fn issue(
+        &self,
+        command: IssueEntitlementRequest,
+        key: String,
+        correlation_id: String,
+    ) -> ApiResult<IssueEntitlementResponse>;
+    async fn void(
+        &self,
+        entitlement_id: String,
+        command: VoidEntitlementRequest,
+        key: String,
+        correlation_id: String,
+    ) -> ApiResult<VoidEntitlementResponse>;
+    async fn get(&self, entitlement_id: String) -> ApiResult<EntitlementDetails>;
+    async fn list(
+        &self,
+        journey_order_id: String,
+        limit: usize,
+        offset: usize,
+    ) -> ApiResult<PaginatedEntitlements>;
+}
+
+type ApiResult<T> = Result<T, ApiErrorKind>;
+
+#[derive(Debug, Clone)]
+pub enum ApiErrorKind {
+    ValidationFailed(String),
+    NotFound(String),
+    Conflict(String),
+    IdempotencyKeyReused(String),
+    PreconditionFailed(String),
+    DomainRuleViolation(String),
+    Unavailable(String),
+}
+
+impl ApiErrorKind {
+    fn status(&self) -> StatusCode {
+        match self {
+            Self::ValidationFailed(_) => StatusCode::BAD_REQUEST,
+            Self::NotFound(_) => StatusCode::NOT_FOUND,
+            Self::Conflict(_) => StatusCode::CONFLICT,
+            Self::IdempotencyKeyReused(_) => StatusCode::UNPROCESSABLE_ENTITY,
+            Self::PreconditionFailed(_) => StatusCode::PRECONDITION_FAILED,
+            Self::DomainRuleViolation(_) => StatusCode::UNPROCESSABLE_ENTITY,
+            Self::Unavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
+        }
+    }
+
+    fn code(&self) -> &'static str {
+        match self {
+            Self::ValidationFailed(_) => "VALIDATION_FAILED",
+            Self::NotFound(_) => "NOT_FOUND",
+            Self::Conflict(_) => "CONFLICT",
+            Self::IdempotencyKeyReused(_) => "IDEMPOTENCY_KEY_REUSED",
+            Self::PreconditionFailed(_) => "PRECONDITION_FAILED",
+            Self::DomainRuleViolation(_) => "DOMAIN_RULE_VIOLATION",
+            Self::Unavailable(_) => "UNAVAILABLE",
+        }
+    }
+
+    fn message(&self) -> &str {
+        match self {
+            Self::ValidationFailed(message)
+            | Self::NotFound(message)
+            | Self::Conflict(message)
+            | Self::IdempotencyKeyReused(message)
+            | Self::PreconditionFailed(message)
+            | Self::DomainRuleViolation(message)
+            | Self::Unavailable(message) => message,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ErrorBody {
+    code: &'static str,
+    message: String,
+    correlation_id: String,
+    details: Value,
+}
+
+fn api_error_response(error: ApiErrorKind, correlation_id: String) -> Response {
+    let status = error.status();
+    let body = ErrorBody {
+        code: error.code(),
+        message: error.message().to_string(),
+        correlation_id,
+        details: json!({}),
+    };
+    (status, Json(body)).into_response()
+}
+
+fn validation_error(correlation_id: String, message: impl Into<String>) -> Response {
+    api_error_response(
+        ApiErrorKind::ValidationFailed(message.into()),
+        correlation_id,
+    )
+}
+
+fn idempotency_key(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get("idempotency-key")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueEntitlementRequest {
+    pub segment_booking_id: String,
+    pub journey_order_id: String,
+    pub traveler_ref: String,
+    pub segment_ref: String,
+    pub issue_purpose: IssuePurposeDto,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum IssuePurposeDto {
+    Initial,
+    Replacement,
+    ManualRecovery,
+    ProviderRebuild,
+    DisruptionReplacement,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VoidEntitlementRequest {
+    pub reason: VoidReasonDto,
+    pub policy: VoidPolicyDto,
+    pub business_case_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum VoidReasonDto {
+    Refund,
+    Change,
+    Disruption,
+    Risk,
+    ManualCorrection,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum VoidPolicyDto {
+    Normal,
+    ExceptionalRule,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IssueEntitlementResponse {
+    pub entitlement_id: String,
+    pub segment_booking_id: String,
+    pub journey_order_id: String,
+    pub credential_no: String,
+    pub credential_type: CredentialTypeDto,
+    pub status: EntitlementStatusDto,
+    pub issued_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VoidEntitlementResponse {
+    pub entitlement_id: String,
+    pub status: EntitlementStatusDto,
+    pub voided_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct EntitlementDetails {
+    pub entitlement_id: String,
+    pub segment_booking_id: String,
+    pub journey_order_id: String,
+    pub traveler_ref: String,
+    pub segment_ref: String,
+    pub credential_no: String,
+    pub credential_type: CredentialTypeDto,
+    pub status: EntitlementStatusDto,
+    pub issued_at: String,
+    pub voided_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PaginatedEntitlements {
+    pub items: Vec<EntitlementDetails>,
+    pub total: usize,
+    pub limit: usize,
+    pub offset: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum CredentialTypeDto {
+    ETicket,
+    PaperTicket,
+    PickupCode,
+    BoardingPass,
+    FerryTicket,
+    CoachETicket,
+    RideCode,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum EntitlementStatusDto {
+    Issued,
+    Voided,
+    Boarded,
+    NoShow,
+    Suspended,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListEntitlementsQuery {
+    journey_order_id: String,
+    limit: Option<usize>,
+    offset: Option<usize>,
+}
+
+async fn issue_entitlement<S>(
+    State(state): State<ApiState<S>>,
+    Extension(context): Extension<RequestContext>,
+    headers: HeaderMap,
+    body: Result<Json<IssueEntitlementRequest>, JsonRejection>,
+) -> Response
+where
+    S: EntitlementApi + 'static,
+{
+    let correlation_id = context.correlation_id().to_string();
+    let Some(key) = idempotency_key(&headers) else {
+        return validation_error(correlation_id, "Idempotency-Key header is required");
+    };
+    let Json(request) = match body {
+        Ok(body) => body,
+        Err(rejection) => return validation_error(correlation_id, rejection.body_text()),
+    };
+    match state
+        .service
+        .issue(request, key, correlation_id.clone())
+        .await
+    {
+        Ok(response) => (StatusCode::CREATED, Json(response)).into_response(),
+        Err(error) => api_error_response(error, correlation_id),
+    }
+}
+
+async fn void_entitlement<S>(
+    State(state): State<ApiState<S>>,
+    Extension(context): Extension<RequestContext>,
+    headers: HeaderMap,
+    Path(entitlement_id): Path<String>,
+    body: Result<Json<VoidEntitlementRequest>, JsonRejection>,
+) -> Response
+where
+    S: EntitlementApi + 'static,
+{
+    let correlation_id = context.correlation_id().to_string();
+    let Some(key) = idempotency_key(&headers) else {
+        return validation_error(correlation_id, "Idempotency-Key header is required");
+    };
+    let Json(request) = match body {
+        Ok(body) => body,
+        Err(rejection) => return validation_error(correlation_id, rejection.body_text()),
+    };
+    match state
+        .service
+        .void(entitlement_id, request, key, correlation_id.clone())
+        .await
+    {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(error) => api_error_response(error, correlation_id),
+    }
+}
+
+async fn get_entitlement<S>(
+    State(state): State<ApiState<S>>,
+    Extension(context): Extension<RequestContext>,
+    Path(entitlement_id): Path<String>,
+) -> Response
+where
+    S: EntitlementApi + 'static,
+{
+    let correlation_id = context.correlation_id().to_string();
+    match state.service.get(entitlement_id).await {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(error) => api_error_response(error, correlation_id),
+    }
+}
+
+async fn list_entitlements<S>(
+    State(state): State<ApiState<S>>,
+    Extension(context): Extension<RequestContext>,
+    Query(query): Query<ListEntitlementsQuery>,
+) -> Response
+where
+    S: EntitlementApi + 'static,
+{
+    let correlation_id = context.correlation_id().to_string();
+    let limit = query.limit.unwrap_or(20).min(100);
+    let offset = query.offset.unwrap_or(0);
+    match state
+        .service
+        .list(query.journey_order_id, limit, offset)
+        .await
+    {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(error) => api_error_response(error, correlation_id),
+    }
+}
+
+pub struct InMemoryEntitlementService {
+    state: Mutex<InMemoryState>,
+    publisher: Arc<dyn application::EventPublisher>,
+}
+
+impl Default for InMemoryEntitlementService {
+    fn default() -> Self {
+        Self::new(Arc::new(
+            adapters::messaging::InMemoryEventPublisher::default(),
+        ))
+    }
+}
+
+impl InMemoryEntitlementService {
+    pub fn new(publisher: Arc<dyn application::EventPublisher>) -> Self {
+        Self {
+            state: Mutex::new(InMemoryState::default()),
+            publisher,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct InMemoryState {
+    entitlements: HashMap<String, EntitlementDetails>,
+    idempotency: HashMap<String, IdempotentRecord>,
+    sequence: u64,
+}
+
+#[derive(Debug, Clone)]
+struct IdempotentRecord {
+    fingerprint: String,
+    response: IdempotentResponse,
+}
+
+#[derive(Debug, Clone)]
+enum IdempotentResponse {
+    Issue(IssueEntitlementResponse),
+    Void(VoidEntitlementResponse),
+}
+
+#[async_trait::async_trait]
+impl EntitlementApi for InMemoryEntitlementService {
+    async fn issue(
+        &self,
+        command: IssueEntitlementRequest,
+        key: String,
+        correlation_id: String,
+    ) -> ApiResult<IssueEntitlementResponse> {
+        validate_non_empty(&command.segment_booking_id, "segmentBookingId")?;
+        validate_non_empty(&command.journey_order_id, "journeyOrderId")?;
+        validate_non_empty(&command.traveler_ref, "travelerRef")?;
+        validate_non_empty(&command.segment_ref, "segmentRef")?;
+        let fingerprint = serde_json::to_string(&command).unwrap_or_default();
+        let response = {
+            let mut state = self
+                .state
+                .lock()
+                .expect("entitlement service lock poisoned");
+            if let Some(record) = state.idempotency.get(&key) {
+                if record.fingerprint != fingerprint {
+                    return Err(ApiErrorKind::IdempotencyKeyReused(
+                        "Idempotency-Key was reused with a different request body".to_string(),
+                    ));
+                }
+                if let IdempotentResponse::Issue(response) = &record.response {
+                    return Ok(response.clone());
+                }
+                return Err(ApiErrorKind::IdempotencyKeyReused(
+                    "Idempotency-Key was reused for a different operation".to_string(),
+                ));
+            }
+            state.sequence += 1;
+            let entitlement_id = format!("ent-{}", uuid::Uuid::now_v7());
+            let issued_at = current_rfc3339();
+            let response = IssueEntitlementResponse {
+                entitlement_id: entitlement_id.clone(),
+                segment_booking_id: command.segment_booking_id.clone(),
+                journey_order_id: command.journey_order_id.clone(),
+                credential_no: format!("ETK-{:012}", state.sequence),
+                credential_type: CredentialTypeDto::ETicket,
+                status: EntitlementStatusDto::Issued,
+                issued_at: issued_at.clone(),
+            };
+            let details = EntitlementDetails {
+                entitlement_id: entitlement_id.clone(),
+                segment_booking_id: command.segment_booking_id,
+                journey_order_id: command.journey_order_id,
+                traveler_ref: command.traveler_ref,
+                segment_ref: command.segment_ref,
+                credential_no: response.credential_no.clone(),
+                credential_type: response.credential_type.clone(),
+                status: response.status.clone(),
+                issued_at,
+                voided_at: None,
+            };
+            state.entitlements.insert(entitlement_id, details);
+            state.idempotency.insert(
+                key,
+                IdempotentRecord {
+                    fingerprint,
+                    response: IdempotentResponse::Issue(response.clone()),
+                },
+            );
+            response
+        };
+        publish_api_event(
+            self.publisher.as_ref(),
+            "EntitlementIssued",
+            &response,
+            correlation_id,
+        )
+        .await?;
+        Ok(response)
+    }
+
+    async fn void(
+        &self,
+        entitlement_id: String,
+        command: VoidEntitlementRequest,
+        key: String,
+        correlation_id: String,
+    ) -> ApiResult<VoidEntitlementResponse> {
+        if command
+            .business_case_ref
+            .as_deref()
+            .is_some_and(|value| value.trim().is_empty())
+        {
+            return Err(ApiErrorKind::ValidationFailed(
+                "businessCaseRef must not be blank when provided".to_string(),
+            ));
+        }
+        let fingerprint = format!(
+            "{}:{}",
+            entitlement_id,
+            serde_json::to_string(&command).unwrap_or_default()
+        );
+        let response = {
+            let mut state = self
+                .state
+                .lock()
+                .expect("entitlement service lock poisoned");
+            if let Some(record) = state.idempotency.get(&key) {
+                if record.fingerprint != fingerprint {
+                    return Err(ApiErrorKind::IdempotencyKeyReused(
+                        "Idempotency-Key was reused with a different request body".to_string(),
+                    ));
+                }
+                if let IdempotentResponse::Void(response) = &record.response {
+                    return Ok(response.clone());
+                }
+                return Err(ApiErrorKind::IdempotencyKeyReused(
+                    "Idempotency-Key was reused for a different operation".to_string(),
+                ));
+            }
+            let entitlement = state
+                .entitlements
+                .get_mut(&entitlement_id)
+                .ok_or_else(|| ApiErrorKind::NotFound("entitlement not found".to_string()))?;
+            if entitlement.status == EntitlementStatusDto::Voided {
+                return Err(ApiErrorKind::PreconditionFailed(
+                    "entitlement is already voided".to_string(),
+                ));
+            }
+            let voided_at = current_rfc3339();
+            entitlement.status = EntitlementStatusDto::Voided;
+            entitlement.voided_at = Some(voided_at.clone());
+            let response = VoidEntitlementResponse {
+                entitlement_id,
+                status: EntitlementStatusDto::Voided,
+                voided_at,
+            };
+            state.idempotency.insert(
+                key,
+                IdempotentRecord {
+                    fingerprint,
+                    response: IdempotentResponse::Void(response.clone()),
+                },
+            );
+            response
+        };
+        publish_api_event(
+            self.publisher.as_ref(),
+            "EntitlementVoided",
+            &response,
+            correlation_id,
+        )
+        .await?;
+        Ok(response)
+    }
+
+    async fn get(&self, entitlement_id: String) -> ApiResult<EntitlementDetails> {
+        self.state
+            .lock()
+            .expect("entitlement service lock poisoned")
+            .entitlements
+            .get(&entitlement_id)
+            .cloned()
+            .ok_or_else(|| ApiErrorKind::NotFound("entitlement not found".to_string()))
+    }
+
+    async fn list(
+        &self,
+        journey_order_id: String,
+        limit: usize,
+        offset: usize,
+    ) -> ApiResult<PaginatedEntitlements> {
+        validate_non_empty(&journey_order_id, "journeyOrderId")?;
+        let mut items: Vec<_> = self
+            .state
+            .lock()
+            .expect("entitlement service lock poisoned")
+            .entitlements
+            .values()
+            .filter(|entitlement| entitlement.journey_order_id == journey_order_id)
+            .cloned()
+            .collect();
+        items.sort_by(|left, right| left.entitlement_id.cmp(&right.entitlement_id));
+        let total = items.len();
+        Ok(PaginatedEntitlements {
+            items: items.into_iter().skip(offset).take(limit).collect(),
+            total,
+            limit,
+            offset,
+        })
+    }
+}
+
+fn validate_non_empty(value: &str, field: &'static str) -> ApiResult<()> {
+    if value.trim().is_empty() {
+        Err(ApiErrorKind::ValidationFailed(format!(
+            "{field} must not be blank"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+fn current_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+async fn publish_api_event<T: Serialize>(
+    publisher: &dyn application::EventPublisher,
+    event_type: &str,
+    payload: &T,
+    correlation_id: String,
+) -> ApiResult<()> {
+    let envelope = application::EventEnvelope::new(
+        event_type,
+        current_rfc3339(),
+        correlation_id,
+        None::<String>,
+        profile().service_id,
+        serde_json::to_value(payload).unwrap_or_else(|_| json!({})),
+    );
+    publisher
+        .publish(envelope)
+        .await
+        .map_err(|error| ApiErrorKind::Unavailable(error.to_string()))
 }

--- a/services/entitlement-ticketing/src/lib.rs
+++ b/services/entitlement-ticketing/src/lib.rs
@@ -1255,112 +1255,6 @@ impl fmt::Display for EntitlementError {
 
 impl std::error::Error for EntitlementError {}
 
-// ---------------------------------------------------------------------------
-// EventEnvelope -- contract-conformant event wrapper
-// ---------------------------------------------------------------------------
-
-/// Contract-conformant event envelope per docs/08-contracts/shared-primitives.md
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct EventEnvelope {
-    pub event_id: String,
-    pub event_type: String,
-    pub schema_version: u32,
-    pub occurred_at: String, // RFC3339 UTC
-    pub correlation_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub causation_id: Option<String>,
-    pub producer: String,
-}
-
-impl EventEnvelope {
-    pub fn new(
-        event_type: impl Into<String>,
-        occurred_at: u64,
-        correlation_id: impl Into<String>,
-        causation_id: Option<impl Into<String>>,
-        producer: impl Into<String>,
-    ) -> Self {
-        Self {
-            event_id: format!("evt-{}", uuid::Uuid::now_v7()),
-            event_type: event_type.into(),
-            schema_version: 1,
-            occurred_at: unix_millis_to_rfc3339(occurred_at),
-            correlation_id: correlation_id.into(),
-            causation_id: causation_id.map(|v| v.into()),
-            producer: producer.into(),
-        }
-    }
-}
-
-/// Helper to wrap a serializable domain payload into a serde_json Value envelope
-pub fn wrap_domain_event<T: serde::Serialize>(
-    envelope: EventEnvelope,
-    payload: &T,
-) -> serde_json::Value {
-    use serde_json::json;
-    json!({
-        "eventId": envelope.event_id,
-        "eventType": envelope.event_type,
-        "schemaVersion": envelope.schema_version,
-        "occurredAt": envelope.occurred_at,
-        "correlationId": envelope.correlation_id,
-        "causationId": envelope.causation_id,
-        "producer": envelope.producer,
-        "payload": serde_json::to_value(payload).unwrap_or_default(),
-    })
-}
-
-/// Convert UnixMillis to RFC3339 UTC string
-pub fn unix_millis_to_rfc3339(ms: u64) -> String {
-    let secs = ms / 1000;
-    let naive = time_secs_to_datetime(secs);
-    format!(
-        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
-        naive.0,
-        naive.1,
-        naive.2,
-        naive.3,
-        naive.4,
-        naive.5,
-        ms % 1000
-    )
-}
-
-fn time_secs_to_datetime(secs: u64) -> (u64, u32, u32, u32, u32, u32) {
-    let days = secs / 86400;
-    let time_secs = secs % 86400;
-    let h = (time_secs / 3600) as u32;
-    let m = ((time_secs % 3600) / 60) as u32;
-    let s = (time_secs % 60) as u32;
-    let mut y = 1970i64;
-    let mut d = days as i64;
-    loop {
-        let days_in_year = if is_leap(y as u64) { 366 } else { 365 };
-        if d < days_in_year {
-            break;
-        }
-        d -= days_in_year;
-        y += 1;
-    }
-    let leap = is_leap(y as u64);
-    const MONTH_DAYS: [i64; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-    let mut mo = 1u32;
-    for &md in MONTH_DAYS.iter() {
-        let md_adj = if mo == 2 && leap { md + 1 } else { md };
-        if d < md_adj {
-            break;
-        }
-        d -= md_adj;
-        mo += 1;
-    }
-    (y as u64, mo, (d + 1) as u32, h, m, s)
-}
-
-fn is_leap(y: u64) -> bool {
-    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1793,34 +1687,6 @@ mod tests {
                 .unwrap_err(),
             EntitlementError::VoidRequiresCompensation
         ));
-    }
-
-    #[test]
-    fn event_envelope_round_trip() {
-        let envelope = EventEnvelope::new(
-            "EntitlementIssued",
-            1800000000000,
-            "corr-1",
-            None::<String>,
-            "entitlement-ticketing",
-        );
-        assert_eq!(envelope.event_type, "EntitlementIssued");
-        assert_eq!(envelope.schema_version, 1);
-        assert_eq!(envelope.producer, "entitlement-ticketing");
-        assert!(
-            envelope.occurred_at.contains("2027-01-") || envelope.occurred_at.contains("2026-")
-        );
-        assert!(envelope.occurred_at.ends_with("Z"));
-
-        // Wrap a domain event
-        let payload = serde_json::json!({
-            "entitlementId": "ent-1",
-            "segmentBookingRef": "sb-1",
-        });
-        let wrapped = wrap_domain_event(envelope, &payload);
-        assert_eq!(wrapped["eventType"], "EntitlementIssued");
-        assert_eq!(wrapped["payload"]["entitlementId"], "ent-1");
-        assert_eq!(wrapped["schemaVersion"], 1);
     }
 }
 // ---------------------------------------------------------------------------
@@ -2424,13 +2290,18 @@ impl InMemoryEntitlementService {
         envelope: application::EventEnvelope,
     ) -> Result<(), application::HandlerError> {
         self.apply_subscribed_event(envelope)
-            .map_err(|error| application::HandlerError::Fatal(error.message().to_string()))
+            .map_err(|error| match error {
+                ApiErrorKind::Unavailable(message) => application::HandlerError::Transient(message),
+                other => application::HandlerError::Fatal(other.message().to_string()),
+            })
     }
 
     fn apply_subscribed_event(&self, envelope: application::EventEnvelope) -> ApiResult<()> {
         match envelope.event_type.as_str() {
             "BoardingVerified" => self.apply_boarding_verified(envelope.payload),
-            "PostSalesApproved" => self.apply_post_sales_approved(envelope.payload),
+            "PostSalesApproved" => {
+                self.apply_post_sales_approved(envelope.payload, envelope.correlation_id)
+            }
             "SegmentTicketed" => Ok(()),
             _ => Ok(()),
         }
@@ -2471,49 +2342,112 @@ impl InMemoryEntitlementService {
         Ok(())
     }
 
-    fn apply_post_sales_approved(&self, payload: Value) -> ApiResult<()> {
-        let Some(entitlement_id) = payload.get("entitlementId").and_then(Value::as_str) else {
-            return Ok(());
-        };
-        validate_prefixed_uuid(entitlement_id, "entitlementId", "ent-")?;
-        let reason = payload
-            .get("reason")
-            .and_then(Value::as_str)
-            .unwrap_or("REFUND");
-        let policy = payload
-            .get("policy")
-            .and_then(Value::as_str)
-            .unwrap_or("NORMAL");
-        let business_case_ref = payload
+    fn apply_post_sales_approved(&self, payload: Value, correlation_id: String) -> ApiResult<()> {
+        let case_id = payload
             .get("caseId")
             .and_then(Value::as_str)
-            .unwrap_or("post-sales-case")
+            .ok_or_else(|| ApiErrorKind::ValidationFailed("caseId is required".to_string()))?
             .to_string();
+        let order_id = payload
+            .get("orderId")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ApiErrorKind::ValidationFailed("orderId is required".to_string()))?
+            .to_string();
+        validate_prefixed_uuid(&order_id, "orderId", "ord-")?;
+
+        let actions = approved_void_actions(payload.get("approvedActions"));
+        if actions.is_empty() {
+            return Ok(());
+        }
+
+        let payloads = self.void_entitlements_for_post_sales(&order_id, &case_id, &actions)?;
+        for payload in payloads {
+            publish_api_event_blocking(
+                Arc::clone(&self.publisher),
+                "EntitlementVoided",
+                serde_json::to_value(&payload).unwrap_or_else(|_| json!({})),
+                correlation_id.clone(),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn void_entitlements_for_post_sales(
+        &self,
+        order_id: &str,
+        case_id: &str,
+        actions: &[ApprovedVoidAction],
+    ) -> ApiResult<Vec<EntitlementVoidedPayload>> {
         let mut state = self
             .state
             .lock()
             .expect("entitlement service lock poisoned");
-        let aggregate = state
-            .aggregates
-            .get_mut(entitlement_id)
-            .ok_or_else(|| ApiErrorKind::NotFound("entitlement aggregate not found".to_string()))?;
-        aggregate
-            .void(VoidEntitlement {
-                command_id: CommandId::new(format!("cmd-{}", uuid::Uuid::now_v7()))
-                    .map_err(ApiErrorKind::from)?,
-                reason: parse_void_reason(reason),
-                policy: parse_void_policy(policy),
-                business_case_ref: BusinessCaseRef::new(business_case_ref)
-                    .map_err(ApiErrorKind::from)?,
-                audit: audit_builder("corr-subscriber", "event bus post-sales approved")
-                    .map_err(ApiErrorKind::from)?,
-            })
-            .map_err(ApiErrorKind::from)?;
-        if let Some(entitlement) = state.entitlements.get_mut(entitlement_id) {
-            entitlement.status = EntitlementStatusDto::Voided;
-            entitlement.voided_at = Some(current_rfc3339());
+        let entitlement_ids: Vec<String> = state
+            .entitlements
+            .values()
+            .filter(|entitlement| entitlement.journey_order_id == order_id)
+            .map(|entitlement| entitlement.entitlement_id.clone())
+            .collect();
+        if entitlement_ids.is_empty() {
+            return Ok(Vec::new());
         }
-        Ok(())
+
+        let mut payloads = Vec::new();
+        for entitlement_id in entitlement_ids {
+            if !actions
+                .iter()
+                .any(|action| action.matches_entitlement(&entitlement_id))
+            {
+                continue;
+            }
+            let reason = actions
+                .iter()
+                .find(|action| action.matches_entitlement(&entitlement_id))
+                .map(|action| action.reason.clone())
+                .unwrap_or(VoidReason::Refund);
+            let policy = actions
+                .iter()
+                .find(|action| action.matches_entitlement(&entitlement_id))
+                .map(|action| action.policy.clone())
+                .unwrap_or(VoidPolicy::Normal);
+            let segment_booking_id = state
+                .entitlements
+                .get(&entitlement_id)
+                .map(|entitlement| entitlement.segment_booking_id.clone())
+                .ok_or_else(|| ApiErrorKind::NotFound("entitlement not found".to_string()))?;
+            let aggregate = state.aggregates.get_mut(&entitlement_id).ok_or_else(|| {
+                ApiErrorKind::NotFound("entitlement aggregate not found".to_string())
+            })?;
+            let events = aggregate
+                .void(VoidEntitlement {
+                    command_id: CommandId::new(format!("cmd-{}", uuid::Uuid::now_v7()))
+                        .map_err(ApiErrorKind::from)?,
+                    reason: reason.clone(),
+                    policy: policy.clone(),
+                    business_case_ref: BusinessCaseRef::new(case_id.to_string())
+                        .map_err(ApiErrorKind::from)?,
+                    audit: audit_builder("corr-subscriber", "event bus post-sales approved")
+                        .map_err(ApiErrorKind::from)?,
+                })
+                .map_err(ApiErrorKind::from)?;
+            if events.is_empty() {
+                continue;
+            }
+            let voided_at = current_rfc3339();
+            if let Some(entitlement) = state.entitlements.get_mut(&entitlement_id) {
+                entitlement.status = EntitlementStatusDto::Voided;
+                entitlement.voided_at = Some(voided_at.clone());
+            }
+            payloads.push(EntitlementVoidedPayload {
+                entitlement_id,
+                segment_booking_id,
+                voided_at,
+                reason: reason_to_contract(&reason),
+                policy: policy_to_contract(&policy),
+                business_case_ref: Some(case_id.to_string()),
+            });
+        }
+        Ok(payloads)
     }
 }
 
@@ -2859,6 +2793,82 @@ impl EntitlementApi for InMemoryEntitlementService {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ApprovedVoidAction {
+    entitlement_ref: Option<String>,
+    reason: VoidReason,
+    policy: VoidPolicy,
+}
+
+impl ApprovedVoidAction {
+    fn matches_entitlement(&self, entitlement_id: &str) -> bool {
+        self.entitlement_ref
+            .as_deref()
+            .is_none_or(|reference| reference == entitlement_id)
+    }
+}
+
+fn approved_void_actions(value: Option<&Value>) -> Vec<ApprovedVoidAction> {
+    let Some(value) = value else {
+        return Vec::new();
+    };
+    let mut actions = Vec::new();
+    collect_void_actions(value, &mut actions);
+    actions
+}
+
+fn collect_void_actions(value: &Value, actions: &mut Vec<ApprovedVoidAction>) {
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                collect_void_actions(item, actions);
+            }
+        }
+        Value::Object(map) => {
+            if action_type(map.get("type")).is_some_and(is_void_action_type)
+                || action_type(map.get("actionType")).is_some_and(is_void_action_type)
+                || action_type(map.get("stepType")).is_some_and(is_void_action_type)
+            {
+                actions.push(ApprovedVoidAction {
+                    entitlement_ref: map
+                        .get("entitlementId")
+                        .and_then(Value::as_str)
+                        .or_else(|| map.get("entitlementRef").and_then(Value::as_str))
+                        .or_else(|| map.get("targetRef").and_then(Value::as_str))
+                        .map(ToString::to_string),
+                    reason: map
+                        .get("reason")
+                        .and_then(Value::as_str)
+                        .map(parse_void_reason)
+                        .unwrap_or(VoidReason::Refund),
+                    policy: map
+                        .get("policy")
+                        .and_then(Value::as_str)
+                        .map(parse_void_policy)
+                        .unwrap_or(VoidPolicy::Normal),
+                });
+            }
+            for nested in map.values() {
+                if nested.is_array() || nested.is_object() {
+                    collect_void_actions(nested, actions);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn action_type(value: Option<&Value>) -> Option<&str> {
+    value.and_then(Value::as_str)
+}
+
+fn is_void_action_type(value: &str) -> bool {
+    matches!(
+        value,
+        "VOID" | "VOID_ENTITLEMENT" | "VOID_OLD_ENTITLEMENT" | "VOID_TICKET"
+    )
+}
+
 fn parse_void_reason(value: &str) -> VoidReason {
     match value {
         "CHANGE" => VoidReason::Change,
@@ -2869,10 +2879,27 @@ fn parse_void_reason(value: &str) -> VoidReason {
     }
 }
 
+fn reason_to_contract(value: &VoidReason) -> &'static str {
+    match value {
+        VoidReason::Refund => "REFUND",
+        VoidReason::Change => "CHANGE",
+        VoidReason::Disruption => "DISRUPTION",
+        VoidReason::Risk => "RISK",
+        VoidReason::ManualCorrection => "MANUAL_CORRECTION",
+    }
+}
+
 fn parse_void_policy(value: &str) -> VoidPolicy {
     match value {
         "EXCEPTIONAL_RULE" => VoidPolicy::ExceptionalRule,
         _ => VoidPolicy::Normal,
+    }
+}
+
+fn policy_to_contract(value: &VoidPolicy) -> &'static str {
+    match value {
+        VoidPolicy::Normal => "NORMAL",
+        VoidPolicy::ExceptionalRule => "EXCEPTIONAL_RULE",
     }
 }
 
@@ -2964,6 +2991,27 @@ fn credential_ref(credential_no: &str) -> Result<CredentialRef, EntitlementError
             Some("QR".to_string()),
         )?,
     )
+}
+
+fn publish_api_event_blocking(
+    publisher: Arc<dyn application::EventPublisher>,
+    event_type: &str,
+    payload: Value,
+    correlation_id: String,
+) -> ApiResult<()> {
+    let event_type = event_type.to_string();
+    std::thread::spawn(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| ApiErrorKind::Unavailable(error.to_string()))?
+            .block_on(async move {
+                publish_api_event_value(publisher.as_ref(), &event_type, payload, correlation_id)
+                    .await
+            })
+    })
+    .join()
+    .map_err(|_| ApiErrorKind::Unavailable("publisher worker panicked".to_string()))?
 }
 
 async fn publish_api_event<T: Serialize>(
@@ -3075,5 +3123,87 @@ mod api_domain_wiring_tests {
             .await
             .unwrap_err();
         assert!(matches!(error, ApiErrorKind::DomainRuleViolation(_)));
+    }
+
+    #[tokio::test]
+    async fn post_sales_approved_contract_payload_voids_order_entitlement_and_publishes_event() {
+        let publisher = Arc::new(adapters::messaging::InMemoryEventPublisher::default());
+        let service = InMemoryEntitlementService::new(publisher.clone());
+        let issue_response = service
+            .issue(
+                IssueEntitlementRequest {
+                    segment_booking_id: "sb-0194f2e0-7b3e-7610-0284-5c26e8b0f111".to_string(),
+                    journey_order_id: "ord-0194f2e0-7b3e-7610-0284-5c26e8b0f222".to_string(),
+                    traveler_ref: "tvl-0194f2e0-7b3e-7610-0284-5c26e8b0f333".to_string(),
+                    segment_ref: "seg-0194f2e0-7b3e-7610-0284-5c26e8b0f444".to_string(),
+                    issue_purpose: IssuePurposeDto::Initial,
+                },
+                "018f2e07-b3e7-7100-8284-5c26e8b0f001".to_string(),
+                "corr-post-sales".to_string(),
+            )
+            .await
+            .unwrap();
+
+        service
+            .apply_subscribed_event(application::EventEnvelope::new(
+                "PostSalesApproved",
+                current_rfc3339(),
+                "corr-0194f2e0-7b3e-7610-0284-5c26e8b0f555",
+                Some("evt-0194f2e0-7b3e-7610-0284-5c26e8b0f666"),
+                "post-sales",
+                json!({
+                    "caseId": "psc-0194f2e0-7b3e-7610-0284-5c26e8b0f777",
+                    "orderId": "ord-0194f2e0-7b3e-7610-0284-5c26e8b0f222",
+                    "approvedActions": [
+                        {"type": "VOID_ENTITLEMENT", "reason": "REFUND", "policy": "NORMAL"}
+                    ]
+                }),
+            ))
+            .unwrap();
+
+        let details = service
+            .get(issue_response.entitlement_id.clone())
+            .await
+            .unwrap();
+        assert_eq!(details.status, EntitlementStatusDto::Voided);
+        let published = publisher.published();
+        let voided = published
+            .iter()
+            .find(|envelope| envelope.event_type == "EntitlementVoided")
+            .expect("bus-triggered void publishes EntitlementVoided");
+        assert_eq!(
+            voided.payload["entitlementId"],
+            issue_response.entitlement_id
+        );
+        assert_eq!(
+            voided.payload["segmentBookingId"],
+            "sb-0194f2e0-7b3e-7610-0284-5c26e8b0f111"
+        );
+        assert_eq!(voided.payload["reason"], "REFUND");
+        assert_eq!(voided.payload["policy"], "NORMAL");
+        assert_eq!(
+            voided.payload["businessCaseRef"],
+            "psc-0194f2e0-7b3e-7610-0284-5c26e8b0f777"
+        );
+        assert!(voided.payload.get("status").is_none());
+    }
+
+    #[test]
+    fn post_sales_approved_without_void_actions_is_ackable_noop() {
+        let service = InMemoryEntitlementService::default();
+        service
+            .apply_subscribed_event(application::EventEnvelope::new(
+                "PostSalesApproved",
+                current_rfc3339(),
+                "corr-0194f2e0-7b3e-7610-0284-5c26e8b0f888",
+                Some("evt-0194f2e0-7b3e-7610-0284-5c26e8b0f999"),
+                "post-sales",
+                json!({
+                    "caseId": "psc-0194f2e0-7b3e-7610-0284-5c26e8b0faaa",
+                    "orderId": "ord-0194f2e0-7b3e-7610-0284-5c26e8b0fbbb",
+                    "approvedActions": []
+                }),
+            ))
+            .unwrap();
     }
 }

--- a/services/entitlement-ticketing/src/lib.rs
+++ b/services/entitlement-ticketing/src/lib.rs
@@ -89,7 +89,10 @@ pub fn build_runtime() -> Result<(Router, JoinHandle<()>), application::Subscrib
                 streams,
                 group,
                 consumer_name,
-                Box::new(move |envelope| handler_service.handle_subscribed_event(envelope)),
+                Box::new(move |envelope| {
+                    let service = Arc::clone(&handler_service);
+                    Box::pin(async move { service.handle_subscribed_event(envelope).await })
+                }),
             )
             .await
             .expect("entitlement-ticketing Redis subscriber stopped");
@@ -2285,22 +2288,43 @@ impl InMemoryEntitlementService {
         );
     }
 
-    fn handle_subscribed_event(
+    fn pending_bus_publication(
+        &self,
+        key: &PendingEventKey,
+    ) -> ApiResult<Option<PendingBusPublication>> {
+        let state = self
+            .state
+            .lock()
+            .expect("entitlement service lock poisoned");
+        Ok(state.pending_events.get(key).cloned())
+    }
+
+    fn clear_pending_bus_publication(&self, key: &PendingEventKey) {
+        self.state
+            .lock()
+            .expect("entitlement service lock poisoned")
+            .pending_events
+            .remove(key);
+    }
+
+    async fn handle_subscribed_event(
         &self,
         envelope: application::EventEnvelope,
     ) -> Result<(), application::HandlerError> {
         self.apply_subscribed_event(envelope)
+            .await
             .map_err(|error| match error {
                 ApiErrorKind::Unavailable(message) => application::HandlerError::Transient(message),
                 other => application::HandlerError::Fatal(other.message().to_string()),
             })
     }
 
-    fn apply_subscribed_event(&self, envelope: application::EventEnvelope) -> ApiResult<()> {
+    async fn apply_subscribed_event(&self, envelope: application::EventEnvelope) -> ApiResult<()> {
         match envelope.event_type.as_str() {
             "BoardingVerified" => self.apply_boarding_verified(envelope.payload),
             "PostSalesApproved" => {
                 self.apply_post_sales_approved(envelope.payload, envelope.correlation_id)
+                    .await
             }
             "SegmentTicketed" => Ok(()),
             _ => Ok(()),
@@ -2342,7 +2366,11 @@ impl InMemoryEntitlementService {
         Ok(())
     }
 
-    fn apply_post_sales_approved(&self, payload: Value, correlation_id: String) -> ApiResult<()> {
+    async fn apply_post_sales_approved(
+        &self,
+        payload: Value,
+        correlation_id: String,
+    ) -> ApiResult<()> {
         let case_id = payload
             .get("caseId")
             .and_then(Value::as_str)
@@ -2360,24 +2388,30 @@ impl InMemoryEntitlementService {
             return Ok(());
         }
 
-        let payloads = self.void_entitlements_for_post_sales(&order_id, &case_id, &actions)?;
-        for payload in payloads {
-            publish_api_event_blocking(
-                Arc::clone(&self.publisher),
-                "EntitlementVoided",
-                serde_json::to_value(&payload).unwrap_or_else(|_| json!({})),
+        let pending_keys =
+            self.ensure_void_entitlements_for_post_sales(&order_id, &case_id, &actions)?;
+        for key in pending_keys {
+            let Some(pending) = self.pending_bus_publication(&key)? else {
+                continue;
+            };
+            publish_api_event_value(
+                self.publisher.as_ref(),
+                pending.event_type,
+                pending.payload.clone(),
                 correlation_id.clone(),
-            )?;
+            )
+            .await?;
+            self.clear_pending_bus_publication(&key);
         }
         Ok(())
     }
 
-    fn void_entitlements_for_post_sales(
+    fn ensure_void_entitlements_for_post_sales(
         &self,
         order_id: &str,
         case_id: &str,
         actions: &[ApprovedVoidAction],
-    ) -> ApiResult<Vec<EntitlementVoidedPayload>> {
+    ) -> ApiResult<Vec<PendingEventKey>> {
         let mut state = self
             .state
             .lock()
@@ -2392,7 +2426,7 @@ impl InMemoryEntitlementService {
             return Ok(Vec::new());
         }
 
-        let mut payloads = Vec::new();
+        let mut pending_keys = Vec::new();
         for entitlement_id in entitlement_ids {
             if !actions
                 .iter()
@@ -2400,14 +2434,13 @@ impl InMemoryEntitlementService {
             {
                 continue;
             }
-            let reason = actions
+            let action = actions
                 .iter()
-                .find(|action| action.matches_entitlement(&entitlement_id))
+                .find(|action| action.matches_entitlement(&entitlement_id));
+            let reason = action
                 .map(|action| action.reason.clone())
                 .unwrap_or(VoidReason::Refund);
-            let policy = actions
-                .iter()
-                .find(|action| action.matches_entitlement(&entitlement_id))
+            let policy = action
                 .map(|action| action.policy.clone())
                 .unwrap_or(VoidPolicy::Normal);
             let segment_booking_id = state
@@ -2415,6 +2448,12 @@ impl InMemoryEntitlementService {
                 .get(&entitlement_id)
                 .map(|entitlement| entitlement.segment_booking_id.clone())
                 .ok_or_else(|| ApiErrorKind::NotFound("entitlement not found".to_string()))?;
+            let pending_key = PendingEventKey::new(&entitlement_id, "EntitlementVoided");
+            if state.pending_events.contains_key(&pending_key) {
+                pending_keys.push(pending_key);
+                continue;
+            }
+
             let aggregate = state.aggregates.get_mut(&entitlement_id).ok_or_else(|| {
                 ApiErrorKind::NotFound("entitlement aggregate not found".to_string())
             })?;
@@ -2438,16 +2477,24 @@ impl InMemoryEntitlementService {
                 entitlement.status = EntitlementStatusDto::Voided;
                 entitlement.voided_at = Some(voided_at.clone());
             }
-            payloads.push(EntitlementVoidedPayload {
-                entitlement_id,
+            let payload = EntitlementVoidedPayload {
+                entitlement_id: entitlement_id.clone(),
                 segment_booking_id,
                 voided_at,
                 reason: reason_to_contract(&reason),
                 policy: policy_to_contract(&policy),
                 business_case_ref: Some(case_id.to_string()),
-            });
+            };
+            state.pending_events.insert(
+                pending_key.clone(),
+                PendingBusPublication {
+                    event_type: "EntitlementVoided",
+                    payload: serde_json::to_value(payload).unwrap_or_else(|_| json!({})),
+                },
+            );
+            pending_keys.push(pending_key);
         }
-        Ok(payloads)
+        Ok(pending_keys)
     }
 }
 
@@ -2458,6 +2505,7 @@ struct InMemoryState {
     credential_registry: CredentialRegistry,
     idempotency: HashMap<String, IdempotentRecord>,
     pending_publications: HashMap<String, PendingPublication>,
+    pending_events: HashMap<PendingEventKey, PendingBusPublication>,
     sequence: u64,
 }
 
@@ -2473,6 +2521,27 @@ struct PendingPublication {
     event_type: &'static str,
     payload: Value,
     response: IdempotentResponse,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct PendingEventKey {
+    aggregate_id: String,
+    event_type: &'static str,
+}
+
+impl PendingEventKey {
+    fn new(aggregate_id: &str, event_type: &'static str) -> Self {
+        Self {
+            aggregate_id: aggregate_id.to_string(),
+            event_type,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PendingBusPublication {
+    event_type: &'static str,
+    payload: Value,
 }
 
 #[derive(Debug, Clone)]
@@ -2993,27 +3062,6 @@ fn credential_ref(credential_no: &str) -> Result<CredentialRef, EntitlementError
     )
 }
 
-fn publish_api_event_blocking(
-    publisher: Arc<dyn application::EventPublisher>,
-    event_type: &str,
-    payload: Value,
-    correlation_id: String,
-) -> ApiResult<()> {
-    let event_type = event_type.to_string();
-    std::thread::spawn(move || {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|error| ApiErrorKind::Unavailable(error.to_string()))?
-            .block_on(async move {
-                publish_api_event_value(publisher.as_ref(), &event_type, payload, correlation_id)
-                    .await
-            })
-    })
-    .join()
-    .map_err(|_| ApiErrorKind::Unavailable("publisher worker panicked".to_string()))?
-}
-
 async fn publish_api_event<T: Serialize>(
     publisher: &dyn application::EventPublisher,
     event_type: &str,
@@ -3126,6 +3174,65 @@ mod api_domain_wiring_tests {
     }
 
     #[tokio::test]
+    async fn post_sales_retry_after_publish_failure_publishes_pending_event_once() {
+        let publisher = Arc::new(adapters::messaging::InMemoryEventPublisher::default());
+        let service = InMemoryEntitlementService::new(publisher.clone());
+        let issue_response = service
+            .issue(
+                IssueEntitlementRequest {
+                    segment_booking_id: "sb-0194f2e0-7b3e-7610-0284-5c26e8b0e111".to_string(),
+                    journey_order_id: "ord-0194f2e0-7b3e-7610-0284-5c26e8b0e222".to_string(),
+                    traveler_ref: "tvl-0194f2e0-7b3e-7610-0284-5c26e8b0e333".to_string(),
+                    segment_ref: "seg-0194f2e0-7b3e-7610-0284-5c26e8b0e444".to_string(),
+                    issue_purpose: IssuePurposeDto::Initial,
+                },
+                "018f2e07-b3e7-7100-8284-5c26e8b0e001".to_string(),
+                "corr-post-sales-retry".to_string(),
+            )
+            .await
+            .unwrap();
+        publisher.fail_next("redis unavailable");
+        let envelope = application::EventEnvelope::new(
+            "PostSalesApproved",
+            current_rfc3339(),
+            "corr-0194f2e0-7b3e-7610-0284-5c26e8b0e555",
+            Some("evt-0194f2e0-7b3e-7610-0284-5c26e8b0e666"),
+            "post-sales",
+            json!({
+                "caseId": "psc-0194f2e0-7b3e-7610-0284-5c26e8b0e777",
+                "orderId": "ord-0194f2e0-7b3e-7610-0284-5c26e8b0e222",
+                "approvedActions": [
+                    {"type": "VOID_ENTITLEMENT", "entitlementId": issue_response.entitlement_id, "reason": "REFUND", "policy": "NORMAL"}
+                ]
+            }),
+        );
+
+        assert!(matches!(
+            service.handle_subscribed_event(envelope.clone()).await,
+            Err(application::HandlerError::Transient(_))
+        ));
+        assert_eq!(
+            publisher
+                .published()
+                .iter()
+                .filter(|envelope| envelope.event_type == "EntitlementVoided")
+                .count(),
+            0
+        );
+
+        service.handle_subscribed_event(envelope).await.unwrap();
+        assert_eq!(
+            publisher
+                .published()
+                .iter()
+                .filter(|envelope| envelope.event_type == "EntitlementVoided")
+                .count(),
+            1
+        );
+        assert!(service.state.lock().unwrap().pending_events.is_empty());
+    }
+
+    #[tokio::test]
     async fn post_sales_approved_contract_payload_voids_order_entitlement_and_publishes_event() {
         let publisher = Arc::new(adapters::messaging::InMemoryEventPublisher::default());
         let service = InMemoryEntitlementService::new(publisher.clone());
@@ -3159,6 +3266,7 @@ mod api_domain_wiring_tests {
                     ]
                 }),
             ))
+            .await
             .unwrap();
 
         let details = service
@@ -3188,8 +3296,8 @@ mod api_domain_wiring_tests {
         assert!(voided.payload.get("status").is_none());
     }
 
-    #[test]
-    fn post_sales_approved_without_void_actions_is_ackable_noop() {
+    #[tokio::test]
+    async fn post_sales_approved_without_void_actions_is_ackable_noop() {
         let service = InMemoryEntitlementService::default();
         service
             .apply_subscribed_event(application::EventEnvelope::new(
@@ -3204,6 +3312,7 @@ mod api_domain_wiring_tests {
                     "approvedActions": []
                 }),
             ))
+            .await
             .unwrap();
     }
 }

--- a/services/entitlement-ticketing/src/lib.rs
+++ b/services/entitlement-ticketing/src/lib.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::sync::{Arc, Mutex};
+use tokio::task::JoinHandle;
 
 use axum::{
     Json, Router,
@@ -59,7 +60,41 @@ pub fn runtime_config() -> RuntimeConfig {
 }
 
 pub fn router() -> Router {
-    router_with_state(Arc::new(InMemoryEntitlementService::default()))
+    let publisher = Arc::new(
+        adapters::messaging::RedisEventPublisher::from_env()
+            .expect("REDIS_URL must be a valid Redis connection URL"),
+    );
+    router_with_state(Arc::new(InMemoryEntitlementService::new(publisher)))
+}
+
+pub fn build_runtime() -> Result<(Router, JoinHandle<()>), application::SubscribeFailed> {
+    use crate::application::EventSubscriber;
+
+    let publisher = Arc::new(
+        adapters::messaging::RedisEventPublisher::from_env()
+            .map_err(|error| application::SubscribeFailed(error.to_string()))?,
+    );
+    let service = Arc::new(InMemoryEntitlementService::new(publisher));
+    let subscriber = adapters::messaging::RedisEventSubscriber::from_env()?;
+    let streams = adapters::messaging::RedisEventSubscriber::entitlement_streams();
+    let group = adapters::messaging::RedisEventSubscriber::entitlement_group().to_string();
+    let consumer_name = std::env::var("HOSTNAME")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| format!("entitlement-ticketing-{}", uuid::Uuid::now_v7()));
+    let handler_service = Arc::clone(&service);
+    let subscriber_handle = tokio::spawn(async move {
+        subscriber
+            .subscribe(
+                streams,
+                group,
+                consumer_name,
+                Box::new(move |envelope| handler_service.handle_subscribed_event(envelope)),
+            )
+            .await
+            .expect("entitlement-ticketing Redis subscriber stopped");
+    });
+    Ok((router_with_state(service), subscriber_handle))
 }
 
 pub fn router_with_state<S>(service: Arc<S>) -> Router
@@ -1437,7 +1472,7 @@ mod tests {
 
     #[test]
     fn axum_router_can_be_constructed() {
-        let _router = router();
+        let _router = router_with_state(Arc::new(InMemoryEntitlementService::default()));
     }
 
     #[tokio::test]
@@ -1455,7 +1490,7 @@ mod tests {
             "/readyz",
             "/metadata",
         ] {
-            let response = router()
+            let response = router_with_state(Arc::new(InMemoryEntitlementService::default()))
                 .oneshot(
                     Request::builder()
                         .uri(path)
@@ -2315,6 +2350,171 @@ impl InMemoryEntitlementService {
             publisher,
         }
     }
+
+    fn replayed_response(
+        &self,
+        key: &str,
+        fingerprint: &str,
+    ) -> ApiResult<Option<IdempotentResponse>> {
+        let state = self
+            .state
+            .lock()
+            .expect("entitlement service lock poisoned");
+        if let Some(record) = state.idempotency.get(key) {
+            if record.fingerprint != fingerprint {
+                return Err(ApiErrorKind::IdempotencyKeyReused(
+                    "Idempotency-Key was reused with a different request body".to_string(),
+                ));
+            }
+            return Ok(Some(record.response.clone()));
+        }
+        Ok(None)
+    }
+
+    fn pending_publication(
+        &self,
+        key: &str,
+        fingerprint: &str,
+    ) -> ApiResult<Option<PendingPublication>> {
+        let state = self
+            .state
+            .lock()
+            .expect("entitlement service lock poisoned");
+        if let Some(record) = state.idempotency.get(key) {
+            if record.fingerprint != fingerprint {
+                return Err(ApiErrorKind::IdempotencyKeyReused(
+                    "Idempotency-Key was reused with a different request body".to_string(),
+                ));
+            }
+            return Ok(None);
+        }
+        if let Some(pending) = state.pending_publications.get(key) {
+            if pending.fingerprint != fingerprint {
+                return Err(ApiErrorKind::IdempotencyKeyReused(
+                    "Idempotency-Key was reused with a different request body".to_string(),
+                ));
+            }
+            return Ok(Some(pending.clone()));
+        }
+        Ok(None)
+    }
+
+    fn record_idempotent_success(
+        &self,
+        key: String,
+        fingerprint: String,
+        response: IdempotentResponse,
+    ) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("entitlement service lock poisoned");
+        state.pending_publications.remove(&key);
+        state.idempotency.insert(
+            key,
+            IdempotentRecord {
+                fingerprint,
+                response,
+            },
+        );
+    }
+
+    fn handle_subscribed_event(
+        &self,
+        envelope: application::EventEnvelope,
+    ) -> Result<(), application::HandlerError> {
+        self.apply_subscribed_event(envelope)
+            .map_err(|error| application::HandlerError::Fatal(error.message().to_string()))
+    }
+
+    fn apply_subscribed_event(&self, envelope: application::EventEnvelope) -> ApiResult<()> {
+        match envelope.event_type.as_str() {
+            "BoardingVerified" => self.apply_boarding_verified(envelope.payload),
+            "PostSalesApproved" => self.apply_post_sales_approved(envelope.payload),
+            "SegmentTicketed" => Ok(()),
+            _ => Ok(()),
+        }
+    }
+
+    fn apply_boarding_verified(&self, payload: Value) -> ApiResult<()> {
+        let entitlement_id = payload
+            .get("entitlementId")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ApiErrorKind::ValidationFailed("entitlementId is required".to_string()))?
+            .to_string();
+        validate_prefixed_uuid(&entitlement_id, "entitlementId", "ent-")?;
+        let fact_ref = payload
+            .get("sourceEventId")
+            .and_then(Value::as_str)
+            .or_else(|| payload.get("fulfillmentRecordId").and_then(Value::as_str))
+            .unwrap_or("fulfillment-fact");
+        let mut state = self
+            .state
+            .lock()
+            .expect("entitlement service lock poisoned");
+        let aggregate = state
+            .aggregates
+            .get_mut(&entitlement_id)
+            .ok_or_else(|| ApiErrorKind::NotFound("entitlement aggregate not found".to_string()))?;
+        aggregate
+            .accept_fulfillment_fact(AcceptFulfillmentFact {
+                command_id: CommandId::new(format!("cmd-{}", uuid::Uuid::now_v7()))
+                    .map_err(ApiErrorKind::from)?,
+                fact: FulfillmentFact::BoardingVerified {
+                    fact_ref: FulfillmentFactRef::new(fact_ref.to_string())
+                        .map_err(ApiErrorKind::from)?,
+                },
+                audit: audit_builder("corr-subscriber", "event bus boarding verified")
+                    .map_err(ApiErrorKind::from)?,
+            })
+            .map_err(ApiErrorKind::from)?;
+        Ok(())
+    }
+
+    fn apply_post_sales_approved(&self, payload: Value) -> ApiResult<()> {
+        let Some(entitlement_id) = payload.get("entitlementId").and_then(Value::as_str) else {
+            return Ok(());
+        };
+        validate_prefixed_uuid(entitlement_id, "entitlementId", "ent-")?;
+        let reason = payload
+            .get("reason")
+            .and_then(Value::as_str)
+            .unwrap_or("REFUND");
+        let policy = payload
+            .get("policy")
+            .and_then(Value::as_str)
+            .unwrap_or("NORMAL");
+        let business_case_ref = payload
+            .get("caseId")
+            .and_then(Value::as_str)
+            .unwrap_or("post-sales-case")
+            .to_string();
+        let mut state = self
+            .state
+            .lock()
+            .expect("entitlement service lock poisoned");
+        let aggregate = state
+            .aggregates
+            .get_mut(entitlement_id)
+            .ok_or_else(|| ApiErrorKind::NotFound("entitlement aggregate not found".to_string()))?;
+        aggregate
+            .void(VoidEntitlement {
+                command_id: CommandId::new(format!("cmd-{}", uuid::Uuid::now_v7()))
+                    .map_err(ApiErrorKind::from)?,
+                reason: parse_void_reason(reason),
+                policy: parse_void_policy(policy),
+                business_case_ref: BusinessCaseRef::new(business_case_ref)
+                    .map_err(ApiErrorKind::from)?,
+                audit: audit_builder("corr-subscriber", "event bus post-sales approved")
+                    .map_err(ApiErrorKind::from)?,
+            })
+            .map_err(ApiErrorKind::from)?;
+        if let Some(entitlement) = state.entitlements.get_mut(entitlement_id) {
+            entitlement.status = EntitlementStatusDto::Voided;
+            entitlement.voided_at = Some(current_rfc3339());
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Default)]
@@ -2323,12 +2523,21 @@ struct InMemoryState {
     aggregates: HashMap<String, Entitlement>,
     credential_registry: CredentialRegistry,
     idempotency: HashMap<String, IdempotentRecord>,
+    pending_publications: HashMap<String, PendingPublication>,
     sequence: u64,
 }
 
 #[derive(Debug, Clone)]
 struct IdempotentRecord {
     fingerprint: String,
+    response: IdempotentResponse,
+}
+
+#[derive(Debug, Clone)]
+struct PendingPublication {
+    fingerprint: String,
+    event_type: &'static str,
+    payload: Value,
     response: IdempotentResponse,
 }
 
@@ -2346,29 +2555,40 @@ impl EntitlementApi for InMemoryEntitlementService {
         key: String,
         correlation_id: String,
     ) -> ApiResult<IssueEntitlementResponse> {
-        validate_non_empty(&command.segment_booking_id, "segmentBookingId")?;
-        validate_non_empty(&command.journey_order_id, "journeyOrderId")?;
-        validate_non_empty(&command.traveler_ref, "travelerRef")?;
-        validate_non_empty(&command.segment_ref, "segmentRef")?;
+        validate_prefixed_uuid(&command.segment_booking_id, "segmentBookingId", "sb-")?;
+        validate_prefixed_uuid(&command.journey_order_id, "journeyOrderId", "ord-")?;
+        validate_prefixed_uuid(&command.traveler_ref, "travelerRef", "tvl-")?;
+        validate_prefixed_uuid(&command.segment_ref, "segmentRef", "seg-")?;
         let fingerprint = serde_json::to_string(&command).unwrap_or_default();
+        if let Some(replayed) = self.replayed_response(&key, &fingerprint)? {
+            if let IdempotentResponse::Issue(response) = replayed {
+                return Ok(response);
+            }
+            return Err(ApiErrorKind::IdempotencyKeyReused(
+                "Idempotency-Key was reused for a different operation".to_string(),
+            ));
+        }
+        if let Some(pending) = self.pending_publication(&key, &fingerprint)? {
+            let IdempotentResponse::Issue(response) = pending.response.clone() else {
+                return Err(ApiErrorKind::IdempotencyKeyReused(
+                    "Idempotency-Key was reused for a different operation".to_string(),
+                ));
+            };
+            publish_api_event_value(
+                self.publisher.as_ref(),
+                pending.event_type,
+                pending.payload.clone(),
+                correlation_id,
+            )
+            .await?;
+            self.record_idempotent_success(key, fingerprint, pending.response);
+            return Ok(response);
+        }
         let (response, event_payload) = {
             let mut state = self
                 .state
                 .lock()
                 .expect("entitlement service lock poisoned");
-            if let Some(record) = state.idempotency.get(&key) {
-                if record.fingerprint != fingerprint {
-                    return Err(ApiErrorKind::IdempotencyKeyReused(
-                        "Idempotency-Key was reused with a different request body".to_string(),
-                    ));
-                }
-                if let IdempotentResponse::Issue(response) = &record.response {
-                    return Ok(response.clone());
-                }
-                return Err(ApiErrorKind::IdempotencyKeyReused(
-                    "Idempotency-Key was reused for a different operation".to_string(),
-                ));
-            }
             state.sequence += 1;
             let entitlement_id = format!("ent-{}", uuid::Uuid::now_v7());
             let issued_at = current_rfc3339();
@@ -2445,10 +2665,14 @@ impl EntitlementApi for InMemoryEntitlementService {
                 .map_err(ApiErrorKind::from)?;
             state.aggregates.insert(entitlement_id.clone(), aggregate);
             state.entitlements.insert(entitlement_id, details);
-            state.idempotency.insert(
-                key,
-                IdempotentRecord {
-                    fingerprint,
+            let pending_payload =
+                serde_json::to_value(&event_payload).unwrap_or_else(|_| json!({}));
+            state.pending_publications.insert(
+                key.clone(),
+                PendingPublication {
+                    fingerprint: fingerprint.clone(),
+                    event_type: "EntitlementIssued",
+                    payload: pending_payload,
                     response: IdempotentResponse::Issue(response.clone()),
                 },
             );
@@ -2461,6 +2685,11 @@ impl EntitlementApi for InMemoryEntitlementService {
             correlation_id,
         )
         .await?;
+        self.record_idempotent_success(
+            key,
+            fingerprint,
+            IdempotentResponse::Issue(response.clone()),
+        );
         Ok(response)
     }
 
@@ -2471,6 +2700,7 @@ impl EntitlementApi for InMemoryEntitlementService {
         key: String,
         correlation_id: String,
     ) -> ApiResult<VoidEntitlementResponse> {
+        validate_prefixed_uuid(&entitlement_id, "entitlementId", "ent-")?;
         if command
             .business_case_ref
             .as_deref()
@@ -2485,24 +2715,35 @@ impl EntitlementApi for InMemoryEntitlementService {
             entitlement_id,
             serde_json::to_string(&command).unwrap_or_default()
         );
+        if let Some(replayed) = self.replayed_response(&key, &fingerprint)? {
+            if let IdempotentResponse::Void(response) = replayed {
+                return Ok(response);
+            }
+            return Err(ApiErrorKind::IdempotencyKeyReused(
+                "Idempotency-Key was reused for a different operation".to_string(),
+            ));
+        }
+        if let Some(pending) = self.pending_publication(&key, &fingerprint)? {
+            let IdempotentResponse::Void(response) = pending.response.clone() else {
+                return Err(ApiErrorKind::IdempotencyKeyReused(
+                    "Idempotency-Key was reused for a different operation".to_string(),
+                ));
+            };
+            publish_api_event_value(
+                self.publisher.as_ref(),
+                pending.event_type,
+                pending.payload.clone(),
+                correlation_id,
+            )
+            .await?;
+            self.record_idempotent_success(key, fingerprint, pending.response);
+            return Ok(response);
+        }
         let (response, event_payload) = {
             let mut state = self
                 .state
                 .lock()
                 .expect("entitlement service lock poisoned");
-            if let Some(record) = state.idempotency.get(&key) {
-                if record.fingerprint != fingerprint {
-                    return Err(ApiErrorKind::IdempotencyKeyReused(
-                        "Idempotency-Key was reused with a different request body".to_string(),
-                    ));
-                }
-                if let IdempotentResponse::Void(response) = &record.response {
-                    return Ok(response.clone());
-                }
-                return Err(ApiErrorKind::IdempotencyKeyReused(
-                    "Idempotency-Key was reused for a different operation".to_string(),
-                ));
-            }
             let segment_booking_id = state
                 .entitlements
                 .get(&entitlement_id)
@@ -2552,10 +2793,14 @@ impl EntitlementApi for InMemoryEntitlementService {
                 status: EntitlementStatusDto::Voided,
                 voided_at,
             };
-            state.idempotency.insert(
-                key,
-                IdempotentRecord {
-                    fingerprint,
+            let pending_payload =
+                serde_json::to_value(&event_payload).unwrap_or_else(|_| json!({}));
+            state.pending_publications.insert(
+                key.clone(),
+                PendingPublication {
+                    fingerprint: fingerprint.clone(),
+                    event_type: "EntitlementVoided",
+                    payload: pending_payload,
                     response: IdempotentResponse::Void(response.clone()),
                 },
             );
@@ -2568,10 +2813,16 @@ impl EntitlementApi for InMemoryEntitlementService {
             correlation_id,
         )
         .await?;
+        self.record_idempotent_success(
+            key,
+            fingerprint,
+            IdempotentResponse::Void(response.clone()),
+        );
         Ok(response)
     }
 
     async fn get(&self, entitlement_id: String) -> ApiResult<EntitlementDetails> {
+        validate_prefixed_uuid(&entitlement_id, "entitlementId", "ent-")?;
         self.state
             .lock()
             .expect("entitlement service lock poisoned")
@@ -2587,7 +2838,7 @@ impl EntitlementApi for InMemoryEntitlementService {
         limit: usize,
         offset: usize,
     ) -> ApiResult<PaginatedEntitlements> {
-        validate_non_empty(&journey_order_id, "journeyOrderId")?;
+        validate_prefixed_uuid(&journey_order_id, "journeyOrderId", "ord-")?;
         let mut items: Vec<_> = self
             .state
             .lock()
@@ -2608,6 +2859,23 @@ impl EntitlementApi for InMemoryEntitlementService {
     }
 }
 
+fn parse_void_reason(value: &str) -> VoidReason {
+    match value {
+        "CHANGE" => VoidReason::Change,
+        "DISRUPTION" => VoidReason::Disruption,
+        "RISK" => VoidReason::Risk,
+        "MANUAL_CORRECTION" => VoidReason::ManualCorrection,
+        _ => VoidReason::Refund,
+    }
+}
+
+fn parse_void_policy(value: &str) -> VoidPolicy {
+    match value {
+        "EXCEPTIONAL_RULE" => VoidPolicy::ExceptionalRule,
+        _ => VoidPolicy::Normal,
+    }
+}
+
 fn validate_non_empty(value: &str, field: &'static str) -> ApiResult<()> {
     if value.trim().is_empty() {
         Err(ApiErrorKind::ValidationFailed(format!(
@@ -2616,6 +2884,19 @@ fn validate_non_empty(value: &str, field: &'static str) -> ApiResult<()> {
     } else {
         Ok(())
     }
+}
+
+fn validate_prefixed_uuid(value: &str, field: &'static str, prefix: &'static str) -> ApiResult<()> {
+    validate_non_empty(value, field)?;
+    let Some(uuid_part) = value.strip_prefix(prefix) else {
+        return Err(ApiErrorKind::ValidationFailed(format!(
+            "{field} must use {prefix}<uuid> format"
+        )));
+    };
+    uuid::Uuid::parse_str(uuid_part).map_err(|_| {
+        ApiErrorKind::ValidationFailed(format!("{field} must use {prefix}<uuid> format"))
+    })?;
+    Ok(())
 }
 
 fn current_rfc3339() -> String {
@@ -2691,13 +2972,28 @@ async fn publish_api_event<T: Serialize>(
     payload: &T,
     correlation_id: String,
 ) -> ApiResult<()> {
+    publish_api_event_value(
+        publisher,
+        event_type,
+        serde_json::to_value(payload).unwrap_or_else(|_| json!({})),
+        correlation_id,
+    )
+    .await
+}
+
+async fn publish_api_event_value(
+    publisher: &dyn application::EventPublisher,
+    event_type: &str,
+    payload: Value,
+    correlation_id: String,
+) -> ApiResult<()> {
     let envelope = application::EventEnvelope::new(
         event_type,
         current_rfc3339(),
         correlation_id,
         None::<String>,
         profile().service_id,
-        serde_json::to_value(payload).unwrap_or_else(|_| json!({})),
+        payload,
     );
     publisher
         .publish(envelope)
@@ -2739,10 +3035,10 @@ mod api_domain_wiring_tests {
         let response = service
             .issue(
                 IssueEntitlementRequest {
-                    segment_booking_id: "sb-domain-invariant".to_string(),
-                    journey_order_id: "ord-domain-invariant".to_string(),
-                    traveler_ref: "tvl-domain-invariant".to_string(),
-                    segment_ref: "seg-domain-invariant".to_string(),
+                    segment_booking_id: "sb-0194f2e0-7b3e-7610-0284-5c26e8b0e111".to_string(),
+                    journey_order_id: "ord-0194f2e0-7b3e-7610-0284-5c26e8b0e222".to_string(),
+                    traveler_ref: "tvl-0194f2e0-7b3e-7610-0284-5c26e8b0e333".to_string(),
+                    segment_ref: "seg-0194f2e0-7b3e-7610-0284-5c26e8b0e444".to_string(),
                     issue_purpose: IssuePurposeDto::Initial,
                 },
                 "018f2e07-b3e7-7100-8284-5c26e8b0d001".to_string(),

--- a/services/entitlement-ticketing/src/main.rs
+++ b/services/entitlement-ticketing/src/main.rs
@@ -1,0 +1,21 @@
+use std::net::SocketAddr;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (app, subscriber_handle) = entitlement_ticketing::build_runtime()?;
+    let port = std::env::var("PORT")
+        .ok()
+        .and_then(|value| value.parse::<u16>().ok())
+        .unwrap_or(8080);
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal(subscriber_handle))
+        .await?;
+    Ok(())
+}
+
+async fn shutdown_signal(subscriber_handle: tokio::task::JoinHandle<()>) {
+    let _ = tokio::signal::ctrl_c().await;
+    subscriber_handle.abort();
+}

--- a/services/entitlement-ticketing/tests/skeleton.rs
+++ b/services/entitlement-ticketing/tests/skeleton.rs
@@ -1,4 +1,9 @@
-use entitlement_ticketing::{health, profile, router};
+use entitlement_ticketing::{InMemoryEntitlementService, health, profile, router_with_state};
+use std::sync::Arc;
+
+fn test_router() -> axum::Router {
+    router_with_state(Arc::new(InMemoryEntitlementService::default()))
+}
 
 #[test]
 fn profile_exports_req_013_contract_metadata() {
@@ -14,7 +19,7 @@ fn profile_exports_req_013_contract_metadata() {
             .any(|entry| entry.contains("issuance preconditions"))
     );
     assert_eq!(health(), "ok");
-    let _router = router();
+    let _router = test_router();
 }
 
 #[tokio::test]
@@ -24,7 +29,7 @@ async fn http_entitlement_endpoints_happy_path_and_idempotency() {
     use serde_json::{Value, json};
     use tower::ServiceExt;
 
-    let app = router();
+    let app = test_router();
     let issue_body = json!({
         "segmentBookingId": "sb-0194f2e0-7b3e-7610-0284-5c26e8b0c111",
         "journeyOrderId": "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c222",
@@ -128,7 +133,7 @@ async fn validation_failure_uses_canonical_error_shape() {
     use serde_json::{Value, json};
     use tower::ServiceExt;
 
-    let response = router()
+    let response = test_router()
         .oneshot(
             Request::builder()
                 .method(Method::POST)
@@ -137,10 +142,10 @@ async fn validation_failure_uses_canonical_error_shape() {
                 .header("x-correlation-id", "corrvalidation")
                 .body(Body::from(
                     json!({
-                        "segmentBookingId":"sb-1",
-                        "journeyOrderId":"ord-1",
-                        "travelerRef":"tvl-1",
-                        "segmentRef":"seg-1",
+                        "segmentBookingId":"sb-0194f2e0-7b3e-7610-0284-5c26e8b0c111",
+                        "journeyOrderId":"ord-0194f2e0-7b3e-7610-0284-5c26e8b0c222",
+                        "travelerRef":"tvl-0194f2e0-7b3e-7610-0284-5c26e8b0c333",
+                        "segmentRef":"seg-0194f2e0-7b3e-7610-0284-5c26e8b0c444",
                         "issuePurpose":"INITIAL"
                     })
                     .to_string(),
@@ -275,7 +280,7 @@ async fn invalid_list_query_uses_canonical_error_shape() {
     use serde_json::Value;
     use tower::ServiceExt;
 
-    let response = router()
+    let response = test_router()
         .oneshot(
             Request::builder()
                 .uri("/api/v1/entitlements?limit=not-a-number")
@@ -299,7 +304,7 @@ async fn invalid_idempotency_key_is_rejected() {
     use serde_json::json;
     use tower::ServiceExt;
 
-    let response = router()
+    let response = test_router()
         .oneshot(
             Request::builder()
                 .method(Method::POST)
@@ -308,10 +313,10 @@ async fn invalid_idempotency_key_is_rejected() {
                 .header("idempotency-key", "not-a-uuid-v7")
                 .body(Body::from(
                     json!({
-                        "segmentBookingId":"sb-1",
-                        "journeyOrderId":"ord-1",
-                        "travelerRef":"tvl-1",
-                        "segmentRef":"seg-1",
+                        "segmentBookingId":"sb-0194f2e0-7b3e-7610-0284-5c26e8b0c111",
+                        "journeyOrderId":"ord-0194f2e0-7b3e-7610-0284-5c26e8b0c222",
+                        "travelerRef":"tvl-0194f2e0-7b3e-7610-0284-5c26e8b0c333",
+                        "segmentRef":"seg-0194f2e0-7b3e-7610-0284-5c26e8b0c444",
                         "issuePurpose":"INITIAL"
                     })
                     .to_string(),
@@ -330,7 +335,7 @@ async fn domain_invariant_violation_surfaces_as_domain_rule_violation() {
     use serde_json::{Value, json};
     use tower::ServiceExt;
 
-    let app = router();
+    let app = test_router();
     let issue_response = app
         .clone()
         .oneshot(
@@ -341,10 +346,10 @@ async fn domain_invariant_violation_surfaces_as_domain_rule_violation() {
                 .header("idempotency-key", "018f2e07-b3e7-7100-8284-5c26e8b0c101")
                 .body(Body::from(
                     json!({
-                        "segmentBookingId":"sb-domain-1",
-                        "journeyOrderId":"ord-domain-1",
-                        "travelerRef":"tvl-domain-1",
-                        "segmentRef":"seg-domain-1",
+                        "segmentBookingId":"sb-0194f2e0-7b3e-7610-0284-5c26e8b0c511",
+                        "journeyOrderId":"ord-0194f2e0-7b3e-7610-0284-5c26e8b0c522",
+                        "travelerRef":"tvl-0194f2e0-7b3e-7610-0284-5c26e8b0c533",
+                        "segmentRef":"seg-0194f2e0-7b3e-7610-0284-5c26e8b0c544",
                         "issuePurpose":"INITIAL"
                     })
                     .to_string(),
@@ -395,4 +400,86 @@ async fn domain_invariant_violation_surfaces_as_domain_rule_violation() {
         .await
         .unwrap();
     assert_eq!(second_void.status(), StatusCode::PRECONDITION_FAILED);
+}
+
+#[tokio::test]
+async fn non_contract_id_shape_is_rejected() {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Method, Request, StatusCode};
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+
+    let response = test_router()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/entitlements")
+                .header("content-type", "application/json")
+                .header("idempotency-key", "018f2e07-b3e7-7100-8284-5c26e8b0c201")
+                .body(Body::from(
+                    json!({
+                        "segmentBookingId":"not-a-segment-booking-id",
+                        "journeyOrderId":"ord-0194f2e0-7b3e-7610-0284-5c26e8b0c222",
+                        "travelerRef":"tvl-0194f2e0-7b3e-7610-0284-5c26e8b0c333",
+                        "segmentRef":"seg-0194f2e0-7b3e-7610-0284-5c26e8b0c444",
+                        "issuePurpose":"INITIAL"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
+    assert_eq!(body["code"], "VALIDATION_FAILED");
+}
+
+#[tokio::test]
+async fn publish_failure_is_not_cached_and_retry_republishes() {
+    use entitlement_ticketing::adapters::messaging::InMemoryEventPublisher;
+    use entitlement_ticketing::{
+        EntitlementApi, InMemoryEntitlementService, IssueEntitlementRequest, IssuePurposeDto,
+    };
+    use std::sync::Arc;
+
+    let publisher = Arc::new(InMemoryEventPublisher::default());
+    let service = InMemoryEntitlementService::new(publisher.clone());
+    let request = IssueEntitlementRequest {
+        segment_booking_id: "sb-0194f2e0-7b3e-7610-0284-5c26e8b0d111".to_string(),
+        journey_order_id: "ord-0194f2e0-7b3e-7610-0284-5c26e8b0d222".to_string(),
+        traveler_ref: "tvl-0194f2e0-7b3e-7610-0284-5c26e8b0d333".to_string(),
+        segment_ref: "seg-0194f2e0-7b3e-7610-0284-5c26e8b0d444".to_string(),
+        issue_purpose: IssuePurposeDto::Initial,
+    };
+
+    publisher.fail_next("redis unavailable");
+    let first = service
+        .issue(
+            request.clone(),
+            "018f2e07-b3e7-7100-8284-5c26e8b0d201".to_string(),
+            "corr-publish-retry".to_string(),
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        first,
+        entitlement_ticketing::ApiErrorKind::Unavailable(_)
+    ));
+    assert!(publisher.published().is_empty());
+
+    let response = service
+        .issue(
+            request,
+            "018f2e07-b3e7-7100-8284-5c26e8b0d201".to_string(),
+            "corr-publish-retry".to_string(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status,
+        entitlement_ticketing::EntitlementStatusDto::Issued
+    );
+    assert_eq!(publisher.published().len(), 1);
 }

--- a/services/entitlement-ticketing/tests/skeleton.rs
+++ b/services/entitlement-ticketing/tests/skeleton.rs
@@ -39,7 +39,7 @@ async fn http_entitlement_endpoints_happy_path_and_idempotency() {
                 .method(Method::POST)
                 .uri("/api/v1/entitlements")
                 .header("content-type", "application/json")
-                .header("idempotency-key", "018f2e07b3e761002845c26e8b0caaa")
+                .header("idempotency-key", "018f2e07-b3e7-7100-8284-5c26e8b0caaa")
                 .header("x-correlation-id", "corrtest")
                 .body(Body::from(issue_body.to_string()))
                 .unwrap(),
@@ -65,7 +65,7 @@ async fn http_entitlement_endpoints_happy_path_and_idempotency() {
                 .method(Method::POST)
                 .uri("/api/v1/entitlements")
                 .header("content-type", "application/json")
-                .header("idempotency-key", "018f2e07b3e761002845c26e8b0caaa")
+                .header("idempotency-key", "018f2e07-b3e7-7100-8284-5c26e8b0caaa")
                 .body(Body::from(issue_body.to_string()))
                 .unwrap(),
         )
@@ -109,7 +109,7 @@ async fn http_entitlement_endpoints_happy_path_and_idempotency() {
                 .method(Method::POST)
                 .uri(format!("/api/v1/entitlements/{entitlement_id}/void"))
                 .header("content-type", "application/json")
-                .header("idempotency-key", "018f2e07b3e761002845c26e8b0cbbb")
+                .header("idempotency-key", "018f2e07-b3e7-7100-8284-5c26e8b0cbbb")
                 .body(Body::from(
                     json!({"reason":"REFUND","policy":"NORMAL","businessCaseRef":"case-1"})
                         .to_string(),
@@ -193,4 +193,133 @@ async fn in_memory_publisher_wraps_contract_envelope_and_dedup_handler_skips_dup
     handler.handle(envelope.clone()).unwrap();
     handler.handle(envelope).unwrap();
     assert_eq!(handler.handled_count(), 1);
+}
+
+#[tokio::test]
+async fn invalid_list_query_uses_canonical_error_shape() {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use serde_json::Value;
+    use tower::ServiceExt;
+
+    let response = router()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/entitlements?limit=not-a-number")
+                .header("x-correlation-id", "corrlistvalidation")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
+    assert_eq!(body["code"], "VALIDATION_FAILED");
+    assert_eq!(body["correlationId"], "corrlistvalidation");
+}
+
+#[tokio::test]
+async fn invalid_idempotency_key_is_rejected() {
+    use axum::body::Body;
+    use axum::http::{Method, Request, StatusCode};
+    use serde_json::json;
+    use tower::ServiceExt;
+
+    let response = router()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/entitlements")
+                .header("content-type", "application/json")
+                .header("idempotency-key", "not-a-uuid-v7")
+                .body(Body::from(
+                    json!({
+                        "segmentBookingId":"sb-1",
+                        "journeyOrderId":"ord-1",
+                        "travelerRef":"tvl-1",
+                        "segmentRef":"seg-1",
+                        "issuePurpose":"INITIAL"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn domain_invariant_violation_surfaces_as_domain_rule_violation() {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Method, Request, StatusCode};
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+
+    let app = router();
+    let issue_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/entitlements")
+                .header("content-type", "application/json")
+                .header("idempotency-key", "018f2e07-b3e7-7100-8284-5c26e8b0c101")
+                .body(Body::from(
+                    json!({
+                        "segmentBookingId":"sb-domain-1",
+                        "journeyOrderId":"ord-domain-1",
+                        "travelerRef":"tvl-domain-1",
+                        "segmentRef":"seg-domain-1",
+                        "issuePurpose":"INITIAL"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let issued: Value = serde_json::from_slice(
+        &to_bytes(issue_response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    let entitlement_id = issued["entitlementId"].as_str().unwrap();
+
+    let first_void = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri(format!("/api/v1/entitlements/{entitlement_id}/void"))
+                .header("content-type", "application/json")
+                .header("idempotency-key", "018f2e07-b3e7-7100-8284-5c26e8b0c102")
+                .body(Body::from(
+                    json!({"reason":"REFUND","policy":"NORMAL","businessCaseRef":"case-domain"})
+                        .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first_void.status(), StatusCode::OK);
+
+    let second_void = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri(format!("/api/v1/entitlements/{entitlement_id}/void"))
+                .header("content-type", "application/json")
+                .header("idempotency-key", "018f2e07-b3e7-7100-8284-5c26e8b0c103")
+                .body(Body::from(
+                    json!({"reason":"REFUND","policy":"NORMAL","businessCaseRef":"case-domain-2"})
+                        .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second_void.status(), StatusCode::PRECONDITION_FAILED);
 }

--- a/services/entitlement-ticketing/tests/skeleton.rs
+++ b/services/entitlement-ticketing/tests/skeleton.rs
@@ -196,6 +196,79 @@ async fn in_memory_publisher_wraps_contract_envelope_and_dedup_handler_skips_dup
 }
 
 #[tokio::test]
+async fn published_entitlement_events_use_contract_payload_shapes() {
+    use entitlement_ticketing::adapters::messaging::InMemoryEventPublisher;
+    use entitlement_ticketing::{
+        EntitlementApi, InMemoryEntitlementService, IssueEntitlementRequest, IssuePurposeDto,
+        VoidEntitlementRequest, VoidPolicyDto, VoidReasonDto,
+    };
+    use std::sync::Arc;
+
+    let publisher = Arc::new(InMemoryEventPublisher::default());
+    let service = InMemoryEntitlementService::new(publisher.clone());
+    let issued = service
+        .issue(
+            IssueEntitlementRequest {
+                segment_booking_id: "sb-0194f2e0-7b3e-7610-0284-5c26e8b0c111".to_string(),
+                journey_order_id: "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c222".to_string(),
+                traveler_ref: "tvl-0194f2e0-7b3e-7610-0284-5c26e8b0c333".to_string(),
+                segment_ref: "seg-0194f2e0-7b3e-7610-0284-5c26e8b0c444".to_string(),
+                issue_purpose: IssuePurposeDto::Initial,
+            },
+            "018f2e07-b3e7-7100-8284-5c26e8b0d101".to_string(),
+            "corr-event-payload".to_string(),
+        )
+        .await
+        .unwrap();
+    let issued_payload = &publisher.published()[0].payload;
+    assert_eq!(issued_payload["entitlementId"], issued.entitlement_id);
+    assert_eq!(
+        issued_payload["segmentBookingId"],
+        "sb-0194f2e0-7b3e-7610-0284-5c26e8b0c111"
+    );
+    assert_eq!(
+        issued_payload["journeyOrderId"],
+        "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c222"
+    );
+    assert_eq!(
+        issued_payload["travelerRef"],
+        "tvl-0194f2e0-7b3e-7610-0284-5c26e8b0c333"
+    );
+    assert_eq!(
+        issued_payload["segmentRef"],
+        "seg-0194f2e0-7b3e-7610-0284-5c26e8b0c444"
+    );
+    assert_eq!(issued_payload["issuePurpose"], "INITIAL");
+    assert_eq!(issued_payload["credentialType"], "E_TICKET");
+    assert!(issued_payload.get("status").is_none());
+
+    service
+        .void(
+            issued.entitlement_id.clone(),
+            VoidEntitlementRequest {
+                reason: VoidReasonDto::Refund,
+                policy: VoidPolicyDto::Normal,
+                business_case_ref: Some("case-event-payload".to_string()),
+            },
+            "018f2e07-b3e7-7100-8284-5c26e8b0d102".to_string(),
+            "corr-event-payload".to_string(),
+        )
+        .await
+        .unwrap();
+    let voided_payload = &publisher.published()[1].payload;
+    assert_eq!(voided_payload["entitlementId"], issued.entitlement_id);
+    assert_eq!(
+        voided_payload["segmentBookingId"],
+        "sb-0194f2e0-7b3e-7610-0284-5c26e8b0c111"
+    );
+    assert!(voided_payload["voidedAt"].as_str().unwrap().ends_with('Z'));
+    assert_eq!(voided_payload["reason"], "REFUND");
+    assert_eq!(voided_payload["policy"], "NORMAL");
+    assert_eq!(voided_payload["businessCaseRef"], "case-event-payload");
+    assert!(voided_payload.get("status").is_none());
+}
+
+#[tokio::test]
 async fn invalid_list_query_uses_canonical_error_shape() {
     use axum::body::{Body, to_bytes};
     use axum::http::{Request, StatusCode};

--- a/services/entitlement-ticketing/tests/skeleton.rs
+++ b/services/entitlement-ticketing/tests/skeleton.rs
@@ -16,3 +16,181 @@ fn profile_exports_req_013_contract_metadata() {
     assert_eq!(health(), "ok");
     let _router = router();
 }
+
+#[tokio::test]
+async fn http_entitlement_endpoints_happy_path_and_idempotency() {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Method, Request, StatusCode};
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+
+    let app = router();
+    let issue_body = json!({
+        "segmentBookingId": "sb-0194f2e0-7b3e-7610-0284-5c26e8b0c111",
+        "journeyOrderId": "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c222",
+        "travelerRef": "tvl-0194f2e0-7b3e-7610-0284-5c26e8b0c333",
+        "segmentRef": "seg-0194f2e0-7b3e-7610-0284-5c26e8b0c444",
+        "issuePurpose": "INITIAL"
+    });
+    let issue_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/entitlements")
+                .header("content-type", "application/json")
+                .header("idempotency-key", "018f2e07b3e761002845c26e8b0caaa")
+                .header("x-correlation-id", "corrtest")
+                .body(Body::from(issue_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(issue_response.status(), StatusCode::CREATED);
+    assert_eq!(issue_response.headers()["x-correlation-id"], "corrtest");
+    let issue_json: Value = serde_json::from_slice(
+        &to_bytes(issue_response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(issue_json["status"], "ISSUED");
+    assert_eq!(issue_json["credentialType"], "E_TICKET");
+    let entitlement_id = issue_json["entitlementId"].as_str().unwrap().to_string();
+
+    let replay_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/entitlements")
+                .header("content-type", "application/json")
+                .header("idempotency-key", "018f2e07b3e761002845c26e8b0caaa")
+                .body(Body::from(issue_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(replay_response.status(), StatusCode::CREATED);
+    let replay_json: Value = serde_json::from_slice(
+        &to_bytes(replay_response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(replay_json, issue_json);
+
+    assert_eq!(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/entitlements/{entitlement_id}"))
+                    .body(Body::empty())
+                    .unwrap()
+            )
+            .await
+            .unwrap()
+            .status(),
+        StatusCode::OK
+    );
+    let list_response = app.clone().oneshot(Request::builder().uri("/api/v1/entitlements?journeyOrderId=ord-0194f2e0-7b3e-7610-0284-5c26e8b0c222&limit=20&offset=0").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(list_response.status(), StatusCode::OK);
+    let list_json: Value = serde_json::from_slice(
+        &to_bytes(list_response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(list_json["total"], 1);
+
+    let void_response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri(format!("/api/v1/entitlements/{entitlement_id}/void"))
+                .header("content-type", "application/json")
+                .header("idempotency-key", "018f2e07b3e761002845c26e8b0cbbb")
+                .body(Body::from(
+                    json!({"reason":"REFUND","policy":"NORMAL","businessCaseRef":"case-1"})
+                        .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(void_response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn validation_failure_uses_canonical_error_shape() {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Method, Request, StatusCode};
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+
+    let response = router()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/entitlements")
+                .header("content-type", "application/json")
+                .header("x-correlation-id", "corrvalidation")
+                .body(Body::from(
+                    json!({
+                        "segmentBookingId":"sb-1",
+                        "journeyOrderId":"ord-1",
+                        "travelerRef":"tvl-1",
+                        "segmentRef":"seg-1",
+                        "issuePurpose":"INITIAL"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "{}",
+        String::from_utf8_lossy(&bytes)
+    );
+    let body: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body["code"], "VALIDATION_FAILED");
+    assert_eq!(body["correlationId"], "corrvalidation");
+    assert!(body.get("details").is_some());
+}
+
+#[tokio::test]
+async fn in_memory_publisher_wraps_contract_envelope_and_dedup_handler_skips_duplicates() {
+    use entitlement_ticketing::adapters::messaging::{
+        DeduplicatingEventHandler, InMemoryEventPublisher,
+    };
+    use entitlement_ticketing::application::{EventEnvelope, EventPublisher};
+    use serde_json::json;
+
+    let publisher = InMemoryEventPublisher::default();
+    let envelope = EventEnvelope::new(
+        "EntitlementIssued",
+        "2026-07-05T10:30:00.000Z",
+        "corr-0194f2e0-7b3e-7610-0284-5c26e8b0c444",
+        Some("cmd-0194f2e0-7b3e-7610-0284-5c26e8b0c555"),
+        "entitlement-ticketing",
+        json!({"entitlementId":"ent-0194f2e0-7b3e-7610-0284-5c26e8b0c111"}),
+    );
+    publisher.publish(envelope.clone()).await.unwrap();
+    let published = publisher.published();
+    assert_eq!(published[0].producer, "entitlement-ticketing");
+    assert!(published[0].event_id.starts_with("evt-"));
+    assert_eq!(
+        published[0].payload["entitlementId"],
+        "ent-0194f2e0-7b3e-7610-0284-5c26e8b0c111"
+    );
+
+    let handler = DeduplicatingEventHandler::default();
+    handler.handle(envelope.clone()).unwrap();
+    handler.handle(envelope).unwrap();
+    assert_eq!(handler.handled_count(), 1);
+}


### PR DESCRIPTION
## Summary
- Implement entitlement-ticketing Axum HTTP endpoints with idempotency and canonical error responses
- Add broker-independent event ports and Redis Streams messaging adapter under adapters/messaging
- Add in-memory publisher/dedup test support and endpoint coverage

## Validation
- cd services/entitlement-ticketing && cargo test
- ! grep -rln 'redis::' services/entitlement-ticketing/src | grep -v adapters
- make check (fails due unrelated provider-integration workspace changes: internal/adapters/messaging/redis.go compile error)