### PR TITLE
REQ-044 wire post-sales API and messaging adapter

### DIFF
--- a/services/post-sales/pom.xml
+++ b/services/post-sales/pom.xml
@@ -22,6 +22,15 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.lettuce</groupId>
+      <artifactId>lettuce-core</artifactId>
+      <version>6.6.0.RELEASE</version>
+    </dependency>
+    <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
       <version>1.46.0</version>

--- a/services/post-sales/src/main/java/com/trainticket/postsales/NoOpRuntimeTracer.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/NoOpRuntimeTracer.java
@@ -1,10 +1,8 @@
 package com.trainticket.postsales;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.stereotype.Component;
 
 @Component
-@ConditionalOnMissingBean(RuntimeTracer.class)
 public class NoOpRuntimeTracer implements RuntimeTracer {
     @Override
     public void requestStarted(RequestTraceContext context) {

--- a/services/post-sales/src/main/java/com/trainticket/postsales/OpenTelemetryRuntimeTracer.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/OpenTelemetryRuntimeTracer.java
@@ -9,11 +9,13 @@ import io.opentelemetry.api.trace.Tracer;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 @Component
 // Spring relaxed binding also accepts OTEL_TRACES_EXPORTER=otlp.
 @ConditionalOnProperty(name = "otel.traces.exporter", havingValue = "otlp")
+@Primary
 public class OpenTelemetryRuntimeTracer implements RuntimeTracer {
     private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
     private static final AttributeKey<String> HTTP_METHOD = AttributeKey.stringKey("http.request.method");

--- a/services/post-sales/src/main/java/com/trainticket/postsales/RequestContextFilter.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/RequestContextFilter.java
@@ -29,7 +29,7 @@ public class RequestContextFilter extends OncePerRequestFilter {
         FilterChain filterChain
     ) throws ServletException, IOException {
         String requestId = headerOrGenerated(request, REQUEST_ID_HEADER);
-        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, requestId);
+        String correlationId = headerOrGenerated(request, CORRELATION_ID_HEADER, "corr-");
         RequestTraceContext context = new RequestTraceContext(
             requestId,
             correlationId,
@@ -54,16 +54,13 @@ public class RequestContextFilter extends OncePerRequestFilter {
     }
 
     private static String headerOrGenerated(HttpServletRequest request, String headerName) {
-        return Optional.ofNullable(request.getHeader(headerName))
-            .map(String::trim)
-            .filter(value -> !value.isEmpty())
-            .orElseGet(() -> UUID.randomUUID().toString());
+        return headerOrGenerated(request, headerName, "");
     }
 
-    private static String headerOrDefault(HttpServletRequest request, String headerName, String defaultValue) {
+    private static String headerOrGenerated(HttpServletRequest request, String headerName, String generatedPrefix) {
         return Optional.ofNullable(request.getHeader(headerName))
             .map(String::trim)
             .filter(value -> !value.isEmpty())
-            .orElse(defaultValue);
+            .orElseGet(() -> generatedPrefix + UUID.randomUUID());
     }
 }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/RequestContextFilter.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/RequestContextFilter.java
@@ -11,7 +11,7 @@ import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-@Component
+@Component("postSalesRequestContextFilter")
 public class RequestContextFilter extends OncePerRequestFilter {
     public static final String REQUEST_ID_HEADER = "X-Request-Id";
     public static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
@@ -36,6 +36,8 @@ public class RequestContextFilter extends OncePerRequestFilter {
             request.getMethod(),
             request.getRequestURI()
         );
+        request.setAttribute("requestId", requestId);
+        request.setAttribute("correlationId", correlationId);
 
         response.setHeader(REQUEST_ID_HEADER, requestId);
         response.setHeader(CORRELATION_ID_HEADER, correlationId);

--- a/services/post-sales/src/main/java/com/trainticket/postsales/adapters/messaging/NoOpEventPublisher.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/adapters/messaging/NoOpEventPublisher.java
@@ -1,0 +1,12 @@
+package com.trainticket.postsales.adapters.messaging;
+
+import com.trainticket.postsales.application.EventEnvelope;
+import com.trainticket.postsales.application.EventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NoOpEventPublisher implements EventPublisher {
+    @Override
+    public void publish(EventEnvelope envelope) {
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/adapters/messaging/RedisEventPublisher.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/adapters/messaging/RedisEventPublisher.java
@@ -1,0 +1,74 @@
+package com.trainticket.postsales.adapters.messaging;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import com.trainticket.postsales.application.EventEnvelope;
+import com.trainticket.postsales.application.EventPublisher;
+import com.trainticket.postsales.application.PublishFailedException;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.XAddArgs;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+import java.time.Duration;
+import java.util.Map;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "post-sales.messaging.redis.enabled", havingValue = "true")
+@Primary
+public class RedisEventPublisher implements EventPublisher, AutoCloseable {
+    private static final int MAX_ATTEMPTS = 3;
+    private static final long MAXLEN = 100_000L;
+
+    private final ObjectMapper objectMapper;
+    private final RedisClient client;
+    private final StatefulRedisConnection<String, String> connection;
+
+    public RedisEventPublisher(ObjectMapper objectMapper, RedisMessagingProperties properties) {
+        this.objectMapper = objectMapper;
+        this.client = RedisClient.create(properties.redisUrl());
+        this.connection = client.connect();
+    }
+
+    @Override
+    public void publish(EventEnvelope envelope) throws PublishFailedException {
+        String stream = RedisStreamNames.forProducer(envelope.producer());
+        String json = serialize(envelope);
+        RuntimeException lastFailure = null;
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            try {
+                RedisCommands<String, String> commands = connection.sync();
+                commands.xadd(stream, XAddArgs.Builder.maxlen(MAXLEN).approximateTrimming(), Map.of("envelope", json));
+                return;
+            } catch (RuntimeException ex) {
+                lastFailure = ex;
+                backoff(attempt);
+            }
+        }
+        throw new PublishFailedException("failed to publish event envelope", lastFailure);
+    }
+
+    @Override
+    public void close() {
+        connection.close();
+        client.shutdown();
+    }
+
+    private String serialize(EventEnvelope envelope) {
+        try {
+            return objectMapper.writeValueAsString(envelope);
+        } catch (JacksonException ex) {
+            throw new PublishFailedException("failed to serialize event envelope", ex);
+        }
+    }
+
+    private static void backoff(int attempt) {
+        try {
+            Thread.sleep(Duration.ofMillis(50L * attempt).toMillis());
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/adapters/messaging/RedisEventSubscriber.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/adapters/messaging/RedisEventSubscriber.java
@@ -4,18 +4,23 @@ import com.trainticket.postsales.application.EventEnvelope;
 import com.trainticket.postsales.application.EventSubscriber;
 import com.trainticket.postsales.application.SubscribeFailedException;
 import io.lettuce.core.Consumer;
+import io.lettuce.core.Limit;
+import io.lettuce.core.Range;
 import io.lettuce.core.RedisBusyException;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.StreamMessage;
 import io.lettuce.core.XAddArgs;
 import io.lettuce.core.XAutoClaimArgs;
 import io.lettuce.core.XGroupCreateArgs;
+import io.lettuce.core.XPendingArgs;
 import io.lettuce.core.XReadArgs;
 import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.models.stream.ClaimedMessages;
 import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.models.stream.ClaimedMessages;
+import io.lettuce.core.models.stream.PendingMessage;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -80,7 +85,7 @@ public class RedisEventSubscriber implements EventSubscriber, AutoCloseable {
                     XReadArgs.StreamOffset.lastConsumed(stream)
                 );
                 for (StreamMessage<String, String> message : messages) {
-                    handle(commands, stream, group, message, handler, 1);
+                    handle(commands, stream, group, message, handler);
                 }
             }
         }
@@ -97,25 +102,45 @@ public class RedisEventSubscriber implements EventSubscriber, AutoCloseable {
             return;
         }
         for (StreamMessage<String, String> message : claimed.getMessages()) {
-            handle(commands, stream, group, message, handler, 2);
+            handle(commands, stream, group, message, handler);
         }
     }
 
-    private void handle(RedisCommands<String, String> commands, String stream, String group, StreamMessage<String, String> message, EventHandler handler, int deliveryCount) {
+    private void handle(RedisCommands<String, String> commands, String stream, String group, StreamMessage<String, String> message, EventHandler handler) {
         String envelopeJson = message.getBody().get("envelope");
         try {
+            int deliveryCount = deliveryCount(commands, stream, group, message.getId()).orElse(1);
             EventEnvelope envelope = objectMapper.readValue(envelopeJson, EventEnvelope.class);
             HandlerResult result = deliveryCount >= MAX_DELIVERIES ? HandlerResult.FATAL_FAILURE : handler.handle(envelope);
             if (result == HandlerResult.SUCCESS) {
                 commands.xack(stream, group, message.getId());
             } else if (result == HandlerResult.FATAL_FAILURE) {
-                commands.xadd(RedisStreamNames.dlq(stream), XAddArgs.Builder.maxlen(MAXLEN).approximateTrimming(), Map.of("envelope", envelopeJson));
+                moveToDlq(commands, stream, envelopeJson);
                 commands.xack(stream, group, message.getId());
             }
         } catch (Exception fatal) {
-            commands.xadd(RedisStreamNames.dlq(stream), XAddArgs.Builder.maxlen(MAXLEN).approximateTrimming(), Map.of("envelope", envelopeJson == null ? "" : envelopeJson));
+            moveToDlq(commands, stream, envelopeJson == null ? "" : envelopeJson);
             commands.xack(stream, group, message.getId());
         }
+    }
+
+    private OptionalInt deliveryCount(RedisCommands<String, String> commands, String stream, String group, String messageId) {
+        List<PendingMessage> pending = commands.xpending(
+            stream,
+            new XPendingArgs<String>()
+                .group(group)
+                .range(Range.create(messageId, messageId))
+                .limit(Limit.create(0, 1))
+        );
+        if (pending == null || pending.isEmpty()) {
+            return OptionalInt.empty();
+        }
+        long deliveryCount = pending.getFirst().getRedeliveryCount();
+        return OptionalInt.of(Math.toIntExact(deliveryCount));
+    }
+
+    private void moveToDlq(RedisCommands<String, String> commands, String stream, String envelopeJson) {
+        commands.xadd(RedisStreamNames.dlq(stream), XAddArgs.Builder.maxlen(MAXLEN).approximateTrimming(), Map.of("envelope", envelopeJson));
     }
 
     private void createGroup(RedisCommands<String, String> commands, String stream, String group) {

--- a/services/post-sales/src/main/java/com/trainticket/postsales/adapters/messaging/RedisEventSubscriber.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/adapters/messaging/RedisEventSubscriber.java
@@ -1,0 +1,128 @@
+package com.trainticket.postsales.adapters.messaging;
+
+import com.trainticket.postsales.application.EventEnvelope;
+import com.trainticket.postsales.application.EventSubscriber;
+import com.trainticket.postsales.application.SubscribeFailedException;
+import io.lettuce.core.Consumer;
+import io.lettuce.core.RedisBusyException;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.StreamMessage;
+import io.lettuce.core.XAddArgs;
+import io.lettuce.core.XAutoClaimArgs;
+import io.lettuce.core.XGroupCreateArgs;
+import io.lettuce.core.XReadArgs;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.models.stream.ClaimedMessages;
+import io.lettuce.core.api.sync.RedisCommands;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+@Component
+@ConditionalOnProperty(name = "post-sales.messaging.redis.enabled", havingValue = "true")
+public class RedisEventSubscriber implements EventSubscriber, AutoCloseable {
+    private static final long MAXLEN = 100_000L;
+    private static final long BLOCK_MILLIS = 2_000L;
+    private static final long MIN_IDLE_MILLIS = 60_000L;
+    private static final int MAX_DELIVERIES = 5;
+
+    private final ObjectMapper objectMapper;
+    private final RedisMessagingProperties properties;
+    private final RedisClient client;
+    private final StatefulRedisConnection<String, String> connection;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private ExecutorService executor;
+
+    public RedisEventSubscriber(ObjectMapper objectMapper, RedisMessagingProperties properties) {
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+        this.client = RedisClient.create(properties.redisUrl());
+        this.connection = client.connect();
+    }
+
+    @Override
+    public void subscribe(List<String> streams, String group, String consumerName, EventHandler handler) throws SubscribeFailedException {
+        try {
+            RedisCommands<String, String> commands = connection.sync();
+            for (String stream : streams) {
+                createGroup(commands, stream, group);
+            }
+            running.set(true);
+            executor = Executors.newSingleThreadExecutor();
+            executor.submit(() -> poll(commands, streams, group, consumerName, handler));
+        } catch (RuntimeException ex) {
+            throw new SubscribeFailedException("failed to subscribe to event streams", ex);
+        }
+    }
+
+    @Override
+    public void close() {
+        running.set(false);
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+        connection.close();
+        client.shutdown();
+    }
+
+    private void poll(RedisCommands<String, String> commands, List<String> streams, String group, String consumerName, EventHandler handler) {
+        while (running.get()) {
+            for (String stream : streams) {
+                recover(commands, stream, group, consumerName, handler);
+                List<StreamMessage<String, String>> messages = commands.xreadgroup(
+                    Consumer.from(group, consumerName),
+                    XReadArgs.Builder.block(BLOCK_MILLIS).count(10),
+                    XReadArgs.StreamOffset.lastConsumed(stream)
+                );
+                for (StreamMessage<String, String> message : messages) {
+                    handle(commands, stream, group, message, handler, 1);
+                }
+            }
+        }
+    }
+
+    private void recover(RedisCommands<String, String> commands, String stream, String group, String consumerName, EventHandler handler) {
+        XAutoClaimArgs<String> args = new XAutoClaimArgs<String>()
+            .consumer(Consumer.from(group, consumerName))
+            .minIdleTime(MIN_IDLE_MILLIS)
+            .startId("0-0")
+            .count(100);
+        ClaimedMessages<String, String> claimed = commands.xautoclaim(stream, args);
+        if (claimed == null) {
+            return;
+        }
+        for (StreamMessage<String, String> message : claimed.getMessages()) {
+            handle(commands, stream, group, message, handler, 2);
+        }
+    }
+
+    private void handle(RedisCommands<String, String> commands, String stream, String group, StreamMessage<String, String> message, EventHandler handler, int deliveryCount) {
+        String envelopeJson = message.getBody().get("envelope");
+        try {
+            EventEnvelope envelope = objectMapper.readValue(envelopeJson, EventEnvelope.class);
+            HandlerResult result = deliveryCount >= MAX_DELIVERIES ? HandlerResult.FATAL_FAILURE : handler.handle(envelope);
+            if (result == HandlerResult.SUCCESS) {
+                commands.xack(stream, group, message.getId());
+            } else if (result == HandlerResult.FATAL_FAILURE) {
+                commands.xadd(RedisStreamNames.dlq(stream), XAddArgs.Builder.maxlen(MAXLEN).approximateTrimming(), Map.of("envelope", envelopeJson));
+                commands.xack(stream, group, message.getId());
+            }
+        } catch (Exception fatal) {
+            commands.xadd(RedisStreamNames.dlq(stream), XAddArgs.Builder.maxlen(MAXLEN).approximateTrimming(), Map.of("envelope", envelopeJson == null ? "" : envelopeJson));
+            commands.xack(stream, group, message.getId());
+        }
+    }
+
+    private void createGroup(RedisCommands<String, String> commands, String stream, String group) {
+        try {
+            commands.xgroupCreate(XReadArgs.StreamOffset.latest(stream), group, XGroupCreateArgs.Builder.mkstream());
+        } catch (RedisBusyException alreadyExists) {
+            // Safe on restart.
+        }
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/adapters/messaging/RedisMessagingProperties.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/adapters/messaging/RedisMessagingProperties.java
@@ -1,0 +1,26 @@
+package com.trainticket.postsales.adapters.messaging;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisMessagingProperties {
+    private final String redisUrl;
+    private final String consumerName;
+
+    public RedisMessagingProperties(
+        @Value("${REDIS_URL:redis://localhost:6379}") String redisUrl,
+        @Value("${HOSTNAME:local}") String instanceId
+    ) {
+        this.redisUrl = redisUrl;
+        this.consumerName = RedisStreamNames.CONSUMER_GROUP + "-" + instanceId;
+    }
+
+    String redisUrl() {
+        return redisUrl;
+    }
+
+    String consumerName() {
+        return consumerName;
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/adapters/messaging/RedisStreamNames.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/adapters/messaging/RedisStreamNames.java
@@ -1,0 +1,17 @@
+package com.trainticket.postsales.adapters.messaging;
+
+final class RedisStreamNames {
+    static final String CONSUMER_GROUP = "post-sales";
+    static final String PRODUCER = "post-sales";
+
+    private RedisStreamNames() {
+    }
+
+    static String forProducer(String producer) {
+        return "events:" + producer;
+    }
+
+    static String dlq(String stream) {
+        return stream + ":dlq";
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/adapters/messaging/RedisSubscriptionLifecycle.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/adapters/messaging/RedisSubscriptionLifecycle.java
@@ -1,0 +1,35 @@
+package com.trainticket.postsales.adapters.messaging;
+
+import com.trainticket.postsales.application.PostSalesEventHandler;
+import jakarta.annotation.PostConstruct;
+import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "post-sales.messaging.redis.enabled", havingValue = "true")
+public class RedisSubscriptionLifecycle {
+    private final RedisEventSubscriber subscriber;
+    private final RedisMessagingProperties properties;
+    private final PostSalesEventHandler handler;
+
+    public RedisSubscriptionLifecycle(RedisEventSubscriber subscriber, RedisMessagingProperties properties, PostSalesEventHandler handler) {
+        this.subscriber = subscriber;
+        this.properties = properties;
+        this.handler = handler;
+    }
+
+    @PostConstruct
+    void subscribe() {
+        subscriber.subscribe(
+            List.of(
+                RedisStreamNames.forProducer("capacity-availability"),
+                RedisStreamNames.forProducer("journey-order"),
+                RedisStreamNames.forProducer("disruption-recovery")
+            ),
+            RedisStreamNames.CONSUMER_GROUP,
+            properties.consumerName(),
+            handler::handle
+        );
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/api/ApiErrorHandler.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/api/ApiErrorHandler.java
@@ -1,6 +1,7 @@
 package com.trainticket.postsales.api;
 
 import com.trainticket.postsales.application.CaseNotFoundException;
+import com.trainticket.postsales.application.IdempotencyKeyReusedException;
 import com.trainticket.postsales.domain.DomainRuleViolation;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
@@ -22,6 +23,11 @@ public class ApiErrorHandler {
     @ExceptionHandler(CaseNotFoundException.class)
     ResponseEntity<ErrorBody> notFound(CaseNotFoundException exception, HttpServletRequest request) {
         return error(HttpStatus.NOT_FOUND, "NOT_FOUND", exception.getMessage(), request);
+    }
+
+    @ExceptionHandler(IdempotencyKeyReusedException.class)
+    ResponseEntity<ErrorBody> idempotency(IdempotencyKeyReusedException exception, HttpServletRequest request) {
+        return error(HttpStatus.UNPROCESSABLE_ENTITY, "IDEMPOTENCY_KEY_REUSED", exception.getMessage(), request);
     }
 
     @ExceptionHandler(DomainRuleViolation.class)

--- a/services/post-sales/src/main/java/com/trainticket/postsales/api/ApiErrorHandler.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/api/ApiErrorHandler.java
@@ -1,0 +1,41 @@
+package com.trainticket.postsales.api;
+
+import com.trainticket.postsales.application.CaseNotFoundException;
+import com.trainticket.postsales.domain.DomainRuleViolation;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ApiErrorHandler {
+    @ExceptionHandler({MethodArgumentNotValidException.class, HttpMessageNotReadableException.class, MissingRequestHeaderException.class, IllegalArgumentException.class})
+    ResponseEntity<ErrorBody> validation(Exception exception, HttpServletRequest request) {
+        return error(HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", exception.getMessage(), request);
+    }
+
+    @ExceptionHandler(CaseNotFoundException.class)
+    ResponseEntity<ErrorBody> notFound(CaseNotFoundException exception, HttpServletRequest request) {
+        return error(HttpStatus.NOT_FOUND, "NOT_FOUND", exception.getMessage(), request);
+    }
+
+    @ExceptionHandler(DomainRuleViolation.class)
+    ResponseEntity<ErrorBody> domain(DomainRuleViolation exception, HttpServletRequest request) {
+        return error(HttpStatus.UNPROCESSABLE_ENTITY, "DOMAIN_RULE_VIOLATION", exception.getMessage(), request);
+    }
+
+    private static ResponseEntity<ErrorBody> error(HttpStatus status, String code, String message, HttpServletRequest request) {
+        String correlationId = (String) request.getAttribute("correlationId");
+        if (correlationId == null) {
+            correlationId = request.getHeader("X-Correlation-Id");
+        }
+        return ResponseEntity.status(status).body(new ErrorBody(code, message, correlationId, Map.of()));
+    }
+
+    public record ErrorBody(String code, String message, String correlationId, Map<String, Object> details) { }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/api/PostSalesController.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/api/PostSalesController.java
@@ -14,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
+import java.util.UUID;
 import java.util.List;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
@@ -56,7 +57,7 @@ public class PostSalesController {
                     request.reasonCode(),
                     request.actorRef(),
                     idempotencyKey,
-                    idempotencyKey,
+                    commandId(),
                     requestCorrelationId(httpRequest)
                 ));
                 return PostSalesMapper.openResponse(postSalesCase);
@@ -74,7 +75,7 @@ public class PostSalesController {
         return idempotencyStore.execute(
             "POST /api/v1/post-sales-cases/" + caseId + "/evaluate " + idempotencyKey,
             fingerprint(caseId),
-            () -> PostSalesMapper.evaluateResponse(service.evaluate(caseId, idempotencyKey, requestCorrelationId(httpRequest)))
+            () -> PostSalesMapper.evaluateResponse(service.evaluate(caseId, commandId(), requestCorrelationId(httpRequest)))
         ).value();
     }
 
@@ -87,7 +88,7 @@ public class PostSalesController {
         return idempotencyStore.execute(
             "POST /api/v1/post-sales-cases/" + caseId + "/approve " + idempotencyKey,
             fingerprint(caseId),
-            () -> PostSalesMapper.approveResponse(service.approve(caseId, idempotencyKey, requestCorrelationId(httpRequest)))
+            () -> PostSalesMapper.approveResponse(service.approve(caseId, commandId(), requestCorrelationId(httpRequest)))
         ).value();
     }
 
@@ -103,6 +104,10 @@ public class PostSalesController {
         }
         String header = request.getHeader("X-Correlation-Id");
         return header == null || header.isBlank() ? null : header;
+    }
+
+    private static String commandId() {
+        return "cmd-" + UUID.randomUUID();
     }
 
     private static String fingerprint(Object request) {

--- a/services/post-sales/src/main/java/com/trainticket/postsales/api/PostSalesController.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/api/PostSalesController.java
@@ -46,8 +46,9 @@ public class PostSalesController {
         HttpServletRequest httpRequest,
         @Valid @RequestBody OpenCaseRequest request
     ) {
+        String validatedIdempotencyKey = requireUuid7(idempotencyKey);
         var result = idempotencyStore.execute(
-            "POST /api/v1/post-sales-cases " + idempotencyKey,
+            "POST /api/v1/post-sales-cases " + validatedIdempotencyKey,
             fingerprint(request),
             () -> {
                 PostSalesCase postSalesCase = service.open(new PostSalesApplicationService.OpenCaseCommand(
@@ -56,7 +57,7 @@ public class PostSalesController {
                     request.scope().toDomain(),
                     request.reasonCode(),
                     request.actorRef(),
-                    idempotencyKey,
+                    validatedIdempotencyKey,
                     commandId(),
                     requestCorrelationId(httpRequest)
                 ));
@@ -72,8 +73,9 @@ public class PostSalesController {
         @RequestHeader("Idempotency-Key") String idempotencyKey,
         HttpServletRequest httpRequest
     ) {
+        String validatedIdempotencyKey = requireUuid7(idempotencyKey);
         return idempotencyStore.execute(
-            "POST /api/v1/post-sales-cases/" + caseId + "/evaluate " + idempotencyKey,
+            "POST /api/v1/post-sales-cases/" + caseId + "/evaluate " + validatedIdempotencyKey,
             fingerprint(caseId),
             () -> PostSalesMapper.evaluateResponse(service.evaluate(caseId, commandId(), requestCorrelationId(httpRequest)))
         ).value();
@@ -85,8 +87,9 @@ public class PostSalesController {
         @RequestHeader("Idempotency-Key") String idempotencyKey,
         HttpServletRequest httpRequest
     ) {
+        String validatedIdempotencyKey = requireUuid7(idempotencyKey);
         return idempotencyStore.execute(
-            "POST /api/v1/post-sales-cases/" + caseId + "/approve " + idempotencyKey,
+            "POST /api/v1/post-sales-cases/" + caseId + "/approve " + validatedIdempotencyKey,
             fingerprint(caseId),
             () -> PostSalesMapper.approveResponse(service.approve(caseId, commandId(), requestCorrelationId(httpRequest)))
         ).value();
@@ -95,6 +98,19 @@ public class PostSalesController {
     @GetMapping("/{caseId}")
     public Map<String, Object> get(@PathVariable String caseId) {
         return PostSalesMapper.caseDetails(service.get(caseId));
+    }
+
+
+    static String requireUuid7(String key) {
+        try {
+            UUID parsed = UUID.fromString(key);
+            if (parsed.version() != 7) {
+                throw new IllegalArgumentException();
+            }
+            return key;
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Idempotency-Key must be a UUID v7");
+        }
     }
 
     private static String requestCorrelationId(HttpServletRequest request) {

--- a/services/post-sales/src/main/java/com/trainticket/postsales/api/PostSalesController.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/api/PostSalesController.java
@@ -10,6 +10,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
@@ -38,22 +42,26 @@ public class PostSalesController {
     @PostMapping
     public ResponseEntity<Map<String, Object>> open(
         @RequestHeader("Idempotency-Key") String idempotencyKey,
-        @RequestHeader(value = "X-Correlation-Id", required = false) String correlationId,
+        HttpServletRequest httpRequest,
         @Valid @RequestBody OpenCaseRequest request
     ) {
-        var result = idempotencyStore.execute("POST /api/v1/post-sales-cases " + idempotencyKey, () -> {
-            PostSalesCase postSalesCase = service.open(new PostSalesApplicationService.OpenCaseCommand(
-                request.journeyOrderId(),
-                request.caseType(),
-                request.scope().toDomain(),
-                request.reasonCode(),
-                request.actorRef(),
-                idempotencyKey,
-                idempotencyKey,
-                correlationIdOrRequest(idempotencyKey, correlationId)
-            ));
-            return PostSalesMapper.openResponse(postSalesCase);
-        });
+        var result = idempotencyStore.execute(
+            "POST /api/v1/post-sales-cases " + idempotencyKey,
+            fingerprint(request),
+            () -> {
+                PostSalesCase postSalesCase = service.open(new PostSalesApplicationService.OpenCaseCommand(
+                    request.journeyOrderId(),
+                    request.caseType(),
+                    request.scope().toDomain(),
+                    request.reasonCode(),
+                    request.actorRef(),
+                    idempotencyKey,
+                    idempotencyKey,
+                    requestCorrelationId(httpRequest)
+                ));
+                return PostSalesMapper.openResponse(postSalesCase);
+            }
+        );
         return ResponseEntity.status(HttpStatus.CREATED).body(result.value());
     }
 
@@ -61,10 +69,12 @@ public class PostSalesController {
     public Map<String, Object> evaluate(
         @PathVariable String caseId,
         @RequestHeader("Idempotency-Key") String idempotencyKey,
-        @RequestHeader(value = "X-Correlation-Id", required = false) String correlationId
+        HttpServletRequest httpRequest
     ) {
-        return idempotencyStore.execute("POST /api/v1/post-sales-cases/" + caseId + "/evaluate " + idempotencyKey, () ->
-            PostSalesMapper.evaluateResponse(service.evaluate(caseId, idempotencyKey, correlationIdOrRequest(idempotencyKey, correlationId)))
+        return idempotencyStore.execute(
+            "POST /api/v1/post-sales-cases/" + caseId + "/evaluate " + idempotencyKey,
+            fingerprint(caseId),
+            () -> PostSalesMapper.evaluateResponse(service.evaluate(caseId, idempotencyKey, requestCorrelationId(httpRequest)))
         ).value();
     }
 
@@ -72,10 +82,12 @@ public class PostSalesController {
     public Map<String, Object> approve(
         @PathVariable String caseId,
         @RequestHeader("Idempotency-Key") String idempotencyKey,
-        @RequestHeader(value = "X-Correlation-Id", required = false) String correlationId
+        HttpServletRequest httpRequest
     ) {
-        return idempotencyStore.execute("POST /api/v1/post-sales-cases/" + caseId + "/approve " + idempotencyKey, () ->
-            PostSalesMapper.approveResponse(service.approve(caseId, idempotencyKey, correlationIdOrRequest(idempotencyKey, correlationId)))
+        return idempotencyStore.execute(
+            "POST /api/v1/post-sales-cases/" + caseId + "/approve " + idempotencyKey,
+            fingerprint(caseId),
+            () -> PostSalesMapper.approveResponse(service.approve(caseId, idempotencyKey, requestCorrelationId(httpRequest)))
         ).value();
     }
 
@@ -84,8 +96,23 @@ public class PostSalesController {
         return PostSalesMapper.caseDetails(service.get(caseId));
     }
 
-    private static String correlationIdOrRequest(String idempotencyKey, String correlationId) {
-        return correlationId == null || correlationId.isBlank() ? idempotencyKey : correlationId;
+    private static String requestCorrelationId(HttpServletRequest request) {
+        Object correlationId = request.getAttribute("correlationId");
+        if (correlationId instanceof String value && !value.isBlank()) {
+            return value;
+        }
+        String header = request.getHeader("X-Correlation-Id");
+        return header == null || header.isBlank() ? null : header;
+    }
+
+    private static String fingerprint(Object request) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest(String.valueOf(request).getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(bytes);
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 is unavailable", ex);
+        }
     }
 
     public record OpenCaseRequest(

--- a/services/post-sales/src/main/java/com/trainticket/postsales/api/PostSalesController.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/api/PostSalesController.java
@@ -1,0 +1,109 @@
+package com.trainticket.postsales.api;
+
+import com.trainticket.postsales.application.IdempotencyStore;
+import com.trainticket.postsales.application.PostSalesApplicationService;
+import com.trainticket.postsales.application.PostSalesMapper;
+import com.trainticket.postsales.domain.PostSalesCase;
+import com.trainticket.postsales.domain.PostSalesCaseType;
+import com.trainticket.postsales.domain.PostSalesScope;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/post-sales-cases")
+@Validated
+public class PostSalesController {
+    private final PostSalesApplicationService service;
+    private final IdempotencyStore idempotencyStore;
+
+    public PostSalesController(PostSalesApplicationService service, IdempotencyStore idempotencyStore) {
+        this.service = service;
+        this.idempotencyStore = idempotencyStore;
+    }
+
+    @PostMapping
+    public ResponseEntity<Map<String, Object>> open(
+        @RequestHeader("Idempotency-Key") String idempotencyKey,
+        @RequestHeader(value = "X-Correlation-Id", required = false) String correlationId,
+        @Valid @RequestBody OpenCaseRequest request
+    ) {
+        var result = idempotencyStore.execute("POST /api/v1/post-sales-cases " + idempotencyKey, () -> {
+            PostSalesCase postSalesCase = service.open(new PostSalesApplicationService.OpenCaseCommand(
+                request.journeyOrderId(),
+                request.caseType(),
+                request.scope().toDomain(),
+                request.reasonCode(),
+                request.actorRef(),
+                idempotencyKey,
+                idempotencyKey,
+                correlationIdOrRequest(idempotencyKey, correlationId)
+            ));
+            return PostSalesMapper.openResponse(postSalesCase);
+        });
+        return ResponseEntity.status(HttpStatus.CREATED).body(result.value());
+    }
+
+    @PostMapping("/{caseId}/evaluate")
+    public Map<String, Object> evaluate(
+        @PathVariable String caseId,
+        @RequestHeader("Idempotency-Key") String idempotencyKey,
+        @RequestHeader(value = "X-Correlation-Id", required = false) String correlationId
+    ) {
+        return idempotencyStore.execute("POST /api/v1/post-sales-cases/" + caseId + "/evaluate " + idempotencyKey, () ->
+            PostSalesMapper.evaluateResponse(service.evaluate(caseId, idempotencyKey, correlationIdOrRequest(idempotencyKey, correlationId)))
+        ).value();
+    }
+
+    @PostMapping("/{caseId}/approve")
+    public Map<String, Object> approve(
+        @PathVariable String caseId,
+        @RequestHeader("Idempotency-Key") String idempotencyKey,
+        @RequestHeader(value = "X-Correlation-Id", required = false) String correlationId
+    ) {
+        return idempotencyStore.execute("POST /api/v1/post-sales-cases/" + caseId + "/approve " + idempotencyKey, () ->
+            PostSalesMapper.approveResponse(service.approve(caseId, idempotencyKey, correlationIdOrRequest(idempotencyKey, correlationId)))
+        ).value();
+    }
+
+    @GetMapping("/{caseId}")
+    public Map<String, Object> get(@PathVariable String caseId) {
+        return PostSalesMapper.caseDetails(service.get(caseId));
+    }
+
+    private static String correlationIdOrRequest(String idempotencyKey, String correlationId) {
+        return correlationId == null || correlationId.isBlank() ? idempotencyKey : correlationId;
+    }
+
+    public record OpenCaseRequest(
+        @NotBlank String journeyOrderId,
+        @NotNull PostSalesCaseType caseType,
+        @NotNull ScopeRequest scope,
+        @NotBlank String reasonCode,
+        @NotBlank String actorRef
+    ) { }
+
+    public record ScopeRequest(
+        @NotNull List<String> orderItemRefs,
+        @NotNull List<String> segmentRefs,
+        @NotNull List<String> travelerRefs,
+        @NotNull List<String> entitlementRefs
+    ) {
+        PostSalesScope toDomain() {
+            return new PostSalesScope(orderItemRefs, segmentRefs, travelerRefs, entitlementRefs);
+        }
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/ApplicationConfig.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/ApplicationConfig.java
@@ -1,0 +1,13 @@
+package com.trainticket.postsales.application;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ApplicationConfig {
+    @Bean
+    Clock clock() {
+        return Clock.systemUTC();
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/CaseNotFoundException.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/CaseNotFoundException.java
@@ -1,0 +1,7 @@
+package com.trainticket.postsales.application;
+
+public class CaseNotFoundException extends RuntimeException {
+    public CaseNotFoundException(String caseId) {
+        super("post-sales case not found: " + caseId);
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/ConsumedEventLog.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/ConsumedEventLog.java
@@ -1,0 +1,5 @@
+package com.trainticket.postsales.application;
+
+public interface ConsumedEventLog {
+    boolean recordIfFirstSeen(String eventId);
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/EventEnvelope.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/EventEnvelope.java
@@ -1,0 +1,50 @@
+package com.trainticket.postsales.application;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+
+public record EventEnvelope(
+    String eventId,
+    String eventType,
+    int schemaVersion,
+    String producer,
+    String sourceCommandId,
+    String causationId,
+    String correlationId,
+    Instant occurredAt,
+    Map<String, String> attributes,
+    Object payload
+) {
+    public EventEnvelope {
+        eventId = requirePrefixed(eventId, "eventId", "evt-");
+        eventType = requireText(eventType, "eventType");
+        if (schemaVersion < 1) {
+            throw new IllegalArgumentException("schemaVersion must be positive");
+        }
+        producer = requireText(producer, "producer");
+        sourceCommandId = requirePrefixed(sourceCommandId, "sourceCommandId", "cmd-");
+        causationId = requirePrefixed(causationId, "causationId", "cmd-", "evt-");
+        correlationId = requirePrefixed(correlationId, "correlationId", "corr-");
+        Objects.requireNonNull(occurredAt, "occurredAt is required");
+        attributes = Map.copyOf(Objects.requireNonNull(attributes, "attributes are required"));
+        Objects.requireNonNull(payload, "payload is required");
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value;
+    }
+
+    private static String requirePrefixed(String value, String name, String... prefixes) {
+        String text = requireText(value, name);
+        for (String prefix : prefixes) {
+            if (text.startsWith(prefix)) {
+                return text;
+            }
+        }
+        throw new IllegalArgumentException(name + " must start with " + String.join(" or ", prefixes));
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/EventEnvelope.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/EventEnvelope.java
@@ -1,33 +1,32 @@
 package com.trainticket.postsales.application;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.Instant;
-import java.util.Map;
 import java.util.Objects;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record EventEnvelope(
     String eventId,
     String eventType,
-    int schemaVersion,
-    String producer,
-    String sourceCommandId,
-    String causationId,
-    String correlationId,
     Instant occurredAt,
-    Map<String, String> attributes,
+    String correlationId,
+    String causationId,
+    String producer,
+    int schemaVersion,
     Object payload
 ) {
     public EventEnvelope {
         eventId = requirePrefixed(eventId, "eventId", "evt-");
         eventType = requireText(eventType, "eventType");
+        Objects.requireNonNull(occurredAt, "occurredAt is required");
+        correlationId = requirePrefixed(correlationId, "correlationId", "corr-");
+        if (causationId != null) {
+            causationId = requirePrefixed(causationId, "causationId", "cmd-", "evt-");
+        }
+        producer = requireText(producer, "producer");
         if (schemaVersion < 1) {
             throw new IllegalArgumentException("schemaVersion must be positive");
         }
-        producer = requireText(producer, "producer");
-        sourceCommandId = requirePrefixed(sourceCommandId, "sourceCommandId", "cmd-");
-        causationId = requirePrefixed(causationId, "causationId", "cmd-", "evt-");
-        correlationId = requirePrefixed(correlationId, "correlationId", "corr-");
-        Objects.requireNonNull(occurredAt, "occurredAt is required");
-        attributes = Map.copyOf(Objects.requireNonNull(attributes, "attributes are required"));
         Objects.requireNonNull(payload, "payload is required");
     }
 

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/EventPublisher.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/EventPublisher.java
@@ -1,0 +1,5 @@
+package com.trainticket.postsales.application;
+
+public interface EventPublisher {
+    void publish(EventEnvelope envelope) throws PublishFailedException;
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/EventSubscriber.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/EventSubscriber.java
@@ -1,0 +1,18 @@
+package com.trainticket.postsales.application;
+
+import java.util.List;
+
+public interface EventSubscriber {
+    void subscribe(List<String> streams, String group, String consumerName, EventHandler handler) throws SubscribeFailedException;
+
+    @FunctionalInterface
+    interface EventHandler {
+        HandlerResult handle(EventEnvelope envelope);
+    }
+
+    enum HandlerResult {
+        SUCCESS,
+        TRANSIENT_FAILURE,
+        FATAL_FAILURE
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/IdempotencyKeyReusedException.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/IdempotencyKeyReusedException.java
@@ -1,0 +1,7 @@
+package com.trainticket.postsales.application;
+
+public class IdempotencyKeyReusedException extends RuntimeException {
+    public IdempotencyKeyReusedException(String key) {
+        super("Idempotency-Key was reused with a different request body: " + key);
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/IdempotencyStore.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/IdempotencyStore.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 public interface IdempotencyStore {
-    <T> IdempotentResult<T> execute(String key, Supplier<T> supplier);
+    <T> IdempotentResult<T> execute(String key, String requestFingerprint, Supplier<T> supplier);
     Optional<Object> get(String key);
 
     record IdempotentResult<T>(T value, boolean replay) { }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/IdempotencyStore.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/IdempotencyStore.java
@@ -1,0 +1,11 @@
+package com.trainticket.postsales.application;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public interface IdempotencyStore {
+    <T> IdempotentResult<T> execute(String key, Supplier<T> supplier);
+    Optional<Object> get(String key);
+
+    record IdempotentResult<T>(T value, boolean replay) { }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/InMemoryConsumedEventLog.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/InMemoryConsumedEventLog.java
@@ -1,0 +1,15 @@
+package com.trainticket.postsales.application;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InMemoryConsumedEventLog implements ConsumedEventLog {
+    private final Set<String> consumedEventIds = ConcurrentHashMap.newKeySet();
+
+    @Override
+    public boolean recordIfFirstSeen(String eventId) {
+        return consumedEventIds.add(eventId);
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/InMemoryIdempotencyStore.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/InMemoryIdempotencyStore.java
@@ -1,0 +1,32 @@
+package com.trainticket.postsales.application;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InMemoryIdempotencyStore implements IdempotencyStore {
+    private final ConcurrentMap<String, Object> results = new ConcurrentHashMap<>();
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> IdempotentResult<T> execute(String key, Supplier<T> supplier) {
+        Object existing = results.get(key);
+        if (existing != null) {
+            return new IdempotentResult<>((T) existing, true);
+        }
+        Object created = supplier.get();
+        Object raced = results.putIfAbsent(key, created);
+        if (raced != null) {
+            return new IdempotentResult<>((T) raced, true);
+        }
+        return new IdempotentResult<>((T) created, false);
+    }
+
+    @Override
+    public Optional<Object> get(String key) {
+        return Optional.ofNullable(results.get(key));
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/InMemoryIdempotencyStore.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/InMemoryIdempotencyStore.java
@@ -1,5 +1,6 @@
 package com.trainticket.postsales.application;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -8,25 +9,37 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class InMemoryIdempotencyStore implements IdempotencyStore {
-    private final ConcurrentMap<String, Object> results = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Entry> results = new ConcurrentHashMap<>();
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> IdempotentResult<T> execute(String key, Supplier<T> supplier) {
-        Object existing = results.get(key);
+    public <T> IdempotentResult<T> execute(String key, String requestFingerprint, Supplier<T> supplier) {
+        String fingerprint = Objects.requireNonNull(requestFingerprint, "requestFingerprint is required");
+        Entry existing = results.get(key);
         if (existing != null) {
-            return new IdempotentResult<>((T) existing, true);
+            ensureSameFingerprint(key, fingerprint, existing);
+            return new IdempotentResult<>((T) existing.result(), true);
         }
         Object created = supplier.get();
-        Object raced = results.putIfAbsent(key, created);
+        Entry createdEntry = new Entry(fingerprint, created);
+        Entry raced = results.putIfAbsent(key, createdEntry);
         if (raced != null) {
-            return new IdempotentResult<>((T) raced, true);
+            ensureSameFingerprint(key, fingerprint, raced);
+            return new IdempotentResult<>((T) raced.result(), true);
         }
         return new IdempotentResult<>((T) created, false);
     }
 
     @Override
     public Optional<Object> get(String key) {
-        return Optional.ofNullable(results.get(key));
+        return Optional.ofNullable(results.get(key)).map(Entry::result);
     }
+
+    private static void ensureSameFingerprint(String key, String fingerprint, Entry entry) {
+        if (!entry.requestFingerprint().equals(fingerprint)) {
+            throw new IdempotencyKeyReusedException(key);
+        }
+    }
+
+    private record Entry(String requestFingerprint, Object result) { }
 }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/InMemoryPostSalesRepository.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/InMemoryPostSalesRepository.java
@@ -1,0 +1,29 @@
+package com.trainticket.postsales.application;
+
+import com.trainticket.postsales.domain.PostSalesCase;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryPostSalesRepository implements PostSalesRepository {
+    private final ConcurrentMap<String, PostSalesCase> byId = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, String> caseIdByIdempotencyKey = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(PostSalesCase postSalesCase) {
+        byId.put(postSalesCase.caseId(), postSalesCase);
+        caseIdByIdempotencyKey.put(postSalesCase.idempotencyKey(), postSalesCase.caseId());
+    }
+
+    @Override
+    public Optional<PostSalesCase> findById(String caseId) {
+        return Optional.ofNullable(byId.get(caseId));
+    }
+
+    @Override
+    public Optional<PostSalesCase> findByIdempotencyKey(String idempotencyKey) {
+        return Optional.ofNullable(caseIdByIdempotencyKey.get(idempotencyKey)).flatMap(this::findById);
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
@@ -1,0 +1,143 @@
+package com.trainticket.postsales.application;
+
+import com.trainticket.postsales.domain.AmountDecisionSnapshot;
+import com.trainticket.postsales.domain.ChangeFinancialAction;
+import com.trainticket.postsales.domain.ChangeFlowSnapshot;
+import com.trainticket.postsales.domain.DecisionKind;
+import com.trainticket.postsales.domain.Money;
+import com.trainticket.postsales.domain.PostSalesCase;
+import com.trainticket.postsales.domain.PostSalesCaseType;
+import com.trainticket.postsales.domain.PostSalesDecision;
+import com.trainticket.postsales.domain.PostSalesEvent;
+import com.trainticket.postsales.domain.PostSalesScope;
+import com.trainticket.postsales.domain.RuleEvaluationSnapshot;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PostSalesApplicationService {
+    private final PostSalesRepository repository;
+    private final EventPublisher eventPublisher;
+    private final Clock clock;
+    private final ConcurrentMap<String, Integer> publishedEventCounts = new ConcurrentHashMap<>();
+
+    public PostSalesApplicationService(PostSalesRepository repository, EventPublisher eventPublisher, Clock clock) {
+        this.repository = repository;
+        this.eventPublisher = eventPublisher;
+        this.clock = clock;
+    }
+
+    public PostSalesCase open(OpenCaseCommand command) {
+        return repository.findByIdempotencyKey(command.idempotencyKey())
+            .orElseGet(() -> {
+                Instant now = clock.instant();
+                PostSalesCase postSalesCase = PostSalesCase.open(
+                    command.journeyOrderId(),
+                    command.caseType(),
+                    command.scope(),
+                    command.reasonCode(),
+                    command.actorRef(),
+                    command.idempotencyKey(),
+                    now,
+                    command.sourceCommandId(),
+                    command.correlationId()
+                );
+                repository.save(postSalesCase);
+                publishNewEvents(postSalesCase);
+                return postSalesCase;
+            });
+    }
+
+    public PostSalesCase evaluate(String caseId, String sourceCommandId, String correlationId) {
+        PostSalesCase postSalesCase = get(caseId);
+        if (postSalesCase.decision() != null) {
+            return postSalesCase;
+        }
+        Instant now = clock.instant();
+        if (postSalesCase.status().name().equals("OPENED")) {
+            postSalesCase.beginEvaluation(now, sourceCommandId, sourceCommandId, correlationId);
+        }
+        PostSalesDecision decision = decisionFor(postSalesCase, now);
+        postSalesCase.recordDecision(decision, false, false, now, sourceCommandId, sourceCommandId, correlationId);
+        repository.save(postSalesCase);
+        publishNewEvents(postSalesCase);
+        return postSalesCase;
+    }
+
+    public PostSalesCase approve(String caseId, String sourceCommandId, String correlationId) {
+        PostSalesCase postSalesCase = get(caseId);
+        if (postSalesCase.status().name().equals("APPROVED")) {
+            return postSalesCase;
+        }
+        if (postSalesCase.decision() == null) {
+            evaluate(caseId, sourceCommandId, correlationId);
+            postSalesCase = get(caseId);
+        }
+        postSalesCase.approve("http-approval", clock.instant(), sourceCommandId, sourceCommandId, correlationId);
+        repository.save(postSalesCase);
+        publishNewEvents(postSalesCase);
+        return postSalesCase;
+    }
+
+    public PostSalesCase get(String caseId) {
+        return repository.findById(PostSalesMapper.stripCasePrefix(caseId))
+            .orElseThrow(() -> new CaseNotFoundException(caseId));
+    }
+
+    private PostSalesDecision decisionFor(PostSalesCase postSalesCase, Instant now) {
+        RuleEvaluationSnapshot ruleSnapshot = new RuleEvaluationSnapshot(
+            "adjq-" + postSalesCase.caseId(),
+            "offer-rule-snapshot-" + postSalesCase.caseId(),
+            "rule-v1",
+            now,
+            Map.of("journeyOrderId", postSalesCase.journeyOrderId(), "postSalesCaseId", postSalesCase.caseId())
+        );
+        Money zero = Money.zero("CNY");
+        AmountDecisionSnapshot amount = switch (postSalesCase.caseType()) {
+            case REFUND, CANCELLATION, REBOOK -> AmountDecisionSnapshot.refund(zero, Money.fromMinorUnits(0, "CNY"), "HTTP eligibility evaluation");
+            case CHANGE -> AmountDecisionSnapshot.extraCharge(zero, Money.fromMinorUnits(0, "CNY"), "HTTP eligibility evaluation");
+            case COMPENSATION -> AmountDecisionSnapshot.refund(zero, Money.fromMinorUnits(0, "CNY"), "HTTP eligibility evaluation");
+        };
+        DecisionKind kind = switch (postSalesCase.caseType()) {
+            case REFUND, CANCELLATION, REBOOK -> DecisionKind.REFUND;
+            case CHANGE -> DecisionKind.CHANGE;
+            case COMPENSATION -> DecisionKind.COMPENSATION;
+        };
+        ChangeFlowSnapshot changeFlowSnapshot = kind == DecisionKind.CHANGE
+            ? new ChangeFlowSnapshot(
+                "change-offer-" + postSalesCase.caseId(),
+                "capacity-hold-" + postSalesCase.caseId(),
+                ChangeFinancialAction.NONE,
+                "void-old-entitlement-" + postSalesCase.caseId(),
+                "issue-new-entitlement-" + postSalesCase.caseId(),
+                "release-old-capacity-" + postSalesCase.caseId()
+            )
+            : null;
+        return new PostSalesDecision(postSalesCase.caseId(), 1, kind, true, "ELIGIBLE", ruleSnapshot, amount, changeFlowSnapshot, now, now.plusSeconds(900));
+    }
+
+    private void publishNewEvents(PostSalesCase postSalesCase) {
+        List<PostSalesEvent> events = postSalesCase.domainEvents();
+        int alreadyPublished = publishedEventCounts.getOrDefault(postSalesCase.caseId(), 0);
+        for (PostSalesEvent event : events.subList(alreadyPublished, events.size())) {
+            eventPublisher.publish(PostSalesMapper.toEnvelope(event));
+        }
+        publishedEventCounts.put(postSalesCase.caseId(), events.size());
+    }
+
+    public record OpenCaseCommand(
+        String journeyOrderId,
+        PostSalesCaseType caseType,
+        PostSalesScope scope,
+        String reasonCode,
+        String actorRef,
+        String idempotencyKey,
+        String sourceCommandId,
+        String correlationId
+    ) { }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
@@ -42,9 +42,9 @@ public class PostSalesApplicationService {
                     command.scope(),
                     command.reasonCode(),
                     command.actorRef(),
-                    command.idempotencyKey(),
+                    command.commandId(),
                     now,
-                    command.sourceCommandId(),
+                    command.commandId(),
                     command.correlationId()
                 );
                 repository.save(postSalesCase);
@@ -137,7 +137,7 @@ public class PostSalesApplicationService {
         String reasonCode,
         String actorRef,
         String idempotencyKey,
-        String sourceCommandId,
+        String commandId,
         String correlationId
     ) { }
 }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesEventHandler.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesEventHandler.java
@@ -1,0 +1,19 @@
+package com.trainticket.postsales.application;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class PostSalesEventHandler {
+    private final ConsumedEventLog consumedEventLog;
+
+    public PostSalesEventHandler(ConsumedEventLog consumedEventLog) {
+        this.consumedEventLog = consumedEventLog;
+    }
+
+    public EventSubscriber.HandlerResult handle(EventEnvelope envelope) {
+        if (!consumedEventLog.recordIfFirstSeen(envelope.eventId())) {
+            return EventSubscriber.HandlerResult.SUCCESS;
+        }
+        return EventSubscriber.HandlerResult.SUCCESS;
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesMapper.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesMapper.java
@@ -28,13 +28,11 @@ public final class PostSalesMapper {
         return new EventEnvelope(
             prefixed(metadata.eventId(), "evt-"),
             event.getClass().getSimpleName(),
-            metadata.schemaVersion(),
-            PRODUCER,
-            prefixed(metadata.sourceCommandId(), "cmd-"),
-            prefixedCausation(metadata.causationId()),
-            prefixed(metadata.correlationId(), "corr-"),
             metadata.occurredAt(),
-            metadata.attributes(),
+            prefixed(metadata.correlationId(), "corr-"),
+            prefixedCausation(metadata.causationId()),
+            PRODUCER,
+            metadata.schemaVersion(),
             payload(event)
         );
     }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesMapper.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesMapper.java
@@ -1,0 +1,167 @@
+package com.trainticket.postsales.application;
+
+import com.trainticket.postsales.domain.AmountDecisionSnapshot;
+import com.trainticket.postsales.domain.DecisionKind;
+import com.trainticket.postsales.domain.EventMetadata;
+import com.trainticket.postsales.domain.Money;
+import com.trainticket.postsales.domain.PostSalesApplied;
+import com.trainticket.postsales.domain.PostSalesApproved;
+import com.trainticket.postsales.domain.PostSalesCase;
+import com.trainticket.postsales.domain.PostSalesCaseOpened;
+import com.trainticket.postsales.domain.PostSalesCaseStatus;
+import com.trainticket.postsales.domain.PostSalesDecision;
+import com.trainticket.postsales.domain.PostSalesEvaluated;
+import com.trainticket.postsales.domain.PostSalesEvent;
+import com.trainticket.postsales.domain.PostSalesRejected;
+import com.trainticket.postsales.domain.PostSalesRequested;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class PostSalesMapper {
+    public static final String PRODUCER = "post-sales";
+
+    private PostSalesMapper() {
+    }
+
+    public static EventEnvelope toEnvelope(PostSalesEvent event) {
+        EventMetadata metadata = event.metadata();
+        return new EventEnvelope(
+            prefixed(metadata.eventId(), "evt-"),
+            event.getClass().getSimpleName(),
+            metadata.schemaVersion(),
+            PRODUCER,
+            prefixed(metadata.sourceCommandId(), "cmd-"),
+            prefixedCausation(metadata.causationId()),
+            prefixed(metadata.correlationId(), "corr-"),
+            metadata.occurredAt(),
+            metadata.attributes(),
+            payload(event)
+        );
+    }
+
+    public static Map<String, Object> caseDetails(PostSalesCase postSalesCase) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("caseId", prefixed(postSalesCase.caseId(), "psc-"));
+        body.put("journeyOrderId", postSalesCase.journeyOrderId());
+        body.put("caseType", postSalesCase.caseType().name());
+        body.put("status", contractStatus(postSalesCase.status()));
+        body.put("scope", postSalesCase.scope());
+        body.put("reasonCode", postSalesCase.reasonCode());
+        body.put("actorRef", postSalesCase.actorRef());
+        if (postSalesCase.decision() != null) {
+            body.put("decision", decisionDetails(postSalesCase.decision()));
+        }
+        if (postSalesCase.terminalReason() != null) {
+            body.put("terminalReason", postSalesCase.terminalReason());
+        }
+        String createdAt = postSalesCase.domainEvents().stream().findFirst()
+            .map(PostSalesEvent::metadata)
+            .map(EventMetadata::occurredAt)
+            .map(Object::toString)
+            .orElse(null);
+        body.put("createdAt", createdAt);
+        return body;
+    }
+
+    public static Map<String, Object> openResponse(PostSalesCase postSalesCase) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("caseId", prefixed(postSalesCase.caseId(), "psc-"));
+        body.put("journeyOrderId", postSalesCase.journeyOrderId());
+        body.put("caseType", postSalesCase.caseType().name());
+        body.put("status", contractStatus(postSalesCase.status()));
+        body.put("createdAt", postSalesCase.domainEvents().getFirst().metadata().occurredAt().toString());
+        return body;
+    }
+
+    public static Map<String, Object> evaluateResponse(PostSalesCase postSalesCase) {
+        PostSalesDecision decision = postSalesCase.decision();
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("caseId", prefixed(postSalesCase.caseId(), "psc-"));
+        body.put("eligible", decision.eligible());
+        body.put("adjustmentQuoteId", decision.ruleSnapshot().farePricingEvaluationRef());
+        body.put("refundableAmount", money(decision.amountSnapshot().refundAmount()));
+        body.put("amountDue", money(decision.amountSnapshot().extraChargeAmount()));
+        return body;
+    }
+
+    public static Map<String, Object> approveResponse(PostSalesCase postSalesCase) {
+        return Map.of("caseId", prefixed(postSalesCase.caseId(), "psc-"), "status", "APPROVED");
+    }
+
+    public static Map<String, Object> money(Money money) {
+        return Map.of("currency", money.currency().getCurrencyCode(), "minorUnits", money.toMinorUnits());
+    }
+
+    public static String stripCasePrefix(String caseId) {
+        return caseId != null && caseId.startsWith("psc-") ? caseId.substring(4) : caseId;
+    }
+
+    public static String prefixed(String value, String prefix) {
+        if (value == null || value.startsWith(prefix)) {
+            return value;
+        }
+        return prefix + value;
+    }
+
+    public static String contractStatus(PostSalesCaseStatus status) {
+        return switch (status) {
+            case ELIGIBILITY_CHECKING, QUOTED, PENDING_USER_CONFIRMATION, PENDING_APPROVAL -> "EVALUATING";
+            case EXECUTING, COMPENSATION_PENDING, MANUAL_REVIEW_REQUIRED -> "APPROVED";
+            case CANCELLED -> "REJECTED";
+            default -> status.name();
+        };
+    }
+
+    private static Object payload(PostSalesEvent event) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("caseId", prefixed(event.caseId(), "psc-"));
+        if (event instanceof PostSalesCaseOpened opened) {
+            payload.put("journeyOrderId", opened.journeyOrderId());
+            payload.put("caseType", opened.caseType().name());
+            payload.put("scope", opened.scope());
+            payload.put("reasonCode", opened.reasonCode());
+            payload.put("actorRef", opened.actorRef());
+        } else if (event instanceof PostSalesRequested requested) {
+            payload.put("journeyOrderId", requested.journeyOrderId());
+            payload.put("caseType", requested.caseType().name());
+            payload.put("scope", requested.scope());
+            payload.put("reasonCode", requested.reasonCode());
+        } else if (event instanceof PostSalesEvaluated evaluated) {
+            payload.put("decisionKind", evaluated.decisionKind().name());
+            payload.put("eligible", evaluated.eligible());
+            payload.put("adjustmentQuoteId", evaluated.farePricingEvaluationRef());
+        } else if (event instanceof PostSalesApproved approved) {
+            payload.put("decisionKind", approved.decisionKind().name());
+            payload.put("approvalRef", approved.approvalRef());
+        } else if (event instanceof PostSalesRejected rejected) {
+            payload.put("reason", rejected.reasonCode());
+        } else if (event instanceof PostSalesApplied applied) {
+            payload.put("journeyOrderId", applied.journeyOrderId());
+            payload.put("caseType", applied.caseType().name());
+            payload.put("resultSummary", applied.resultSummary());
+        }
+        return payload;
+    }
+
+    private static Map<String, Object> decisionDetails(PostSalesDecision decision) {
+        AmountDecisionSnapshot amount = decision.amountSnapshot();
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("version", decision.version());
+        body.put("kind", decision.kind().name());
+        body.put("eligible", decision.eligible());
+        body.put("reasonCode", decision.reasonCode());
+        body.put("adjustmentQuoteId", decision.ruleSnapshot().farePricingEvaluationRef());
+        body.put("refundableAmount", money(amount.refundAmount()));
+        body.put("amountDue", money(amount.extraChargeAmount()));
+        body.put("quotedAt", decision.quotedAt().toString());
+        body.put("expiresAt", decision.expiresAt().toString());
+        return body;
+    }
+
+    private static String prefixedCausation(String value) {
+        if (value != null && (value.startsWith("cmd-") || value.startsWith("evt-"))) {
+            return value;
+        }
+        return prefixed(value, "cmd-");
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesMapper.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesMapper.java
@@ -9,6 +9,7 @@ import com.trainticket.postsales.domain.PostSalesApproved;
 import com.trainticket.postsales.domain.PostSalesCase;
 import com.trainticket.postsales.domain.PostSalesCaseOpened;
 import com.trainticket.postsales.domain.PostSalesCaseStatus;
+import com.trainticket.postsales.domain.PostSalesCaseType;
 import com.trainticket.postsales.domain.PostSalesDecision;
 import com.trainticket.postsales.domain.PostSalesEvaluated;
 import com.trainticket.postsales.domain.PostSalesEvent;
@@ -120,25 +121,44 @@ public final class PostSalesMapper {
             payload.put("reasonCode", opened.reasonCode());
             payload.put("actorRef", opened.actorRef());
         } else if (event instanceof PostSalesRequested requested) {
-            payload.put("journeyOrderId", requested.journeyOrderId());
-            payload.put("caseType", requested.caseType().name());
-            payload.put("scope", requested.scope());
-            payload.put("reasonCode", requested.reasonCode());
+            payload.put("orderId", requested.journeyOrderId());
+            payload.put("requestType", requestType(requested.caseType()));
+            payload.put("requestedAt", requested.metadata().occurredAt().toString());
         } else if (event instanceof PostSalesEvaluated evaluated) {
             payload.put("decisionKind", evaluated.decisionKind().name());
             payload.put("eligible", evaluated.eligible());
             payload.put("adjustmentQuoteId", evaluated.farePricingEvaluationRef());
         } else if (event instanceof PostSalesApproved approved) {
-            payload.put("decisionKind", approved.decisionKind().name());
-            payload.put("approvalRef", approved.approvalRef());
+            payload.put("orderId", approved.journeyOrderId());
+            payload.put("approvedActions", approvedActions(approved));
         } else if (event instanceof PostSalesRejected rejected) {
             payload.put("reason", rejected.reasonCode());
         } else if (event instanceof PostSalesApplied applied) {
-            payload.put("journeyOrderId", applied.journeyOrderId());
-            payload.put("caseType", applied.caseType().name());
-            payload.put("resultSummary", applied.resultSummary());
+            payload.put("orderId", applied.journeyOrderId());
+            payload.put("resultSummary", resultSummary(applied));
         }
         return payload;
+    }
+
+    private static String requestType(PostSalesCaseType caseType) {
+        return switch (caseType) {
+            case CANCELLATION -> "CANCELLATION";
+            case CHANGE, REBOOK -> "CHANGE";
+            case REFUND, COMPENSATION -> "REFUND_BY_RULE";
+        };
+    }
+
+    private static Map<String, Object> approvedActions(PostSalesApproved approved) {
+        Map<String, Object> actions = new LinkedHashMap<>();
+        actions.put("decisionKind", approved.decisionKind().name());
+        actions.put("approvalRef", approved.approvalRef());
+        return actions;
+    }
+
+    private static Map<String, Object> resultSummary(PostSalesApplied applied) {
+        Map<String, Object> summary = new LinkedHashMap<>();
+        summary.put("description", applied.resultSummary());
+        return summary;
     }
 
     private static Map<String, Object> decisionDetails(PostSalesDecision decision) {

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesRepository.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesRepository.java
@@ -1,0 +1,10 @@
+package com.trainticket.postsales.application;
+
+import com.trainticket.postsales.domain.PostSalesCase;
+import java.util.Optional;
+
+public interface PostSalesRepository {
+    void save(PostSalesCase postSalesCase);
+    Optional<PostSalesCase> findById(String caseId);
+    Optional<PostSalesCase> findByIdempotencyKey(String idempotencyKey);
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PublishFailedException.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PublishFailedException.java
@@ -1,0 +1,7 @@
+package com.trainticket.postsales.application;
+
+public class PublishFailedException extends RuntimeException {
+    public PublishFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/SubscribeFailedException.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/SubscribeFailedException.java
@@ -1,0 +1,7 @@
+package com.trainticket.postsales.application;
+
+public class SubscribeFailedException extends RuntimeException {
+    public SubscribeFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesApproved.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesApproved.java
@@ -2,6 +2,7 @@ package com.trainticket.postsales.domain;
 
 public record PostSalesApproved(
     String caseId,
+    String journeyOrderId,
     DecisionKind decisionKind,
     String approvalRef,
     EventMetadata metadata

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesCase.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesCase.java
@@ -151,7 +151,7 @@ public final class PostSalesCase {
             throw new DomainRuleViolation("post-sales decision quote has expired");
         }
         status = PostSalesCaseStatus.APPROVED;
-        domainEvents.add(new PostSalesApproved(caseId, decision.kind(), PostSalesScope.requireText(approvalRef, "approvalRef"),
+        domainEvents.add(new PostSalesApproved(caseId, journeyOrderId, decision.kind(), PostSalesScope.requireText(approvalRef, "approvalRef"),
             metadata(occurredAt, sourceCommandId, causationId, correlationId, status)));
     }
 

--- a/services/post-sales/src/main/resources/application.properties
+++ b/services/post-sales/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+post-sales.messaging.redis.enabled=${POST_SALES_REDIS_MESSAGING_ENABLED:false}

--- a/services/post-sales/src/test/java/com/trainticket/postsales/ApplicationTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/ApplicationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.servlet.ServletException;
 import java.io.IOException;
@@ -72,7 +73,10 @@ class ApplicationTest {
         String requestId = response.getHeader(RequestContextFilter.REQUEST_ID_HEADER);
         assertNotNull(requestId);
         assertFalse(requestId.isBlank());
-        assertEquals(requestId, response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+        String correlationId = response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER);
+        assertNotNull(correlationId);
+        assertFalse(correlationId.isBlank());
+        assertTrue(correlationId.startsWith("corr-"));
     }
 
     private static final class RecordingTracer implements RuntimeTracer {

--- a/services/post-sales/src/test/java/com/trainticket/postsales/api/PostSalesControllerTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/api/PostSalesControllerTest.java
@@ -1,0 +1,102 @@
+package com.trainticket.postsales.api;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest(properties = "post-sales.messaging.redis.enabled=false")
+class PostSalesControllerTest {
+    private MockMvc mockMvc;
+
+    @Autowired
+    void setApplicationContext(WebApplicationContext context) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context).addFilters(context.getBean(com.trainticket.postsales.RequestContextFilter.class)).build();
+    }
+
+    @Test
+    void openEvaluateApproveAndGetHappyPath() throws Exception {
+        String caseId = openCase("cmd-test-open-1")
+            .andExpect(status().isCreated())
+            .andExpect(header().string("X-Correlation-Id", "corr-test-1"))
+            .andExpect(jsonPath("$.caseId", notNullValue()))
+            .andExpect(jsonPath("$.journeyOrderId", equalTo("ord-test-1")))
+            .andExpect(jsonPath("$.status", equalTo("OPENED")))
+            .andReturn().getResponse().getContentAsString().split("\"caseId\":\"")[1].split("\"")[0];
+
+        mockMvc.perform(post("/api/v1/post-sales-cases/{caseId}/evaluate", caseId)
+                .header("Idempotency-Key", "cmd-test-evaluate-1")
+                .header("X-Correlation-Id", "corr-test-1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.caseId", equalTo(caseId)))
+            .andExpect(jsonPath("$.eligible", equalTo(true)))
+            .andExpect(jsonPath("$.refundableAmount.currency", equalTo("CNY")))
+            .andExpect(jsonPath("$.refundableAmount.minorUnits", equalTo(0)));
+
+        mockMvc.perform(post("/api/v1/post-sales-cases/{caseId}/approve", caseId)
+                .header("Idempotency-Key", "cmd-test-approve-1")
+                .header("X-Correlation-Id", "corr-test-1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.caseId", equalTo(caseId)))
+            .andExpect(jsonPath("$.status", equalTo("APPROVED")));
+
+        mockMvc.perform(get("/api/v1/post-sales-cases/{caseId}", caseId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.caseId", equalTo(caseId)))
+            .andExpect(jsonPath("$.status", equalTo("APPROVED")));
+    }
+
+    @Test
+    void validationFailureUsesCanonicalErrorBody() throws Exception {
+        mockMvc.perform(post("/api/v1/post-sales-cases")
+                .header("Idempotency-Key", "cmd-test-invalid")
+                .header("X-Correlation-Id", "corr-validation")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code", equalTo("VALIDATION_FAILED")))
+            .andExpect(jsonPath("$.correlationId", equalTo("corr-validation")))
+            .andExpect(jsonPath("$.details", notNullValue()));
+    }
+
+    @Test
+    void idempotentReplayReturnsOriginalOpenResult() throws Exception {
+        MvcResult first = openCase("cmd-test-replay").andExpect(status().isCreated()).andReturn();
+        openCase("cmd-test-replay")
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.caseId", equalTo(first.getResponse().getContentAsString().split("\"caseId\":\"")[1].split("\"")[0])));
+    }
+
+    private org.springframework.test.web.servlet.ResultActions openCase(String idempotencyKey) throws Exception {
+        return mockMvc.perform(post("/api/v1/post-sales-cases")
+            .header("Idempotency-Key", idempotencyKey)
+            .header("X-Correlation-Id", "corr-test-1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""
+                {
+                  "journeyOrderId": "ord-test-1",
+                  "caseType": "REFUND",
+                  "scope": {
+                    "orderItemRefs": ["oi-test-1"],
+                    "segmentRefs": ["seg-test-1"],
+                    "travelerRefs": ["tvl-test-1"],
+                    "entitlementRefs": ["ent-test-1"]
+                  },
+                  "reasonCode": "CUSTOMER_REQUEST",
+                  "actorRef": "acct-test-1"
+                }
+                """));
+    }
+}

--- a/services/post-sales/src/test/java/com/trainticket/postsales/api/PostSalesControllerTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/api/PostSalesControllerTest.java
@@ -1,8 +1,8 @@
 package com.trainticket.postsales.api;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -14,12 +14,21 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-import org.springframework.test.web.servlet.MvcResult;
 
 @SpringBootTest(properties = "post-sales.messaging.redis.enabled=false")
 class PostSalesControllerTest {
+    private static final String OPEN_KEY = "01890f47-9b7c-7cc2-98c4-dc0c0c073001";
+    private static final String EVALUATE_KEY = "01890f47-9b7c-7cc2-98c4-dc0c0c073002";
+    private static final String APPROVE_KEY = "01890f47-9b7c-7cc2-98c4-dc0c0c073003";
+    private static final String VALIDATION_KEY = "01890f47-9b7c-7cc2-98c4-dc0c0c073004";
+    private static final String REPLAY_KEY = "01890f47-9b7c-7cc2-98c4-dc0c0c073005";
+    private static final String REUSED_KEY = "01890f47-9b7c-7cc2-98c4-dc0c0c073006";
+    private static final String GENERATED_CORRELATION_KEY = "01890f47-9b7c-7cc2-98c4-dc0c0c073007";
+    private static final String UUID4_KEY = "550e8400-e29b-41d4-a716-446655440000";
+
     private MockMvc mockMvc;
 
     @Autowired
@@ -29,7 +38,7 @@ class PostSalesControllerTest {
 
     @Test
     void openEvaluateApproveAndGetHappyPath() throws Exception {
-        String caseId = openCase("cmd-test-open-1")
+        String caseId = openCase(OPEN_KEY)
             .andExpect(status().isCreated())
             .andExpect(header().string("X-Correlation-Id", "corr-test-1"))
             .andExpect(jsonPath("$.caseId", notNullValue()))
@@ -38,7 +47,7 @@ class PostSalesControllerTest {
             .andReturn().getResponse().getContentAsString().split("\"caseId\":\"")[1].split("\"")[0];
 
         mockMvc.perform(post("/api/v1/post-sales-cases/{caseId}/evaluate", caseId)
-                .header("Idempotency-Key", "cmd-test-evaluate-1")
+                .header("Idempotency-Key", EVALUATE_KEY)
                 .header("X-Correlation-Id", "corr-test-1"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.caseId", equalTo(caseId)))
@@ -47,7 +56,7 @@ class PostSalesControllerTest {
             .andExpect(jsonPath("$.refundableAmount.minorUnits", equalTo(0)));
 
         mockMvc.perform(post("/api/v1/post-sales-cases/{caseId}/approve", caseId)
-                .header("Idempotency-Key", "cmd-test-approve-1")
+                .header("Idempotency-Key", APPROVE_KEY)
                 .header("X-Correlation-Id", "corr-test-1"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.caseId", equalTo(caseId)))
@@ -62,7 +71,7 @@ class PostSalesControllerTest {
     @Test
     void validationFailureUsesCanonicalErrorBody() throws Exception {
         mockMvc.perform(post("/api/v1/post-sales-cases")
-                .header("Idempotency-Key", "cmd-test-invalid")
+                .header("Idempotency-Key", VALIDATION_KEY)
                 .header("X-Correlation-Id", "corr-validation")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{}"))
@@ -74,19 +83,18 @@ class PostSalesControllerTest {
 
     @Test
     void idempotentReplayReturnsOriginalOpenResult() throws Exception {
-        MvcResult first = openCase("cmd-test-replay").andExpect(status().isCreated()).andReturn();
-        openCase("cmd-test-replay")
+        MvcResult first = openCase(REPLAY_KEY).andExpect(status().isCreated()).andReturn();
+        openCase(REPLAY_KEY)
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.caseId", equalTo(first.getResponse().getContentAsString().split("\"caseId\":\"")[1].split("\"")[0])));
     }
 
-
     @Test
     void idempotencyKeyReuseWithDifferentBodyReturns422() throws Exception {
-        openCase("cmd-test-reused").andExpect(status().isCreated());
+        openCase(REUSED_KEY).andExpect(status().isCreated());
 
         mockMvc.perform(post("/api/v1/post-sales-cases")
-                .header("Idempotency-Key", "cmd-test-reused")
+                .header("Idempotency-Key", REUSED_KEY)
                 .header("X-Correlation-Id", "corr-test-1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("""
@@ -111,7 +119,7 @@ class PostSalesControllerTest {
     @Test
     void missingCorrelationHeaderUsesGeneratedRequestCorrelationId() throws Exception {
         mockMvc.perform(post("/api/v1/post-sales-cases")
-                .header("Idempotency-Key", "cmd-test-generated-correlation")
+                .header("Idempotency-Key", GENERATED_CORRELATION_KEY)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("""
                     {
@@ -129,7 +137,63 @@ class PostSalesControllerTest {
                     """))
             .andExpect(status().isCreated())
             .andExpect(header().exists("X-Correlation-Id"))
-            .andExpect(header().string("X-Correlation-Id", not(equalTo("cmd-test-generated-correlation"))));
+            .andExpect(header().string("X-Correlation-Id", not(equalTo(GENERATED_CORRELATION_KEY))));
+    }
+
+    @Test
+    void openRejectsMalformedIdempotencyKey() throws Exception {
+        openCase("not-a-uuid")
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code", equalTo("VALIDATION_FAILED")))
+            .andExpect(jsonPath("$.message", equalTo("Idempotency-Key must be a UUID v7")));
+    }
+
+    @Test
+    void openRejectsUuid4IdempotencyKey() throws Exception {
+        openCase(UUID4_KEY)
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code", equalTo("VALIDATION_FAILED")))
+            .andExpect(jsonPath("$.message", equalTo("Idempotency-Key must be a UUID v7")));
+    }
+
+    @Test
+    void evaluateRejectsMalformedIdempotencyKey() throws Exception {
+        mockMvc.perform(post("/api/v1/post-sales-cases/{caseId}/evaluate", "psc-test-case")
+                .header("Idempotency-Key", "not-a-uuid")
+                .header("X-Correlation-Id", "corr-test-1"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code", equalTo("VALIDATION_FAILED")))
+            .andExpect(jsonPath("$.message", equalTo("Idempotency-Key must be a UUID v7")));
+    }
+
+    @Test
+    void evaluateRejectsUuid4IdempotencyKey() throws Exception {
+        mockMvc.perform(post("/api/v1/post-sales-cases/{caseId}/evaluate", "psc-test-case")
+                .header("Idempotency-Key", UUID4_KEY)
+                .header("X-Correlation-Id", "corr-test-1"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code", equalTo("VALIDATION_FAILED")))
+            .andExpect(jsonPath("$.message", equalTo("Idempotency-Key must be a UUID v7")));
+    }
+
+    @Test
+    void approveRejectsMalformedIdempotencyKey() throws Exception {
+        mockMvc.perform(post("/api/v1/post-sales-cases/{caseId}/approve", "psc-test-case")
+                .header("Idempotency-Key", "not-a-uuid")
+                .header("X-Correlation-Id", "corr-test-1"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code", equalTo("VALIDATION_FAILED")))
+            .andExpect(jsonPath("$.message", equalTo("Idempotency-Key must be a UUID v7")));
+    }
+
+    @Test
+    void approveRejectsUuid4IdempotencyKey() throws Exception {
+        mockMvc.perform(post("/api/v1/post-sales-cases/{caseId}/approve", "psc-test-case")
+                .header("Idempotency-Key", UUID4_KEY)
+                .header("X-Correlation-Id", "corr-test-1"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code", equalTo("VALIDATION_FAILED")))
+            .andExpect(jsonPath("$.message", equalTo("Idempotency-Key must be a UUID v7")));
     }
 
     private org.springframework.test.web.servlet.ResultActions openCase(String idempotencyKey) throws Exception {

--- a/services/post-sales/src/test/java/com/trainticket/postsales/api/PostSalesControllerTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/api/PostSalesControllerTest.java
@@ -2,6 +2,7 @@ package com.trainticket.postsales.api;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.not;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -77,6 +78,58 @@ class PostSalesControllerTest {
         openCase("cmd-test-replay")
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.caseId", equalTo(first.getResponse().getContentAsString().split("\"caseId\":\"")[1].split("\"")[0])));
+    }
+
+
+    @Test
+    void idempotencyKeyReuseWithDifferentBodyReturns422() throws Exception {
+        openCase("cmd-test-reused").andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/v1/post-sales-cases")
+                .header("Idempotency-Key", "cmd-test-reused")
+                .header("X-Correlation-Id", "corr-test-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "journeyOrderId": "ord-test-different",
+                      "caseType": "REFUND",
+                      "scope": {
+                        "orderItemRefs": ["oi-test-1"],
+                        "segmentRefs": ["seg-test-1"],
+                        "travelerRefs": ["tvl-test-1"],
+                        "entitlementRefs": ["ent-test-1"]
+                      },
+                      "reasonCode": "CUSTOMER_REQUEST",
+                      "actorRef": "acct-test-1"
+                    }
+                    """))
+            .andExpect(status().isUnprocessableEntity())
+            .andExpect(jsonPath("$.code", equalTo("IDEMPOTENCY_KEY_REUSED")))
+            .andExpect(jsonPath("$.correlationId", equalTo("corr-test-1")));
+    }
+
+    @Test
+    void missingCorrelationHeaderUsesGeneratedRequestCorrelationId() throws Exception {
+        mockMvc.perform(post("/api/v1/post-sales-cases")
+                .header("Idempotency-Key", "cmd-test-generated-correlation")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "journeyOrderId": "ord-generated-correlation",
+                      "caseType": "REFUND",
+                      "scope": {
+                        "orderItemRefs": ["oi-test-1"],
+                        "segmentRefs": ["seg-test-1"],
+                        "travelerRefs": ["tvl-test-1"],
+                        "entitlementRefs": ["ent-test-1"]
+                      },
+                      "reasonCode": "CUSTOMER_REQUEST",
+                      "actorRef": "acct-test-1"
+                    }
+                    """))
+            .andExpect(status().isCreated())
+            .andExpect(header().exists("X-Correlation-Id"))
+            .andExpect(header().string("X-Correlation-Id", not(equalTo("cmd-test-generated-correlation"))));
     }
 
     private org.springframework.test.web.servlet.ResultActions openCase(String idempotencyKey) throws Exception {

--- a/services/post-sales/src/test/java/com/trainticket/postsales/application/MessagingPortsTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/application/MessagingPortsTest.java
@@ -1,0 +1,76 @@
+package com.trainticket.postsales.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.trainticket.postsales.domain.PostSalesCase;
+import com.trainticket.postsales.domain.PostSalesCaseType;
+import com.trainticket.postsales.domain.PostSalesScope;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MessagingPortsTest {
+    @Test
+    void publisherWrapsDomainEventInContractEnvelope() {
+        PostSalesCase postSalesCase = PostSalesCase.open(
+            "ord-test-2",
+            PostSalesCaseType.REFUND,
+            PostSalesScope.ticket("oi-test-2", "seg-test-2", "tvl-test-2", "ent-test-2"),
+            "CUSTOMER_REQUEST",
+            "acct-test-2",
+            "cmd-open-2",
+            Instant.parse("2026-07-05T10:30:00Z"),
+            "open-2",
+            "corr-2"
+        );
+
+        EventEnvelope envelope = PostSalesMapper.toEnvelope(postSalesCase.domainEvents().get(1));
+
+        assertTrue(envelope.eventId().startsWith("evt-"));
+        assertEquals("PostSalesRequested", envelope.eventType());
+        assertEquals(1, envelope.schemaVersion());
+        assertEquals("post-sales", envelope.producer());
+        assertTrue(envelope.sourceCommandId().startsWith("cmd-"));
+        assertTrue(envelope.correlationId().startsWith("corr-"));
+        assertEquals(Instant.parse("2026-07-05T10:30:00Z"), envelope.occurredAt());
+        assertTrue(envelope.payload().toString().contains("ord-test-2"));
+    }
+
+    @Test
+    void subscriberHandlerDeduplicatesDuplicateEventId() {
+        RecordingConsumedEventLog log = new RecordingConsumedEventLog();
+        PostSalesEventHandler handler = new PostSalesEventHandler(log);
+        EventEnvelope envelope = new EventEnvelope(
+            "evt-duplicate",
+            "JourneyOrderCancelled",
+            1,
+            "journey-order",
+            "cmd-cancelled",
+            "evt-source",
+            "corr-duplicate",
+            Instant.parse("2026-07-05T10:30:00Z"),
+            java.util.Map.of(),
+            java.util.Map.of("journeyOrderId", "ord-test-3")
+        );
+
+        assertEquals(EventSubscriber.HandlerResult.SUCCESS, handler.handle(envelope));
+        assertEquals(EventSubscriber.HandlerResult.SUCCESS, handler.handle(envelope));
+        assertEquals(1, log.recorded.size());
+    }
+
+    private static final class RecordingConsumedEventLog implements ConsumedEventLog {
+        private final List<String> recorded = new ArrayList<>();
+
+        @Override
+        public boolean recordIfFirstSeen(String eventId) {
+            if (recorded.contains(eventId)) {
+                return false;
+            }
+            recorded.add(eventId);
+            return true;
+        }
+    }
+}

--- a/services/post-sales/src/test/java/com/trainticket/postsales/application/MessagingPortsTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/application/MessagingPortsTest.java
@@ -2,6 +2,7 @@ package com.trainticket.postsales.application;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.trainticket.postsales.domain.PostSalesCase;
@@ -53,6 +54,62 @@ class MessagingPortsTest {
     }
 
     @Test
+    void postSalesRequestedPayloadUsesContractFieldNames() {
+        PostSalesCase postSalesCase = PostSalesCase.open(
+            "ord-test-5",
+            PostSalesCaseType.REFUND,
+            PostSalesScope.ticket("oi-test-5", "seg-test-5", "tvl-test-5", "ent-test-5"),
+            "CUSTOMER_REQUEST",
+            "acct-test-5",
+            "cmd-open-5",
+            Instant.parse("2026-07-05T10:30:00Z"),
+            "open-5",
+            "corr-5"
+        );
+
+        Map<?, ?> payload = assertPayload(PostSalesMapper.toEnvelope(postSalesCase.domainEvents().get(1)).payload());
+
+        assertEquals(List.of("caseId", "orderId", "requestType", "requestedAt"), new ArrayList<>(payload.keySet()));
+        assertEquals("ord-test-5", payload.get("orderId"));
+        assertEquals("REFUND_BY_RULE", payload.get("requestType"));
+        assertEquals("2026-07-05T10:30:00Z", payload.get("requestedAt"));
+    }
+
+    @Test
+    void postSalesApprovedPayloadUsesContractFieldNames() {
+        PostSalesCase postSalesCase = approvedCase();
+        EventEnvelope envelope = postSalesCase.domainEvents().stream()
+            .filter(com.trainticket.postsales.domain.PostSalesApproved.class::isInstance)
+            .map(PostSalesMapper::toEnvelope)
+            .findFirst()
+            .orElseThrow();
+
+        Map<?, ?> payload = assertPayload(envelope.payload());
+
+        assertEquals(List.of("caseId", "orderId", "approvedActions"), new ArrayList<>(payload.keySet()));
+        assertEquals("ord-test-6", payload.get("orderId"));
+        assertInstanceOf(Map.class, payload.get("approvedActions"));
+    }
+
+    @Test
+    void postSalesAppliedPayloadUsesContractFieldNames() {
+        PostSalesCase postSalesCase = approvedCase();
+        postSalesCase.requestExecution(Instant.parse("2026-07-05T10:33:00Z"), "execute-6", "approve-6", "corr-6");
+        postSalesCase.applyResult("applied by contract test", Instant.parse("2026-07-05T10:34:00Z"), "apply-6", "execute-6", "corr-6");
+        EventEnvelope envelope = postSalesCase.domainEvents().stream()
+            .filter(com.trainticket.postsales.domain.PostSalesApplied.class::isInstance)
+            .map(PostSalesMapper::toEnvelope)
+            .findFirst()
+            .orElseThrow();
+
+        Map<?, ?> payload = assertPayload(envelope.payload());
+
+        assertEquals(List.of("caseId", "orderId", "resultSummary"), new ArrayList<>(payload.keySet()));
+        assertEquals("ord-test-6", payload.get("orderId"));
+        assertInstanceOf(Map.class, payload.get("resultSummary"));
+    }
+
+    @Test
     void subscriberHandlerDeduplicatesDuplicateEventId() {
         RecordingConsumedEventLog log = new RecordingConsumedEventLog();
         PostSalesEventHandler handler = new PostSalesEventHandler(log);
@@ -93,6 +150,55 @@ class MessagingPortsTest {
 
         assertEquals(1, subscriber.dlq.size());
         assertEquals("evt-retry", subscriber.dlq.getFirst().eventId());
+    }
+
+    private static PostSalesCase approvedCase() {
+        PostSalesCase postSalesCase = PostSalesCase.open(
+            "ord-test-6",
+            PostSalesCaseType.REFUND,
+            PostSalesScope.ticket("oi-test-6", "seg-test-6", "tvl-test-6", "ent-test-6"),
+            "CUSTOMER_REQUEST",
+            "acct-test-6",
+            "cmd-open-6",
+            Instant.parse("2026-07-05T10:30:00Z"),
+            "open-6",
+            "corr-6"
+        );
+        postSalesCase.beginEvaluation(Instant.parse("2026-07-05T10:31:00Z"), "evaluate-6", "open-6", "corr-6");
+        postSalesCase.recordDecision(
+            com.trainticket.postsales.domain.PostSalesDecision.refund(
+                postSalesCase.caseId(),
+                true,
+                "REFUNDABLE",
+                new com.trainticket.postsales.domain.RuleEvaluationSnapshot(
+                    "fare-eval-6",
+                    "rule-snapshot-6",
+                    "rule-v1",
+                    Instant.parse("2026-07-05T10:31:00Z"),
+                    Map.of("orderId", "ord-test-6")
+                ),
+                com.trainticket.postsales.domain.AmountDecisionSnapshot.refund(
+                    com.trainticket.postsales.domain.Money.of("0.00", "USD"),
+                    com.trainticket.postsales.domain.Money.of("5.00", "USD"),
+                    "contract test refund"
+                ),
+                Instant.parse("2026-07-05T10:31:00Z"),
+                Instant.parse("2026-07-05T11:31:00Z")
+            ),
+            false,
+            false,
+            Instant.parse("2026-07-05T10:31:00Z"),
+            "quote-6",
+            "evaluate-6",
+            "corr-6"
+        );
+        postSalesCase.approve("approval-6", Instant.parse("2026-07-05T10:32:00Z"), "approve-6", "quote-6", "corr-6");
+        return postSalesCase;
+    }
+
+    private static Map<?, ?> assertPayload(Object payload) {
+        assertInstanceOf(Map.class, payload);
+        return (Map<?, ?>) payload;
     }
 
     private static final class FakeDeliveryCounterSubscriber {

--- a/services/post-sales/src/test/java/com/trainticket/postsales/application/MessagingPortsTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/application/MessagingPortsTest.java
@@ -10,11 +10,13 @@ import com.trainticket.postsales.domain.PostSalesScope;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
 
 class MessagingPortsTest {
     @Test
-    void publisherWrapsDomainEventInContractEnvelope() {
+    void publisherWrapsDomainEventInContractEnvelope() throws Exception {
         PostSalesCase postSalesCase = PostSalesCase.open(
             "ord-test-2",
             PostSalesCaseType.REFUND,
@@ -33,10 +35,21 @@ class MessagingPortsTest {
         assertEquals("PostSalesRequested", envelope.eventType());
         assertEquals(1, envelope.schemaVersion());
         assertEquals("post-sales", envelope.producer());
-        assertTrue(envelope.sourceCommandId().startsWith("cmd-"));
+        assertTrue(envelope.causationId().startsWith("cmd-"));
         assertTrue(envelope.correlationId().startsWith("corr-"));
         assertEquals(Instant.parse("2026-07-05T10:30:00Z"), envelope.occurredAt());
         assertTrue(envelope.payload().toString().contains("ord-test-2"));
+
+        Map<?, ?> serialized = JsonMapper.builderWithJackson2Defaults().build().readValue(
+            JsonMapper.builderWithJackson2Defaults().build().writeValueAsString(envelope),
+            Map.class
+        );
+        assertEquals(
+            List.of("eventId", "eventType", "occurredAt", "correlationId", "causationId", "producer", "schemaVersion", "payload"),
+            new ArrayList<>(serialized.keySet())
+        );
+        assertFalse(serialized.containsKey("sourceCommandId"));
+        assertFalse(serialized.containsKey("attributes"));
     }
 
     @Test
@@ -46,19 +59,53 @@ class MessagingPortsTest {
         EventEnvelope envelope = new EventEnvelope(
             "evt-duplicate",
             "JourneyOrderCancelled",
-            1,
-            "journey-order",
-            "cmd-cancelled",
-            "evt-source",
-            "corr-duplicate",
             Instant.parse("2026-07-05T10:30:00Z"),
-            java.util.Map.of(),
-            java.util.Map.of("journeyOrderId", "ord-test-3")
+            "corr-duplicate",
+            "evt-source",
+            "journey-order",
+            1,
+            Map.of("journeyOrderId", "ord-test-3")
         );
 
         assertEquals(EventSubscriber.HandlerResult.SUCCESS, handler.handle(envelope));
         assertEquals(EventSubscriber.HandlerResult.SUCCESS, handler.handle(envelope));
         assertEquals(1, log.recorded.size());
+    }
+
+    @Test
+    void fakeSubscriberUsesDeliveryCountForDlqDecision() {
+        FakeDeliveryCounterSubscriber subscriber = new FakeDeliveryCounterSubscriber();
+        EventEnvelope envelope = new EventEnvelope(
+            "evt-retry",
+            "JourneyOrderCancelled",
+            Instant.parse("2026-07-05T10:30:00Z"),
+            "corr-retry",
+            "evt-source",
+            "journey-order",
+            1,
+            Map.of("journeyOrderId", "ord-test-4")
+        );
+
+        for (int attempt = 1; attempt < 5; attempt++) {
+            subscriber.deliver(envelope, attempt, ignored -> EventSubscriber.HandlerResult.TRANSIENT_FAILURE);
+        }
+        subscriber.deliver(envelope, 5, ignored -> EventSubscriber.HandlerResult.TRANSIENT_FAILURE);
+
+        assertEquals(1, subscriber.dlq.size());
+        assertEquals("evt-retry", subscriber.dlq.getFirst().eventId());
+    }
+
+    private static final class FakeDeliveryCounterSubscriber {
+        private final List<EventEnvelope> dlq = new ArrayList<>();
+
+        void deliver(EventEnvelope envelope, int deliveryCount, EventSubscriber.EventHandler handler) {
+            EventSubscriber.HandlerResult result = deliveryCount >= 5
+                ? EventSubscriber.HandlerResult.FATAL_FAILURE
+                : handler.handle(envelope);
+            if (result == EventSubscriber.HandlerResult.FATAL_FAILURE) {
+                dlq.add(envelope);
+            }
+        }
     }
 
     private static final class RecordingConsumedEventLog implements ConsumedEventLog {


### PR DESCRIPTION
## Summary
- Add post-sales Spring HTTP endpoints with idempotency/correlation/error handling
- Add application messaging ports, event envelope mapping, in-memory dedup/repositories
- Add Redis Streams publisher/subscriber adapter under adapters/messaging with env configuration

## Validation
- cd services/post-sales && mvn -q test
- ! grep -rl 'lettuce\|RedisClient' services/post-sales/src/main/java | grep -v adapters
- make check