### PR TITLE
REQ-047 admin audit API and messaging adapter

### DIFF
--- a/services/admin-audit/pom.xml
+++ b/services/admin-audit/pom.xml
@@ -22,6 +22,19 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.lettuce</groupId>
+      <artifactId>lettuce-core</artifactId>
+      <version>6.6.0.RELEASE</version>
+    </dependency>
+    <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
       <version>1.46.0</version>
@@ -29,6 +42,11 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-webmvc-test</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/NoOpRuntimeTracer.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/NoOpRuntimeTracer.java
@@ -1,10 +1,10 @@
 package com.trainticket.adminaudit;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
-@ConditionalOnMissingBean(RuntimeTracer.class)
+@ConditionalOnProperty(name = "otel.traces.exporter", havingValue = "none", matchIfMissing = true)
 public class NoOpRuntimeTracer implements RuntimeTracer {
     @Override
     public void requestStarted(RequestTraceContext context) {

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/RequestContextFilter.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/RequestContextFilter.java
@@ -11,7 +11,7 @@ import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-@Component
+@Component("adminAuditRequestContextFilter")
 public class RequestContextFilter extends OncePerRequestFilter {
     public static final String REQUEST_ID_HEADER = "X-Request-Id";
     public static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
@@ -37,6 +37,8 @@ public class RequestContextFilter extends OncePerRequestFilter {
             request.getRequestURI()
         );
 
+        request.setAttribute(REQUEST_ID_HEADER, requestId);
+        request.setAttribute(CORRELATION_ID_HEADER, correlationId);
         response.setHeader(REQUEST_ID_HEADER, requestId);
         response.setHeader(CORRELATION_ID_HEADER, correlationId);
         MDC.put("requestId", requestId);

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/http/AdminAuditController.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/http/AdminAuditController.java
@@ -1,0 +1,235 @@
+package com.trainticket.adminaudit.adapters.http;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import com.trainticket.adminaudit.RequestContextFilter;
+import com.trainticket.adminaudit.application.AdminAuditService;
+import com.trainticket.adminaudit.domain.AuditEntry;
+import com.trainticket.adminaudit.domain.ManualAction;
+import com.trainticket.adminaudit.domain.OperatorIdentity;
+import com.trainticket.adminaudit.domain.OperatorRole;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin")
+public class AdminAuditController {
+    private final AdminAuditService service;
+    private final IdempotencyService idempotency;
+
+    @Autowired
+    public AdminAuditController(AdminAuditService service, IdempotencyService idempotency) {
+        this.service = service;
+        this.idempotency = idempotency;
+    }
+
+    @PostMapping("/operators")
+    public ResponseEntity<Object> registerOperator(
+        @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
+        @RequestBody RegisterOperatorRequest request,
+        HttpServletRequest httpRequest
+    ) {
+        request.validate();
+        return idempotency.execute(idempotencyKey, request, 201, () -> OperatorResponse.from(service.registerOperator(
+            request.email(),
+            OperatorRole.valueOf(request.role()),
+            AdminAuditService.parseScopes(request.scopes()),
+            correlationId(httpRequest)
+        )));
+    }
+
+    @PostMapping("/manual-actions")
+    public ResponseEntity<Object> requestManualAction(
+        @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
+        @RequestBody ManualActionRequest request,
+        HttpServletRequest httpRequest
+    ) {
+        request.validate();
+        return idempotency.execute(idempotencyKey, request, 201, () -> ManualActionResponse.from(service.requestManualAction(
+            request.targetDomain(),
+            request.targetCommand(),
+            request.businessRef(),
+            request.reasonCode(),
+            request.description(),
+            request.requestedByOperatorId(),
+            request.requiresApproval(),
+            correlationId(httpRequest)
+        )));
+    }
+
+    @PostMapping("/manual-actions/{manualActionId}/approve")
+    public ResponseEntity<Object> approveManualAction(
+        @PathVariable String manualActionId,
+        @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
+        @RequestBody ApproveManualActionRequest request,
+        HttpServletRequest httpRequest
+    ) {
+        request.validate();
+        ApproveFingerprint fingerprint = new ApproveFingerprint(manualActionId, request.approvedByOperatorId());
+        return idempotency.execute(idempotencyKey, fingerprint, 200, () -> ApprovalResponse.from(service.approveManualAction(
+            manualActionId,
+            request.approvedByOperatorId(),
+            correlationId(httpRequest)
+        )));
+    }
+
+    @GetMapping("/audit-trail")
+    public AuditTrailPage listAuditTrail(
+        @RequestParam(value = "businessRef", required = false) String businessRef,
+        @RequestParam(value = "limit", defaultValue = "20") int limit,
+        @RequestParam(value = "offset", defaultValue = "0") int offset
+    ) {
+        AdminAuditService.Page<AuditEntry> page = service.listAuditTrail(businessRef, limit, offset);
+        return new AuditTrailPage(
+            page.items().stream().map(AuditEntryResponse::from).toList(),
+            page.total(),
+            page.limit(),
+            page.offset()
+        );
+    }
+
+    @GetMapping("/operators/{operatorId}")
+    public OperatorDetailsResponse getOperator(@PathVariable String operatorId) {
+        return OperatorDetailsResponse.from(service.getOperator(operatorId));
+    }
+
+    private static String correlationId(HttpServletRequest request) {
+        return (String) request.getAttribute(RequestContextFilter.CORRELATION_ID_HEADER);
+    }
+
+    public record RegisterOperatorRequest(String email, String role, List<String> scopes, String displayName) {
+        void validate() {
+            requireText(email, "email");
+            requireText(role, "role");
+            requireText(displayName, "displayName");
+            try {
+                OperatorRole.valueOf(role);
+            } catch (IllegalArgumentException exception) {
+                throw new com.trainticket.adminaudit.application.ValidationException("invalid role");
+            }
+            if (scopes == null || scopes.isEmpty()) {
+                throw new com.trainticket.adminaudit.application.ValidationException("scopes are required");
+            }
+        }
+    }
+
+    public record ManualActionRequest(
+        String targetDomain,
+        String targetCommand,
+        String businessRef,
+        String reasonCode,
+        String description,
+        String requestedByOperatorId,
+        Boolean requiresApproval
+    ) {
+        void validate() {
+            requireText(targetDomain, "targetDomain");
+            requireText(targetCommand, "targetCommand");
+            requireText(businessRef, "businessRef");
+            requireText(reasonCode, "reasonCode");
+            requireText(description, "description");
+            requireText(requestedByOperatorId, "requestedByOperatorId");
+            if (requiresApproval == null) {
+                throw new com.trainticket.adminaudit.application.ValidationException("requiresApproval is required");
+            }
+        }
+    }
+
+    public record ApproveManualActionRequest(String approvedByOperatorId) {
+        void validate() {
+            requireText(approvedByOperatorId, "approvedByOperatorId");
+        }
+    }
+
+    private record ApproveFingerprint(String manualActionId, String approvedByOperatorId) {}
+
+    public record OperatorResponse(String operatorId, String email, String role, List<String> scopes, String status) {
+        static OperatorResponse from(OperatorIdentity operator) {
+            return new OperatorResponse(
+                operator.operatorId(),
+                operator.email(),
+                operator.role().name(),
+                operator.scopes().stream().map(Enum::name).sorted().toList(),
+                operator.active() ? "ACTIVE" : "SUSPENDED"
+            );
+        }
+    }
+
+    public record OperatorDetailsResponse(
+        String operatorId,
+        String email,
+        String role,
+        List<String> scopes,
+        String status,
+        String registeredAt
+    ) {
+        static OperatorDetailsResponse from(OperatorIdentity operator) {
+            return new OperatorDetailsResponse(
+                operator.operatorId(),
+                operator.email(),
+                operator.role().name(),
+                operator.scopes().stream().map(Enum::name).sorted().toList(),
+                operator.active() ? "ACTIVE" : "SUSPENDED",
+                operator.registeredAt().toString()
+            );
+        }
+    }
+
+    public record ManualActionResponse(String manualActionId, String targetDomain, String status) {
+        static ManualActionResponse from(ManualAction action) {
+            return new ManualActionResponse(action.manualActionId(), action.targetDomain(), action.state().name());
+        }
+    }
+
+    public record ApprovalResponse(String manualActionId, String status) {
+        static ApprovalResponse from(ManualAction action) {
+            return new ApprovalResponse(action.manualActionId(), action.state().name());
+        }
+    }
+
+    public record AuditTrailPage(List<AuditEntryResponse> items, int total, int limit, int offset) {}
+
+    public record AuditEntryResponse(
+        String entryId,
+        String actorId,
+        String actorDisplayName,
+        String actionType,
+        String resourceRef,
+        String resourceDomain,
+        String reasonCode,
+        String correlationId,
+        String resultSummary,
+        String correctedEntryId,
+        String recordedAt
+    ) {
+        static AuditEntryResponse from(AuditEntry entry) {
+            return new AuditEntryResponse(
+                entry.entryId(),
+                entry.actorId(),
+                entry.actorDisplayName(),
+                entry.actionType(),
+                entry.resourceRef(),
+                entry.resourceDomain(),
+                entry.reasonCode(),
+                entry.correlationId(),
+                entry.resultSummary(),
+                entry.correctedEntryId(),
+                entry.recordedAt().toString()
+            );
+        }
+    }
+
+    private static void requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new com.trainticket.adminaudit.application.ValidationException(field + " is required");
+        }
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/http/ApiError.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/http/ApiError.java
@@ -1,0 +1,5 @@
+package com.trainticket.adminaudit.adapters.http;
+
+import java.util.Map;
+
+public record ApiError(String code, String message, String correlationId, Map<String, Object> details) {}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/http/ApiExceptionHandler.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/http/ApiExceptionHandler.java
@@ -1,0 +1,66 @@
+package com.trainticket.adminaudit.adapters.http;
+
+import com.trainticket.adminaudit.RequestContextFilter;
+import com.trainticket.adminaudit.application.ConflictException;
+import com.trainticket.adminaudit.application.NotFoundException;
+import com.trainticket.adminaudit.application.PreconditionFailedException;
+import com.trainticket.adminaudit.application.ValidationException;
+import com.trainticket.adminaudit.application.ports.PublishFailedException;
+import com.trainticket.adminaudit.domain.DomainRuleViolation;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+    @ExceptionHandler({ValidationException.class, IllegalArgumentException.class, HttpMessageNotReadableException.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    ApiError validation(Exception exception, HttpServletRequest request) {
+        return error("VALIDATION_FAILED", exception.getMessage(), request);
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    ApiError notFound(Exception exception, HttpServletRequest request) {
+        return error("NOT_FOUND", exception.getMessage(), request);
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    ApiError conflict(Exception exception, HttpServletRequest request) {
+        return error("CONFLICT", exception.getMessage(), request);
+    }
+
+    @ExceptionHandler(IdempotencyKeyReusedException.class)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    ApiError idempotency(Exception exception, HttpServletRequest request) {
+        return error("IDEMPOTENCY_KEY_REUSED", exception.getMessage(), request);
+    }
+
+    @ExceptionHandler(PreconditionFailedException.class)
+    @ResponseStatus(HttpStatus.PRECONDITION_FAILED)
+    ApiError precondition(Exception exception, HttpServletRequest request) {
+        return error("PRECONDITION_FAILED", exception.getMessage(), request);
+    }
+
+    @ExceptionHandler(DomainRuleViolation.class)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    ApiError domain(Exception exception, HttpServletRequest request) {
+        return error("DOMAIN_RULE_VIOLATION", exception.getMessage(), request);
+    }
+
+    @ExceptionHandler(PublishFailedException.class)
+    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+    ApiError unavailable(Exception exception, HttpServletRequest request) {
+        return error("UNAVAILABLE", exception.getMessage(), request);
+    }
+
+    private static ApiError error(String code, String message, HttpServletRequest request) {
+        Object correlationId = request.getAttribute(RequestContextFilter.CORRELATION_ID_HEADER);
+        return new ApiError(code, message == null ? code : message, correlationId == null ? "" : correlationId.toString(), Map.of());
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/http/IdempotencyKeyReusedException.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/http/IdempotencyKeyReusedException.java
@@ -1,0 +1,7 @@
+package com.trainticket.adminaudit.adapters.http;
+
+public class IdempotencyKeyReusedException extends RuntimeException {
+    public IdempotencyKeyReusedException(String message) {
+        super(message);
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/http/IdempotencyService.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/http/IdempotencyService.java
@@ -1,0 +1,56 @@
+package com.trainticket.adminaudit.adapters.http;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.adminaudit.application.ValidationException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.function.Supplier;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IdempotencyService {
+    private final IdempotencyStore store;
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public IdempotencyService(IdempotencyStore store, ObjectMapper objectMapper) {
+        this.store = store;
+        this.objectMapper = objectMapper;
+    }
+
+    public ResponseEntity<Object> execute(String key, Object request, int successStatus, Supplier<Object> action) {
+        if (key == null || key.isBlank()) {
+            throw new ValidationException("Idempotency-Key header is required");
+        }
+        String fingerprint = fingerprint(request);
+        return store.find(key)
+            .map(stored -> replayOrReject(stored, fingerprint))
+            .orElseGet(() -> {
+                Object body = action.get();
+                store.save(key, fingerprint, successStatus, body);
+                return ResponseEntity.status(successStatus).body(body);
+            });
+    }
+
+    private ResponseEntity<Object> replayOrReject(IdempotencyStore.StoredResponse stored, String fingerprint) {
+        if (!stored.fingerprint().equals(fingerprint)) {
+            throw new IdempotencyKeyReusedException("Idempotency-Key reused with a different request body");
+        }
+        return ResponseEntity.status(stored.status()).body(stored.body());
+    }
+
+    private String fingerprint(Object request) {
+        try {
+            byte[] json = objectMapper.writeValueAsBytes(request);
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(json));
+        } catch (JsonProcessingException | NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("could not fingerprint request", exception);
+        }
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/http/IdempotencyStore.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/http/IdempotencyStore.java
@@ -1,0 +1,10 @@
+package com.trainticket.adminaudit.adapters.http;
+
+import java.util.Optional;
+
+public interface IdempotencyStore {
+    Optional<StoredResponse> find(String key);
+    void save(String key, String fingerprint, int status, Object body);
+
+    record StoredResponse(String fingerprint, int status, Object body) {}
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/http/InMemoryIdempotencyStore.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/http/InMemoryIdempotencyStore.java
@@ -1,0 +1,21 @@
+package com.trainticket.adminaudit.adapters.http;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InMemoryIdempotencyStore implements IdempotencyStore {
+    private final ConcurrentMap<String, StoredResponse> responses = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<StoredResponse> find(String key) {
+        return Optional.ofNullable(responses.get(key));
+    }
+
+    @Override
+    public void save(String key, String fingerprint, int status, Object body) {
+        responses.putIfAbsent(key, new StoredResponse(fingerprint, status, body));
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/messaging/ConsumedEventLog.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/messaging/ConsumedEventLog.java
@@ -1,0 +1,6 @@
+package com.trainticket.adminaudit.adapters.messaging;
+
+public interface ConsumedEventLog {
+    boolean alreadyProcessed(String eventId);
+    void recordProcessed(String eventId);
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/messaging/DeduplicatingEventHandler.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/messaging/DeduplicatingEventHandler.java
@@ -1,0 +1,26 @@
+package com.trainticket.adminaudit.adapters.messaging;
+
+import com.trainticket.adminaudit.application.ports.EventEnvelope;
+import com.trainticket.adminaudit.application.ports.EventSubscriber;
+
+public class DeduplicatingEventHandler implements EventSubscriber.EventHandler {
+    private final ConsumedEventLog consumedEventLog;
+    private final EventSubscriber.EventHandler delegate;
+
+    public DeduplicatingEventHandler(ConsumedEventLog consumedEventLog, EventSubscriber.EventHandler delegate) {
+        this.consumedEventLog = consumedEventLog;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public EventSubscriber.HandlerResult handle(EventEnvelope envelope) {
+        if (consumedEventLog.alreadyProcessed(envelope.eventId())) {
+            return EventSubscriber.HandlerResult.SUCCESS;
+        }
+        EventSubscriber.HandlerResult result = delegate.handle(envelope);
+        if (result == EventSubscriber.HandlerResult.SUCCESS) {
+            consumedEventLog.recordProcessed(envelope.eventId());
+        }
+        return result;
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/messaging/InMemoryConsumedEventLog.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/messaging/InMemoryConsumedEventLog.java
@@ -1,0 +1,20 @@
+package com.trainticket.adminaudit.adapters.messaging;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InMemoryConsumedEventLog implements ConsumedEventLog {
+    private final Set<String> processed = ConcurrentHashMap.newKeySet();
+
+    @Override
+    public boolean alreadyProcessed(String eventId) {
+        return processed.contains(eventId);
+    }
+
+    @Override
+    public void recordProcessed(String eventId) {
+        processed.add(eventId);
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/messaging/RedisEventPublisher.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/messaging/RedisEventPublisher.java
@@ -1,0 +1,75 @@
+package com.trainticket.adminaudit.adapters.messaging;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.adminaudit.application.ports.EventEnvelope;
+import com.trainticket.adminaudit.application.ports.EventPublisher;
+import com.trainticket.adminaudit.application.ports.PublishFailedException;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.XAddArgs;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+import java.time.Duration;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "ADMIN_AUDIT_REDIS_ENABLED", havingValue = "true", matchIfMissing = true)
+public class RedisEventPublisher implements EventPublisher, AutoCloseable {
+    private static final String FIELD = "envelope";
+    private static final long MAX_LEN = 100_000L;
+
+    private final ObjectMapper objectMapper;
+    private final RedisClient client;
+    private final StatefulRedisConnection<String, String> connection;
+
+    public RedisEventPublisher(@Value("${REDIS_URL:redis://localhost:6379}") String redisUrl, ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        this.client = RedisClient.create(RedisURI.create(redisUrl));
+        this.connection = client.connect();
+    }
+
+    @Override
+    public void publish(EventEnvelope envelope) throws PublishFailedException {
+        String body;
+        try {
+            body = objectMapper.writeValueAsString(envelope);
+        } catch (JsonProcessingException exception) {
+            throw new PublishFailedException("failed to serialize event envelope", exception);
+        }
+        RuntimeException last = null;
+        for (int attempt = 1; attempt <= 3; attempt++) {
+            try {
+                RedisCommands<String, String> commands = connection.sync();
+                commands.xadd(streamFor(envelope.producer()), XAddArgs.Builder.maxlen(MAX_LEN).approximateTrimming(), Map.of(FIELD, body));
+                return;
+            } catch (RuntimeException exception) {
+                last = exception;
+                sleep(attempt);
+            }
+        }
+        throw new PublishFailedException("failed to publish event envelope", last);
+    }
+
+    private static String streamFor(String producer) {
+        return "events:" + producer;
+    }
+
+    private static void sleep(int attempt) {
+        try {
+            Thread.sleep(Duration.ofMillis(50L * attempt).toMillis());
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new PublishFailedException("interrupted while retrying publish", interrupted);
+        }
+    }
+
+    @Override
+    public void close() {
+        connection.close();
+        client.shutdown();
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/messaging/RedisEventSubscriber.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/messaging/RedisEventSubscriber.java
@@ -1,0 +1,158 @@
+package com.trainticket.adminaudit.adapters.messaging;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.adminaudit.application.ports.EventEnvelope;
+import com.trainticket.adminaudit.application.ports.EventSubscriber;
+import com.trainticket.adminaudit.application.ports.SubscribeFailedException;
+import io.lettuce.core.Consumer;
+import io.lettuce.core.Range;
+import io.lettuce.core.RedisBusyException;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.Limit;
+import io.lettuce.core.XAddArgs;
+import io.lettuce.core.XAutoClaimArgs;
+import io.lettuce.core.XGroupCreateArgs;
+import io.lettuce.core.XReadArgs;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "ADMIN_AUDIT_REDIS_ENABLED", havingValue = "true", matchIfMissing = true)
+public class RedisEventSubscriber implements EventSubscriber, AutoCloseable {
+    private static final String FIELD = "envelope";
+    private static final long MAX_LEN = 100_000L;
+    private static final long BLOCK_MILLIS = 2_000L;
+    private static final long MIN_IDLE_MILLIS = 60_000L;
+    private static final long MAX_ATTEMPTS = 5L;
+
+    private final ObjectMapper objectMapper;
+    private final RedisClient client;
+    private final StatefulRedisConnection<String, String> connection;
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    public RedisEventSubscriber(@Value("${REDIS_URL:redis://localhost:6379}") String redisUrl, ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        this.client = RedisClient.create(RedisURI.create(redisUrl));
+        this.connection = client.connect();
+    }
+
+    @Override
+    public void subscribe(List<String> streams, String group, String consumerName, EventHandler handler)
+        throws SubscribeFailedException {
+        RedisCommands<String, String> commands = connection.sync();
+        try {
+            for (String stream : streams) {
+                createGroup(commands, stream, group);
+            }
+            running.set(true);
+            executor.submit(() -> poll(streams, group, consumerName, handler));
+            executor.submit(() -> recover(streams, group, consumerName, handler));
+        } catch (RuntimeException exception) {
+            throw new SubscribeFailedException("failed to start Redis stream subscriber", exception);
+        }
+    }
+
+    private void poll(List<String> streams, String group, String consumerName, EventHandler handler) {
+        RedisCommands<String, String> commands = connection.sync();
+        while (running.get()) {
+            for (String stream : streams) {
+                List<io.lettuce.core.StreamMessage<String, String>> messages = commands.xreadgroup(
+                    Consumer.from(group, consumerName),
+                    XReadArgs.Builder.block(BLOCK_MILLIS).count(10),
+                    XReadArgs.StreamOffset.lastConsumed(stream)
+                );
+                for (io.lettuce.core.StreamMessage<String, String> message : messages) {
+                    process(commands, stream, group, message, handler, 1L);
+                }
+            }
+        }
+    }
+
+    private void recover(List<String> streams, String group, String consumerName, EventHandler handler) {
+        RedisCommands<String, String> commands = connection.sync();
+        while (running.get()) {
+            for (String stream : streams) {
+                commands.xautoclaim(stream, XAutoClaimArgs.Builder.xautoclaim(Consumer.from(group, consumerName), MIN_IDLE_MILLIS, "0-0"))
+                    .getMessages()
+                    .forEach(message -> process(commands, stream, group, message, handler, deliveryCount(commands, stream, group, message.getId())));
+            }
+            sleep(MIN_IDLE_MILLIS);
+        }
+    }
+
+    private void process(
+        RedisCommands<String, String> commands,
+        String stream,
+        String group,
+        io.lettuce.core.StreamMessage<String, String> message,
+        EventHandler handler,
+        long deliveryCount
+    ) {
+        String envelopeJson = message.getBody().get(FIELD);
+        if (deliveryCount >= MAX_ATTEMPTS) {
+            moveToDlq(commands, stream, envelopeJson);
+            commands.xack(stream, group, message.getId());
+            return;
+        }
+        try {
+            HandlerResult result = handler.handle(objectMapper.readValue(envelopeJson, EventEnvelope.class));
+            if (result == HandlerResult.SUCCESS) {
+                commands.xack(stream, group, message.getId());
+            } else if (result == HandlerResult.FATAL_FAILURE) {
+                moveToDlq(commands, stream, envelopeJson);
+                commands.xack(stream, group, message.getId());
+            }
+        } catch (JsonProcessingException exception) {
+            moveToDlq(commands, stream, envelopeJson);
+            commands.xack(stream, group, message.getId());
+        }
+    }
+
+    private long deliveryCount(RedisCommands<String, String> commands, String stream, String group, String messageId) {
+        return commands.xpending(stream, group, Range.create(messageId, messageId), Limit.from(1)).stream()
+            .filter(pending -> pending.getId().equals(messageId))
+            .findFirst()
+            .map(pending -> pending.getRedeliveryCount())
+            .orElse(1L);
+    }
+
+    private void moveToDlq(RedisCommands<String, String> commands, String stream, String envelopeJson) {
+        commands.xadd(stream + ":dlq", XAddArgs.Builder.maxlen(MAX_LEN).approximateTrimming(), Map.of(FIELD, envelopeJson));
+    }
+
+    private void createGroup(RedisCommands<String, String> commands, String stream, String group) {
+        try {
+            commands.xgroupCreate(XReadArgs.StreamOffset.from(stream, "$"), group, XGroupCreateArgs.Builder.mkstream());
+        } catch (RedisBusyException ignored) {
+            // Consumer group already exists.
+        }
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public void close() {
+        running.set(false);
+        executor.shutdownNow();
+        connection.close();
+        client.shutdown();
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/messaging/RedisMessagingConfiguration.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/messaging/RedisMessagingConfiguration.java
@@ -1,0 +1,37 @@
+package com.trainticket.adminaudit.adapters.messaging;
+
+import com.trainticket.adminaudit.application.ports.EventEnvelope;
+import com.trainticket.adminaudit.application.ports.EventSubscriber;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnBean(RedisEventSubscriber.class)
+public class RedisMessagingConfiguration implements ApplicationRunner {
+    private final RedisEventSubscriber subscriber;
+    private final ConsumedEventLog consumedEventLog;
+
+    public RedisMessagingConfiguration(RedisEventSubscriber subscriber, ConsumedEventLog consumedEventLog) {
+        this.subscriber = subscriber;
+        this.consumedEventLog = consumedEventLog;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        // The contract currently lists no business streams consumed by admin-audit.
+        // Keep the adapter wired and ready; an empty subscription set requires no Redis group.
+        List<String> streams = List.of();
+        if (!streams.isEmpty()) {
+            EventSubscriber.EventHandler handler = new DeduplicatingEventHandler(consumedEventLog, this::handle);
+            subscriber.subscribe(streams, "admin-audit", "admin-audit-" + UUID.randomUUID(), handler);
+        }
+    }
+
+    private EventSubscriber.HandlerResult handle(EventEnvelope envelope) {
+        return EventSubscriber.HandlerResult.SUCCESS;
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/persistence/InMemoryAdminAuditRepository.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/persistence/InMemoryAdminAuditRepository.java
@@ -1,0 +1,79 @@
+package com.trainticket.adminaudit.application.ports;
+
+import com.trainticket.adminaudit.application.ports.AdminAuditRepository;
+import com.trainticket.adminaudit.domain.AuditEntry;
+import com.trainticket.adminaudit.domain.ManualAction;
+import com.trainticket.adminaudit.domain.OperatorIdentity;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryAdminAuditRepository implements AdminAuditRepository {
+    private final ConcurrentMap<String, OperatorIdentity> operators = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, ManualAction> manualActions = new ConcurrentHashMap<>();
+    private final List<AuditEntry> auditEntries = java.util.Collections.synchronizedList(new ArrayList<>());
+
+    @Override
+    public Optional<OperatorIdentity> findOperator(String operatorId) {
+        return Optional.ofNullable(operators.get(operatorId));
+    }
+
+    @Override
+    public Optional<OperatorIdentity> findOperatorByEmail(String email) {
+        if (email == null) {
+            return Optional.empty();
+        }
+        String normalized = email.toLowerCase(Locale.ROOT);
+        return operators.values().stream()
+            .filter(operator -> operator.email().toLowerCase(Locale.ROOT).equals(normalized))
+            .findFirst();
+    }
+
+    @Override
+    public void saveOperator(OperatorIdentity operator) {
+        operators.put(operator.operatorId(), operator);
+    }
+
+    @Override
+    public Optional<ManualAction> findManualAction(String manualActionId) {
+        return Optional.ofNullable(manualActions.get(manualActionId));
+    }
+
+    @Override
+    public void saveManualAction(ManualAction manualAction) {
+        manualActions.put(manualAction.manualActionId(), manualAction);
+    }
+
+    @Override
+    public void saveAuditEntry(AuditEntry entry) {
+        auditEntries.add(entry);
+    }
+
+    @Override
+    public List<AuditEntry> listAuditEntries(String businessRef, int limit, int offset) {
+        return filteredEntries(businessRef).stream()
+            .skip(offset)
+            .limit(limit)
+            .toList();
+    }
+
+    @Override
+    public int countAuditEntries(String businessRef) {
+        return filteredEntries(businessRef).size();
+    }
+
+    private List<AuditEntry> filteredEntries(String businessRef) {
+        synchronized (auditEntries) {
+            return auditEntries.stream()
+                .filter(entry -> businessRef == null || businessRef.isBlank() || businessRef.equals(entry.resourceRef()))
+                .sorted(Comparator.comparing(AuditEntry::recordedAt).reversed())
+                .toList();
+        }
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/AdminAuditService.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/AdminAuditService.java
@@ -1,0 +1,247 @@
+package com.trainticket.adminaudit.application;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import com.trainticket.adminaudit.application.ports.AdminAuditRepository;
+import com.trainticket.adminaudit.application.ports.EventEnvelope;
+import com.trainticket.adminaudit.application.ports.EventPublisher;
+import com.trainticket.adminaudit.domain.AdminAuditEvent;
+import com.trainticket.adminaudit.domain.AuditEntry;
+import com.trainticket.adminaudit.domain.AuditTrail;
+import com.trainticket.adminaudit.domain.DomainRuleViolation;
+import com.trainticket.adminaudit.domain.ManualAction;
+import com.trainticket.adminaudit.domain.OperatorIdentity;
+import com.trainticket.adminaudit.domain.OperatorRef;
+import com.trainticket.adminaudit.domain.OperatorRole;
+import com.trainticket.adminaudit.domain.PermissionScope;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AdminAuditService {
+    private static final String PRODUCER = "admin-audit";
+
+    private final AdminAuditRepository repository;
+    private final EventPublisher eventPublisher;
+    private final Clock clock;
+
+    @Autowired
+    public AdminAuditService(AdminAuditRepository repository, EventPublisher eventPublisher) {
+        this(repository, eventPublisher, Clock.systemUTC());
+    }
+
+    public AdminAuditService(AdminAuditRepository repository, EventPublisher eventPublisher, Clock clock) {
+        this.repository = repository;
+        this.eventPublisher = eventPublisher;
+        this.clock = clock;
+    }
+
+    public OperatorIdentity registerOperator(
+        String email,
+        OperatorRole role,
+        Set<PermissionScope> scopes,
+        String correlationId
+    ) {
+        if (repository.findOperatorByEmail(email).isPresent()) {
+            throw new ConflictException("operator email already registered");
+        }
+        OperatorIdentity operator = OperatorIdentity.register(
+            email,
+            role,
+            scopes,
+            Instant.now(clock),
+            newCommandId(),
+            normalizeCorrelationId(correlationId)
+        );
+        repository.saveOperator(operator);
+        publish(operator.domainEvents());
+        return operator;
+    }
+
+    public ManualAction requestManualAction(
+        String targetDomain,
+        String targetCommand,
+        String businessRef,
+        String reasonCode,
+        String description,
+        String requestedByOperatorId,
+        boolean requiresApproval,
+        String correlationId
+    ) {
+        OperatorIdentity requester = repository.findOperator(requestedByOperatorId)
+            .orElseThrow(() -> new NotFoundException("operator not found"));
+        requester.assertActive();
+        ManualAction action = ManualAction.request(
+            targetDomain,
+            targetCommand,
+            businessRef,
+            reasonCode,
+            description,
+            new OperatorRef(requester.operatorId(), requester.email()),
+            requiresApproval,
+            Instant.now(clock),
+            newCommandId(),
+            normalizeCorrelationId(correlationId)
+        );
+        repository.saveManualAction(action);
+        publish(action.domainEvents());
+        recordAudit(
+            requester.operatorId(),
+            requester.email(),
+            "MANUAL_ACTION_REQUESTED",
+            businessRef,
+            targetDomain,
+            reasonCode,
+            normalizeCorrelationId(correlationId),
+            "Manual action requested: " + action.manualActionId()
+        );
+        return action;
+    }
+
+    public ManualAction approveManualAction(String manualActionId, String approvedByOperatorId, String correlationId) {
+        ManualAction action = repository.findManualAction(manualActionId)
+            .orElseThrow(() -> new NotFoundException("manual action not found"));
+        OperatorIdentity approver = repository.findOperator(approvedByOperatorId)
+            .orElseThrow(() -> new NotFoundException("operator not found"));
+        int alreadyPublished = action.domainEvents().size();
+        try {
+            action.approve(
+                approver,
+                new OperatorRef(approver.operatorId(), approver.email()),
+                Instant.now(clock),
+                newCommandId(),
+                normalizeCorrelationId(correlationId)
+            );
+        } catch (DomainRuleViolation violation) {
+            throw new PreconditionFailedException(violation.getMessage(), violation);
+        }
+        repository.saveManualAction(action);
+        publish(action.domainEvents().subList(alreadyPublished, action.domainEvents().size()));
+        recordAudit(
+            approver.operatorId(),
+            approver.email(),
+            "MANUAL_ACTION_APPROVED",
+            action.businessRef(),
+            action.targetDomain(),
+            action.reasonCode(),
+            normalizeCorrelationId(correlationId),
+            "Manual action approved: " + action.manualActionId()
+        );
+        return action;
+    }
+
+    public OperatorIdentity getOperator(String operatorId) {
+        return repository.findOperator(operatorId)
+            .orElseThrow(() -> new NotFoundException("operator not found"));
+    }
+
+    public Page<AuditEntry> listAuditTrail(String businessRef, int limit, int offset) {
+        if (limit < 1 || limit > 100 || offset < 0) {
+            throw new ValidationException("limit must be 1..100 and offset must be >= 0");
+        }
+        return new Page<>(repository.listAuditEntries(businessRef, limit, offset), repository.countAuditEntries(businessRef), limit, offset);
+    }
+
+    private void recordAudit(
+        String actorId,
+        String actorDisplayName,
+        String actionType,
+        String resourceRef,
+        String resourceDomain,
+        String reasonCode,
+        String correlationId,
+        String resultSummary
+    ) {
+        AuditTrail trail = new AuditTrail();
+        AuditEntry entry = trail.recordEntry(
+            actorId,
+            actorDisplayName,
+            actionType,
+            resourceRef,
+            resourceDomain,
+            reasonCode,
+            correlationId,
+            resultSummary,
+            null,
+            Instant.now(clock),
+            newCommandId()
+        );
+        repository.saveAuditEntry(entry);
+    }
+
+    private void publish(List<AdminAuditEvent> events) {
+        for (AdminAuditEvent event : events) {
+            eventPublisher.publish(toContractEnvelope(event));
+        }
+    }
+
+    public static EventEnvelope toContractEnvelope(AdminAuditEvent event) {
+        com.trainticket.adminaudit.domain.EventEnvelope source = event.envelope();
+        return new EventEnvelope(
+            ensurePrefix(source.eventId(), "evt-"),
+            source.eventType(),
+            source.occurredAt(),
+            ensurePrefix(source.correlationId(), "corr-"),
+            ensureCausationPrefix(source.causationId()),
+            source.producer(),
+            source.schemaVersion(),
+            payloadFor(event)
+        );
+    }
+
+    private static Map<String, Object> payloadFor(AdminAuditEvent event) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        for (java.lang.reflect.RecordComponent component : event.getClass().getRecordComponents()) {
+            if ("envelope".equals(component.getName())) {
+                continue;
+            }
+            try {
+                payload.put(component.getName(), component.getAccessor().invoke(event));
+            } catch (ReflectiveOperationException exception) {
+                throw new IllegalStateException("could not read event payload", exception);
+            }
+        }
+        return payload;
+    }
+
+    private static String normalizeCorrelationId(String correlationId) {
+        if (correlationId == null || correlationId.isBlank()) {
+            return "corr-" + UUID.randomUUID();
+        }
+        return correlationId.startsWith("corr-") ? correlationId : "corr-" + correlationId;
+    }
+
+    private static String ensurePrefix(String value, String prefix) {
+        return value.startsWith(prefix) ? value : prefix + value;
+    }
+
+    private static String ensureCausationPrefix(String value) {
+        if (value.startsWith("cmd-") || value.startsWith("evt-")) {
+            return value;
+        }
+        return "cmd-" + value;
+    }
+
+    private static String newCommandId() {
+        return "cmd-" + UUID.randomUUID();
+    }
+
+    public record Page<T>(List<T> items, int total, int limit, int offset) {}
+
+    public static Set<PermissionScope> parseScopes(List<String> scopes) {
+        if (scopes == null) {
+            throw new ValidationException("scopes are required");
+        }
+        try {
+            return scopes.stream().map(PermissionScope::valueOf).collect(Collectors.toSet());
+        } catch (IllegalArgumentException exception) {
+            throw new ValidationException("invalid scope");
+        }
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/ConflictException.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/ConflictException.java
@@ -1,0 +1,6 @@
+package com.trainticket.adminaudit.application;
+
+public class ConflictException extends RuntimeException {
+    public ConflictException(String message) { super(message); }
+    public ConflictException(String message, Throwable cause) { super(message, cause); }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/DefaultEventPublisherConfiguration.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/DefaultEventPublisherConfiguration.java
@@ -1,0 +1,21 @@
+package com.trainticket.adminaudit.application;
+
+import com.trainticket.adminaudit.application.ports.EventEnvelope;
+import com.trainticket.adminaudit.application.ports.EventPublisher;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DefaultEventPublisherConfiguration {
+    @Bean
+    @ConditionalOnMissingBean(EventPublisher.class)
+    EventPublisher inMemoryEventPublisher() {
+        return new EventPublisher() {
+            @Override
+            public void publish(EventEnvelope envelope) {
+                // In-memory default for local/test runtime without Redis.
+            }
+        };
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/JacksonConfiguration.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/JacksonConfiguration.java
@@ -1,0 +1,19 @@
+package com.trainticket.adminaudit.application;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfiguration {
+    @Bean
+    @ConditionalOnMissingBean(ObjectMapper.class)
+    ObjectMapper objectMapper() {
+        return new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/NotFoundException.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/NotFoundException.java
@@ -1,0 +1,6 @@
+package com.trainticket.adminaudit.application;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) { super(message); }
+    public NotFoundException(String message, Throwable cause) { super(message, cause); }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/PreconditionFailedException.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/PreconditionFailedException.java
@@ -1,0 +1,6 @@
+package com.trainticket.adminaudit.application;
+
+public class PreconditionFailedException extends RuntimeException {
+    public PreconditionFailedException(String message) { super(message); }
+    public PreconditionFailedException(String message, Throwable cause) { super(message, cause); }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/ValidationException.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/ValidationException.java
@@ -1,0 +1,6 @@
+package com.trainticket.adminaudit.application;
+
+public class ValidationException extends RuntimeException {
+    public ValidationException(String message) { super(message); }
+    public ValidationException(String message, Throwable cause) { super(message, cause); }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/ports/AdminAuditRepository.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/ports/AdminAuditRepository.java
@@ -1,0 +1,20 @@
+package com.trainticket.adminaudit.application.ports;
+
+import com.trainticket.adminaudit.domain.AuditEntry;
+import com.trainticket.adminaudit.domain.ManualAction;
+import com.trainticket.adminaudit.domain.OperatorIdentity;
+import java.util.List;
+import java.util.Optional;
+
+public interface AdminAuditRepository {
+    Optional<OperatorIdentity> findOperator(String operatorId);
+    Optional<OperatorIdentity> findOperatorByEmail(String email);
+    void saveOperator(OperatorIdentity operator);
+
+    Optional<ManualAction> findManualAction(String manualActionId);
+    void saveManualAction(ManualAction manualAction);
+
+    void saveAuditEntry(AuditEntry entry);
+    List<AuditEntry> listAuditEntries(String businessRef, int limit, int offset);
+    int countAuditEntries(String businessRef);
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/ports/EventEnvelope.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/ports/EventEnvelope.java
@@ -1,0 +1,25 @@
+package com.trainticket.adminaudit.application.ports;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.time.Instant;
+
+@JsonPropertyOrder({
+    "eventId",
+    "eventType",
+    "occurredAt",
+    "correlationId",
+    "causationId",
+    "producer",
+    "schemaVersion",
+    "payload"
+})
+public record EventEnvelope(
+    String eventId,
+    String eventType,
+    Instant occurredAt,
+    String correlationId,
+    String causationId,
+    String producer,
+    int schemaVersion,
+    Object payload
+) {}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/ports/EventPublisher.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/ports/EventPublisher.java
@@ -1,0 +1,5 @@
+package com.trainticket.adminaudit.application.ports;
+
+public interface EventPublisher {
+    void publish(EventEnvelope envelope) throws PublishFailedException;
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/ports/EventSubscriber.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/ports/EventSubscriber.java
@@ -1,0 +1,19 @@
+package com.trainticket.adminaudit.application.ports;
+
+import java.util.List;
+
+public interface EventSubscriber {
+    void subscribe(List<String> streams, String group, String consumerName, EventHandler handler)
+        throws SubscribeFailedException;
+
+    @FunctionalInterface
+    interface EventHandler {
+        HandlerResult handle(EventEnvelope envelope);
+    }
+
+    enum HandlerResult {
+        SUCCESS,
+        TRANSIENT_FAILURE,
+        FATAL_FAILURE
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/ports/PublishFailedException.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/ports/PublishFailedException.java
@@ -1,0 +1,11 @@
+package com.trainticket.adminaudit.application.ports;
+
+public class PublishFailedException extends RuntimeException {
+    public PublishFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PublishFailedException(String message) {
+        super(message);
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/ports/SubscribeFailedException.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/ports/SubscribeFailedException.java
@@ -1,0 +1,7 @@
+package com.trainticket.adminaudit.application.ports;
+
+public class SubscribeFailedException extends RuntimeException {
+    public SubscribeFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/services/admin-audit/src/test/java/com/trainticket/adminaudit/adapters/http/AdminAuditControllerTest.java
+++ b/services/admin-audit/src/test/java/com/trainticket/adminaudit/adapters/http/AdminAuditControllerTest.java
@@ -1,0 +1,130 @@
+package com.trainticket.adminaudit.adapters.http;
+
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest(properties = "ADMIN_AUDIT_REDIS_ENABLED=false")
+@AutoConfigureMockMvc
+class AdminAuditControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void registerOperatorHappyPathAndGetOperator() throws Exception {
+        MvcResult result = register("ops@example.com", "key-register-1")
+            .andExpect(status().isCreated())
+            .andExpect(header().string("X-Correlation-Id", "corr-test-1"))
+            .andExpect(jsonPath("$.operatorId", startsWith("op-")))
+            .andExpect(jsonPath("$.email").value("ops@example.com"))
+            .andExpect(jsonPath("$.role").value("ADMIN"))
+            .andExpect(jsonPath("$.status").value("ACTIVE"))
+            .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        String operatorId = body.substring(body.indexOf("op-"), body.indexOf("op-") + 39);
+
+        mockMvc.perform(get("/api/v1/admin/operators/{operatorId}", operatorId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.operatorId").value(operatorId));
+    }
+
+    @Test
+    void manualActionHappyPathsAndAuditTrail() throws Exception {
+        String requester = operatorId(register("requester@example.com", "key-register-2").andReturn());
+        String approver = operatorId(register("approver@example.com", "key-register-3").andReturn());
+
+        MvcResult action = mockMvc.perform(post("/api/v1/admin/manual-actions")
+                .header("Idempotency-Key", "key-manual-1")
+                .header("X-Correlation-Id", "corr-test-2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"targetDomain":"payment","targetCommand":"RefundPayment","businessRef":"pi-1","reasonCode":"CUSTOMER_REQUEST","description":"refund","requestedByOperatorId":"%s","requiresApproval":true}
+                    """.formatted(requester)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.manualActionId", startsWith("ma-")))
+            .andExpect(jsonPath("$.targetDomain").value("payment"))
+            .andExpect(jsonPath("$.status").value("REQUESTED"))
+            .andReturn();
+
+        String manualActionId = actionId(action);
+
+        mockMvc.perform(post("/api/v1/admin/manual-actions/{manualActionId}/approve", manualActionId)
+                .header("Idempotency-Key", "key-approve-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"approvedByOperatorId\":\"%s\"}".formatted(approver)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.manualActionId").value(manualActionId))
+            .andExpect(jsonPath("$.status").value("APPROVED"));
+
+        mockMvc.perform(get("/api/v1/admin/audit-trail").param("businessRef", "pi-1").param("limit", "20").param("offset", "0"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.total").value(2))
+            .andExpect(jsonPath("$.items[0].resourceRef").value("pi-1"));
+    }
+
+    @Test
+    void validationFailureUsesCanonicalBody() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/operators")
+                .header("Idempotency-Key", "key-validation-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"role\":\"ADMIN\",\"scopes\":[\"OPERATOR_WRITE\"],\"displayName\":\"Ops\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"))
+            .andExpect(jsonPath("$.correlationId").exists())
+            .andExpect(jsonPath("$.details").isMap());
+    }
+
+    @Test
+    void idempotentReplayReturnsOriginalAndDifferentBodyIsRejected() throws Exception {
+        MvcResult first = register("replay@example.com", "key-replay-1").andReturn();
+        String firstBody = first.getResponse().getContentAsString();
+
+        MvcResult replay = register("replay@example.com", "key-replay-1")
+            .andExpect(status().isCreated())
+            .andReturn();
+        org.assertj.core.api.Assertions.assertThat(replay.getResponse().getContentAsString()).isEqualTo(firstBody);
+
+        mockMvc.perform(post("/api/v1/admin/operators")
+                .header("Idempotency-Key", "key-replay-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(operatorJson("different@example.com")))
+            .andExpect(status().isUnprocessableEntity())
+            .andExpect(jsonPath("$.code").value("IDEMPOTENCY_KEY_REUSED"));
+    }
+
+    private org.springframework.test.web.servlet.ResultActions register(String email, String key) throws Exception {
+        return mockMvc.perform(post("/api/v1/admin/operators")
+            .header("Idempotency-Key", key)
+            .header("X-Correlation-Id", "corr-test-1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(operatorJson(email)));
+    }
+
+    private static String operatorJson(String email) {
+        return """
+            {"email":"%s","role":"ADMIN","scopes":["OPERATOR_WRITE","AUDIT_READ"],"displayName":"Ops"}
+            """.formatted(email);
+    }
+
+    private static String operatorId(MvcResult result) throws Exception {
+        String body = result.getResponse().getContentAsString();
+        return body.substring(body.indexOf("op-"), body.indexOf("op-") + 39);
+    }
+
+    private static String actionId(MvcResult result) throws Exception {
+        String body = result.getResponse().getContentAsString();
+        return body.substring(body.indexOf("ma-"), body.indexOf("ma-") + 39);
+    }
+}

--- a/services/admin-audit/src/test/java/com/trainticket/adminaudit/adapters/messaging/MessagingAdapterTest.java
+++ b/services/admin-audit/src/test/java/com/trainticket/adminaudit/adapters/messaging/MessagingAdapterTest.java
@@ -1,0 +1,74 @@
+package com.trainticket.adminaudit.adapters.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.trainticket.adminaudit.application.AdminAuditService;
+import com.trainticket.adminaudit.application.ports.EventEnvelope;
+import com.trainticket.adminaudit.application.ports.EventSubscriber;
+import com.trainticket.adminaudit.domain.ManualActionRequested;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MessagingAdapterTest {
+    @Test
+    void wrapsDomainEventInCanonicalEnvelope() {
+        com.trainticket.adminaudit.domain.EventEnvelope domainEnvelope = new com.trainticket.adminaudit.domain.EventEnvelope(
+            "evt-11111111-1111-4111-8111-111111111111",
+            "ManualActionRequested",
+            1,
+            Instant.parse("2026-07-05T10:30:00Z"),
+            "corr-22222222-2222-4222-8222-222222222222",
+            "cmd-33333333-3333-4333-8333-333333333333",
+            "admin-audit"
+        );
+        ManualActionRequested event = new ManualActionRequested(
+            domainEnvelope,
+            "ma-1",
+            "payment",
+            "RefundPayment",
+            "pi-1",
+            "CUSTOMER_REQUEST",
+            "refund",
+            "op-1",
+            "Ops",
+            true
+        );
+
+        EventEnvelope envelope = AdminAuditService.toContractEnvelope(event);
+
+        assertThat(envelope.eventId()).startsWith("evt-");
+        assertThat(envelope.correlationId()).startsWith("corr-");
+        assertThat(envelope.causationId()).startsWith("cmd-");
+        assertThat(envelope.producer()).isEqualTo("admin-audit");
+        assertThat(envelope.schemaVersion()).isEqualTo(1);
+        assertThat(envelope.payload()).isInstanceOfSatisfying(java.util.Map.class, payload ->
+            assertThat(payload).containsEntry("manualActionId", "ma-1"));
+    }
+
+    @Test
+    void subscriberDeduplicatesDuplicateEventId() {
+        InMemoryConsumedEventLog log = new InMemoryConsumedEventLog();
+        List<String> handled = new ArrayList<>();
+        DeduplicatingEventHandler handler = new DeduplicatingEventHandler(log, envelope -> {
+            handled.add(envelope.eventId());
+            return EventSubscriber.HandlerResult.SUCCESS;
+        });
+        EventEnvelope envelope = new EventEnvelope(
+            "evt-duplicate",
+            "AnythingHappened",
+            Instant.parse("2026-07-05T10:30:00Z"),
+            "corr-1",
+            "evt-1",
+            "payment",
+            1,
+            java.util.Map.of()
+        );
+
+        assertThat(handler.handle(envelope)).isEqualTo(EventSubscriber.HandlerResult.SUCCESS);
+        assertThat(handler.handle(envelope)).isEqualTo(EventSubscriber.HandlerResult.SUCCESS);
+
+        assertThat(handled).containsExactly("evt-duplicate");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds admin-audit HTTP endpoints with idempotency, correlation propagation, and canonical error bodies.
- Wires existing domain aggregates through an application service and in-memory persistence for runtime/tests.
- Adds broker-neutral event ports plus Redis Streams publisher/subscriber adapter with envelope wrapping, ack/DLQ recovery, and dedup handler tests.

## Validation
- cd services/admin-audit && mvn -q test
- ! grep -rl 'lettuce\|RedisClient' services/admin-audit/src/main/java | grep -v adapters
- make check