### PR TITLE
REQ-040 traveler profile API and messaging adapter

### DIFF
--- a/services/traveler-profile/pom.xml
+++ b/services/traveler-profile/pom.xml
@@ -27,8 +27,28 @@
       <version>1.46.0</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.20.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>2.20.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.lettuce</groupId>
+      <artifactId>lettuce-core</artifactId>
+      <version>6.6.0.RELEASE</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test-autoconfigure</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/RequestContextFilter.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/RequestContextFilter.java
@@ -37,6 +37,8 @@ public class RequestContextFilter extends OncePerRequestFilter {
             request.getRequestURI()
         );
 
+        request.setAttribute(REQUEST_ID_HEADER, requestId);
+        request.setAttribute(CORRELATION_ID_HEADER, correlationId);
         response.setHeader(REQUEST_ID_HEADER, requestId);
         response.setHeader(CORRELATION_ID_HEADER, correlationId);
         MDC.put("requestId", requestId);

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/http/ApiError.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/http/ApiError.java
@@ -1,0 +1,11 @@
+package com.trainticket.travelerprofile.adapters.http;
+
+import java.util.Map;
+
+public record ApiError(
+    String code,
+    String message,
+    String correlationId,
+    Map<String, ?> details
+) {
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/http/ApiExceptionHandler.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/http/ApiExceptionHandler.java
@@ -1,0 +1,51 @@
+package com.trainticket.travelerprofile.adapters.http;
+
+import com.trainticket.travelerprofile.RequestContextFilter;
+import com.trainticket.travelerprofile.application.IdempotencyKeyReusedException;
+import com.trainticket.travelerprofile.application.TravelerNotFoundException;
+import com.trainticket.travelerprofile.application.ValidationException;
+import com.trainticket.travelerprofile.domain.DomainRuleViolation;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+    @ExceptionHandler(ValidationException.class)
+    ResponseEntity<ApiError> validation(ValidationException exception, HttpServletRequest request) {
+        return error(HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", exception.getMessage(), request, exception.details());
+    }
+
+    @ExceptionHandler({HttpMessageNotReadableException.class, MissingRequestHeaderException.class})
+    ResponseEntity<ApiError> malformed(Exception exception, HttpServletRequest request) {
+        return error(HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", "Request validation failed", request, Map.of("request", exception.getMessage()));
+    }
+
+    @ExceptionHandler(TravelerNotFoundException.class)
+    ResponseEntity<ApiError> notFound(TravelerNotFoundException exception, HttpServletRequest request) {
+        return error(HttpStatus.NOT_FOUND, "NOT_FOUND", exception.getMessage(), request, Map.of());
+    }
+
+    @ExceptionHandler(IdempotencyKeyReusedException.class)
+    ResponseEntity<ApiError> idempotency(IdempotencyKeyReusedException exception, HttpServletRequest request) {
+        return error(HttpStatus.UNPROCESSABLE_ENTITY, "IDEMPOTENCY_KEY_REUSED", exception.getMessage(), request, Map.of());
+    }
+
+    @ExceptionHandler(DomainRuleViolation.class)
+    ResponseEntity<ApiError> domain(DomainRuleViolation exception, HttpServletRequest request) {
+        return error(HttpStatus.UNPROCESSABLE_ENTITY, "DOMAIN_RULE_VIOLATION", exception.getMessage(), request, Map.of());
+    }
+
+    private static ResponseEntity<ApiError> error(HttpStatus status, String code, String message, HttpServletRequest request, Map<String, ?> details) {
+        String correlationId = (String) request.getAttribute(RequestContextFilter.CORRELATION_ID_HEADER);
+        if (correlationId == null) {
+            correlationId = request.getHeader(RequestContextFilter.CORRELATION_ID_HEADER);
+        }
+        return ResponseEntity.status(status).body(new ApiError(code, message, correlationId, details));
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/http/TravelerController.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/http/TravelerController.java
@@ -1,0 +1,140 @@
+package com.trainticket.travelerprofile.adapters.http;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.trainticket.travelerprofile.application.ApiDocumentType;
+import com.trainticket.travelerprofile.application.CreateTravelerCommand;
+import com.trainticket.travelerprofile.application.EligibilityResult;
+import com.trainticket.travelerprofile.application.TravelerCreatedView;
+import com.trainticket.travelerprofile.application.TravelerProfileService;
+import com.trainticket.travelerprofile.application.TravelerProfileView;
+import com.trainticket.travelerprofile.application.TravelerType;
+import com.trainticket.travelerprofile.application.UpdateTravelerCommand;
+import com.trainticket.travelerprofile.application.ValidationException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/travelers")
+public class TravelerController {
+    private final TravelerProfileService travelerProfileService;
+
+    public TravelerController(TravelerProfileService travelerProfileService) {
+        this.travelerProfileService = travelerProfileService;
+    }
+
+    @PostMapping
+    public ResponseEntity<TravelerCreatedView> create(
+        @RequestBody JsonNode body,
+        @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
+        @RequestHeader(value = "X-Correlation-Id", required = false) String correlationId,
+        HttpServletRequest request
+    ) {
+        requireIdempotencyKey(idempotencyKey);
+        CreateTravelerCommand command = new CreateTravelerCommand(
+            text(body, "accountId"),
+            enumValue(body, "travelerType", TravelerType.class),
+            text(body, "givenName"),
+            text(body, "familyName"),
+            enumValue(body, "documentType", ApiDocumentType.class),
+            text(body, "documentNumber"),
+            text(body, "contactEmail"),
+            text(body, "contactPhone"),
+            idempotencyKey.trim(),
+            correlationId(request, correlationId)
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(travelerProfileService.create(command, fingerprint(request, body)));
+    }
+
+    @GetMapping("/{travelerId}")
+    public TravelerProfileView get(@PathVariable String travelerId) {
+        return travelerProfileService.get(travelerId);
+    }
+
+    @PatchMapping("/{travelerId}")
+    public TravelerProfileView update(
+        @PathVariable String travelerId,
+        @RequestBody JsonNode body,
+        @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
+        @RequestHeader(value = "X-Correlation-Id", required = false) String correlationId,
+        HttpServletRequest request
+    ) {
+        requireIdempotencyKey(idempotencyKey);
+        UpdateTravelerCommand command = new UpdateTravelerCommand(
+            travelerId,
+            text(body, "accountId"),
+            enumValue(body, "travelerType", TravelerType.class),
+            text(body, "givenName"),
+            text(body, "familyName"),
+            enumValue(body, "documentType", ApiDocumentType.class),
+            text(body, "documentNumber"),
+            text(body, "contactEmail"),
+            text(body, "contactPhone"),
+            idempotencyKey.trim(),
+            correlationId(request, correlationId)
+        );
+        return travelerProfileService.update(command, fingerprint(request, body));
+    }
+
+    @PostMapping("/{travelerId}/eligibility")
+    public EligibilityResult determineEligibility(
+        @PathVariable String travelerId,
+        @RequestBody(required = false) JsonNode body,
+        @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
+        @RequestHeader(value = "X-Correlation-Id", required = false) String correlationId,
+        HttpServletRequest request
+    ) {
+        requireIdempotencyKey(idempotencyKey);
+        return travelerProfileService.determineEligibility(travelerId, idempotencyKey.trim(), correlationId(request, correlationId), fingerprint(request, body));
+    }
+
+    private static String fingerprint(HttpServletRequest request, JsonNode body) {
+        return TravelerProfileService.fingerprint(request.getMethod(), request.getRequestURI(), body);
+    }
+
+    private static String correlationId(HttpServletRequest request, String headerValue) {
+        if (headerValue != null && !headerValue.isBlank()) {
+            return headerValue;
+        }
+        Object attribute = request.getAttribute("X-Correlation-Id");
+        return attribute == null ? "corr-unknown" : attribute.toString();
+    }
+
+    private static void requireIdempotencyKey(String idempotencyKey) {
+        if (idempotencyKey == null || idempotencyKey.isBlank()) {
+            throw new ValidationException("Request validation failed", Map.of("Idempotency-Key", "Idempotency-Key header is required"));
+        }
+    }
+
+    private static String text(JsonNode body, String field) {
+        JsonNode value = body == null ? null : body.get(field);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        return value.asText();
+    }
+
+    private static <E extends Enum<E>> E enumValue(JsonNode body, String field, Class<E> enumType) {
+        String value = text(body, field);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Enum.valueOf(enumType, value);
+        } catch (IllegalArgumentException ex) {
+            Map<String, String> details = new LinkedHashMap<>();
+            details.put(field, "unsupported enum value");
+            throw new ValidationException("Request validation failed", details);
+        }
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/messaging/NoOpEventPublisher.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/messaging/NoOpEventPublisher.java
@@ -1,0 +1,16 @@
+package com.trainticket.travelerprofile.adapters.messaging;
+
+import com.trainticket.travelerprofile.application.EventEnvelope;
+import com.trainticket.travelerprofile.application.EventPublisher;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Component
+@Primary
+@ConditionalOnProperty(name = "traveler-profile.redis.enabled", havingValue = "false")
+public class NoOpEventPublisher implements EventPublisher {
+    @Override
+    public void publish(EventEnvelope envelope) {
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/messaging/RedisEventPublisher.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/messaging/RedisEventPublisher.java
@@ -1,0 +1,82 @@
+package com.trainticket.travelerprofile.adapters.messaging;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.travelerprofile.application.EventEnvelope;
+import com.trainticket.travelerprofile.application.EventPublisher;
+import com.trainticket.travelerprofile.application.PublishFailedException;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.XAddArgs;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+import jakarta.annotation.PreDestroy;
+import java.time.Duration;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "traveler-profile.redis.enabled", havingValue = "true", matchIfMissing = true)
+public class RedisEventPublisher implements EventPublisher {
+    private static final String FIELD_ENVELOPE = "envelope";
+    private static final long MAX_STREAM_LENGTH = 100_000L;
+
+    private final ObjectMapper objectMapper;
+    private final RedisClient client;
+    private final StatefulRedisConnection<String, String> connection;
+
+    public RedisEventPublisher(
+        ObjectMapper objectMapper,
+        @Value("${REDIS_URL:${redis.url:redis://localhost:6379}}") String redisUrl
+    ) {
+        this.objectMapper = objectMapper;
+        this.client = RedisClient.create(redisUrl);
+        this.connection = client.connect();
+    }
+
+    @Override
+    public void publish(EventEnvelope envelope) throws PublishFailedException {
+        String stream = streamFor(envelope.producer());
+        String serialized = serialize(envelope);
+        RuntimeException lastFailure = null;
+        for (int attempt = 1; attempt <= 3; attempt++) {
+            try {
+                RedisCommands<String, String> commands = connection.sync();
+                commands.xadd(stream, XAddArgs.Builder.maxlen(MAX_STREAM_LENGTH).approximateTrimming(), Map.of(FIELD_ENVELOPE, serialized));
+                return;
+            } catch (RuntimeException ex) {
+                lastFailure = ex;
+                sleepBeforeRetry(attempt);
+            }
+        }
+        throw new PublishFailedException("Failed to publish event envelope", lastFailure);
+    }
+
+    @PreDestroy
+    public void close() {
+        connection.close();
+        client.shutdown();
+    }
+
+    private String serialize(EventEnvelope envelope) {
+        try {
+            return objectMapper.writeValueAsString(envelope);
+        } catch (JsonProcessingException ex) {
+            throw new PublishFailedException("Failed to serialize event envelope", ex);
+        }
+    }
+
+    private static String streamFor(String producer) {
+        return "events:" + producer;
+    }
+
+    private static void sleepBeforeRetry(int attempt) {
+        try {
+            Thread.sleep(Duration.ofMillis(50L * attempt).toMillis());
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new PublishFailedException("Interrupted while retrying event publish", ex);
+        }
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/messaging/RedisEventSubscriber.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/messaging/RedisEventSubscriber.java
@@ -1,0 +1,162 @@
+package com.trainticket.travelerprofile.adapters.messaging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.travelerprofile.application.EventEnvelope;
+import com.trainticket.travelerprofile.application.EventSubscriber;
+import com.trainticket.travelerprofile.application.SubscribeFailedException;
+import io.lettuce.core.Consumer;
+import io.lettuce.core.StreamMessage;
+import io.lettuce.core.XAddArgs;
+import io.lettuce.core.XAutoClaimArgs;
+import io.lettuce.core.XGroupCreateArgs;
+import io.lettuce.core.XReadArgs;
+import io.lettuce.core.Range;
+import io.lettuce.core.Limit;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "traveler-profile.redis.enabled", havingValue = "true", matchIfMissing = true)
+public class RedisEventSubscriber implements EventSubscriber, AutoCloseable {
+    private static final String FIELD_ENVELOPE = "envelope";
+    private static final long MAX_STREAM_LENGTH = 100_000L;
+    private static final int MAX_ATTEMPTS = 5;
+
+    private final ObjectMapper objectMapper;
+    private final RedisEventSubscriberConnectionFactory connectionFactory;
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final AtomicBoolean running = new AtomicBoolean(true);
+
+    public RedisEventSubscriber(ObjectMapper objectMapper, @Value("${REDIS_URL:${redis.url:redis://localhost:6379}}") String redisUrl) {
+        this.objectMapper = objectMapper;
+        this.connectionFactory = new RedisEventSubscriberConnectionFactory(redisUrl);
+    }
+
+    @Override
+    public void subscribe(List<String> streams, String group, String consumerName, EventHandler handler) throws SubscribeFailedException {
+        try {
+            StatefulRedisConnection<String, String> connection = connectionFactory.connect();
+            RedisCommands<String, String> commands = connection.sync();
+            for (String stream : streams) {
+                createGroup(commands, stream, group);
+            }
+            executor.submit(() -> poll(commands, streams, group, consumerName, handler));
+            executor.submit(() -> recover(commands, streams, group, consumerName, handler));
+        } catch (RuntimeException ex) {
+            throw new SubscribeFailedException("Failed to start Redis Streams subscriber", ex);
+        }
+    }
+
+    @Override
+    public void close() {
+        running.set(false);
+        executor.shutdownNow();
+        connectionFactory.close();
+    }
+
+    private void poll(RedisCommands<String, String> commands, List<String> streams, String group, String consumerName, EventHandler handler) {
+        while (running.get()) {
+            List<StreamMessage<String, String>> messages = new ArrayList<>();
+            for (String stream : streams) {
+                messages.addAll(commands.xreadgroup(
+                    Consumer.from(group, consumerName),
+                    XReadArgs.Builder.block(2000).count(10),
+                    io.lettuce.core.XReadArgs.StreamOffset.lastConsumed(stream)
+                ));
+            }
+            for (StreamMessage<String, String> message : messages) {
+                handleMessage(commands, message.getStream(), group, message.getId(), message.getBody(), handler, 1);
+            }
+        }
+    }
+
+    private void recover(RedisCommands<String, String> commands, List<String> streams, String group, String consumerName, EventHandler handler) {
+        while (running.get()) {
+            for (String stream : streams) {
+                List<StreamMessage<String, String>> claimed = commands.xautoclaim(stream, new XAutoClaimArgs<String>()
+                    .consumer(Consumer.from(group, consumerName))
+                    .minIdleTime(60_000)
+                    .startId("0-0")
+                    .count(100)).getMessages();
+                for (StreamMessage<String, String> message : claimed) {
+                    handleMessage(commands, stream, group, message.getId(), message.getBody(), handler, 1);
+                }
+            }
+            sleep(60_000);
+        }
+    }
+
+    private void handleMessage(
+        RedisCommands<String, String> commands,
+        String stream,
+        String group,
+        String messageId,
+        Map<String, String> body,
+        EventHandler handler,
+        int attempt
+    ) {
+        int observedAttempts = Math.max(attempt, deliveryAttempts(commands, stream, group, messageId));
+        String serialized = body.get(FIELD_ENVELOPE);
+        try {
+            EventEnvelope envelope = objectMapper.readValue(serialized, EventEnvelope.class);
+            if (observedAttempts >= MAX_ATTEMPTS) {
+                moveToDlq(commands, stream, serialized);
+                commands.xack(stream, group, messageId);
+                return;
+            }
+            HandlerResult result = handler.handle(envelope);
+            if (result == HandlerResult.SUCCESS) {
+                commands.xack(stream, group, messageId);
+            } else if (result == HandlerResult.FATAL_FAILURE) {
+                moveToDlq(commands, stream, serialized);
+                commands.xack(stream, group, messageId);
+            }
+        } catch (Exception ex) {
+            moveToDlq(commands, stream, serialized);
+            commands.xack(stream, group, messageId);
+        }
+    }
+
+    private int deliveryAttempts(RedisCommands<String, String> commands, String stream, String group, String messageId) {
+        return commands.xpending(stream, group, Range.create(messageId, messageId), Limit.from(1))
+            .stream()
+            .findFirst()
+            .map(message -> (int) message.getRedeliveryCount() + 1)
+            .orElse(1);
+    }
+
+    private void createGroup(RedisCommands<String, String> commands, String stream, String group) {
+        try {
+            commands.xgroupCreate(io.lettuce.core.XReadArgs.StreamOffset.latest(stream), group, XGroupCreateArgs.Builder.mkstream());
+        } catch (RuntimeException ex) {
+            if (!String.valueOf(ex.getMessage()).contains("BUSYGROUP")) {
+                throw ex;
+            }
+        }
+    }
+
+    private void moveToDlq(RedisCommands<String, String> commands, String stream, String serialized) {
+        commands.xadd(stream + ":dlq", XAddArgs.Builder.maxlen(MAX_STREAM_LENGTH).approximateTrimming(), Map.of(FIELD_ENVELOPE, serialized));
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    static List<String> travelerProfileSubscriptions() {
+        return new ArrayList<>();
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/messaging/RedisEventSubscriberConnectionFactory.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/messaging/RedisEventSubscriberConnectionFactory.java
@@ -1,0 +1,21 @@
+package com.trainticket.travelerprofile.adapters.messaging;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+
+final class RedisEventSubscriberConnectionFactory implements AutoCloseable {
+    private final RedisClient client;
+
+    RedisEventSubscriberConnectionFactory(String redisUrl) {
+        this.client = RedisClient.create(redisUrl);
+    }
+
+    StatefulRedisConnection<String, String> connect() {
+        return client.connect();
+    }
+
+    @Override
+    public void close() {
+        client.shutdown();
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/ApiDocumentType.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/ApiDocumentType.java
@@ -1,0 +1,7 @@
+package com.trainticket.travelerprofile.application;
+
+public enum ApiDocumentType {
+    ID_CARD,
+    PASSPORT,
+    OTHER
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/ConsumedEventLog.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/ConsumedEventLog.java
@@ -19,8 +19,8 @@ public class ConsumedEventLog {
         this.clock = clock;
     }
 
-    public boolean recordIfFirstSeen(String eventId) {
-        return consumedEventIds.add(eventId);
+    public void record(String eventId) {
+        consumedEventIds.add(eventId);
     }
 
     public boolean hasConsumed(String eventId) {

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/ConsumedEventLog.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/ConsumedEventLog.java
@@ -1,0 +1,33 @@
+package com.trainticket.travelerprofile.application;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ConsumedEventLog {
+    private final Set<String> consumedEventIds = ConcurrentHashMap.newKeySet();
+    private final Clock clock;
+
+    public ConsumedEventLog() {
+        this(Clock.systemUTC());
+    }
+
+    ConsumedEventLog(Clock clock) {
+        this.clock = clock;
+    }
+
+    public boolean recordIfFirstSeen(String eventId) {
+        return consumedEventIds.add(eventId);
+    }
+
+    public boolean hasConsumed(String eventId) {
+        return consumedEventIds.contains(eventId);
+    }
+
+    public Instant now() {
+        return clock.instant();
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/CreateTravelerCommand.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/CreateTravelerCommand.java
@@ -1,0 +1,15 @@
+package com.trainticket.travelerprofile.application;
+
+public record CreateTravelerCommand(
+    String accountId,
+    TravelerType travelerType,
+    String givenName,
+    String familyName,
+    ApiDocumentType documentType,
+    String documentNumber,
+    String contactEmail,
+    String contactPhone,
+    String idempotencyKey,
+    String correlationId
+) {
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/DeduplicatingEventHandler.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/DeduplicatingEventHandler.java
@@ -1,0 +1,21 @@
+package com.trainticket.travelerprofile.application;
+
+import java.util.Objects;
+
+public final class DeduplicatingEventHandler implements EventSubscriber.EventHandler {
+    private final ConsumedEventLog consumedEventLog;
+    private final EventSubscriber.EventHandler delegate;
+
+    public DeduplicatingEventHandler(ConsumedEventLog consumedEventLog, EventSubscriber.EventHandler delegate) {
+        this.consumedEventLog = Objects.requireNonNull(consumedEventLog, "consumedEventLog is required");
+        this.delegate = Objects.requireNonNull(delegate, "delegate is required");
+    }
+
+    @Override
+    public EventSubscriber.HandlerResult handle(EventEnvelope envelope) {
+        if (!consumedEventLog.recordIfFirstSeen(envelope.eventId())) {
+            return EventSubscriber.HandlerResult.SUCCESS;
+        }
+        return delegate.handle(envelope);
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/DeduplicatingEventHandler.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/DeduplicatingEventHandler.java
@@ -13,9 +13,13 @@ public final class DeduplicatingEventHandler implements EventSubscriber.EventHan
 
     @Override
     public EventSubscriber.HandlerResult handle(EventEnvelope envelope) {
-        if (!consumedEventLog.recordIfFirstSeen(envelope.eventId())) {
+        if (consumedEventLog.hasConsumed(envelope.eventId())) {
             return EventSubscriber.HandlerResult.SUCCESS;
         }
-        return delegate.handle(envelope);
+        EventSubscriber.HandlerResult result = delegate.handle(envelope);
+        if (result == EventSubscriber.HandlerResult.SUCCESS) {
+            consumedEventLog.record(envelope.eventId());
+        }
+        return result;
     }
 }

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/EligibilityResult.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/EligibilityResult.java
@@ -1,0 +1,12 @@
+package com.trainticket.travelerprofile.application;
+
+import java.time.Instant;
+
+public record EligibilityResult(
+    String travelerId,
+    String eligibilityRef,
+    boolean eligible,
+    Instant validFrom,
+    Instant validUntil
+) {
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/EventEnvelope.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/EventEnvelope.java
@@ -1,0 +1,16 @@
+package com.trainticket.travelerprofile.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Instant;
+
+public record EventEnvelope(
+    String eventId,
+    String eventType,
+    Instant occurredAt,
+    String correlationId,
+    String causationId,
+    String producer,
+    int schemaVersion,
+    JsonNode payload
+) {
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/EventPublisher.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/EventPublisher.java
@@ -1,0 +1,5 @@
+package com.trainticket.travelerprofile.application;
+
+public interface EventPublisher {
+    void publish(EventEnvelope envelope) throws PublishFailedException;
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/EventSubscriber.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/EventSubscriber.java
@@ -1,0 +1,18 @@
+package com.trainticket.travelerprofile.application;
+
+import java.util.List;
+
+public interface EventSubscriber {
+    void subscribe(List<String> streams, String group, String consumerName, EventHandler handler) throws SubscribeFailedException;
+
+    @FunctionalInterface
+    interface EventHandler {
+        HandlerResult handle(EventEnvelope envelope);
+    }
+
+    enum HandlerResult {
+        SUCCESS,
+        TRANSIENT_FAILURE,
+        FATAL_FAILURE
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/IdempotencyKeyReusedException.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/IdempotencyKeyReusedException.java
@@ -1,0 +1,7 @@
+package com.trainticket.travelerprofile.application;
+
+public class IdempotencyKeyReusedException extends RuntimeException {
+    public IdempotencyKeyReusedException() {
+        super("Idempotency-Key was reused with a different request body");
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/PublishFailedException.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/PublishFailedException.java
@@ -1,0 +1,7 @@
+package com.trainticket.travelerprofile.application;
+
+public class PublishFailedException extends RuntimeException {
+    public PublishFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/SubscribeFailedException.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/SubscribeFailedException.java
@@ -1,0 +1,7 @@
+package com.trainticket.travelerprofile.application;
+
+public class SubscribeFailedException extends RuntimeException {
+    public SubscribeFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/TravelerCreatedView.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/TravelerCreatedView.java
@@ -1,0 +1,11 @@
+package com.trainticket.travelerprofile.application;
+
+import java.time.Instant;
+
+public record TravelerCreatedView(
+    String travelerId,
+    String snapshotVersion,
+    TravelerType travelerType,
+    Instant createdAt
+) {
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/TravelerNotFoundException.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/TravelerNotFoundException.java
@@ -1,0 +1,7 @@
+package com.trainticket.travelerprofile.application;
+
+public class TravelerNotFoundException extends RuntimeException {
+    public TravelerNotFoundException(String travelerId) {
+        super("Traveler profile not found: " + travelerId);
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/TravelerProfileService.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/TravelerProfileService.java
@@ -1,6 +1,15 @@
 package com.trainticket.travelerprofile.application;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.trainticket.travelerprofile.domain.Document;
+import com.trainticket.travelerprofile.domain.DocumentAdded;
+import com.trainticket.travelerprofile.domain.DocumentType;
+import com.trainticket.travelerprofile.domain.DocumentVerified;
+import com.trainticket.travelerprofile.domain.EligibilityExpired;
+import com.trainticket.travelerprofile.domain.EligibilityGranted;
+import com.trainticket.travelerprofile.domain.EligibilityRevoked;
+import com.trainticket.travelerprofile.domain.EligibilitySummary;
 import com.trainticket.travelerprofile.domain.TravelerProfile;
 import com.trainticket.travelerprofile.domain.TravelerProfileEvent;
 import java.nio.charset.StandardCharsets;
@@ -11,6 +20,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.HexFormat;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,10 +54,10 @@ public class TravelerProfileService {
             return replay.responseAs(TravelerCreatedView.class, requestFingerprint);
         }
 
-        Instant now = clock.instant().truncatedTo(ChronoUnit.MILLIS);
+        Instant now = now();
         String commandId = commandId();
         TravelerProfile aggregate = TravelerProfile.create(
-            command.accountId(),
+            command.accountId().trim(),
             displayName(command.givenName(), command.familyName()),
             "1970-01-01",
             command.idempotencyKey(),
@@ -55,25 +65,39 @@ public class TravelerProfileService {
             commandId,
             command.correlationId()
         );
+        if (command.documentType() != null) {
+            aggregate.addDocument(
+                toDomainDocumentType(command.documentType()),
+                command.documentNumber(),
+                "CN",
+                now.minus(1, ChronoUnit.DAYS),
+                now.plus(3650, ChronoUnit.DAYS),
+                displayName(command.givenName(), command.familyName()),
+                true,
+                now,
+                commandId,
+                commandId,
+                command.correlationId()
+            );
+        }
         String travelerId = canonicalTravelerId(aggregate.profileId());
         StoredTraveler stored = new StoredTraveler(
+            aggregate,
             travelerId,
             "sv-1",
             command.accountId().trim(),
             command.travelerType(),
             command.givenName().trim(),
             command.familyName().trim(),
-            command.documentType(),
-            command.documentNumber(),
             command.contactEmail(),
             command.contactPhone(),
             now,
             now
         );
         travelers.put(travelerId, stored);
-        publish(aggregate.domainEvents().getLast(), stored);
+        publishNewEvents(aggregate.domainEvents(), 0, stored);
         TravelerCreatedView response = new TravelerCreatedView(travelerId, stored.snapshotVersion(), stored.travelerType(), stored.createdAt());
-        idempotencyRecords.put(key, IdempotencyRecord.of(requestFingerprint, response, objectMapper));
+        idempotencyRecords.put(key, IdempotencyRecord.of(requestFingerprint, response));
         return response;
     }
 
@@ -89,12 +113,36 @@ public class TravelerProfileService {
             return replay.responseAs(TravelerProfileView.class, requestFingerprint);
         }
         StoredTraveler current = find(command.travelerId());
-        Instant now = clock.instant().truncatedTo(ChronoUnit.MILLIS);
+        TravelerProfile aggregate = current.aggregate();
+        int eventOffset = aggregate.domainEvents().size();
+        Instant now = now();
+        String commandId = commandId();
+
+        if (command.documentType() != null) {
+            aggregate.addDocument(
+                toDomainDocumentType(command.documentType()),
+                command.documentNumber(),
+                "CN",
+                now.minus(1, ChronoUnit.DAYS),
+                now.plus(3650, ChronoUnit.DAYS),
+                displayName(
+                    command.givenName() != null ? command.givenName() : current.givenName(),
+                    command.familyName() != null ? command.familyName() : current.familyName()
+                ),
+                true,
+                now,
+                commandId,
+                commandId,
+                command.correlationId()
+            );
+        }
+        updateAggregatePreferences(command, current, aggregate, eventOffset, now, commandId);
+
         StoredTraveler updated = current.updatedWith(command, nextSnapshotVersion(current.snapshotVersion()), now);
         travelers.put(command.travelerId(), updated);
-        publishProfileUpdated(updated, command.correlationId(), commandId());
+        publishNewEvents(aggregate.domainEvents(), eventOffset, updated);
         TravelerProfileView response = updated.toView();
-        idempotencyRecords.put(key, IdempotencyRecord.of(requestFingerprint, response, objectMapper));
+        idempotencyRecords.put(key, IdempotencyRecord.of(requestFingerprint, response));
         return response;
     }
 
@@ -105,15 +153,33 @@ public class TravelerProfileService {
             return replay.responseAs(EligibilityResult.class, requestFingerprint);
         }
         StoredTraveler traveler = find(travelerId);
-        Instant now = clock.instant().truncatedTo(ChronoUnit.MILLIS);
+        TravelerProfile aggregate = traveler.aggregate();
+        int eventOffset = aggregate.domainEvents().size();
+        Instant now = now();
         boolean eligible = switch (traveler.travelerType()) {
             case STUDENT, SENIOR, MILITARY, CHILD, INFANT -> true;
             case ADULT -> false;
         };
-        String eligibilityRef = "elig-" + UUID.randomUUID();
+
+        EligibilitySummary summary = null;
+        String commandId = commandId();
+        if (eligible) {
+            summary = aggregate.grantEligibility(
+                traveler.travelerType().name(),
+                "TRAVELER_PROFILE_API",
+                fingerprint("eligibility", travelerId, objectMapper.createObjectNode().put("travelerType", traveler.travelerType().name())),
+                now,
+                now.plus(365, ChronoUnit.DAYS),
+                now,
+                commandId,
+                commandId,
+                correlationId
+            );
+        }
+        String eligibilityRef = summary == null ? "elig-" + UUID.randomUUID() : canonicalEligibilityRef(summary.eligibilityId());
         EligibilityResult result = new EligibilityResult(travelerId, eligibilityRef, eligible, now, now.plus(365, ChronoUnit.DAYS));
-        publishEligibilityChanged(traveler, result, correlationId, commandId());
-        idempotencyRecords.put(key, IdempotencyRecord.of(requestFingerprint, result, objectMapper));
+        publishNewEvents(aggregate.domainEvents(), eventOffset, traveler);
+        idempotencyRecords.put(key, IdempotencyRecord.of(requestFingerprint, result));
         return result;
     }
 
@@ -162,54 +228,114 @@ public class TravelerProfileService {
         return value == null || value.isBlank();
     }
 
+    private void updateAggregatePreferences(
+        UpdateTravelerCommand command,
+        StoredTraveler current,
+        TravelerProfile aggregate,
+        int eventOffset,
+        Instant now,
+        String commandId
+    ) {
+        if (command.accountId() != null && !command.accountId().trim().equals(current.accountId())) {
+            aggregate.updatePreference("accountId", command.accountId().trim(), now, commandId, commandId, command.correlationId());
+        }
+        if (command.travelerType() != null && command.travelerType() != current.travelerType()) {
+            aggregate.updatePreference("travelerType", command.travelerType().name(), now, commandId, commandId, command.correlationId());
+        }
+        if (command.givenName() != null || command.familyName() != null) {
+            String nextGiven = command.givenName() != null ? command.givenName().trim() : current.givenName();
+            String nextFamily = command.familyName() != null ? command.familyName().trim() : current.familyName();
+            String nextDisplayName = displayName(nextGiven, nextFamily);
+            if (!nextDisplayName.equals(displayName(current.givenName(), current.familyName()))) {
+                aggregate.updatePreference("displayName", nextDisplayName, now, commandId, commandId, command.correlationId());
+            }
+        }
+        if (command.contactEmail() != null && !command.contactEmail().equals(current.contactEmail())) {
+            aggregate.updatePreference("contactEmail", command.contactEmail(), now, commandId, commandId, command.correlationId());
+        }
+        if (command.contactPhone() != null && !command.contactPhone().equals(current.contactPhone())) {
+            aggregate.updatePreference("contactPhone", command.contactPhone(), now, commandId, commandId, command.correlationId());
+        }
+        if (command.documentType() == null && aggregate.domainEvents().size() == eventOffset) {
+            aggregate.updatePreference("snapshotTouchedAt", now.toString(), now, commandId, commandId, command.correlationId());
+        }
+    }
+
+    private void publishNewEvents(List<TravelerProfileEvent> events, int eventOffset, StoredTraveler traveler) {
+        for (int index = eventOffset; index < events.size(); index++) {
+            publish(events.get(index), traveler);
+        }
+    }
+
     private void publish(TravelerProfileEvent event, StoredTraveler traveler) {
         eventPublisher.publish(new EventEnvelope(
             canonicalEventId(event.eventId()),
-            "TravelerProfileUpdated",
+            externalEventType(event),
             event.occurredAt(),
             canonicalCorrelationId(event.correlationId()),
-            canonicalCommandId(event.causationId()),
+            canonicalCausationId(event.causationId()),
             PRODUCER,
             event.schemaVersion(),
-            objectMapper.valueToTree(Map.of(
-                "travelerId", traveler.travelerId(),
-                "snapshotVersion", traveler.snapshotVersion(),
-                "travelerType", traveler.travelerType().name(),
-                "updatedAt", traveler.updatedAt().toString()
-            ))
+            payloadFor(event, traveler)
         ));
     }
 
-    private void publishProfileUpdated(StoredTraveler traveler, String correlationId, String causationId) {
-        eventPublisher.publish(new EventEnvelope(
-            canonicalEventId(UUID.randomUUID().toString()),
-            "TravelerProfileUpdated",
-            clock.instant().truncatedTo(ChronoUnit.MILLIS),
-            canonicalCorrelationId(correlationId),
-            canonicalCommandId(causationId),
-            PRODUCER,
-            1,
-            objectMapper.valueToTree(traveler.toView())
-        ));
+    private ObjectNode payloadFor(TravelerProfileEvent event, StoredTraveler traveler) {
+        if (event instanceof EligibilityGranted granted) {
+            return objectMapper.createObjectNode()
+                .put("travelerId", traveler.travelerId())
+                .put("eligibilityRef", canonicalEligibilityRef(granted.eligibilityId()))
+                .put("eligible", true)
+                .put("validFrom", granted.validFrom().toString())
+                .put("validUntil", granted.validUntil().toString())
+                .put("determinedAt", granted.occurredAt().toString());
+        }
+        if (event instanceof EligibilityExpired expired) {
+            return objectMapper.createObjectNode()
+                .put("travelerId", traveler.travelerId())
+                .put("eligibilityRef", canonicalEligibilityRef(expired.eligibilityId()))
+                .put("expiredAt", expired.occurredAt().toString());
+        }
+        if (event instanceof EligibilityRevoked revoked) {
+            return objectMapper.createObjectNode()
+                .put("travelerId", traveler.travelerId())
+                .put("eligibilityRef", canonicalEligibilityRef(revoked.eligibilityId()))
+                .put("revokedAt", revoked.occurredAt().toString())
+                .put("reason", revoked.reason());
+        }
+        if (event instanceof DocumentVerified verified) {
+            return objectMapper.createObjectNode()
+                .put("travelerId", traveler.travelerId())
+                .put("documentId", verified.documentId())
+                .put("documentType", verified.documentType().name())
+                .put("verifiedAt", verified.occurredAt().toString());
+        }
+        ObjectNode payload = objectMapper.createObjectNode()
+            .put("travelerId", traveler.travelerId())
+            .put("snapshotVersion", traveler.snapshotVersion())
+            .put("updatedAt", traveler.updatedAt().toString())
+            .put("travelerType", traveler.travelerType().name());
+        if (traveler.maskedDocumentRef() != null) {
+            payload.put("maskedDocumentRef", traveler.maskedDocumentRef());
+        }
+        if (event instanceof DocumentAdded added) {
+            payload.put("documentType", toApiDocumentType(added.documentType()).name());
+        }
+        return payload;
     }
 
-    private void publishEligibilityChanged(StoredTraveler traveler, EligibilityResult result, String correlationId, String causationId) {
-        eventPublisher.publish(new EventEnvelope(
-            canonicalEventId(UUID.randomUUID().toString()),
-            "TravelerEligibilityChanged",
-            clock.instant().truncatedTo(ChronoUnit.MILLIS),
-            canonicalCorrelationId(correlationId),
-            canonicalCommandId(causationId),
-            PRODUCER,
-            1,
-            objectMapper.valueToTree(Map.of(
-                "travelerId", traveler.travelerId(),
-                "eligibilityRef", result.eligibilityRef(),
-                "eligible", result.eligible(),
-                "validFrom", result.validFrom().toString(),
-                "validUntil", result.validUntil().toString()
-            ))
-        ));
+    private static String externalEventType(TravelerProfileEvent event) {
+        if (event instanceof EligibilityGranted || event instanceof EligibilityExpired || event instanceof EligibilityRevoked) {
+            return "TravelerEligibilityChanged";
+        }
+        if (event instanceof DocumentVerified) {
+            return "TravelerDocumentVerified";
+        }
+        return "TravelerProfileUpdated";
+    }
+
+    private Instant now() {
+        return clock.instant().truncatedTo(ChronoUnit.MILLIS);
     }
 
     private static String displayName(String givenName, String familyName) {
@@ -217,7 +343,11 @@ public class TravelerProfileService {
     }
 
     private static String canonicalTravelerId(String profileId) {
-        return "tvl-" + profileId;
+        return profileId.startsWith("tvl-") ? profileId : "tvl-" + profileId;
+    }
+
+    private static String canonicalEligibilityRef(String eligibilityId) {
+        return eligibilityId.startsWith("elig-") ? eligibilityId : "elig-" + eligibilityId;
     }
 
     private static String commandId() {
@@ -230,6 +360,10 @@ public class TravelerProfileService {
 
     private static String canonicalCommandId(String id) {
         return id.startsWith("cmd-") ? id : "cmd-" + id;
+    }
+
+    private static String canonicalCausationId(String id) {
+        return id.startsWith("cmd-") || id.startsWith("evt-") ? id : "cmd-" + id;
     }
 
     private static String canonicalCorrelationId(String id) {
@@ -245,6 +379,22 @@ public class TravelerProfileService {
         return "sv-" + (value + 1);
     }
 
+    private static DocumentType toDomainDocumentType(ApiDocumentType documentType) {
+        return switch (documentType) {
+            case ID_CARD -> DocumentType.IDENTITY_CARD;
+            case PASSPORT -> DocumentType.PASSPORT;
+            case OTHER -> DocumentType.OTHER;
+        };
+    }
+
+    private static ApiDocumentType toApiDocumentType(DocumentType documentType) {
+        return switch (documentType) {
+            case IDENTITY_CARD -> ApiDocumentType.ID_CARD;
+            case PASSPORT -> ApiDocumentType.PASSPORT;
+            default -> ApiDocumentType.OTHER;
+        };
+    }
+
     public static String fingerprint(String method, String path, com.fasterxml.jackson.databind.JsonNode body) {
         String input = method + " " + path + " " + (body == null ? "" : body.toString());
         try {
@@ -256,7 +406,7 @@ public class TravelerProfileService {
     }
 
     private record IdempotencyRecord(String requestFingerprint, Object response) {
-        static IdempotencyRecord of(String requestFingerprint, Object response, ObjectMapper objectMapper) {
+        static IdempotencyRecord of(String requestFingerprint, Object response) {
             return new IdempotencyRecord(requestFingerprint, response);
         }
 
@@ -269,14 +419,13 @@ public class TravelerProfileService {
     }
 
     private record StoredTraveler(
+        TravelerProfile aggregate,
         String travelerId,
         String snapshotVersion,
         String accountId,
         TravelerType travelerType,
         String givenName,
         String familyName,
-        ApiDocumentType documentType,
-        String documentNumber,
         String contactEmail,
         String contactPhone,
         Instant createdAt,
@@ -290,8 +439,8 @@ public class TravelerProfileService {
                 travelerType,
                 givenName,
                 familyName,
-                documentType,
-                mask(documentNumber),
+                documentType(),
+                maskedDocumentRef(),
                 contactEmail,
                 contactPhone,
                 createdAt,
@@ -301,14 +450,13 @@ public class TravelerProfileService {
 
         StoredTraveler updatedWith(UpdateTravelerCommand command, String nextVersion, Instant now) {
             return new StoredTraveler(
+                aggregate,
                 travelerId,
                 nextVersion,
                 command.accountId() != null ? command.accountId().trim() : accountId,
                 command.travelerType() != null ? command.travelerType() : travelerType,
                 command.givenName() != null ? command.givenName().trim() : givenName,
                 command.familyName() != null ? command.familyName().trim() : familyName,
-                command.documentType() != null ? command.documentType() : documentType,
-                command.documentNumber() != null ? command.documentNumber() : documentNumber,
                 command.contactEmail() != null ? command.contactEmail() : contactEmail,
                 command.contactPhone() != null ? command.contactPhone() : contactPhone,
                 createdAt,
@@ -316,15 +464,14 @@ public class TravelerProfileService {
             );
         }
 
-        private static String mask(String documentNumber) {
-            if (documentNumber == null || documentNumber.isBlank()) {
-                return null;
-            }
-            if (documentNumber.length() <= 4) {
-                return "***" + documentNumber;
-            }
-            return documentNumber.substring(0, Math.min(2, documentNumber.length())) + "***" + documentNumber.substring(documentNumber.length() - 4);
+        ApiDocumentType documentType() {
+            Document document = aggregate.primaryDocument();
+            return document == null ? null : toApiDocumentType(document.documentType());
+        }
+
+        String maskedDocumentRef() {
+            Document document = aggregate.primaryDocument();
+            return document == null ? null : document.maskedDocumentRef();
         }
     }
-
 }

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/TravelerProfileService.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/TravelerProfileService.java
@@ -1,0 +1,330 @@
+package com.trainticket.travelerprofile.application;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.travelerprofile.domain.TravelerProfile;
+import com.trainticket.travelerprofile.domain.TravelerProfileEvent;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TravelerProfileService {
+    private static final String PRODUCER = "traveler-profile";
+
+    private final Map<String, StoredTraveler> travelers = new ConcurrentHashMap<>();
+    private final Map<String, IdempotencyRecord> idempotencyRecords = new ConcurrentHashMap<>();
+    private final EventPublisher eventPublisher;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    public TravelerProfileService(EventPublisher eventPublisher, ObjectMapper objectMapper) {
+        this(eventPublisher, objectMapper, Clock.systemUTC());
+    }
+
+    TravelerProfileService(EventPublisher eventPublisher, ObjectMapper objectMapper, Clock clock) {
+        this.eventPublisher = eventPublisher;
+        this.objectMapper = objectMapper;
+        this.clock = clock;
+    }
+
+    public TravelerCreatedView create(CreateTravelerCommand command, String requestFingerprint) {
+        validateCreate(command);
+        String key = scopedKey("POST:/api/v1/travelers", command.idempotencyKey());
+        IdempotencyRecord replay = idempotencyRecords.get(key);
+        if (replay != null) {
+            return replay.responseAs(TravelerCreatedView.class, requestFingerprint);
+        }
+
+        Instant now = clock.instant().truncatedTo(ChronoUnit.MILLIS);
+        String commandId = commandId();
+        TravelerProfile aggregate = TravelerProfile.create(
+            command.accountId(),
+            displayName(command.givenName(), command.familyName()),
+            "1970-01-01",
+            command.idempotencyKey(),
+            now,
+            commandId,
+            command.correlationId()
+        );
+        String travelerId = canonicalTravelerId(aggregate.profileId());
+        StoredTraveler stored = new StoredTraveler(
+            travelerId,
+            "sv-1",
+            command.accountId().trim(),
+            command.travelerType(),
+            command.givenName().trim(),
+            command.familyName().trim(),
+            command.documentType(),
+            command.documentNumber(),
+            command.contactEmail(),
+            command.contactPhone(),
+            now,
+            now
+        );
+        travelers.put(travelerId, stored);
+        publish(aggregate.domainEvents().getLast(), stored);
+        TravelerCreatedView response = new TravelerCreatedView(travelerId, stored.snapshotVersion(), stored.travelerType(), stored.createdAt());
+        idempotencyRecords.put(key, IdempotencyRecord.of(requestFingerprint, response, objectMapper));
+        return response;
+    }
+
+    public TravelerProfileView get(String travelerId) {
+        return find(travelerId).toView();
+    }
+
+    public TravelerProfileView update(UpdateTravelerCommand command, String requestFingerprint) {
+        validateUpdate(command);
+        String key = scopedKey("PATCH:/api/v1/travelers/" + command.travelerId(), command.idempotencyKey());
+        IdempotencyRecord replay = idempotencyRecords.get(key);
+        if (replay != null) {
+            return replay.responseAs(TravelerProfileView.class, requestFingerprint);
+        }
+        StoredTraveler current = find(command.travelerId());
+        Instant now = clock.instant().truncatedTo(ChronoUnit.MILLIS);
+        StoredTraveler updated = current.updatedWith(command, nextSnapshotVersion(current.snapshotVersion()), now);
+        travelers.put(command.travelerId(), updated);
+        publishProfileUpdated(updated, command.correlationId(), commandId());
+        TravelerProfileView response = updated.toView();
+        idempotencyRecords.put(key, IdempotencyRecord.of(requestFingerprint, response, objectMapper));
+        return response;
+    }
+
+    public EligibilityResult determineEligibility(String travelerId, String idempotencyKey, String correlationId, String requestFingerprint) {
+        String key = scopedKey("POST:/api/v1/travelers/" + travelerId + "/eligibility", idempotencyKey);
+        IdempotencyRecord replay = idempotencyRecords.get(key);
+        if (replay != null) {
+            return replay.responseAs(EligibilityResult.class, requestFingerprint);
+        }
+        StoredTraveler traveler = find(travelerId);
+        Instant now = clock.instant().truncatedTo(ChronoUnit.MILLIS);
+        boolean eligible = switch (traveler.travelerType()) {
+            case STUDENT, SENIOR, MILITARY, CHILD, INFANT -> true;
+            case ADULT -> false;
+        };
+        String eligibilityRef = "elig-" + UUID.randomUUID();
+        EligibilityResult result = new EligibilityResult(travelerId, eligibilityRef, eligible, now, now.plus(365, ChronoUnit.DAYS));
+        publishEligibilityChanged(traveler, result, correlationId, commandId());
+        idempotencyRecords.put(key, IdempotencyRecord.of(requestFingerprint, result, objectMapper));
+        return result;
+    }
+
+    private StoredTraveler find(String travelerId) {
+        StoredTraveler traveler = travelers.get(travelerId);
+        if (traveler == null) {
+            throw new TravelerNotFoundException(travelerId);
+        }
+        return traveler;
+    }
+
+    private void validateCreate(CreateTravelerCommand command) {
+        Map<String, String> errors = new LinkedHashMap<>();
+        requireText(command.accountId(), "accountId", errors);
+        if (command.travelerType() == null) errors.put("travelerType", "travelerType is required");
+        requireText(command.givenName(), "givenName", errors);
+        requireText(command.familyName(), "familyName", errors);
+        if ((command.documentType() == null) != isBlank(command.documentNumber())) {
+            errors.put("document", "documentType and documentNumber must be supplied together");
+        }
+        if (!errors.isEmpty()) {
+            throw new ValidationException("Request validation failed", errors);
+        }
+    }
+
+    private void validateUpdate(UpdateTravelerCommand command) {
+        Map<String, String> errors = new LinkedHashMap<>();
+        if (command.accountId() != null) requireText(command.accountId(), "accountId", errors);
+        if (command.givenName() != null) requireText(command.givenName(), "givenName", errors);
+        if (command.familyName() != null) requireText(command.familyName(), "familyName", errors);
+        if ((command.documentType() == null) != (command.documentNumber() == null || isBlank(command.documentNumber()))) {
+            errors.put("document", "documentType and documentNumber must be supplied together");
+        }
+        if (!errors.isEmpty()) {
+            throw new ValidationException("Request validation failed", errors);
+        }
+    }
+
+    private static void requireText(String value, String field, Map<String, String> errors) {
+        if (isBlank(value)) {
+            errors.put(field, field + " is required");
+        }
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private void publish(TravelerProfileEvent event, StoredTraveler traveler) {
+        eventPublisher.publish(new EventEnvelope(
+            canonicalEventId(event.eventId()),
+            "TravelerProfileUpdated",
+            event.occurredAt(),
+            canonicalCorrelationId(event.correlationId()),
+            canonicalCommandId(event.causationId()),
+            PRODUCER,
+            event.schemaVersion(),
+            objectMapper.valueToTree(Map.of(
+                "travelerId", traveler.travelerId(),
+                "snapshotVersion", traveler.snapshotVersion(),
+                "travelerType", traveler.travelerType().name(),
+                "updatedAt", traveler.updatedAt().toString()
+            ))
+        ));
+    }
+
+    private void publishProfileUpdated(StoredTraveler traveler, String correlationId, String causationId) {
+        eventPublisher.publish(new EventEnvelope(
+            canonicalEventId(UUID.randomUUID().toString()),
+            "TravelerProfileUpdated",
+            clock.instant().truncatedTo(ChronoUnit.MILLIS),
+            canonicalCorrelationId(correlationId),
+            canonicalCommandId(causationId),
+            PRODUCER,
+            1,
+            objectMapper.valueToTree(traveler.toView())
+        ));
+    }
+
+    private void publishEligibilityChanged(StoredTraveler traveler, EligibilityResult result, String correlationId, String causationId) {
+        eventPublisher.publish(new EventEnvelope(
+            canonicalEventId(UUID.randomUUID().toString()),
+            "TravelerEligibilityChanged",
+            clock.instant().truncatedTo(ChronoUnit.MILLIS),
+            canonicalCorrelationId(correlationId),
+            canonicalCommandId(causationId),
+            PRODUCER,
+            1,
+            objectMapper.valueToTree(Map.of(
+                "travelerId", traveler.travelerId(),
+                "eligibilityRef", result.eligibilityRef(),
+                "eligible", result.eligible(),
+                "validFrom", result.validFrom().toString(),
+                "validUntil", result.validUntil().toString()
+            ))
+        ));
+    }
+
+    private static String displayName(String givenName, String familyName) {
+        return givenName.trim() + " " + familyName.trim();
+    }
+
+    private static String canonicalTravelerId(String profileId) {
+        return "tvl-" + profileId;
+    }
+
+    private static String commandId() {
+        return canonicalCommandId(UUID.randomUUID().toString());
+    }
+
+    private static String canonicalEventId(String id) {
+        return id.startsWith("evt-") ? id : "evt-" + id;
+    }
+
+    private static String canonicalCommandId(String id) {
+        return id.startsWith("cmd-") ? id : "cmd-" + id;
+    }
+
+    private static String canonicalCorrelationId(String id) {
+        return id.startsWith("corr-") ? id : "corr-" + id;
+    }
+
+    private static String scopedKey(String scope, String idempotencyKey) {
+        return scope + ":" + idempotencyKey;
+    }
+
+    private static String nextSnapshotVersion(String current) {
+        int value = Integer.parseInt(current.substring("sv-".length()));
+        return "sv-" + (value + 1);
+    }
+
+    public static String fingerprint(String method, String path, com.fasterxml.jackson.databind.JsonNode body) {
+        String input = method + " " + path + " " + (body == null ? "" : body.toString());
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(input.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 digest is unavailable", e);
+        }
+    }
+
+    private record IdempotencyRecord(String requestFingerprint, Object response) {
+        static IdempotencyRecord of(String requestFingerprint, Object response, ObjectMapper objectMapper) {
+            return new IdempotencyRecord(requestFingerprint, response);
+        }
+
+        <T> T responseAs(Class<T> type, String candidateFingerprint) {
+            if (!requestFingerprint.equals(candidateFingerprint)) {
+                throw new IdempotencyKeyReusedException();
+            }
+            return type.cast(response);
+        }
+    }
+
+    private record StoredTraveler(
+        String travelerId,
+        String snapshotVersion,
+        String accountId,
+        TravelerType travelerType,
+        String givenName,
+        String familyName,
+        ApiDocumentType documentType,
+        String documentNumber,
+        String contactEmail,
+        String contactPhone,
+        Instant createdAt,
+        Instant updatedAt
+    ) {
+        TravelerProfileView toView() {
+            return new TravelerProfileView(
+                travelerId,
+                snapshotVersion,
+                accountId,
+                travelerType,
+                givenName,
+                familyName,
+                documentType,
+                mask(documentNumber),
+                contactEmail,
+                contactPhone,
+                createdAt,
+                updatedAt
+            );
+        }
+
+        StoredTraveler updatedWith(UpdateTravelerCommand command, String nextVersion, Instant now) {
+            return new StoredTraveler(
+                travelerId,
+                nextVersion,
+                command.accountId() != null ? command.accountId().trim() : accountId,
+                command.travelerType() != null ? command.travelerType() : travelerType,
+                command.givenName() != null ? command.givenName().trim() : givenName,
+                command.familyName() != null ? command.familyName().trim() : familyName,
+                command.documentType() != null ? command.documentType() : documentType,
+                command.documentNumber() != null ? command.documentNumber() : documentNumber,
+                command.contactEmail() != null ? command.contactEmail() : contactEmail,
+                command.contactPhone() != null ? command.contactPhone() : contactPhone,
+                createdAt,
+                now
+            );
+        }
+
+        private static String mask(String documentNumber) {
+            if (documentNumber == null || documentNumber.isBlank()) {
+                return null;
+            }
+            if (documentNumber.length() <= 4) {
+                return "***" + documentNumber;
+            }
+            return documentNumber.substring(0, Math.min(2, documentNumber.length())) + "***" + documentNumber.substring(documentNumber.length() - 4);
+        }
+    }
+
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/TravelerProfileView.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/TravelerProfileView.java
@@ -1,0 +1,19 @@
+package com.trainticket.travelerprofile.application;
+
+import java.time.Instant;
+
+public record TravelerProfileView(
+    String travelerId,
+    String snapshotVersion,
+    String accountId,
+    TravelerType travelerType,
+    String givenName,
+    String familyName,
+    ApiDocumentType documentType,
+    String maskedDocumentRef,
+    String contactEmail,
+    String contactPhone,
+    Instant createdAt,
+    Instant updatedAt
+) {
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/TravelerType.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/TravelerType.java
@@ -1,0 +1,10 @@
+package com.trainticket.travelerprofile.application;
+
+public enum TravelerType {
+    ADULT,
+    CHILD,
+    INFANT,
+    STUDENT,
+    SENIOR,
+    MILITARY
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/UpdateTravelerCommand.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/UpdateTravelerCommand.java
@@ -1,0 +1,16 @@
+package com.trainticket.travelerprofile.application;
+
+public record UpdateTravelerCommand(
+    String travelerId,
+    String accountId,
+    TravelerType travelerType,
+    String givenName,
+    String familyName,
+    ApiDocumentType documentType,
+    String documentNumber,
+    String contactEmail,
+    String contactPhone,
+    String idempotencyKey,
+    String correlationId
+) {
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/ValidationException.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/ValidationException.java
@@ -1,0 +1,16 @@
+package com.trainticket.travelerprofile.application;
+
+import java.util.Map;
+
+public class ValidationException extends RuntimeException {
+    private final Map<String, String> details;
+
+    public ValidationException(String message, Map<String, String> details) {
+        super(message);
+        this.details = Map.copyOf(details);
+    }
+
+    public Map<String, String> details() {
+        return details;
+    }
+}

--- a/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/adapters/http/Json.java
+++ b/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/adapters/http/Json.java
@@ -1,0 +1,13 @@
+package com.trainticket.travelerprofile.adapters.http;
+
+import com.jayway.jsonpath.JsonPath;
+import org.springframework.test.web.servlet.MvcResult;
+
+final class Json {
+    private Json() {
+    }
+
+    static String read(MvcResult result, String path) throws Exception {
+        return JsonPath.read(result.getResponse().getContentAsString(), path);
+    }
+}

--- a/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/adapters/http/TravelerControllerTest.java
+++ b/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/adapters/http/TravelerControllerTest.java
@@ -1,0 +1,156 @@
+package com.trainticket.travelerprofile.adapters.http;
+
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.travelerprofile.NoOpRuntimeTracer;
+import com.trainticket.travelerprofile.RequestContextFilter;
+import com.trainticket.travelerprofile.application.EventEnvelope;
+import com.trainticket.travelerprofile.application.EventPublisher;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.test.web.servlet.MvcResult;
+
+class TravelerControllerTest {
+    MockMvc mockMvc;
+    RecordingEventPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+        publisher = new RecordingEventPublisher();
+        TravelerController controller = new TravelerController(
+            new com.trainticket.travelerprofile.application.TravelerProfileService(publisher, objectMapper)
+        );
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+            .addFilters(new RequestContextFilter(new NoOpRuntimeTracer()))
+            .setControllerAdvice(new ApiExceptionHandler())
+            .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+            .build();
+    }
+
+    @Test
+    void createTravelerHappyPathAndReplayReturnsOriginalResult() throws Exception {
+        String body = """
+            {"accountId":"acc-1","travelerType":"ADULT","givenName":"Wei","familyName":"Zhang","documentType":"ID_CARD","documentNumber":"110101199001151234","contactEmail":"wei@example.test","contactPhone":"13800000000"}
+            """;
+
+        MvcResult first = mockMvc.perform(post("/api/v1/travelers")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Idempotency-Key", "018f0000-0000-7000-8000-000000000001")
+                .header("X-Correlation-Id", "corr-018f0000-0000-7000-8000-000000000099")
+                .content(body))
+            .andExpect(status().isCreated())
+            .andExpect(header().string("X-Correlation-Id", "corr-018f0000-0000-7000-8000-000000000099"))
+            .andExpect(jsonPath("$.travelerId", startsWith("tvl-")))
+            .andExpect(jsonPath("$.snapshotVersion").value("sv-1"))
+            .andExpect(jsonPath("$.travelerType").value("ADULT"))
+            .andReturn();
+        org.junit.jupiter.api.Assertions.assertEquals("TravelerProfileUpdated", publisher.envelopes.getFirst().eventType());
+        org.junit.jupiter.api.Assertions.assertEquals("traveler-profile", publisher.envelopes.getFirst().producer());
+
+        mockMvc.perform(post("/api/v1/travelers")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Idempotency-Key", "018f0000-0000-7000-8000-000000000001")
+                .header("X-Correlation-Id", "corr-018f0000-0000-7000-8000-000000000099")
+                .content(body))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.travelerId").value(Json.read(first, "$.travelerId")));
+    }
+
+    @Test
+    void getPatchAndEligibilityHappyPaths() throws Exception {
+        String travelerId = createTraveler();
+
+        mockMvc.perform(get("/api/v1/travelers/{travelerId}", travelerId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.travelerId").value(travelerId))
+            .andExpect(jsonPath("$.maskedDocumentRef").value("E1***5678"));
+
+        mockMvc.perform(patch("/api/v1/travelers/{travelerId}", travelerId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Idempotency-Key", "018f0000-0000-7000-8000-000000000002")
+                .content("{\"travelerType\":\"STUDENT\",\"contactPhone\":\"13900000000\"}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.travelerType").value("STUDENT"))
+            .andExpect(jsonPath("$.snapshotVersion").value("sv-2"));
+
+        mockMvc.perform(post("/api/v1/travelers/{travelerId}/eligibility", travelerId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Idempotency-Key", "018f0000-0000-7000-8000-000000000003")
+                .content("{}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.travelerId").value(travelerId))
+            .andExpect(jsonPath("$.eligibilityRef", startsWith("elig-")))
+            .andExpect(jsonPath("$.eligible").value(true));
+    }
+
+    @Test
+    void validationFailureUsesCanonicalErrorShape() throws Exception {
+        mockMvc.perform(post("/api/v1/travelers")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Idempotency-Key", "018f0000-0000-7000-8000-000000000004")
+                .header("X-Correlation-Id", "corr-err")
+                .content("{\"travelerType\":\"ADULT\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"))
+            .andExpect(jsonPath("$.correlationId").value("corr-err"))
+            .andExpect(jsonPath("$.details.accountId").exists());
+    }
+
+    @Test
+    void idempotencyKeyReuseWithDifferentBodyReturns422() throws Exception {
+        String first = "{\"accountId\":\"acc-1\",\"travelerType\":\"ADULT\",\"givenName\":\"Wei\",\"familyName\":\"Zhang\"}";
+        String second = "{\"accountId\":\"acc-1\",\"travelerType\":\"CHILD\",\"givenName\":\"Wei\",\"familyName\":\"Zhang\"}";
+        mockMvc.perform(post("/api/v1/travelers")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Idempotency-Key", "018f0000-0000-7000-8000-000000000005")
+                .content(first))
+            .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/v1/travelers")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Idempotency-Key", "018f0000-0000-7000-8000-000000000005")
+                .content(second))
+            .andExpect(status().isUnprocessableEntity())
+            .andExpect(jsonPath("$.code").value("IDEMPOTENCY_KEY_REUSED"));
+    }
+
+    @Test
+    void getUnknownTravelerReturns404() throws Exception {
+        mockMvc.perform(get("/api/v1/travelers/tvl-missing"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    private String createTraveler() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/travelers")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Idempotency-Key", "018f0000-0000-7000-8000-000000000006")
+                .content("{\"accountId\":\"acc-2\",\"travelerType\":\"ADULT\",\"givenName\":\"Mei\",\"familyName\":\"Li\",\"documentType\":\"PASSPORT\",\"documentNumber\":\"E12345678\"}"))
+            .andExpect(status().isCreated())
+            .andReturn();
+        return Json.read(result, "$.travelerId");
+    }
+
+    static class RecordingEventPublisher implements EventPublisher {
+        final List<EventEnvelope> envelopes = new ArrayList<>();
+
+        @Override
+        public void publish(EventEnvelope envelope) {
+            envelopes.add(envelope);
+        }
+    }
+}

--- a/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/adapters/http/TravelerControllerTest.java
+++ b/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/adapters/http/TravelerControllerTest.java
@@ -60,6 +60,8 @@ class TravelerControllerTest {
             .andReturn();
         org.junit.jupiter.api.Assertions.assertEquals("TravelerProfileUpdated", publisher.envelopes.getFirst().eventType());
         org.junit.jupiter.api.Assertions.assertEquals("traveler-profile", publisher.envelopes.getFirst().producer());
+        org.junit.jupiter.api.Assertions.assertTrue(publisher.envelopes.stream().allMatch(envelope -> envelope.eventId().startsWith("evt-")));
+        org.junit.jupiter.api.Assertions.assertTrue(publisher.envelopes.stream().allMatch(envelope -> envelope.causationId().startsWith("cmd-") || envelope.causationId().startsWith("evt-")));
 
         mockMvc.perform(post("/api/v1/travelers")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -133,6 +135,18 @@ class TravelerControllerTest {
         mockMvc.perform(get("/api/v1/travelers/tvl-missing"))
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void updateDomainInvariantViolationSurfacesCanonicalDomainError() throws Exception {
+        String travelerId = createTraveler();
+
+        mockMvc.perform(patch("/api/v1/travelers/{travelerId}", travelerId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Idempotency-Key", "018f0000-0000-7000-8000-000000000007")
+                .content("{\"documentType\":\"PASSPORT\",\"documentNumber\":\"E12345678\"}"))
+            .andExpect(status().isUnprocessableEntity())
+            .andExpect(jsonPath("$.code").value("DOMAIN_RULE_VIOLATION"));
     }
 
     private String createTraveler() throws Exception {

--- a/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/application/MessagingPortTest.java
+++ b/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/application/MessagingPortTest.java
@@ -1,0 +1,73 @@
+package com.trainticket.travelerprofile.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MessagingPortTest {
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    @Test
+    void publisherReceivesCorrectEnvelopeShape() {
+        InMemoryPublisher publisher = new InMemoryPublisher();
+        EventEnvelope envelope = new EventEnvelope(
+            "evt-018f0000-0000-7000-8000-000000000010",
+            "TravelerProfileUpdated",
+            Instant.parse("2026-07-05T10:30:00Z"),
+            "corr-018f0000-0000-7000-8000-000000000011",
+            "cmd-018f0000-0000-7000-8000-000000000012",
+            "traveler-profile",
+            1,
+            objectMapper.createObjectNode().put("travelerId", "tvl-018f0000-0000-7000-8000-000000000013")
+        );
+
+        publisher.publish(envelope);
+
+        EventEnvelope published = publisher.envelopes.getFirst();
+        assertTrue(published.eventId().startsWith("evt-"));
+        assertEquals("TravelerProfileUpdated", published.eventType());
+        assertEquals("traveler-profile", published.producer());
+        assertEquals(1, published.schemaVersion());
+        assertEquals("tvl-018f0000-0000-7000-8000-000000000013", published.payload().get("travelerId").asText());
+    }
+
+    @Test
+    void subscriberDeduplicatesDuplicateEventId() {
+        ConsumedEventLog log = new ConsumedEventLog();
+        List<String> handled = new ArrayList<>();
+        DeduplicatingEventHandler handler = new DeduplicatingEventHandler(log, envelope -> {
+            handled.add(envelope.eventId());
+            return EventSubscriber.HandlerResult.SUCCESS;
+        });
+        EventEnvelope envelope = new EventEnvelope(
+            "evt-duplicate",
+            "TravelerProfileUpdated",
+            Instant.parse("2026-07-05T10:30:00Z"),
+            "corr-1",
+            "cmd-1",
+            "traveler-profile",
+            1,
+            objectMapper.createObjectNode()
+        );
+
+        assertEquals(EventSubscriber.HandlerResult.SUCCESS, handler.handle(envelope));
+        assertEquals(EventSubscriber.HandlerResult.SUCCESS, handler.handle(envelope));
+
+        assertEquals(List.of("evt-duplicate"), handled);
+        assertTrue(log.hasConsumed("evt-duplicate"));
+    }
+
+    private static final class InMemoryPublisher implements EventPublisher {
+        private final List<EventEnvelope> envelopes = new ArrayList<>();
+
+        @Override
+        public void publish(EventEnvelope envelope) {
+            envelopes.add(envelope);
+        }
+    }
+}

--- a/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/application/MessagingPortTest.java
+++ b/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/application/MessagingPortTest.java
@@ -62,6 +62,34 @@ class MessagingPortTest {
         assertTrue(log.hasConsumed("evt-duplicate"));
     }
 
+    @Test
+    void transientFailureIsNotRecordedAndRedeliveryInvokesDelegateAgain() {
+        ConsumedEventLog log = new ConsumedEventLog();
+        List<String> handled = new ArrayList<>();
+        DeduplicatingEventHandler handler = new DeduplicatingEventHandler(log, envelope -> {
+            handled.add(envelope.eventId());
+            return handled.size() == 1
+                ? EventSubscriber.HandlerResult.TRANSIENT_FAILURE
+                : EventSubscriber.HandlerResult.SUCCESS;
+        });
+        EventEnvelope envelope = new EventEnvelope(
+            "evt-redelivered",
+            "TravelerProfileUpdated",
+            Instant.parse("2026-07-05T10:30:00Z"),
+            "corr-1",
+            "cmd-1",
+            "traveler-profile",
+            1,
+            objectMapper.createObjectNode()
+        );
+
+        assertEquals(EventSubscriber.HandlerResult.TRANSIENT_FAILURE, handler.handle(envelope));
+        assertEquals(EventSubscriber.HandlerResult.SUCCESS, handler.handle(envelope));
+
+        assertEquals(List.of("evt-redelivered", "evt-redelivered"), handled);
+        assertTrue(log.hasConsumed("evt-redelivered"));
+    }
+
     private static final class InMemoryPublisher implements EventPublisher {
         private final List<EventEnvelope> envelopes = new ArrayList<>();
 


### PR DESCRIPTION
## Summary
- add traveler-profile HTTP API endpoints with idempotency and canonical error handling
- add application event bus ports plus Redis Streams publisher/subscriber adapter
- add endpoint and messaging tests using in-memory/fake ports

## Validation
- cd services/traveler-profile && mvn -q test
- ! grep -rl 'lettuce\|RedisClient' services/traveler-profile/src/main/java | grep -v adapters
- make check