### PR TITLE
REQ-046 risk compliance HTTP API and event bus adapter

### DIFF
--- a/services/risk-compliance/pyproject.toml
+++ b/services/risk-compliance/pyproject.toml
@@ -5,6 +5,7 @@ description = "Risk & Compliance service skeleton"
 requires-python = ">=3.11"
 dependencies = [
   "fastapi==0.138.1",
+  "redis==5.2.1",
 ]
 
 [dependency-groups]

--- a/services/risk-compliance/src/risk_compliance/__init__.py
+++ b/services/risk-compliance/src/risk_compliance/__init__.py
@@ -25,6 +25,16 @@ from .domain import (
     record_evidence,
     resolve_challenge,
 )
+from .application import (
+    ConsumedEventDeduplicator,
+    EventEnvelope,
+    EventPublisher,
+    EventSubscriber,
+    InMemoryAssessmentRepository,
+    InMemoryEventPublisher,
+    InMemoryEventSubscriber,
+    RiskComplianceService,
+)
 from .runtime import SERVICE_PROFILE, ServiceProfile, health, profile
 
 __all__ = [
@@ -57,6 +67,15 @@ __all__ = [
     "issue_challenge",
     "record_evidence",
     "resolve_challenge",
+    # Application
+    "ConsumedEventDeduplicator",
+    "EventEnvelope",
+    "EventPublisher",
+    "EventSubscriber",
+    "InMemoryAssessmentRepository",
+    "InMemoryEventPublisher",
+    "InMemoryEventSubscriber",
+    "RiskComplianceService",
     # Runtime
     "SERVICE_PROFILE",
     "ServiceProfile",

--- a/services/risk-compliance/src/risk_compliance/__init__.py
+++ b/services/risk-compliance/src/risk_compliance/__init__.py
@@ -33,6 +33,7 @@ from .application import (
     InMemoryAssessmentRepository,
     InMemoryEventPublisher,
     InMemoryEventSubscriber,
+    PublishFailed,
     RiskComplianceService,
 )
 from .runtime import SERVICE_PROFILE, ServiceProfile, health, profile
@@ -75,6 +76,7 @@ __all__ = [
     "InMemoryAssessmentRepository",
     "InMemoryEventPublisher",
     "InMemoryEventSubscriber",
+    "PublishFailed",
     "RiskComplianceService",
     # Runtime
     "SERVICE_PROFILE",

--- a/services/risk-compliance/src/risk_compliance/adapters/messaging/__init__.py
+++ b/services/risk-compliance/src/risk_compliance/adapters/messaging/__init__.py
@@ -1,0 +1,3 @@
+from .redis_streams import RedisEventPublisher, RedisEventSubscriber
+
+__all__ = ["RedisEventPublisher", "RedisEventSubscriber"]

--- a/services/risk-compliance/src/risk_compliance/adapters/messaging/redis_streams.py
+++ b/services/risk-compliance/src/risk_compliance/adapters/messaging/redis_streams.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import Mapping
+from typing import Any
+
+import redis
+
+from ...application import (
+    EventEnvelope,
+    EventHandler,
+    FatalHandlerError,
+    PublishFailed,
+    SubscribeFailed,
+    TransientHandlerError,
+)
+
+_STREAM_PREFIX = "events:"
+_ENVELOPE_FIELD = "envelope"
+_MAXLEN = 100_000
+_MAX_ATTEMPTS = 5
+_MIN_IDLE_MS = 60_000
+_BLOCK_MS = 2_000
+_READ_COUNT = 10
+
+
+def redis_url_from_env() -> str:
+    return os.getenv("REDIS_URL", "redis://localhost:6379")
+
+
+def _stream_for_producer(producer: str) -> str:
+    return f"{_STREAM_PREFIX}{producer}"
+
+
+def _dlq_for_stream(stream: str) -> str:
+    return f"{stream}:dlq"
+
+
+class RedisEventPublisher:
+    def __init__(self, url: str | None = None, client: Any | None = None) -> None:
+        self._client = client or redis.Redis.from_url(url or redis_url_from_env(), decode_responses=True)
+
+    def publish(self, envelope: EventEnvelope) -> None:
+        stream = _stream_for_producer(envelope.producer)
+        payload = json.dumps(envelope.to_dict(), separators=(",", ":"), sort_keys=True)
+        last_error: BaseException | None = None
+        for attempt in range(3):
+            try:
+                self._client.xadd(stream, {_ENVELOPE_FIELD: payload}, maxlen=_MAXLEN, approximate=True)
+                return
+            except redis.RedisError as exc:
+                last_error = exc
+                if attempt < 2:
+                    time.sleep(0.05 * (2**attempt))
+        raise PublishFailed("event was not published") from last_error
+
+
+class RedisEventSubscriber:
+    def __init__(self, url: str | None = None, client: Any | None = None, *, poll_once: bool = False) -> None:
+        self._client = client or redis.Redis.from_url(url or redis_url_from_env(), decode_responses=True)
+        self._running = False
+        self._seen_event_ids: set[str] = set()
+        self._poll_once = poll_once
+
+    def stop(self) -> None:
+        self._running = False
+
+    def subscribe(
+        self,
+        streams: list[str],
+        group: str,
+        consumerName: str,
+        handler: EventHandler,
+    ) -> None:
+        try:
+            for stream in streams:
+                self._ensure_group(stream, group)
+            self._running = True
+            while self._running:
+                self._recover_pending(streams, group, consumerName, handler)
+                response = self._client.xreadgroup(
+                    group,
+                    consumerName,
+                    {stream: ">" for stream in streams},
+                    count=_READ_COUNT,
+                    block=_BLOCK_MS,
+                )
+                self._handle_response(response, group, handler)
+                if self._poll_once:
+                    self._running = False
+        except redis.RedisError as exc:
+            raise SubscribeFailed("subscriber failed") from exc
+
+    def _ensure_group(self, stream: str, group: str) -> None:
+        try:
+            self._client.xgroup_create(stream, group, id="$", mkstream=True)
+        except redis.ResponseError as exc:
+            if "BUSYGROUP" not in str(exc):
+                raise
+
+    def _recover_pending(
+        self,
+        streams: list[str],
+        group: str,
+        consumer_name: str,
+        handler: EventHandler,
+    ) -> None:
+        for stream in streams:
+            claimed = self._client.xautoclaim(stream, group, consumer_name, _MIN_IDLE_MS, "0", count=100)
+            messages = claimed[1] if len(claimed) > 1 else []
+            self._handle_stream_messages(stream, messages, group, handler)
+
+    def _handle_response(self, response: list[Any], group: str, handler: EventHandler) -> None:
+        for stream, messages in response or []:
+            self._handle_stream_messages(stream, messages, group, handler)
+
+    def _handle_stream_messages(self, stream: str, messages: list[Any], group: str, handler: EventHandler) -> None:
+        for entry_id, fields in messages:
+            envelope_json = _field_value(fields, _ENVELOPE_FIELD)
+            if envelope_json is None:
+                self._move_to_dlq(stream, entry_id, group, fields)
+                continue
+            if self._delivery_count(stream, group, entry_id) >= _MAX_ATTEMPTS:
+                self._move_to_dlq(stream, entry_id, group, fields)
+                continue
+            try:
+                envelope = EventEnvelope.from_mapping(json.loads(envelope_json))
+                if envelope.eventId in self._seen_event_ids:
+                    self._client.xack(stream, group, entry_id)
+                    continue
+                handler(envelope)
+                self._seen_event_ids.add(envelope.eventId)
+                self._client.xack(stream, group, entry_id)
+            except TransientHandlerError:
+                continue
+            except (FatalHandlerError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+                self._move_to_dlq(stream, entry_id, group, fields)
+
+    def _delivery_count(self, stream: str, group: str, entry_id: str) -> int:
+        try:
+            pending = self._client.xpending_range(stream, group, entry_id, entry_id, 1)
+        except redis.RedisError:
+            return 1
+        if not pending:
+            return 1
+        value = pending[0]
+        if isinstance(value, Mapping):
+            return int(value.get("times_delivered") or value.get("delivery_count") or 1)
+        return int(value[3]) if len(value) > 3 else 1
+
+    def _move_to_dlq(self, stream: str, entry_id: str, group: str, fields: Mapping[str, Any]) -> None:
+        self._client.xadd(_dlq_for_stream(stream), dict(fields), maxlen=_MAXLEN, approximate=True)
+        self._client.xack(stream, group, entry_id)
+
+
+def _field_value(fields: Mapping[str, Any], key: str) -> str | None:
+    value = fields.get(key)
+    if value is None:
+        value = fields.get(key.encode("utf-8"))
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    if value is None:
+        return None
+    return str(value)

--- a/services/risk-compliance/src/risk_compliance/api.py
+++ b/services/risk-compliance/src/risk_compliance/api.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager, nullcontext
 from typing import Any, Protocol
-from uuid import uuid4
 
 from fastapi import FastAPI, Header, Request
 from fastapi.exceptions import RequestValidationError
@@ -16,7 +15,10 @@ from .application import (
     IdempotencyKeyReusedError,
     InMemoryAssessmentRepository,
     InMemoryEventPublisher,
+    PublishFailed,
     RiskComplianceService,
+    is_uuid7,
+    uuid7,
 )
 from .runtime import health, profile
 
@@ -88,13 +90,13 @@ def _set_span_attribute(span: RuntimeSpan | None, key: str, value: object) -> No
 
 
 def _request_identifiers(request: Request) -> tuple[str, str]:
-    request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid4())
+    request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid7())
     correlation_id = request.headers.get(CORRELATION_ID_HEADER) or request_id
     return request_id, correlation_id
 
 
 def error_response(request: Request, status_code: int, code: str, message: str, details: dict[str, Any] | None = None) -> JSONResponse:
-    correlation_id = getattr(request.state, "correlation_id", request.headers.get(CORRELATION_ID_HEADER) or str(uuid4()))
+    correlation_id = getattr(request.state, "correlation_id", request.headers.get(CORRELATION_ID_HEADER) or str(uuid7()))
     return JSONResponse(
         status_code=status_code,
         content=ErrorBody(
@@ -198,8 +200,10 @@ def configure_risk_endpoints(app: FastAPI, service: RiskComplianceService) -> No
     ) -> JSONResponse | dict[str, Any]:
         if not idempotency_key:
             return error_response(request, 400, "VALIDATION_FAILED", "Idempotency-Key header is required")
+        if not is_uuid7(idempotency_key):
+            return error_response(request, 400, "VALIDATION_FAILED", "Idempotency-Key must be a UUID v7")
         try:
-            result, replayed = service.assess(
+            result, _ = service.assess(
                 subject_ref=payload.subjectRef,
                 scenario=payload.scenario,
                 context=payload.context,
@@ -208,7 +212,14 @@ def configure_risk_endpoints(app: FastAPI, service: RiskComplianceService) -> No
             )
         except IdempotencyKeyReusedError as exc:
             return error_response(request, 422, "IDEMPOTENCY_KEY_REUSED", str(exc))
-        del replayed
+        except PublishFailed:
+            return error_response(
+                request,
+                503,
+                "UNAVAILABLE",
+                "Risk assessment was saved but its result event could not be published; retry with the same Idempotency-Key to retrieve the saved result.",
+                {"deliverySemantics": "AT_LEAST_ONCE"},
+            )
         return JSONResponse(status_code=201, content=result.to_dict())
 
     @app.get("/api/v1/risk-assessments/{assessmentId}", response_model=None)

--- a/services/risk-compliance/src/risk_compliance/api.py
+++ b/services/risk-compliance/src/risk_compliance/api.py
@@ -91,12 +91,13 @@ def _set_span_attribute(span: RuntimeSpan | None, key: str, value: object) -> No
 
 def _request_identifiers(request: Request) -> tuple[str, str]:
     request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid7())
-    correlation_id = request.headers.get(CORRELATION_ID_HEADER) or request_id
+    supplied_correlation_id = request.headers.get(CORRELATION_ID_HEADER)
+    correlation_id = supplied_correlation_id if supplied_correlation_id and is_uuid7(supplied_correlation_id) else str(uuid7())
     return request_id, correlation_id
 
 
 def error_response(request: Request, status_code: int, code: str, message: str, details: dict[str, Any] | None = None) -> JSONResponse:
-    correlation_id = getattr(request.state, "correlation_id", request.headers.get(CORRELATION_ID_HEADER) or str(uuid7()))
+    correlation_id = getattr(request.state, "correlation_id", str(uuid7()))
     return JSONResponse(
         status_code=status_code,
         content=ErrorBody(

--- a/services/risk-compliance/src/risk_compliance/api.py
+++ b/services/risk-compliance/src/risk_compliance/api.py
@@ -14,7 +14,6 @@ from .application import (
     AssessmentNotFoundError,
     IdempotencyKeyReusedError,
     InMemoryAssessmentRepository,
-    InMemoryEventPublisher,
     PublishFailed,
     RiskComplianceService,
     is_uuid7,
@@ -90,7 +89,7 @@ def _set_span_attribute(span: RuntimeSpan | None, key: str, value: object) -> No
 
 
 def _request_identifiers(request: Request) -> tuple[str, str]:
-    request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid7())
+    request_id = str(uuid7())
     supplied_correlation_id = request.headers.get(CORRELATION_ID_HEADER)
     correlation_id = supplied_correlation_id if supplied_correlation_id and is_uuid7(supplied_correlation_id) else str(uuid7())
     return request_id, correlation_id

--- a/services/risk-compliance/src/risk_compliance/api.py
+++ b/services/risk-compliance/src/risk_compliance/api.py
@@ -1,14 +1,28 @@
+from __future__ import annotations
+
 from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager, nullcontext
 from typing import Any, Protocol
 from uuid import uuid4
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Header, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
+from .application import (
+    AssessmentNotFoundError,
+    IdempotencyKeyReusedError,
+    InMemoryAssessmentRepository,
+    InMemoryEventPublisher,
+    RiskComplianceService,
+)
 from .runtime import health, profile
 
 REQUEST_ID_HEADER = "X-Request-ID"
 CORRELATION_ID_HEADER = "X-Correlation-ID"
+IDEMPOTENCY_KEY_HEADER = "Idempotency-Key"
 TraceHook = Callable[[str, Mapping[str, object]], None]
 
 
@@ -20,6 +34,21 @@ class RuntimeSpan(AbstractContextManager["RuntimeSpan"], Protocol):
 
 class RuntimeTracer(Protocol):
     def start_as_current_span(self, name: str) -> RuntimeSpan: ...
+
+
+class AssessRiskRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    subjectRef: str = Field(min_length=1)
+    scenario: str = Field(pattern="^(order_risk|payment_risk|post_sales_risk|account_risk)$")
+    context: dict[str, Any]
+
+
+class ErrorBody(BaseModel):
+    code: str
+    message: str
+    correlationId: str
+    details: dict[str, Any]
 
 
 def _emit_trace(tracer: TraceHook | None, event: str, attributes: Mapping[str, object]) -> None:
@@ -62,6 +91,19 @@ def _request_identifiers(request: Request) -> tuple[str, str]:
     request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid4())
     correlation_id = request.headers.get(CORRELATION_ID_HEADER) or request_id
     return request_id, correlation_id
+
+
+def error_response(request: Request, status_code: int, code: str, message: str, details: dict[str, Any] | None = None) -> JSONResponse:
+    correlation_id = getattr(request.state, "correlation_id", request.headers.get(CORRELATION_ID_HEADER) or str(uuid4()))
+    return JSONResponse(
+        status_code=status_code,
+        content=ErrorBody(
+            code=code,
+            message=message,
+            correlationId=correlation_id,
+            details=details or {},
+        ).model_dump(),
+    )
 
 
 def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None) -> None:
@@ -116,12 +158,86 @@ def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None, o
     def ready_endpoint() -> dict[str, str]:
         return {"status": health()}
 
+    @app.get("/healthz")
+    def healthz_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
+    @app.get("/readyz")
+    def readyz_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
     @app.get("/metadata")
     def metadata_endpoint() -> dict[str, object]:
         return {"service": profile(), "observability": {"tracing": "opt-in", "default": "noop"}}
 
 
-def create_app(tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None) -> FastAPI:
-    app = FastAPI(title='Risk & Compliance', version="0.1.0")
+def configure_error_handlers(app: FastAPI) -> None:
+    @app.exception_handler(RequestValidationError)
+    async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+        return error_response(
+            request,
+            400,
+            "VALIDATION_FAILED",
+            "Request validation failed",
+            {"errors": exc.errors()},
+        )
+
+    @app.exception_handler(StarletteHTTPException)
+    async def http_exception_handler(request: Request, exc: StarletteHTTPException) -> JSONResponse:
+        if exc.status_code == 404:
+            return error_response(request, 404, "NOT_FOUND", "The requested resource was not found")
+        return error_response(request, exc.status_code, "UNAVAILABLE", str(exc.detail))
+
+
+def configure_risk_endpoints(app: FastAPI, service: RiskComplianceService) -> None:
+    @app.post("/api/v1/risk-assessments", status_code=201, response_model=None)
+    def assess_risk_endpoint(
+        request: Request,
+        payload: AssessRiskRequest,
+        idempotency_key: str | None = Header(default=None, alias=IDEMPOTENCY_KEY_HEADER),
+    ) -> JSONResponse | dict[str, Any]:
+        if not idempotency_key:
+            return error_response(request, 400, "VALIDATION_FAILED", "Idempotency-Key header is required")
+        try:
+            result, replayed = service.assess(
+                subject_ref=payload.subjectRef,
+                scenario=payload.scenario,
+                context=payload.context,
+                idempotency_key=idempotency_key,
+                correlation_id=request.state.correlation_id,
+            )
+        except IdempotencyKeyReusedError as exc:
+            return error_response(request, 422, "IDEMPOTENCY_KEY_REUSED", str(exc))
+        del replayed
+        return JSONResponse(status_code=201, content=result.to_dict())
+
+    @app.get("/api/v1/risk-assessments/{assessmentId}", response_model=None)
+    def get_risk_assessment(request: Request, assessmentId: str) -> dict[str, Any] | JSONResponse:
+        try:
+            return service.get_assessment(assessmentId).to_dict()
+        except AssessmentNotFoundError:
+            return error_response(request, 404, "NOT_FOUND", "Risk assessment was not found")
+
+
+def create_app(
+    tracer: TraceHook | None = None,
+    otel_tracer: RuntimeTracer | None = None,
+    service: RiskComplianceService | None = None,
+) -> FastAPI:
+    app = FastAPI(title="Risk & Compliance", version="0.1.0")
+    app.state.assessment_repository = InMemoryAssessmentRepository()
+    if service is None:
+        from .adapters.messaging import RedisEventPublisher
+
+        app.state.publisher = RedisEventPublisher()
+        app.state.risk_service = RiskComplianceService(
+            publisher=app.state.publisher,
+            repository=app.state.assessment_repository,
+        )
+    else:
+        app.state.risk_service = service
+        app.state.publisher = service.publisher
+    configure_error_handlers(app)
     configure_runtime_endpoints(app, tracer, otel_tracer or opentelemetry_tracer_from_env(profile()["service_id"]))
+    configure_risk_endpoints(app, app.state.risk_service)
     return app

--- a/services/risk-compliance/src/risk_compliance/application.py
+++ b/services/risk-compliance/src/risk_compliance/application.py
@@ -142,6 +142,13 @@ class IdempotencyRecord:
     body: dict[str, Any]
 
 
+@dataclass(frozen=True, slots=True)
+class PendingPublication:
+    request_hash: str
+    body: dict[str, Any]
+    envelope: EventEnvelope
+
+
 class IdempotencyKeyReusedError(ValueError):
     pass
 
@@ -154,6 +161,7 @@ class InMemoryAssessmentRepository:
     def __init__(self) -> None:
         self._assessments: dict[str, RiskAssessmentResult] = {}
         self._idempotency: dict[str, IdempotencyRecord] = {}
+        self._pending_publications: dict[str, PendingPublication] = {}
 
     def get(self, assessment_id: str) -> RiskAssessmentResult:
         try:
@@ -172,7 +180,19 @@ class InMemoryAssessmentRepository:
             raise IdempotencyKeyReusedError("Idempotency-Key was reused with a different request body")
         return record
 
+    def get_pending_publication(self, idempotency_key: str, request_hash: str) -> PendingPublication | None:
+        pending = self._pending_publications.get(idempotency_key)
+        if pending is None:
+            return None
+        if pending.request_hash != request_hash:
+            raise IdempotencyKeyReusedError("Idempotency-Key was reused with a different request body")
+        return pending
+
+    def save_pending_publication(self, idempotency_key: str, pending: PendingPublication) -> None:
+        self._pending_publications[idempotency_key] = pending
+
     def save_replay(self, idempotency_key: str, record: IdempotencyRecord) -> None:
+        self._pending_publications.pop(idempotency_key, None)
         self._idempotency[idempotency_key] = record
 
 
@@ -235,6 +255,15 @@ class RiskComplianceService:
         if replay is not None:
             return RiskAssessmentResult(**replay.body), True
 
+        pending = self.repository.get_pending_publication(idempotency_key, request_hash)
+        if pending is not None:
+            self.publisher.publish(pending.envelope)
+            self.repository.save_replay(
+                idempotency_key,
+                IdempotencyRecord(request_hash=request_hash, body=pending.body),
+            )
+            return RiskAssessmentResult(**pending.body), False
+
         assessment_id = prefixed_id("asmt")
         requested = assess_risk(
             assessment_id=assessment_id,
@@ -245,12 +274,18 @@ class RiskComplianceService:
         )
         completed = _evaluate(requested)
         result = _to_result(completed)
+        envelope = _assessment_envelope(result, correlation_id, prefixed_id("cmd"))
+        replay_body = result.to_event_payload()
         self.repository.save(result)
+        self.repository.save_pending_publication(
+            idempotency_key,
+            PendingPublication(request_hash=request_hash, body=replay_body, envelope=envelope),
+        )
+        self.publisher.publish(envelope)
         self.repository.save_replay(
             idempotency_key,
-            IdempotencyRecord(request_hash=request_hash, body=result.to_event_payload()),
+            IdempotencyRecord(request_hash=request_hash, body=replay_body),
         )
-        self.publisher.publish(_assessment_envelope(result, correlation_id, prefixed_id("cmd")))
         return result, False
 
     def get_assessment(self, assessment_id: str) -> RiskAssessmentResult:

--- a/services/risk-compliance/src/risk_compliance/application.py
+++ b/services/risk-compliance/src/risk_compliance/application.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from hashlib import sha256
+from typing import Any, Protocol, TypeAlias
+from uuid import uuid4
+
+from .domain import Decision, PolicyVersionRef, RiskAssessment, RiskLevel, assess_risk
+
+PRODUCER = "risk-compliance"
+SCHEMA_VERSION = 1
+DEFAULT_POLICY_VERSION = PolicyVersionRef(policy_set_id="risk-rules", version="1.0.0")
+RiskScenario: TypeAlias = str
+
+
+class PublishFailed(RuntimeError):
+    """Raised when an event cannot be published after adapter retries."""
+
+
+class SubscribeFailed(RuntimeError):
+    """Raised when an event subscriber cannot start or poll its source."""
+
+
+class HandlerError(RuntimeError):
+    """Base class for subscriber handler failures."""
+
+
+class TransientHandlerError(HandlerError):
+    """A retryable event handler failure; the message must not be acked."""
+
+
+class FatalHandlerError(HandlerError):
+    """A non-retryable event handler failure; the message should be sent to DLQ."""
+
+
+@dataclass(frozen=True, slots=True)
+class EventEnvelope:
+    eventId: str
+    eventType: str
+    occurredAt: str
+    correlationId: str
+    causationId: str
+    producer: str
+    schemaVersion: int
+    payload: Mapping[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "eventId": self.eventId,
+            "eventType": self.eventType,
+            "occurredAt": self.occurredAt,
+            "correlationId": self.correlationId,
+            "causationId": self.causationId,
+            "producer": self.producer,
+            "schemaVersion": self.schemaVersion,
+            "payload": dict(self.payload),
+        }
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> EventEnvelope:
+        return cls(
+            eventId=str(data["eventId"]),
+            eventType=str(data["eventType"]),
+            occurredAt=str(data["occurredAt"]),
+            correlationId=str(data["correlationId"]),
+            causationId=str(data["causationId"]),
+            producer=str(data["producer"]),
+            schemaVersion=int(data["schemaVersion"]),
+            payload=dict(data["payload"]),
+        )
+
+
+class EventPublisher(Protocol):
+    """Abstract event publishing port defined by docs/08-contracts/messaging.md."""
+
+    def publish(self, envelope: EventEnvelope) -> None:
+        """Publish a fully-populated EventEnvelope."""
+
+
+EventHandler: TypeAlias = Callable[[EventEnvelope], None]
+
+
+class EventSubscriber(Protocol):
+    """Abstract event subscriber port defined by docs/08-contracts/messaging.md."""
+
+    def subscribe(
+        self,
+        streams: list[str],
+        group: str,
+        consumerName: str,
+        handler: EventHandler,
+    ) -> None:
+        """Subscribe to event streams as a consumer group member."""
+
+
+@dataclass(frozen=True, slots=True)
+class RiskAssessmentResult:
+    assessmentId: str
+    subjectRef: str
+    scenario: str
+    decision: str
+    score: int
+    level: str
+    policyVersion: str
+    reasonCode: str
+    reasonExplanation: str
+    assessedAt: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "assessmentId": self.assessmentId,
+            "subjectRef": self.subjectRef,
+            "scenario": self.scenario,
+            "decision": self.decision,
+            "score": self.score,
+            "level": self.level,
+            "policyVersion": self.policyVersion,
+            "reasonCode": self.reasonCode,
+            "reasonExplanation": self.reasonExplanation,
+            "assessedAt": self.assessedAt,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class IdempotencyRecord:
+    request_hash: str
+    body: dict[str, Any]
+
+
+class IdempotencyKeyReusedError(ValueError):
+    pass
+
+
+class AssessmentNotFoundError(KeyError):
+    pass
+
+
+class InMemoryAssessmentRepository:
+    def __init__(self) -> None:
+        self._assessments: dict[str, RiskAssessmentResult] = {}
+        self._idempotency: dict[str, IdempotencyRecord] = {}
+
+    def get(self, assessment_id: str) -> RiskAssessmentResult:
+        try:
+            return self._assessments[assessment_id]
+        except KeyError as exc:
+            raise AssessmentNotFoundError(assessment_id) from exc
+
+    def save(self, assessment: RiskAssessmentResult) -> None:
+        self._assessments[assessment.assessmentId] = assessment
+
+    def get_replay(self, idempotency_key: str, request_hash: str) -> IdempotencyRecord | None:
+        record = self._idempotency.get(idempotency_key)
+        if record is None:
+            return None
+        if record.request_hash != request_hash:
+            raise IdempotencyKeyReusedError("Idempotency-Key was reused with a different request body")
+        return record
+
+    def save_replay(self, idempotency_key: str, record: IdempotencyRecord) -> None:
+        self._idempotency[idempotency_key] = record
+
+
+class InMemoryEventPublisher:
+    def __init__(self) -> None:
+        self.envelopes: list[EventEnvelope] = []
+
+    def publish(self, envelope: EventEnvelope) -> None:
+        self.envelopes.append(envelope)
+
+
+class ConsumedEventDeduplicator:
+    def __init__(self) -> None:
+        self._seen: set[str] = set()
+
+    def handle_once(self, envelope: EventEnvelope, handler: EventHandler) -> bool:
+        if envelope.eventId in self._seen:
+            return False
+        handler(envelope)
+        self._seen.add(envelope.eventId)
+        return True
+
+    def seen(self, event_id: str) -> bool:
+        return event_id in self._seen
+
+
+class InMemoryEventSubscriber:
+    def __init__(self, envelopes: list[EventEnvelope] | None = None) -> None:
+        self.envelopes = envelopes or []
+        self.deduplicator = ConsumedEventDeduplicator()
+
+    def subscribe(
+        self,
+        streams: list[str],
+        group: str,
+        consumerName: str,
+        handler: EventHandler,
+    ) -> None:
+        del streams, group, consumerName
+        for envelope in self.envelopes:
+            self.deduplicator.handle_once(envelope, handler)
+
+
+@dataclass(slots=True)
+class RiskComplianceService:
+    publisher: EventPublisher
+    repository: InMemoryAssessmentRepository = field(default_factory=InMemoryAssessmentRepository)
+
+    def assess(
+        self,
+        *,
+        subject_ref: str,
+        scenario: RiskScenario,
+        context: Mapping[str, Any],
+        idempotency_key: str,
+        correlation_id: str,
+    ) -> tuple[RiskAssessmentResult, bool]:
+        request_hash = _request_hash(subject_ref, scenario, context)
+        replay = self.repository.get_replay(idempotency_key, request_hash)
+        if replay is not None:
+            return RiskAssessmentResult(**replay.body), True
+
+        assessment_id = prefixed_id("asmt")
+        requested = assess_risk(
+            assessment_id=assessment_id,
+            subject_ref=subject_ref,
+            scenario=scenario,
+            input_data=context,
+            idempotency_key=idempotency_key,
+        )
+        completed = _evaluate(requested)
+        result = _to_result(completed)
+        self.repository.save(result)
+        self.repository.save_replay(
+            idempotency_key,
+            IdempotencyRecord(request_hash=request_hash, body=result.to_dict()),
+        )
+        self.publisher.publish(_assessment_envelope(result, correlation_id, prefixed_id("cmd")))
+        return result, False
+
+    def get_assessment(self, assessment_id: str) -> RiskAssessmentResult:
+        return self.repository.get(assessment_id)
+
+
+def prefixed_id(prefix: str) -> str:
+    return f"{prefix}-{uuid4()}"
+
+
+def datetime_to_rfc3339(value: datetime) -> str:
+    aware = value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    return aware.astimezone(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def canonical_correlation_id(correlation_id: str) -> str:
+    return correlation_id if correlation_id.startswith("corr-") else f"corr-{correlation_id}"
+
+
+def _request_hash(subject_ref: str, scenario: str, context: Mapping[str, Any]) -> str:
+    import json
+
+    payload = {"subjectRef": subject_ref, "scenario": scenario, "context": context}
+    return sha256(json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")).hexdigest()
+
+
+def _evaluate(assessment: RiskAssessment) -> RiskAssessment:
+    score = _score(assessment)
+    if score >= 850:
+        return assessment.deny(
+            policy_version=DEFAULT_POLICY_VERSION,
+            reason_code="HIGH_RISK_SIGNAL",
+            reason_explanation="Risk score exceeded deny threshold",
+            score=score,
+            level=RiskLevel.CRITICAL,
+        )
+    if score >= 600:
+        return assessment.challenge(
+            policy_version=DEFAULT_POLICY_VERSION,
+            reason_code="ADDITIONAL_VERIFICATION_REQUIRED",
+            reason_explanation="Additional verification is required before continuing",
+            score=score,
+            level=RiskLevel.HIGH,
+        )
+    if score >= 400:
+        return assessment.allow(
+            decision=Decision.HOLD,
+            policy_version=DEFAULT_POLICY_VERSION,
+            reason_code="MANUAL_REVIEW_REQUIRED",
+            reason_explanation="Assessment is held for manual review",
+            score=score,
+            level=RiskLevel.MEDIUM,
+        )
+    return assessment.allow(
+        decision=Decision.ALLOW,
+        policy_version=DEFAULT_POLICY_VERSION,
+        reason_code="PASSED_RISK_CHECKS",
+        reason_explanation="All configured risk checks passed",
+        score=score,
+        level=RiskLevel.LOW,
+    )
+
+
+def _score(assessment: RiskAssessment) -> int:
+    context = assessment.input_snapshot.input_data
+    explicit = context.get("riskScore") or context.get("score")
+    if isinstance(explicit, int) and 0 <= explicit <= 1000:
+        return explicit
+    digest = assessment.input_snapshot.digest
+    return int(digest[:8], 16) % 350
+
+
+def _to_result(assessment: RiskAssessment) -> RiskAssessmentResult:
+    if assessment.decision is None or assessment.score is None or assessment.level is None:
+        raise ValueError("assessment has not been completed")
+    if assessment.policy_version is None or assessment.assessed_at is None or assessment.reason_code is None:
+        raise ValueError("assessment is missing result details")
+    return RiskAssessmentResult(
+        assessmentId=assessment.assessment_id,
+        subjectRef=assessment.subject_ref,
+        scenario=assessment.scenario,
+        decision=assessment.decision.value,
+        score=assessment.score,
+        level=assessment.level.value,
+        policyVersion=assessment.policy_version.version,
+        reasonCode=assessment.reason_code,
+        reasonExplanation=assessment.reason_explanation or "",
+        assessedAt=datetime_to_rfc3339(assessment.assessed_at),
+    )
+
+
+def _assessment_envelope(result: RiskAssessmentResult, correlation_id: str, causation_id: str) -> EventEnvelope:
+    return EventEnvelope(
+        eventId=prefixed_id("evt"),
+        eventType="RiskAssessmentResult",
+        occurredAt=result.assessedAt,
+        correlationId=canonical_correlation_id(correlation_id),
+        causationId=causation_id,
+        producer=PRODUCER,
+        schemaVersion=SCHEMA_VERSION,
+        payload=result.to_dict(),
+    )

--- a/services/risk-compliance/src/risk_compliance/application.py
+++ b/services/risk-compliance/src/risk_compliance/application.py
@@ -4,8 +4,10 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from hashlib import sha256
+from secrets import randbits
+from time import time
 from typing import Any, Protocol, TypeAlias
-from uuid import uuid4
+from uuid import UUID
 
 from .domain import Decision, PolicyVersionRef, RiskAssessment, RiskLevel, assess_risk
 
@@ -41,22 +43,24 @@ class EventEnvelope:
     eventType: str
     occurredAt: str
     correlationId: str
-    causationId: str
+    causationId: str | None
     producer: str
     schemaVersion: int
     payload: Mapping[str, Any]
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        envelope = {
             "eventId": self.eventId,
             "eventType": self.eventType,
             "occurredAt": self.occurredAt,
             "correlationId": self.correlationId,
-            "causationId": self.causationId,
             "producer": self.producer,
             "schemaVersion": self.schemaVersion,
             "payload": dict(self.payload),
         }
+        if self.causationId is not None:
+            envelope["causationId"] = self.causationId
+        return envelope
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any]) -> EventEnvelope:
@@ -65,7 +69,7 @@ class EventEnvelope:
             eventType=str(data["eventType"]),
             occurredAt=str(data["occurredAt"]),
             correlationId=str(data["correlationId"]),
-            causationId=str(data["causationId"]),
+            causationId=str(data["causationId"]) if "causationId" in data else None,
             producer=str(data["producer"]),
             schemaVersion=int(data["schemaVersion"]),
             payload=dict(data["payload"]),
@@ -245,7 +249,25 @@ class RiskComplianceService:
 
 
 def prefixed_id(prefix: str) -> str:
-    return f"{prefix}-{uuid4()}"
+    return f"{prefix}-{uuid7()}"
+
+
+def uuid7() -> UUID:
+    unix_ts_ms = int(time() * 1000) & ((1 << 48) - 1)
+    uuid_int = unix_ts_ms << 80
+    uuid_int |= 0x7 << 76
+    uuid_int |= randbits(12) << 64
+    uuid_int |= 0b10 << 62
+    uuid_int |= randbits(62)
+    return UUID(int=uuid_int)
+
+
+def is_uuid7(value: str) -> bool:
+    try:
+        parsed = UUID(value)
+    except (TypeError, ValueError):
+        return False
+    return parsed.version == 7
 
 
 def datetime_to_rfc3339(value: datetime) -> str:
@@ -303,7 +325,7 @@ def _evaluate(assessment: RiskAssessment) -> RiskAssessment:
 
 def _score(assessment: RiskAssessment) -> int:
     context = assessment.input_snapshot.input_data
-    explicit = context.get("riskScore") or context.get("score")
+    explicit = context["riskScore"] if "riskScore" in context else context.get("score")
     if isinstance(explicit, int) and 0 <= explicit <= 1000:
         return explicit
     digest = assessment.input_snapshot.digest

--- a/services/risk-compliance/src/risk_compliance/application.py
+++ b/services/risk-compliance/src/risk_compliance/application.py
@@ -111,6 +111,8 @@ class RiskAssessmentResult:
     reasonCode: str
     reasonExplanation: str
     assessedAt: str
+    evidenceRef: str
+    assessmentSnapshotHash: str
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -124,6 +126,13 @@ class RiskAssessmentResult:
             "reasonCode": self.reasonCode,
             "reasonExplanation": self.reasonExplanation,
             "assessedAt": self.assessedAt,
+        }
+
+    def to_event_payload(self) -> dict[str, Any]:
+        return {
+            **self.to_dict(),
+            "evidenceRef": self.evidenceRef,
+            "assessmentSnapshotHash": self.assessmentSnapshotHash,
         }
 
 
@@ -239,7 +248,7 @@ class RiskComplianceService:
         self.repository.save(result)
         self.repository.save_replay(
             idempotency_key,
-            IdempotencyRecord(request_hash=request_hash, body=result.to_dict()),
+            IdempotencyRecord(request_hash=request_hash, body=result.to_event_payload()),
         )
         self.publisher.publish(_assessment_envelope(result, correlation_id, prefixed_id("cmd")))
         return result, False
@@ -265,9 +274,18 @@ def uuid7() -> UUID:
 def is_uuid7(value: str) -> bool:
     try:
         parsed = UUID(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, AttributeError):
         return False
     return parsed.version == 7
+
+
+def prefixed_uuid7(prefix: str) -> str:
+    return f"{prefix}-{uuid7()}"
+
+
+def is_prefixed_uuid7(value: str, prefix: str) -> bool:
+    expected = f"{prefix}-"
+    return value.startswith(expected) and is_uuid7(value[len(expected):])
 
 
 def datetime_to_rfc3339(value: datetime) -> str:
@@ -348,17 +366,19 @@ def _to_result(assessment: RiskAssessment) -> RiskAssessmentResult:
         reasonCode=assessment.reason_code,
         reasonExplanation=assessment.reason_explanation or "",
         assessedAt=datetime_to_rfc3339(assessment.assessed_at),
+        evidenceRef=assessment.evidence_bundle.bundle_id if assessment.evidence_bundle is not None else f"evid-{assessment.assessment_id}",
+        assessmentSnapshotHash=assessment.input_snapshot.digest,
     )
 
 
 def _assessment_envelope(result: RiskAssessmentResult, correlation_id: str, causation_id: str) -> EventEnvelope:
     return EventEnvelope(
         eventId=prefixed_id("evt"),
-        eventType="RiskAssessmentResult",
+        eventType="RiskAssessed",
         occurredAt=result.assessedAt,
         correlationId=canonical_correlation_id(correlation_id),
         causationId=causation_id,
         producer=PRODUCER,
         schemaVersion=SCHEMA_VERSION,
-        payload=result.to_dict(),
+        payload=result.to_event_payload(),
     )

--- a/services/risk-compliance/tests/test_api_and_messaging.py
+++ b/services/risk-compliance/tests/test_api_and_messaging.py
@@ -11,6 +11,7 @@ from risk_compliance import (
     RiskComplianceService,
     create_app,
 )
+from risk_compliance.application import is_prefixed_uuid7, is_uuid7, uuid7
 
 
 def fake_app():
@@ -23,7 +24,7 @@ def test_assess_risk_happy_path_and_get() -> None:
 
     response = client.post(
         "/api/v1/risk-assessments",
-        headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c333", "X-Correlation-Id": "corr-test"},
+        headers={"Idempotency-Key": str(uuid7()), "X-Correlation-Id": str(uuid7())},
         json={"subjectRef": "ord-123", "scenario": "order_risk", "context": {"riskScore": 120}},
     )
 
@@ -50,21 +51,21 @@ def test_assess_risk_happy_path_and_get() -> None:
 
 
 def test_get_unknown_assessment_returns_not_found_error_body() -> None:
-    response = TestClient(fake_app()).get("/api/v1/risk-assessments/asmt-missing", headers={"X-Correlation-Id": "corr-404"})
+    response = TestClient(fake_app()).get("/api/v1/risk-assessments/asmt-missing", headers={"X-Correlation-Id": str(uuid7())})
 
     assert response.status_code == 404
-    assert response.json() == {
-        "code": "NOT_FOUND",
-        "message": "Risk assessment was not found",
-        "correlationId": "corr-404",
-        "details": {},
-    }
+    body = response.json()
+    assert body["code"] == "NOT_FOUND"
+    assert body["message"] == "Risk assessment was not found"
+    assert body["correlationId"] == response.headers["X-Correlation-Id"]
+    assert is_uuid7(body["correlationId"])
+    assert body["details"] == {}
 
 
 def test_validation_failure_uses_canonical_400_body() -> None:
     response = TestClient(fake_app()).post(
         "/api/v1/risk-assessments",
-        headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c334", "X-Correlation-Id": "corr-validation"},
+        headers={"Idempotency-Key": str(uuid7()), "X-Correlation-Id": str(uuid7())},
         json={"subjectRef": "ord-123", "scenario": "invalid", "context": {}},
     )
 
@@ -72,14 +73,14 @@ def test_validation_failure_uses_canonical_400_body() -> None:
     body = response.json()
     assert body["code"] == "VALIDATION_FAILED"
     assert body["message"] == "Request validation failed"
-    assert body["correlationId"] == "corr-validation"
+    assert is_uuid7(body["correlationId"])
     assert "errors" in body["details"]
 
 
 def test_missing_idempotency_key_is_validation_error() -> None:
     response = TestClient(fake_app()).post(
         "/api/v1/risk-assessments",
-        headers={"X-Correlation-Id": "corr-idem"},
+        headers={"X-Correlation-Id": str(uuid7())},
         json={"subjectRef": "ord-123", "scenario": "order_risk", "context": {}},
     )
 
@@ -95,17 +96,16 @@ class FailingPublisher(InMemoryEventPublisher):
 def test_malformed_idempotency_key_is_validation_error() -> None:
     response = TestClient(fake_app()).post(
         "/api/v1/risk-assessments",
-        headers={"Idempotency-Key": "not-a-uuid-v7", "X-Correlation-Id": "corr-idem-format"},
+        headers={"Idempotency-Key": "not-a-uuid-v7", "X-Correlation-Id": str(uuid7())},
         json={"subjectRef": "ord-123", "scenario": "order_risk", "context": {}},
     )
 
     assert response.status_code == 400
-    assert response.json() == {
-        "code": "VALIDATION_FAILED",
-        "message": "Idempotency-Key must be a UUID v7",
-        "correlationId": "corr-idem-format",
-        "details": {},
-    }
+    body = response.json()
+    assert body["code"] == "VALIDATION_FAILED"
+    assert body["message"] == "Idempotency-Key must be a UUID v7"
+    assert is_uuid7(body["correlationId"])
+    assert body["details"] == {}
 
 
 def test_publish_failure_returns_unavailable_body_after_save() -> None:
@@ -114,7 +114,7 @@ def test_publish_failure_returns_unavailable_body_after_save() -> None:
 
     response = TestClient(app).post(
         "/api/v1/risk-assessments",
-        headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c338", "X-Correlation-Id": "corr-publish"},
+        headers={"Idempotency-Key": str(uuid7()), "X-Correlation-Id": str(uuid7())},
         json={"subjectRef": "ord-123", "scenario": "order_risk", "context": {"riskScore": 120}},
     )
 
@@ -126,7 +126,7 @@ def test_publish_failure_returns_unavailable_body_after_save() -> None:
 
 def test_idempotent_replay_returns_original_result() -> None:
     client = TestClient(fake_app())
-    headers = {"Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c335", "X-Correlation-Id": "corr-replay"}
+    headers = {"Idempotency-Key": str(uuid7()), "X-Correlation-Id": str(uuid7())}
     payload = {"subjectRef": "pi-123", "scenario": "payment_risk", "context": {"riskScore": 910}}
 
     created = client.post("/api/v1/risk-assessments", headers=headers, json=payload)
@@ -139,7 +139,7 @@ def test_idempotent_replay_returns_original_result() -> None:
 
 def test_idempotency_key_reused_with_different_body_is_rejected() -> None:
     client = TestClient(fake_app())
-    headers = {"Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c336", "X-Correlation-Id": "corr-reused"}
+    headers = {"Idempotency-Key": str(uuid7()), "X-Correlation-Id": str(uuid7())}
     first = {"subjectRef": "ord-123", "scenario": "order_risk", "context": {"riskScore": 10}}
     second = {"subjectRef": "ord-456", "scenario": "order_risk", "context": {"riskScore": 10}}
 
@@ -153,10 +153,11 @@ def test_idempotency_key_reused_with_different_body_is_rejected() -> None:
 def test_publisher_wraps_domain_event_in_contract_envelope() -> None:
     app = fake_app()
     client = TestClient(app)
+    valid_correlation_id = str(uuid7())
 
     response = client.post(
         "/api/v1/risk-assessments",
-        headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c337", "X-Correlation-Id": "corr-envelope"},
+        headers={"Idempotency-Key": str(uuid7()), "X-Correlation-Id": valid_correlation_id},
         json={"subjectRef": "acct-123", "scenario": "account_risk", "context": {"riskScore": 650}},
     )
 
@@ -165,23 +166,42 @@ def test_publisher_wraps_domain_event_in_contract_envelope() -> None:
     assert envelope.eventId.startswith("evt-")
     assert envelope.eventId.split("-", 1)[1][14] == "7"
     assert response.json()["assessmentId"].split("-", 1)[1][14] == "7"
-    assert envelope.eventType == "RiskAssessmentResult"
+    assert envelope.eventType == "RiskAssessed"
     assert envelope.producer == "risk-compliance"
     assert envelope.schemaVersion == 1
-    assert envelope.correlationId == "corr-envelope"
-    assert envelope.causationId.startswith("cmd-")
-    assert envelope.causationId.split("-", 1)[1][14] == "7"
+    assert envelope.correlationId == f"corr-{valid_correlation_id}"
+    event_payload_keys = set(envelope.payload)
+    assert event_payload_keys == {
+        "assessmentId",
+        "subjectRef",
+        "scenario",
+        "decision",
+        "score",
+        "level",
+        "policyVersion",
+        "reasonCode",
+        "reasonExplanation",
+        "assessedAt",
+        "evidenceRef",
+        "assessmentSnapshotHash",
+    }
+    assert envelope.causationId is not None and is_prefixed_uuid7(envelope.causationId, "cmd")
     assert envelope.occurredAt == response.json()["assessedAt"]
-    assert envelope.payload == response.json()
+    assert envelope.payload == {
+        **response.json(),
+        "evidenceRef": f"evid-{response.json()['assessmentId']}",
+        "assessmentSnapshotHash": envelope.payload["assessmentSnapshotHash"],
+    }
+    assert envelope.payload["assessmentSnapshotHash"]
 
 
 def test_subscriber_deduplicates_duplicate_event_id() -> None:
     envelope = EventEnvelope(
         eventId="evt-duplicate",
-        eventType="RiskAssessmentResult",
+        eventType="RiskAssessed",
         occurredAt="2026-07-05T10:30:00.000Z",
-        correlationId="corr-duplicate",
-        causationId="cmd-duplicate",
+        correlationId=str(uuid7()),
+        causationId=f"cmd-{uuid7()}",
         producer="risk-compliance",
         schemaVersion=1,
         payload={"assessmentId": "asmt-1"},
@@ -215,10 +235,36 @@ def test_envelope_accepts_optional_causation_id() -> None:
 def test_risk_score_zero_is_respected_when_score_fallback_present() -> None:
     response = TestClient(fake_app()).post(
         "/api/v1/risk-assessments",
-        headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c341", "X-Correlation-Id": "corr-zero"},
+        headers={"Idempotency-Key": str(uuid7()), "X-Correlation-Id": str(uuid7())},
         json={"subjectRef": "ord-123", "scenario": "order_risk", "context": {"riskScore": 0, "score": 999}},
     )
 
     assert response.status_code == 201
     assert response.json()["score"] == 0
     assert response.json()["decision"] == "ALLOW"
+
+
+def test_correlation_id_policy_absent_valid_and_malformed() -> None:
+    client = TestClient(fake_app())
+    valid = str(uuid7())
+
+    absent = client.post(
+        "/api/v1/risk-assessments",
+        headers={"Idempotency-Key": "not-a-v7"},
+        json={"subjectRef": "ord-123", "scenario": "order_risk", "context": {}},
+    )
+    valid_response = client.post(
+        "/api/v1/risk-assessments",
+        headers={"Idempotency-Key": "not-a-v7", "X-Correlation-Id": valid},
+        json={"subjectRef": "ord-123", "scenario": "order_risk", "context": {}},
+    )
+    malformed = client.post(
+        "/api/v1/risk-assessments",
+        headers={"Idempotency-Key": "not-a-v7", "X-Correlation-Id": "corr-bad"},
+        json={"subjectRef": "ord-123", "scenario": "order_risk", "context": {}},
+    )
+
+    assert is_uuid7(absent.json()["correlationId"])
+    assert valid_response.json()["correlationId"] == valid
+    assert is_uuid7(malformed.json()["correlationId"])
+    assert malformed.json()["correlationId"] != "corr-bad"

--- a/services/risk-compliance/tests/test_api_and_messaging.py
+++ b/services/risk-compliance/tests/test_api_and_messaging.py
@@ -268,3 +268,21 @@ def test_correlation_id_policy_absent_valid_and_malformed() -> None:
     assert valid_response.json()["correlationId"] == valid
     assert is_uuid7(malformed.json()["correlationId"])
     assert malformed.json()["correlationId"] != "corr-bad"
+
+
+def test_request_id_is_server_assigned_and_caller_value_is_not_echoed() -> None:
+    caller_request_id = str(uuid7())
+
+    response = TestClient(fake_app()).post(
+        "/api/v1/risk-assessments",
+        headers={
+            "Idempotency-Key": str(uuid7()),
+            "X-Correlation-Id": str(uuid7()),
+            "X-Request-Id": caller_request_id,
+        },
+        json={"subjectRef": "ord-123", "scenario": "order_risk", "context": {"riskScore": 10}},
+    )
+
+    assert response.status_code == 201
+    assert response.headers["X-Request-Id"] != caller_request_id
+    assert is_uuid7(response.headers["X-Request-Id"])

--- a/services/risk-compliance/tests/test_api_and_messaging.py
+++ b/services/risk-compliance/tests/test_api_and_messaging.py
@@ -93,6 +93,18 @@ class FailingPublisher(InMemoryEventPublisher):
         raise PublishFailed("downstream unavailable")
 
 
+class FlakyPublisher(InMemoryEventPublisher):
+    def __init__(self) -> None:
+        super().__init__()
+        self.failures_remaining = 1
+
+    def publish(self, envelope: EventEnvelope) -> None:
+        if self.failures_remaining > 0:
+            self.failures_remaining -= 1
+            raise PublishFailed("downstream unavailable")
+        super().publish(envelope)
+
+
 def test_malformed_idempotency_key_is_validation_error() -> None:
     response = TestClient(fake_app()).post(
         "/api/v1/risk-assessments",
@@ -122,6 +134,28 @@ def test_publish_failure_returns_unavailable_body_after_save() -> None:
     assert response.json()["code"] == "UNAVAILABLE"
     assert response.json()["details"] == {"deliverySemantics": "AT_LEAST_ONCE"}
     assert len(repository._assessments) == 1
+    assert len(repository._idempotency) == 0
+    assert len(repository._pending_publications) == 1
+
+
+def test_publish_failure_retry_same_key_publishes_and_returns_created() -> None:
+    repository = InMemoryAssessmentRepository()
+    publisher = FlakyPublisher()
+    app = create_app(service=RiskComplianceService(publisher, repository))
+    client = TestClient(app)
+    headers = {"Idempotency-Key": str(uuid7()), "X-Correlation-Id": str(uuid7())}
+    payload = {"subjectRef": "ord-123", "scenario": "order_risk", "context": {"riskScore": 120}}
+
+    first = client.post("/api/v1/risk-assessments", headers=headers, json=payload)
+    retry = client.post("/api/v1/risk-assessments", headers=headers, json=payload)
+
+    assert first.status_code == 503
+    assert retry.status_code == 201
+    assert len(repository._assessments) == 1
+    assert len(repository._pending_publications) == 0
+    assert len(repository._idempotency) == 1
+    assert len(publisher.envelopes) == 1
+    assert retry.json()["assessmentId"] == next(iter(repository._assessments))
 
 
 def test_idempotent_replay_returns_original_result() -> None:

--- a/services/risk-compliance/tests/test_api_and_messaging.py
+++ b/services/risk-compliance/tests/test_api_and_messaging.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from risk_compliance import (
+    EventEnvelope,
+    InMemoryAssessmentRepository,
+    InMemoryEventPublisher,
+    InMemoryEventSubscriber,
+    RiskComplianceService,
+    create_app,
+)
+
+
+def fake_app():
+    return create_app(service=RiskComplianceService(InMemoryEventPublisher(), InMemoryAssessmentRepository()))
+
+
+def test_assess_risk_happy_path_and_get() -> None:
+    app = fake_app()
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/risk-assessments",
+        headers={"Idempotency-Key": "0194f2e0-7b3e-7610-0284-5c26e8b0c333", "X-Correlation-Id": "corr-test"},
+        json={"subjectRef": "ord-123", "scenario": "order_risk", "context": {"riskScore": 120}},
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body == {
+        "assessmentId": body["assessmentId"],
+        "subjectRef": "ord-123",
+        "scenario": "order_risk",
+        "decision": "ALLOW",
+        "score": 120,
+        "level": "LOW",
+        "policyVersion": "1.0.0",
+        "reasonCode": "PASSED_RISK_CHECKS",
+        "reasonExplanation": "All configured risk checks passed",
+        "assessedAt": body["assessedAt"],
+    }
+    assert body["assessmentId"].startswith("asmt-")
+    assert body["assessedAt"].endswith("Z")
+
+    fetched = client.get(f"/api/v1/risk-assessments/{body['assessmentId']}")
+    assert fetched.status_code == 200
+    assert fetched.json() == body
+
+
+def test_get_unknown_assessment_returns_not_found_error_body() -> None:
+    response = TestClient(fake_app()).get("/api/v1/risk-assessments/asmt-missing", headers={"X-Correlation-Id": "corr-404"})
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "code": "NOT_FOUND",
+        "message": "Risk assessment was not found",
+        "correlationId": "corr-404",
+        "details": {},
+    }
+
+
+def test_validation_failure_uses_canonical_400_body() -> None:
+    response = TestClient(fake_app()).post(
+        "/api/v1/risk-assessments",
+        headers={"Idempotency-Key": "idem-validation", "X-Correlation-Id": "corr-validation"},
+        json={"subjectRef": "ord-123", "scenario": "invalid", "context": {}},
+    )
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["code"] == "VALIDATION_FAILED"
+    assert body["message"] == "Request validation failed"
+    assert body["correlationId"] == "corr-validation"
+    assert "errors" in body["details"]
+
+
+def test_missing_idempotency_key_is_validation_error() -> None:
+    response = TestClient(fake_app()).post(
+        "/api/v1/risk-assessments",
+        headers={"X-Correlation-Id": "corr-idem"},
+        json={"subjectRef": "ord-123", "scenario": "order_risk", "context": {}},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["code"] == "VALIDATION_FAILED"
+
+
+def test_idempotent_replay_returns_original_result() -> None:
+    client = TestClient(fake_app())
+    headers = {"Idempotency-Key": "idem-replay", "X-Correlation-Id": "corr-replay"}
+    payload = {"subjectRef": "pi-123", "scenario": "payment_risk", "context": {"riskScore": 910}}
+
+    created = client.post("/api/v1/risk-assessments", headers=headers, json=payload)
+    replayed = client.post("/api/v1/risk-assessments", headers=headers, json=payload)
+
+    assert created.status_code == 201
+    assert replayed.status_code == 201
+    assert replayed.json() == created.json()
+
+
+def test_idempotency_key_reused_with_different_body_is_rejected() -> None:
+    client = TestClient(fake_app())
+    headers = {"Idempotency-Key": "idem-reused", "X-Correlation-Id": "corr-reused"}
+    first = {"subjectRef": "ord-123", "scenario": "order_risk", "context": {"riskScore": 10}}
+    second = {"subjectRef": "ord-456", "scenario": "order_risk", "context": {"riskScore": 10}}
+
+    assert client.post("/api/v1/risk-assessments", headers=headers, json=first).status_code == 201
+    response = client.post("/api/v1/risk-assessments", headers=headers, json=second)
+
+    assert response.status_code == 422
+    assert response.json()["code"] == "IDEMPOTENCY_KEY_REUSED"
+
+
+def test_publisher_wraps_domain_event_in_contract_envelope() -> None:
+    app = fake_app()
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/risk-assessments",
+        headers={"Idempotency-Key": "idem-envelope", "X-Correlation-Id": "corr-envelope"},
+        json={"subjectRef": "acct-123", "scenario": "account_risk", "context": {"riskScore": 650}},
+    )
+
+    assert response.status_code == 201
+    [envelope] = app.state.publisher.envelopes
+    assert envelope.eventId.startswith("evt-")
+    assert envelope.eventType == "RiskAssessmentResult"
+    assert envelope.producer == "risk-compliance"
+    assert envelope.schemaVersion == 1
+    assert envelope.correlationId == "corr-envelope"
+    assert envelope.causationId.startswith("cmd-")
+    assert envelope.occurredAt == response.json()["assessedAt"]
+    assert envelope.payload == response.json()
+
+
+def test_subscriber_deduplicates_duplicate_event_id() -> None:
+    envelope = EventEnvelope(
+        eventId="evt-duplicate",
+        eventType="RiskAssessmentResult",
+        occurredAt="2026-07-05T10:30:00.000Z",
+        correlationId="corr-duplicate",
+        causationId="cmd-duplicate",
+        producer="risk-compliance",
+        schemaVersion=1,
+        payload={"assessmentId": "asmt-1"},
+    )
+    subscriber = InMemoryEventSubscriber([envelope, envelope])
+    handled: list[str] = []
+
+    subscriber.subscribe(["unused"], "risk-compliance", "risk-compliance-test", lambda event: handled.append(event.eventId))
+
+    assert handled == ["evt-duplicate"]

--- a/services/risk-compliance/tests/test_api_and_messaging.py
+++ b/services/risk-compliance/tests/test_api_and_messaging.py
@@ -7,6 +7,7 @@ from risk_compliance import (
     InMemoryAssessmentRepository,
     InMemoryEventPublisher,
     InMemoryEventSubscriber,
+    PublishFailed,
     RiskComplianceService,
     create_app,
 )
@@ -22,7 +23,7 @@ def test_assess_risk_happy_path_and_get() -> None:
 
     response = client.post(
         "/api/v1/risk-assessments",
-        headers={"Idempotency-Key": "0194f2e0-7b3e-7610-0284-5c26e8b0c333", "X-Correlation-Id": "corr-test"},
+        headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c333", "X-Correlation-Id": "corr-test"},
         json={"subjectRef": "ord-123", "scenario": "order_risk", "context": {"riskScore": 120}},
     )
 
@@ -63,7 +64,7 @@ def test_get_unknown_assessment_returns_not_found_error_body() -> None:
 def test_validation_failure_uses_canonical_400_body() -> None:
     response = TestClient(fake_app()).post(
         "/api/v1/risk-assessments",
-        headers={"Idempotency-Key": "idem-validation", "X-Correlation-Id": "corr-validation"},
+        headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c334", "X-Correlation-Id": "corr-validation"},
         json={"subjectRef": "ord-123", "scenario": "invalid", "context": {}},
     )
 
@@ -86,9 +87,46 @@ def test_missing_idempotency_key_is_validation_error() -> None:
     assert response.json()["code"] == "VALIDATION_FAILED"
 
 
+class FailingPublisher(InMemoryEventPublisher):
+    def publish(self, envelope: EventEnvelope) -> None:
+        raise PublishFailed("downstream unavailable")
+
+
+def test_malformed_idempotency_key_is_validation_error() -> None:
+    response = TestClient(fake_app()).post(
+        "/api/v1/risk-assessments",
+        headers={"Idempotency-Key": "not-a-uuid-v7", "X-Correlation-Id": "corr-idem-format"},
+        json={"subjectRef": "ord-123", "scenario": "order_risk", "context": {}},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "code": "VALIDATION_FAILED",
+        "message": "Idempotency-Key must be a UUID v7",
+        "correlationId": "corr-idem-format",
+        "details": {},
+    }
+
+
+def test_publish_failure_returns_unavailable_body_after_save() -> None:
+    repository = InMemoryAssessmentRepository()
+    app = create_app(service=RiskComplianceService(FailingPublisher(), repository))
+
+    response = TestClient(app).post(
+        "/api/v1/risk-assessments",
+        headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c338", "X-Correlation-Id": "corr-publish"},
+        json={"subjectRef": "ord-123", "scenario": "order_risk", "context": {"riskScore": 120}},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["code"] == "UNAVAILABLE"
+    assert response.json()["details"] == {"deliverySemantics": "AT_LEAST_ONCE"}
+    assert len(repository._assessments) == 1
+
+
 def test_idempotent_replay_returns_original_result() -> None:
     client = TestClient(fake_app())
-    headers = {"Idempotency-Key": "idem-replay", "X-Correlation-Id": "corr-replay"}
+    headers = {"Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c335", "X-Correlation-Id": "corr-replay"}
     payload = {"subjectRef": "pi-123", "scenario": "payment_risk", "context": {"riskScore": 910}}
 
     created = client.post("/api/v1/risk-assessments", headers=headers, json=payload)
@@ -101,7 +139,7 @@ def test_idempotent_replay_returns_original_result() -> None:
 
 def test_idempotency_key_reused_with_different_body_is_rejected() -> None:
     client = TestClient(fake_app())
-    headers = {"Idempotency-Key": "idem-reused", "X-Correlation-Id": "corr-reused"}
+    headers = {"Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c336", "X-Correlation-Id": "corr-reused"}
     first = {"subjectRef": "ord-123", "scenario": "order_risk", "context": {"riskScore": 10}}
     second = {"subjectRef": "ord-456", "scenario": "order_risk", "context": {"riskScore": 10}}
 
@@ -118,18 +156,21 @@ def test_publisher_wraps_domain_event_in_contract_envelope() -> None:
 
     response = client.post(
         "/api/v1/risk-assessments",
-        headers={"Idempotency-Key": "idem-envelope", "X-Correlation-Id": "corr-envelope"},
+        headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c337", "X-Correlation-Id": "corr-envelope"},
         json={"subjectRef": "acct-123", "scenario": "account_risk", "context": {"riskScore": 650}},
     )
 
     assert response.status_code == 201
     [envelope] = app.state.publisher.envelopes
     assert envelope.eventId.startswith("evt-")
+    assert envelope.eventId.split("-", 1)[1][14] == "7"
+    assert response.json()["assessmentId"].split("-", 1)[1][14] == "7"
     assert envelope.eventType == "RiskAssessmentResult"
     assert envelope.producer == "risk-compliance"
     assert envelope.schemaVersion == 1
     assert envelope.correlationId == "corr-envelope"
     assert envelope.causationId.startswith("cmd-")
+    assert envelope.causationId.split("-", 1)[1][14] == "7"
     assert envelope.occurredAt == response.json()["assessedAt"]
     assert envelope.payload == response.json()
 
@@ -151,3 +192,33 @@ def test_subscriber_deduplicates_duplicate_event_id() -> None:
     subscriber.subscribe(["unused"], "risk-compliance", "risk-compliance-test", lambda event: handled.append(event.eventId))
 
     assert handled == ["evt-duplicate"]
+
+
+
+def test_envelope_accepts_optional_causation_id() -> None:
+    envelope = EventEnvelope.from_mapping(
+        {
+            "eventId": "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c339",
+            "eventType": "PaymentCaptured",
+            "occurredAt": "2026-07-05T10:30:00.000Z",
+            "correlationId": "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c340",
+            "producer": "payment",
+            "schemaVersion": 1,
+            "payload": {"paymentIntentId": "pi-123"},
+        }
+    )
+
+    assert envelope.causationId is None
+    assert "causationId" not in envelope.to_dict()
+
+
+def test_risk_score_zero_is_respected_when_score_fallback_present() -> None:
+    response = TestClient(fake_app()).post(
+        "/api/v1/risk-assessments",
+        headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c341", "X-Correlation-Id": "corr-zero"},
+        json={"subjectRef": "ord-123", "scenario": "order_risk", "context": {"riskScore": 0, "score": 999}},
+    )
+
+    assert response.status_code == 201
+    assert response.json()["score"] == 0
+    assert response.json()["decision"] == "ALLOW"

--- a/services/risk-compliance/tests/test_skeleton.py
+++ b/services/risk-compliance/tests/test_skeleton.py
@@ -64,7 +64,7 @@ class SkeletonTest(unittest.TestCase):
         self.assertIn("/ready", routes)
         self.assertIn("/metadata", routes)
 
-    def test_request_and_correlation_ids_are_propagated(self) -> None:
+    def test_correlation_id_is_propagated_and_request_id_is_server_assigned(self) -> None:
         client = TestClient(create_app())
         correlation_id = str(uuid7())
         response = client.get(
@@ -72,7 +72,8 @@ class SkeletonTest(unittest.TestCase):
             headers={"X-Request-ID": "req-123", "X-Correlation-ID": correlation_id},
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.headers["X-Request-ID"], "req-123")
+        self.assertNotEqual(response.headers["X-Request-ID"], "req-123")
+        self.assertTrue(is_uuid7(response.headers["X-Request-ID"]))
         self.assertEqual(response.headers["X-Correlation-ID"], correlation_id)
 
     def test_request_and_correlation_ids_are_generated(self) -> None:
@@ -94,7 +95,8 @@ class SkeletonTest(unittest.TestCase):
         response = client.get("/metadata", headers={"X-Request-ID": "req-trace"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual([event for event, _ in events], ["http.request.start", "http.request.complete"])
-        self.assertEqual(events[0][1]["request_id"], "req-trace")
+        self.assertNotEqual(events[0][1]["request_id"], "req-trace")
+        self.assertTrue(is_uuid7(str(events[0][1]["request_id"])))
         self.assertEqual(events[1][1]["status_code"], 200)
 
 

--- a/services/risk-compliance/tests/test_skeleton.py
+++ b/services/risk-compliance/tests/test_skeleton.py
@@ -22,6 +22,7 @@ from risk_compliance import (
     record_evidence,
     resolve_challenge,
 )
+from risk_compliance.application import is_uuid7, uuid7
 
 
 class SkeletonTest(unittest.TestCase):
@@ -65,13 +66,14 @@ class SkeletonTest(unittest.TestCase):
 
     def test_request_and_correlation_ids_are_propagated(self) -> None:
         client = TestClient(create_app())
+        correlation_id = str(uuid7())
         response = client.get(
             "/health",
-            headers={"X-Request-ID": "req-123", "X-Correlation-ID": "corr-456"},
+            headers={"X-Request-ID": "req-123", "X-Correlation-ID": correlation_id},
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers["X-Request-ID"], "req-123")
-        self.assertEqual(response.headers["X-Correlation-ID"], "corr-456")
+        self.assertEqual(response.headers["X-Correlation-ID"], correlation_id)
 
     def test_request_and_correlation_ids_are_generated(self) -> None:
         client = TestClient(create_app())
@@ -79,7 +81,8 @@ class SkeletonTest(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         request_id = response.headers["X-Request-ID"]
         self.assertTrue(request_id)
-        self.assertEqual(response.headers["X-Correlation-ID"], request_id)
+        self.assertTrue(is_uuid7(request_id))
+        self.assertTrue(is_uuid7(response.headers["X-Correlation-ID"]))
 
     def test_observability_trace_hook_is_opt_in(self) -> None:
         events: list[tuple[str, dict[str, object]]] = []

--- a/services/risk-compliance/uv.lock
+++ b/services/risk-compliance/uv.lock
@@ -34,6 +34,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -275,11 +284,24 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/da/d283a37303a995cd36f8b92db85135153dc4f7a8e4441aa827721b442cfb/redis-5.2.1.tar.gz", hash = "sha256:16f2e22dff21d5125e8481515e386711a34cbec50f0e44413dd7d9c060a54e0f", size = 4608355, upload-time = "2024-12-06T09:50:41.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/5f/fa26b9b2672cbe30e07d9a5bdf39cf16e3b80b42916757c5f92bca88e4ba/redis-5.2.1-py3-none-any.whl", hash = "sha256:ee7e1056b9aea0f04c6c2ed59452947f34c4940ee025f5dd83e6a6418b6989e4", size = 261502, upload-time = "2024-12-06T09:50:39.656Z" },
+]
+
+[[package]]
 name = "risk-compliance"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "redis" },
 ]
 
 [package.dev-dependencies]
@@ -289,7 +311,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "fastapi", specifier = "==0.138.1" }]
+requires-dist = [
+    { name = "fastapi", specifier = "==0.138.1" },
+    { name = "redis", specifier = "==5.2.1" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Implement risk assessment HTTP endpoints with canonical error envelopes, correlation headers, and idempotency replay
- Add application-level event ports, in-memory test fakes, and Redis Streams publisher/subscriber adapter under adapters/messaging
- Cover endpoints, idempotency, event envelope publication, and subscriber dedup tests

## Validation
- cd services/risk-compliance && pip install -e . -q && python -m pytest tests/ -q
- grep guard for Redis imports outside adapters
- make check