### PR TITLE
REQ-050 account HTTP API and messaging adapter

### DIFF
--- a/services/account/package-lock.json
+++ b/services/account/package-lock.json
@@ -8,7 +8,8 @@
       "name": "@trainticket/account",
       "version": "0.1.0",
       "dependencies": {
-        "fastify": "5.9.0"
+        "fastify": "5.9.0",
+        "ioredis": "^5.4.2"
       },
       "devDependencies": {
         "@types/node": "26.0.1",
@@ -126,6 +127,12 @@
         "ipaddr.js": "^2.1.0"
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmmirror.com/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+      "license": "MIT"
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmmirror.com/@pinojs/redact/-/redact-0.4.0.tgz",
@@ -210,6 +217,15 @@
         "fastq": "^1.17.1"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmmirror.com/cookie/-/cookie-1.1.1.tgz",
@@ -221,6 +237,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/dequal": {
@@ -349,6 +391,30 @@
         "node": ">=20"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmmirror.com/ioredis/-/ioredis-5.4.2.tgz",
+      "integrity": "sha512-0SZXGNGZ+WzISQ67QDyZ2x0+wVxjjUndtD8oSeik/4ajifeiRufed8fCb8QW8VMyi4MXcS+UO1k/0NGhvq1PAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "2.4.0",
       "resolved": "https://registry.npmmirror.com/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
@@ -418,6 +484,24 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/on-exit-leak-free": {
@@ -495,6 +579,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/require-from-string": {
@@ -613,6 +718,12 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/thread-stream": {
       "version": "4.2.0",

--- a/services/account/package.json
+++ b/services/account/package.json
@@ -8,7 +8,8 @@
     "test": "rm -rf test-output && tsc --noEmit false --outDir test-output && node --test test-output/**/*.test.js"
   },
   "dependencies": {
-    "fastify": "5.9.0"
+    "fastify": "5.9.0",
+    "ioredis": "^5.4.2"
   },
   "devDependencies": {
     "@types/node": "26.0.1",

--- a/services/account/src/adapters/messaging/dlq-handler.ts
+++ b/services/account/src/adapters/messaging/dlq-handler.ts
@@ -1,0 +1,7 @@
+import type { Redis } from "ioredis";
+
+import { maxStreamLength } from "./stream-config.js";
+
+export async function moveToDlq(redis: Redis, stream: string, serializedEnvelope: string): Promise<void> {
+  await redis.xadd(`${stream}:dlq`, "MAXLEN", "~", maxStreamLength, "*", "envelope", serializedEnvelope);
+}

--- a/services/account/src/adapters/messaging/publisher.ts
+++ b/services/account/src/adapters/messaging/publisher.ts
@@ -1,0 +1,38 @@
+import { Redis } from "ioredis";
+
+import type { EventEnvelope, EventPublisher } from "../../ports.js";
+import { accountStream, maxStreamLength } from "./stream-config.js";
+
+export class PublishFailed extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "PublishFailed";
+  }
+}
+
+export class RedisStreamEventPublisher implements EventPublisher {
+  constructor(private readonly redis: Redis = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379")) {}
+
+  async publish(envelope: EventEnvelope): Promise<void> {
+    const serialized = JSON.stringify(envelope);
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      try {
+        await this.redis.xadd(accountStream, "MAXLEN", "~", maxStreamLength, "*", "envelope", serialized);
+        return;
+      } catch (error) {
+        if (attempt === 3) {
+          throw new PublishFailed("Failed to publish account event", { cause: error });
+        }
+        await delay(25 * 2 ** (attempt - 1));
+      }
+    }
+  }
+
+  async close(): Promise<void> {
+    this.redis.disconnect();
+  }
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/services/account/src/adapters/messaging/stream-config.ts
+++ b/services/account/src/adapters/messaging/stream-config.ts
@@ -1,0 +1,11 @@
+export const accountStream = "events:account";
+export const accountConsumerGroup = "account";
+export const maxStreamLength = 100_000;
+export const maxDeliveryAttempts = 5;
+export const recoveryMinIdleMs = 60_000;
+export const pollBlockMs = 2_000;
+export const pollCount = 10;
+
+export function accountConsumerName(instanceId = process.env.HOSTNAME ?? process.pid.toString()): string {
+  return `account-${instanceId}`;
+}

--- a/services/account/src/adapters/messaging/stream-config.ts
+++ b/services/account/src/adapters/messaging/stream-config.ts
@@ -1,4 +1,5 @@
-export const accountStream = "events:account";
+export const ACCOUNT_STREAM = "events:account";
+export const accountStream = ACCOUNT_STREAM;
 export const accountConsumerGroup = "account";
 export const maxStreamLength = 100_000;
 export const maxDeliveryAttempts = 5;

--- a/services/account/src/adapters/messaging/subscriber.ts
+++ b/services/account/src/adapters/messaging/subscriber.ts
@@ -1,4 +1,5 @@
 import { Redis } from "ioredis";
+import { setTimeout as delay } from "node:timers/promises";
 
 import type { EventEnvelope, EventSubscriber, HandlerResult } from "../../ports.js";
 import { moveToDlq } from "./dlq-handler.js";
@@ -78,20 +79,25 @@ export class RedisStreamEventSubscriber implements EventSubscriber {
     handler: (envelope: EventEnvelope) => Promise<HandlerResult> | HandlerResult,
   ): Promise<void> {
     while (!this.closed) {
-      const response = await this.redis.call(
-        "XREADGROUP",
-        "GROUP",
-        group,
-        consumerName,
-        "BLOCK",
-        pollBlockMs,
-        "COUNT",
-        pollCount,
-        "STREAMS",
-        ...streams,
-        ...streams.map(() => ">"),
-      ) as StreamRead;
-      await this.processRead(response, group, handler);
+      try {
+        const response = await this.redis.call(
+          "XREADGROUP",
+          "GROUP",
+          group,
+          consumerName,
+          "BLOCK",
+          pollBlockMs,
+          "COUNT",
+          pollCount,
+          "STREAMS",
+          ...streams,
+          ...streams.map(() => ">"),
+        ) as StreamRead;
+        await this.processRead(response, group, handler);
+      } catch (error) {
+        this.reportLoopError(error);
+        await delay(10);
+      }
     }
   }
 
@@ -101,23 +107,37 @@ export class RedisStreamEventSubscriber implements EventSubscriber {
     consumerName: string,
     handler: (envelope: EventEnvelope) => Promise<HandlerResult> | HandlerResult,
   ): Promise<void> {
-    for (const stream of streams) {
-      const claimed = await this.redis.xautoclaim(stream, group, consumerName, recoveryMinIdleMs, "0", "COUNT", 100) as AutoClaimResult;
-      for (const entry of claimed[1] ?? []) {
-        const attempts = await this.deliveryAttempts(stream, group, entry[0]);
-        if (attempts >= maxDeliveryAttempts) {
-          await this.deadLetterAndAck(stream, group, entry);
-        } else {
-          await this.processEntry(stream, group, entry, handler);
+    try {
+      for (const stream of streams) {
+        const claimed = await this.redis.xautoclaim(stream, group, consumerName, recoveryMinIdleMs, "0", "COUNT", 100) as AutoClaimResult;
+        for (const entry of claimed[1] ?? []) {
+          try {
+            const attempts = await this.deliveryAttempts(stream, group, entry[0]);
+            if (attempts >= maxDeliveryAttempts) {
+            await this.deadLetterAndAck(stream, group, entry);
+            } else {
+              await this.processEntry(stream, group, entry, handler);
+            }
+          } catch (error) {
+            this.reportLoopError(error);
+            await this.deadLetterAndAck(stream, group, entry);
+          }
         }
       }
+    } catch (error) {
+      this.reportLoopError(error);
     }
   }
 
   private async processRead(response: StreamRead, group: string, handler: (envelope: EventEnvelope) => Promise<HandlerResult> | HandlerResult): Promise<void> {
     for (const [stream, entries] of response ?? []) {
       for (const entry of entries) {
-        await this.processEntry(stream, group, entry, handler);
+        try {
+          await this.processEntry(stream, group, entry, handler);
+        } catch (error) {
+          this.reportLoopError(error);
+          await this.deadLetterAndAck(stream, group, entry);
+        }
       }
     }
   }
@@ -133,7 +153,7 @@ export class RedisStreamEventSubscriber implements EventSubscriber {
     try {
       envelope = JSON.parse(serializedEnvelope) as EventEnvelope;
     } catch {
-      await this.deadLetterAndAck(stream, group, entry);
+            await this.deadLetterAndAck(stream, group, entry);
       return;
     }
 
@@ -150,7 +170,7 @@ export class RedisStreamEventSubscriber implements EventSubscriber {
     }
 
     if (result.errorType === "fatal") {
-      await this.deadLetterAndAck(stream, group, entry);
+            await this.deadLetterAndAck(stream, group, entry);
     }
   }
 
@@ -158,6 +178,12 @@ export class RedisStreamEventSubscriber implements EventSubscriber {
     const serializedEnvelope = field(entry[1], "envelope") ?? "{}";
     await moveToDlq(this.redis, stream, serializedEnvelope);
     await this.redis.xack(stream, group, entry[0]);
+  }
+
+  private reportLoopError(error: unknown): void {
+    if (!this.closed) {
+      console.error("Account event subscriber poll iteration failed", error);
+    }
   }
 
   private async deliveryAttempts(stream: string, group: string, entryId: string): Promise<number> {

--- a/services/account/src/adapters/messaging/subscriber.ts
+++ b/services/account/src/adapters/messaging/subscriber.ts
@@ -1,0 +1,178 @@
+import { Redis } from "ioredis";
+
+import type { EventEnvelope, EventSubscriber, HandlerResult } from "../../ports.js";
+import { moveToDlq } from "./dlq-handler.js";
+import {
+  accountConsumerGroup,
+  accountConsumerName,
+  accountStream,
+  maxDeliveryAttempts,
+  pollBlockMs,
+  pollCount,
+  recoveryMinIdleMs,
+} from "./stream-config.js";
+
+type StreamEntry = [string, string[]];
+type StreamRead = Array<[string, StreamEntry[]]> | null;
+type AutoClaimResult = [string, StreamEntry[], unknown?];
+
+export class SubscribeFailed extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "SubscribeFailed";
+  }
+}
+
+export class RedisStreamEventSubscriber implements EventSubscriber {
+  private closed = false;
+  private readonly consumedEventIds = new Set<string>();
+  private recoveryTimer?: NodeJS.Timeout;
+
+  constructor(
+    private readonly redis: Redis = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379"),
+  ) {}
+
+  async subscribe(
+    streams: readonly string[] = [accountStream],
+    group = accountConsumerGroup,
+    consumerName = accountConsumerName(),
+    handler: (envelope: EventEnvelope) => Promise<HandlerResult> | HandlerResult,
+  ): Promise<void> {
+    try {
+      await this.ensureGroups(streams, group);
+    } catch (error) {
+      throw new SubscribeFailed("Failed to start account event subscriber", { cause: error });
+    }
+
+    this.recoveryTimer = setInterval(() => {
+      void this.recover(streams, group, consumerName, handler);
+    }, recoveryMinIdleMs);
+
+    void this.poll(streams, group, consumerName, handler);
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    if (this.recoveryTimer) {
+      clearInterval(this.recoveryTimer);
+    }
+    this.redis.disconnect();
+  }
+
+  private async ensureGroups(streams: readonly string[], group: string): Promise<void> {
+    for (const stream of streams) {
+      try {
+        await this.redis.xgroup("CREATE", stream, group, "$", "MKSTREAM");
+      } catch (error) {
+        if (!String(error).includes("BUSYGROUP")) {
+          throw error;
+        }
+      }
+    }
+  }
+
+  private async poll(
+    streams: readonly string[],
+    group: string,
+    consumerName: string,
+    handler: (envelope: EventEnvelope) => Promise<HandlerResult> | HandlerResult,
+  ): Promise<void> {
+    while (!this.closed) {
+      const response = await this.redis.call(
+        "XREADGROUP",
+        "GROUP",
+        group,
+        consumerName,
+        "BLOCK",
+        pollBlockMs,
+        "COUNT",
+        pollCount,
+        "STREAMS",
+        ...streams,
+        ...streams.map(() => ">"),
+      ) as StreamRead;
+      await this.processRead(response, group, handler);
+    }
+  }
+
+  private async recover(
+    streams: readonly string[],
+    group: string,
+    consumerName: string,
+    handler: (envelope: EventEnvelope) => Promise<HandlerResult> | HandlerResult,
+  ): Promise<void> {
+    for (const stream of streams) {
+      const claimed = await this.redis.xautoclaim(stream, group, consumerName, recoveryMinIdleMs, "0", "COUNT", 100) as AutoClaimResult;
+      for (const entry of claimed[1] ?? []) {
+        const attempts = await this.deliveryAttempts(stream, group, entry[0]);
+        if (attempts >= maxDeliveryAttempts) {
+          await this.deadLetterAndAck(stream, group, entry);
+        } else {
+          await this.processEntry(stream, group, entry, handler);
+        }
+      }
+    }
+  }
+
+  private async processRead(response: StreamRead, group: string, handler: (envelope: EventEnvelope) => Promise<HandlerResult> | HandlerResult): Promise<void> {
+    for (const [stream, entries] of response ?? []) {
+      for (const entry of entries) {
+        await this.processEntry(stream, group, entry, handler);
+      }
+    }
+  }
+
+  private async processEntry(stream: string, group: string, entry: StreamEntry, handler: (envelope: EventEnvelope) => Promise<HandlerResult> | HandlerResult): Promise<void> {
+    const serializedEnvelope = field(entry[1], "envelope");
+    if (!serializedEnvelope) {
+      await this.redis.xack(stream, group, entry[0]);
+      return;
+    }
+
+    let envelope: EventEnvelope;
+    try {
+      envelope = JSON.parse(serializedEnvelope) as EventEnvelope;
+    } catch {
+      await this.deadLetterAndAck(stream, group, entry);
+      return;
+    }
+
+    if (this.consumedEventIds.has(envelope.eventId)) {
+      await this.redis.xack(stream, group, entry[0]);
+      return;
+    }
+
+    const result = await handler(envelope);
+    if (result.ok) {
+      this.consumedEventIds.add(envelope.eventId);
+      await this.redis.xack(stream, group, entry[0]);
+      return;
+    }
+
+    if (result.errorType === "fatal") {
+      await this.deadLetterAndAck(stream, group, entry);
+    }
+  }
+
+  private async deadLetterAndAck(stream: string, group: string, entry: StreamEntry): Promise<void> {
+    const serializedEnvelope = field(entry[1], "envelope") ?? "{}";
+    await moveToDlq(this.redis, stream, serializedEnvelope);
+    await this.redis.xack(stream, group, entry[0]);
+  }
+
+  private async deliveryAttempts(stream: string, group: string, entryId: string): Promise<number> {
+    const pending = await this.redis.xpending(stream, group, entryId, entryId, 1) as unknown[];
+    const row = pending[0] as unknown[] | undefined;
+    const attempts = row?.[3];
+    return typeof attempts === "number" ? attempts : 1;
+  }
+}
+
+function field(fields: string[], name: string): string | undefined {
+  for (let index = 0; index < fields.length; index += 2) {
+    if (fields[index] === name) {
+      return fields[index + 1];
+    }
+  }
+  return undefined;
+}

--- a/services/account/src/adapters/messaging/subscriber.ts
+++ b/services/account/src/adapters/messaging/subscriber.ts
@@ -114,7 +114,7 @@ export class RedisStreamEventSubscriber implements EventSubscriber {
           try {
             const attempts = await this.deliveryAttempts(stream, group, entry[0]);
             if (attempts >= maxDeliveryAttempts) {
-            await this.deadLetterAndAck(stream, group, entry);
+              await this.deadLetterAndAck(stream, group, entry);
             } else {
               await this.processEntry(stream, group, entry, handler);
             }
@@ -153,7 +153,7 @@ export class RedisStreamEventSubscriber implements EventSubscriber {
     try {
       envelope = JSON.parse(serializedEnvelope) as EventEnvelope;
     } catch {
-            await this.deadLetterAndAck(stream, group, entry);
+      await this.deadLetterAndAck(stream, group, entry);
       return;
     }
 
@@ -170,7 +170,7 @@ export class RedisStreamEventSubscriber implements EventSubscriber {
     }
 
     if (result.errorType === "fatal") {
-            await this.deadLetterAndAck(stream, group, entry);
+      await this.deadLetterAndAck(stream, group, entry);
     }
   }
 

--- a/services/account/src/app.test.ts
+++ b/services/account/src/app.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { createApp } from "./index.js";
+import { createApp, InMemoryEventPublisher } from "./index.js";
 
 describe("account service operational foundation", () => {
   it("serves health, liveness, readiness, and metadata with request correlation headers", async () => {
@@ -131,12 +131,12 @@ describe("account HTTP API", () => {
 
   it("freezes and unfreezes an account through the domain aggregate", async () => {
     const app = createApp();
-    await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "create-freeze" }, payload: { accountId: "acct_freeze" } });
+    await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c002" }, payload: { accountId: "acct_freeze" } });
 
     const freeze = await app.inject({
       method: "POST",
       url: "/api/v1/accounts/acct_freeze/freeze",
-      headers: { "idempotency-key": "freeze-1" },
+      headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c003" },
       payload: { reason: "risk", operator: "ops", caseRef: "case-1" },
     });
     assert.equal(freeze.statusCode, 200);
@@ -145,7 +145,7 @@ describe("account HTTP API", () => {
     const unfreeze = await app.inject({
       method: "POST",
       url: "/api/v1/accounts/acct_freeze/unfreeze",
-      headers: { "idempotency-key": "unfreeze-1" },
+      headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c004" },
       payload: { reason: "resolved" },
     });
     assert.equal(unfreeze.statusCode, 200);
@@ -154,12 +154,12 @@ describe("account HTTP API", () => {
 
   it("updates preferences and starts account closure", async () => {
     const app = createApp();
-    await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "create-pref" }, payload: { accountId: "acct_pref" } });
+    await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c005" }, payload: { accountId: "acct_pref" } });
 
     const pref = await app.inject({
       method: "PATCH",
       url: "/api/v1/accounts/acct_pref/preferences",
-      headers: { "idempotency-key": "pref-1" },
+      headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c006" },
       payload: { preferenceKey: "language", value: "zh-CN" },
     });
     assert.equal(pref.statusCode, 200);
@@ -168,12 +168,46 @@ describe("account HTTP API", () => {
     const closure = await app.inject({
       method: "POST",
       url: "/api/v1/accounts/acct_pref/start-closure",
-      headers: { "idempotency-key": "closure-1" },
+      headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c007" },
       payload: {},
     });
     assert.equal(closure.statusCode, 200);
     assert.equal(closure.json().status, "CLOSURE_INITIATED");
     assert.ok(closure.json().closureRequestId.startsWith("clr_"));
+  });
+
+
+  it("uses one resolved correlation id for response headers, errors, and published events", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const app = createApp({ publisher });
+
+    const create = await app.inject({
+      method: "POST",
+      url: "/api/v1/accounts",
+      headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c017" },
+      payload: { accountId: "acct_corr_once" },
+    });
+    const correlationId = String(create.headers["x-correlation-id"]);
+    assert.match(correlationId, /^corr-/);
+    assert.equal(publisher.envelopes[0]?.correlationId, correlationId);
+
+    const invalid = await app.inject({
+      method: "POST",
+      url: "/api/v1/accounts/acct_corr_once/freeze",
+      headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c018" },
+      payload: { reason: "risk" },
+    });
+    assert.equal(invalid.headers["x-correlation-id"], invalid.json().correlationId);
+  });
+
+  it("rejects non-UUID-v7 idempotency keys", async () => {
+    const app = createApp();
+
+    const response = await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "not-a-uuid-v7" }, payload: { accountId: "acct_bad_idem" } });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.json().code, "VALIDATION_FAILED");
+    assert.equal(response.json().details.field, "Idempotency-Key");
   });
 
   it("returns validation failure body shape for invalid requests", async () => {
@@ -182,7 +216,7 @@ describe("account HTTP API", () => {
     const response = await app.inject({
       method: "POST",
       url: "/api/v1/accounts/acct_missing/freeze",
-      headers: { "idempotency-key": "freeze-invalid", "x-correlation-id": "corr-validation" },
+      headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c008", "x-correlation-id": "corr-validation" },
       payload: { reason: "risk" },
     });
 
@@ -202,24 +236,24 @@ describe("account HTTP API", () => {
     assert.equal(missing.statusCode, 400);
     assert.equal(missing.json().code, "VALIDATION_FAILED");
 
-    const first = await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "idem-create" }, payload: { accountId: "acct_idem" } });
-    const replay = await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "idem-create" }, payload: { accountId: "acct_idem" } });
+    const first = await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c009" }, payload: { accountId: "acct_idem" } });
+    const replay = await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c009" }, payload: { accountId: "acct_idem" } });
     assert.equal(replay.statusCode, 201);
     assert.deepEqual(replay.json(), first.json());
 
-    const reused = await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "idem-create" }, payload: { accountId: "acct_other" } });
+    const reused = await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c009" }, payload: { accountId: "acct_other" } });
     assert.equal(reused.statusCode, 422);
     assert.equal(reused.json().code, "IDEMPOTENCY_KEY_REUSED");
   });
 
   it("maps unfreeze and start-closure invalid account states to PRECONDITION_FAILED", async () => {
     const app = createApp();
-    await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "create-precondition" }, payload: { accountId: "acct_precondition" } });
+    await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c013" }, payload: { accountId: "acct_precondition" } });
 
     const unfreeze = await app.inject({
       method: "POST",
       url: "/api/v1/accounts/acct_precondition/unfreeze",
-      headers: { "idempotency-key": "unfreeze-precondition" },
+      headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c014" },
       payload: { reason: "not frozen" },
     });
     assert.equal(unfreeze.statusCode, 412);
@@ -229,7 +263,7 @@ describe("account HTTP API", () => {
     const closure = await app.inject({
       method: "POST",
       url: "/api/v1/accounts/acct_precondition/start-closure",
-      headers: { "idempotency-key": "closure-precondition-1" },
+      headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c015" },
       payload: {},
     });
     assert.equal(closure.statusCode, 200);
@@ -237,7 +271,7 @@ describe("account HTTP API", () => {
     const closureAgain = await app.inject({
       method: "POST",
       url: "/api/v1/accounts/acct_precondition/start-closure",
-      headers: { "idempotency-key": "closure-precondition-2" },
+      headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c016" },
       payload: {},
     });
     assert.equal(closureAgain.statusCode, 412);
@@ -247,13 +281,13 @@ describe("account HTTP API", () => {
 
   it("surfaces domain invariant violations as DOMAIN_RULE_VIOLATION", async () => {
     const app = createApp();
-    await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "create-domain" }, payload: { accountId: "acct_domain" } });
-    await app.inject({ method: "POST", url: "/api/v1/accounts/acct_domain/freeze", headers: { "idempotency-key": "freeze-domain-1" }, payload: { reason: "risk", operator: "ops" } });
+    await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c010" }, payload: { accountId: "acct_domain" } });
+    await app.inject({ method: "POST", url: "/api/v1/accounts/acct_domain/freeze", headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c011" }, payload: { reason: "risk", operator: "ops" } });
 
     const response = await app.inject({
       method: "POST",
       url: "/api/v1/accounts/acct_domain/freeze",
-      headers: { "idempotency-key": "freeze-domain-2" },
+      headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c012" },
       payload: { reason: "risk again", operator: "ops" },
     });
 

--- a/services/account/src/app.test.ts
+++ b/services/account/src/app.test.ts
@@ -212,6 +212,39 @@ describe("account HTTP API", () => {
     assert.equal(reused.json().code, "IDEMPOTENCY_KEY_REUSED");
   });
 
+  it("maps unfreeze and start-closure invalid account states to PRECONDITION_FAILED", async () => {
+    const app = createApp();
+    await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "create-precondition" }, payload: { accountId: "acct_precondition" } });
+
+    const unfreeze = await app.inject({
+      method: "POST",
+      url: "/api/v1/accounts/acct_precondition/unfreeze",
+      headers: { "idempotency-key": "unfreeze-precondition" },
+      payload: { reason: "not frozen" },
+    });
+    assert.equal(unfreeze.statusCode, 412);
+    assert.equal(unfreeze.json().code, "PRECONDITION_FAILED");
+    assert.equal(unfreeze.json().details.domainCode, "ACCOUNT_NOT_FROZEN");
+
+    const closure = await app.inject({
+      method: "POST",
+      url: "/api/v1/accounts/acct_precondition/start-closure",
+      headers: { "idempotency-key": "closure-precondition-1" },
+      payload: {},
+    });
+    assert.equal(closure.statusCode, 200);
+
+    const closureAgain = await app.inject({
+      method: "POST",
+      url: "/api/v1/accounts/acct_precondition/start-closure",
+      headers: { "idempotency-key": "closure-precondition-2" },
+      payload: {},
+    });
+    assert.equal(closureAgain.statusCode, 412);
+    assert.equal(closureAgain.json().code, "PRECONDITION_FAILED");
+    assert.equal(closureAgain.json().details.domainCode, "CLOSURE_ALREADY_PENDING");
+  });
+
   it("surfaces domain invariant violations as DOMAIN_RULE_VIOLATION", async () => {
     const app = createApp();
     await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "create-domain" }, payload: { accountId: "acct_domain" } });

--- a/services/account/src/app.test.ts
+++ b/services/account/src/app.test.ts
@@ -44,7 +44,8 @@ describe("account service operational foundation", () => {
     assert.equal(response.statusCode, 200);
     assert.equal(typeof response.headers["x-request-id"], "string");
     assert.notEqual(response.headers["x-request-id"], "");
-    assert.equal(response.headers["x-correlation-id"], response.headers["x-request-id"]);
+    assert.equal(typeof response.headers["x-correlation-id"], "string");
+    assert.match(String(response.headers["x-correlation-id"]), /^corr-/);
   });
 
   it("returns the standard error envelope for missing routes", async () => {
@@ -57,14 +58,10 @@ describe("account service operational foundation", () => {
     });
 
     assert.equal(response.statusCode, 404);
-    assert.deepEqual(response.json(), {
-      error: {
-        code: "NOT_FOUND",
-        message: "Route GET /missing was not found",
-        requestId: "req-account-404",
-        correlationId: "req-account-404",
-      },
-    });
+    assert.equal(response.json().code, "NOT_FOUND");
+    assert.equal(response.json().message, "Route GET /missing was not found");
+    assert.match(response.json().correlationId, /^corr-/);
+    assert.deepEqual(response.json().details, {});
   });
 
   it("exposes a no-op-by-default opt-in tracing seam", async () => {
@@ -107,5 +104,128 @@ describe("account service operational foundation", () => {
     ]);
 
     assert.equal((await createApp().inject("/health")).statusCode, 200);
+  });
+});
+
+
+describe("account HTTP API", () => {
+  it("creates and fetches an account", async () => {
+    const app = createApp();
+
+    const create = await app.inject({
+      method: "POST",
+      url: "/api/v1/accounts",
+      headers: { "idempotency-key": "0194f2e0-7b3e-7610-0284-5c26e8b0c001", "x-correlation-id": "corr-http-create" },
+      payload: { accountId: "acct_http_001" },
+    });
+
+    assert.equal(create.statusCode, 201);
+    assert.equal(create.json().accountId, "acct_http_001");
+    assert.equal(create.json().status, "ACTIVE");
+    assert.equal(typeof create.json().createdAt, "string");
+
+    const get = await app.inject("/api/v1/accounts/acct_http_001");
+    assert.equal(get.statusCode, 200);
+    assert.equal(get.json().accountId, "acct_http_001");
+  });
+
+  it("freezes and unfreezes an account through the domain aggregate", async () => {
+    const app = createApp();
+    await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "create-freeze" }, payload: { accountId: "acct_freeze" } });
+
+    const freeze = await app.inject({
+      method: "POST",
+      url: "/api/v1/accounts/acct_freeze/freeze",
+      headers: { "idempotency-key": "freeze-1" },
+      payload: { reason: "risk", operator: "ops", caseRef: "case-1" },
+    });
+    assert.equal(freeze.statusCode, 200);
+    assert.equal(freeze.json().status, "FROZEN");
+
+    const unfreeze = await app.inject({
+      method: "POST",
+      url: "/api/v1/accounts/acct_freeze/unfreeze",
+      headers: { "idempotency-key": "unfreeze-1" },
+      payload: { reason: "resolved" },
+    });
+    assert.equal(unfreeze.statusCode, 200);
+    assert.equal(unfreeze.json().status, "ACTIVE");
+  });
+
+  it("updates preferences and starts account closure", async () => {
+    const app = createApp();
+    await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "create-pref" }, payload: { accountId: "acct_pref" } });
+
+    const pref = await app.inject({
+      method: "PATCH",
+      url: "/api/v1/accounts/acct_pref/preferences",
+      headers: { "idempotency-key": "pref-1" },
+      payload: { preferenceKey: "language", value: "zh-CN" },
+    });
+    assert.equal(pref.statusCode, 200);
+    assert.deepEqual(pref.json().preferences, { language: "zh-CN" });
+
+    const closure = await app.inject({
+      method: "POST",
+      url: "/api/v1/accounts/acct_pref/start-closure",
+      headers: { "idempotency-key": "closure-1" },
+      payload: {},
+    });
+    assert.equal(closure.statusCode, 200);
+    assert.equal(closure.json().status, "CLOSURE_INITIATED");
+    assert.ok(closure.json().closureRequestId.startsWith("clr_"));
+  });
+
+  it("returns validation failure body shape for invalid requests", async () => {
+    const app = createApp();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/accounts/acct_missing/freeze",
+      headers: { "idempotency-key": "freeze-invalid", "x-correlation-id": "corr-validation" },
+      payload: { reason: "risk" },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(response.json(), {
+      code: "VALIDATION_FAILED",
+      message: "operator is required",
+      correlationId: "corr-validation",
+      details: { field: "operator" },
+    });
+  });
+
+  it("requires idempotency keys, replays original result, and rejects key reuse with a different body", async () => {
+    const app = createApp();
+
+    const missing = await app.inject({ method: "POST", url: "/api/v1/accounts", payload: { accountId: "acct_no_key" } });
+    assert.equal(missing.statusCode, 400);
+    assert.equal(missing.json().code, "VALIDATION_FAILED");
+
+    const first = await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "idem-create" }, payload: { accountId: "acct_idem" } });
+    const replay = await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "idem-create" }, payload: { accountId: "acct_idem" } });
+    assert.equal(replay.statusCode, 201);
+    assert.deepEqual(replay.json(), first.json());
+
+    const reused = await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "idem-create" }, payload: { accountId: "acct_other" } });
+    assert.equal(reused.statusCode, 422);
+    assert.equal(reused.json().code, "IDEMPOTENCY_KEY_REUSED");
+  });
+
+  it("surfaces domain invariant violations as DOMAIN_RULE_VIOLATION", async () => {
+    const app = createApp();
+    await app.inject({ method: "POST", url: "/api/v1/accounts", headers: { "idempotency-key": "create-domain" }, payload: { accountId: "acct_domain" } });
+    await app.inject({ method: "POST", url: "/api/v1/accounts/acct_domain/freeze", headers: { "idempotency-key": "freeze-domain-1" }, payload: { reason: "risk", operator: "ops" } });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/accounts/acct_domain/freeze",
+      headers: { "idempotency-key": "freeze-domain-2" },
+      payload: { reason: "risk again", operator: "ops" },
+    });
+
+    assert.equal(response.statusCode, 422);
+    assert.equal(response.json().code, "DOMAIN_RULE_VIOLATION");
+    assert.equal(response.json().details.domainCode, "ACCOUNT_NOT_ACTIVE");
   });
 });

--- a/services/account/src/app.ts
+++ b/services/account/src/app.ts
@@ -2,6 +2,19 @@ import { randomUUID } from "node:crypto";
 
 import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from "fastify";
 
+import {
+  AccountApplicationService,
+  ApplicationError,
+  InMemoryAccountRepository,
+  InMemoryEventPublisher,
+  InMemoryIdempotencyStore,
+  commandId,
+  fingerprintRequest,
+  mapError,
+  type AccountRepository,
+  type IdempotencyRecord,
+} from "./application.js";
+import { type EventPublisher } from "./ports.js";
 import { serviceProfile } from "./profile.js";
 
 export type HealthStatus = Readonly<{
@@ -23,12 +36,10 @@ export type ServiceMetadata = Readonly<{
 }>;
 
 export type ErrorEnvelope = Readonly<{
-  error: Readonly<{
-    code: string;
-    message: string;
-    requestId: string;
-    correlationId: string;
-  }>;
+  code: string;
+  message: string;
+  correlationId: string;
+  details: Record<string, unknown>;
 }>;
 
 export type RequestContext = Readonly<{
@@ -54,6 +65,13 @@ export type TraceSpan = Readonly<{
 export type InstrumentationHooks = Readonly<{
   onRequest?: (context: RequestContext) => void | Promise<void>;
   startSpan?: (context: RequestTraceContext) => void | TraceSpan | Promise<void | TraceSpan>;
+}>;
+
+export type AppOptions = Readonly<{
+  instrumentation?: InstrumentationHooks;
+  repository?: AccountRepository;
+  publisher?: EventPublisher;
+  idempotencyStore?: InMemoryIdempotencyStore;
 }>;
 
 type OTelSpan = Readonly<{
@@ -110,7 +128,13 @@ export function metadata(): ServiceMetadata {
   };
 }
 
-export function createApp(instrumentation: InstrumentationHooks = {}): FastifyInstance {
+export function createApp(options: AppOptions | InstrumentationHooks = {}): FastifyInstance {
+  const appOptions = normalizeOptions(options);
+  const instrumentation = appOptions.instrumentation ?? {};
+  const repository = appOptions.repository ?? new InMemoryAccountRepository();
+  const publisher = appOptions.publisher ?? new InMemoryEventPublisher();
+  const idempotencyStore = appOptions.idempotencyStore ?? new InMemoryIdempotencyStore();
+  const accountService = new AccountApplicationService(repository, publisher);
   const app: FastifyInstance = Fastify({ logger: false });
   const spans = new WeakMap<FastifyRequest, TraceSpan>();
 
@@ -133,6 +157,7 @@ export function createApp(instrumentation: InstrumentationHooks = {}): FastifyIn
   });
 
   app.get("/health", async () => healthBody());
+  app.get("/healthz", async () => probeBody("live"));
   app.get("/metadata", async () => metadata());
 
   app.get("/live", async () => probeBody("live"));
@@ -140,15 +165,106 @@ export function createApp(instrumentation: InstrumentationHooks = {}): FastifyIn
   app.get("/ready", async () => probeBody("ready"));
   app.get("/readyz", async () => probeBody("ready"));
 
+  app.post("/api/v1/accounts", async (request, reply) => {
+    await withIdempotency(request, reply, idempotencyStore, 201, async (context, causationId) => {
+      const body = objectBody(request.body);
+      assertOptionalString(body.accountId, "accountId");
+      return accountService.createAccount({ accountId: body.accountId as string | undefined, correlationId: context.correlationId, causationId });
+    });
+  });
+
+  app.get("/api/v1/accounts/:accountId", async (request, reply) => {
+    try {
+      return await accountService.getAccount(accountIdParam(request));
+    } catch (error) {
+      sendApplicationError(reply, mapError(error), requestContext(request));
+    }
+  });
+
+  app.post("/api/v1/accounts/:accountId/freeze", async (request, reply) => {
+    await withIdempotency(request, reply, idempotencyStore, 200, async (context, causationId) => {
+      const body = objectBody(request.body);
+      const reason = requiredString(body.reason, "reason");
+      const operator = requiredString(body.operator, "operator");
+      assertOptionalString(body.caseRef, "caseRef");
+      return accountService.freezeAccount({ accountId: accountIdParam(request), reason, operator, caseRef: body.caseRef as string | undefined, correlationId: context.correlationId, causationId });
+    });
+  });
+
+  app.post("/api/v1/accounts/:accountId/unfreeze", async (request, reply) => {
+    await withIdempotency(request, reply, idempotencyStore, 200, async (context, causationId) => {
+      const body = objectBody(request.body);
+      const reason = requiredString(body.reason, "reason");
+      return accountService.unfreezeAccount({ accountId: accountIdParam(request), reason, correlationId: context.correlationId, causationId });
+    });
+  });
+
+  app.patch("/api/v1/accounts/:accountId/preferences", async (request, reply) => {
+    await withIdempotency(request, reply, idempotencyStore, 200, async (context, causationId) => {
+      const body = objectBody(request.body);
+      const preferenceKey = requiredString(body.preferenceKey, "preferenceKey");
+      const value = requiredString(body.value, "value");
+      return accountService.updatePreference({ accountId: accountIdParam(request), preferenceKey, value, correlationId: context.correlationId, causationId });
+    });
+  });
+
+  app.post("/api/v1/accounts/:accountId/start-closure", async (request, reply) => {
+    await withIdempotency(request, reply, idempotencyStore, 200, async (context, causationId) =>
+      accountService.startClosure({ accountId: accountIdParam(request), correlationId: context.correlationId, causationId }),
+    );
+  });
+
   app.setNotFoundHandler((request, reply) => {
     sendError(reply, 404, "NOT_FOUND", `Route ${request.method} ${request.url} was not found`, requestContext(request));
   });
 
   app.setErrorHandler((error, request, reply) => {
-    sendError(reply, 500, "INTERNAL_ERROR", errorMessage(error), requestContext(request));
+    sendApplicationError(reply, mapError(error), requestContext(request));
   });
 
   return app;
+}
+
+async function withIdempotency(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  store: InMemoryIdempotencyStore,
+  successStatus: number,
+  handler: (context: RequestContext, causationId: string) => Promise<unknown>,
+): Promise<void> {
+  const context = requestContext(request);
+  const key = headerValue(request.headers["idempotency-key"]);
+  if (!key) {
+    sendError(reply, 400, "VALIDATION_FAILED", "Idempotency-Key header is required", context, { field: "Idempotency-Key" });
+    return;
+  }
+
+  const fingerprint = fingerprintRequest(request.method, request.url.split("?")[0] ?? request.url, request.body ?? {});
+  const existing = store.get(key);
+  if (existing) {
+    if (existing.fingerprint !== fingerprint) {
+      sendError(reply, 422, "IDEMPOTENCY_KEY_REUSED", "Idempotency-Key was reused with a different request", context);
+      return;
+    }
+    reply.status(existing.statusCode).send(existing.body);
+    return;
+  }
+
+  try {
+    const body = await handler(context, commandId());
+    const record: IdempotencyRecord = { fingerprint, statusCode: successStatus, body };
+    store.set(key, record);
+    reply.status(successStatus).send(body);
+  } catch (error) {
+    sendApplicationError(reply, mapError(error), context);
+  }
+}
+
+function normalizeOptions(options: AppOptions | InstrumentationHooks): AppOptions {
+  if ("repository" in options || "publisher" in options || "idempotencyStore" in options || "instrumentation" in options) {
+    return options as AppOptions;
+  }
+  return { instrumentation: options as InstrumentationHooks };
 }
 
 function errorMessage(error: unknown): string {
@@ -173,7 +289,7 @@ function traceContext(request: AppRequest, context: RequestContext = requestCont
 
 function requestContext(request: AppRequest): RequestContext {
   const requestId = headerValue(request.headers["x-request-id"]) ?? request.id ?? randomUUID();
-  const correlationId = headerValue(request.headers["x-correlation-id"]) ?? requestId;
+  const correlationId = headerValue(request.headers["x-correlation-id"]) ?? `corr-${randomUUID()}`;
   return { requestId, correlationId };
 }
 
@@ -185,14 +301,40 @@ function headerValue(value: string | string[] | undefined): string | undefined {
   return candidate && candidate.trim().length > 0 ? candidate : undefined;
 }
 
-function sendError(reply: AppReply, statusCode: number, code: string, message: string, context: RequestContext): void {
+function sendApplicationError(reply: AppReply, error: ApplicationError, context: RequestContext): void {
+  sendError(reply, error.statusCode, error.code, errorMessage(error), context, error.details);
+}
+
+function sendError(reply: AppReply, statusCode: number, code: string, message: string, context: RequestContext, details: Record<string, unknown> = {}): void {
   const envelope: ErrorEnvelope = {
-    error: {
-      code,
-      message,
-      requestId: context.requestId,
-      correlationId: context.correlationId,
-    },
+    code,
+    message,
+    correlationId: context.correlationId,
+    details,
   };
   reply.status(statusCode).send(envelope);
+}
+
+function objectBody(body: unknown): Record<string, unknown> {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new ApplicationError("VALIDATION_FAILED", "Request body must be a JSON object", 400);
+  }
+  return body as Record<string, unknown>;
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new ApplicationError("VALIDATION_FAILED", `${field} is required`, 400, { field });
+  }
+  return value;
+}
+
+function assertOptionalString(value: unknown, field: string): void {
+  if (value !== undefined && typeof value !== "string") {
+    throw new ApplicationError("VALIDATION_FAILED", `${field} must be a string`, 400, { field });
+  }
+}
+
+function accountIdParam(request: FastifyRequest): string {
+  return requiredString((request.params as { accountId?: unknown }).accountId, "accountId");
 }

--- a/services/account/src/app.ts
+++ b/services/account/src/app.ts
@@ -12,6 +12,7 @@ import {
   fingerprintRequest,
   mapError,
   type AccountRepository,
+  type DomainErrorMapping,
   type IdempotencyRecord,
 } from "./application.js";
 import { type EventPublisher } from "./ports.js";
@@ -182,7 +183,7 @@ export function createApp(options: AppOptions | InstrumentationHooks = {}): Fast
   });
 
   app.post("/api/v1/accounts/:accountId/freeze", async (request, reply) => {
-    await withIdempotency(request, reply, idempotencyStore, 200, async (context, causationId) => {
+    await withIdempotency(request, reply, idempotencyStore, 200, { preconditionDomainCodes: [] }, async (context, causationId) => {
       const body = objectBody(request.body);
       const reason = requiredString(body.reason, "reason");
       const operator = requiredString(body.operator, "operator");
@@ -192,7 +193,7 @@ export function createApp(options: AppOptions | InstrumentationHooks = {}): Fast
   });
 
   app.post("/api/v1/accounts/:accountId/unfreeze", async (request, reply) => {
-    await withIdempotency(request, reply, idempotencyStore, 200, async (context, causationId) => {
+    await withIdempotency(request, reply, idempotencyStore, 200, { preconditionDomainCodes: "all" }, async (context, causationId) => {
       const body = objectBody(request.body);
       const reason = requiredString(body.reason, "reason");
       return accountService.unfreezeAccount({ accountId: accountIdParam(request), reason, correlationId: context.correlationId, causationId });
@@ -209,7 +210,7 @@ export function createApp(options: AppOptions | InstrumentationHooks = {}): Fast
   });
 
   app.post("/api/v1/accounts/:accountId/start-closure", async (request, reply) => {
-    await withIdempotency(request, reply, idempotencyStore, 200, async (context, causationId) =>
+    await withIdempotency(request, reply, idempotencyStore, 200, { preconditionDomainCodes: "all" }, async (context, causationId) =>
       accountService.startClosure({ accountId: accountIdParam(request), correlationId: context.correlationId, causationId }),
     );
   });
@@ -230,8 +231,14 @@ async function withIdempotency(
   reply: FastifyReply,
   store: InMemoryIdempotencyStore,
   successStatus: number,
-  handler: (context: RequestContext, causationId: string) => Promise<unknown>,
+  mappingOrHandler: DomainErrorMapping | ((context: RequestContext, causationId: string) => Promise<unknown>),
+  maybeHandler?: (context: RequestContext, causationId: string) => Promise<unknown>,
 ): Promise<void> {
+  const mapping = typeof mappingOrHandler === "function" ? {} : mappingOrHandler;
+  const handler = typeof mappingOrHandler === "function" ? mappingOrHandler : maybeHandler;
+  if (!handler) {
+    throw new ApplicationError("UNAVAILABLE", "Idempotent handler was not configured", 503);
+  }
   const context = requestContext(request);
   const key = headerValue(request.headers["idempotency-key"]);
   if (!key) {
@@ -256,7 +263,7 @@ async function withIdempotency(
     store.set(key, record);
     reply.status(successStatus).send(body);
   } catch (error) {
-    sendApplicationError(reply, mapError(error), context);
+    sendApplicationError(reply, mapError(error, mapping), context);
   }
 }
 

--- a/services/account/src/app.ts
+++ b/services/account/src/app.ts
@@ -140,7 +140,8 @@ export function createApp(options: AppOptions | InstrumentationHooks = {}): Fast
   const spans = new WeakMap<FastifyRequest, TraceSpan>();
 
   app.addHook("onRequest", async (request, reply) => {
-    const context = requestContext(request);
+    const context = resolveRequestContext(request);
+    request.ctx = context;
     reply.header("x-request-id", context.requestId);
     reply.header("x-correlation-id", context.correlationId);
     await instrumentation.onRequest?.(context);
@@ -245,6 +246,10 @@ async function withIdempotency(
     sendError(reply, 400, "VALIDATION_FAILED", "Idempotency-Key header is required", context, { field: "Idempotency-Key" });
     return;
   }
+  if (!isUuidV7(key)) {
+    sendError(reply, 400, "VALIDATION_FAILED", "Idempotency-Key must be a UUID v7", context, { field: "Idempotency-Key" });
+    return;
+  }
 
   const fingerprint = fingerprintRequest(request.method, request.url.split("?")[0] ?? request.url, request.body ?? {});
   const existing = store.get(key);
@@ -295,12 +300,21 @@ function traceContext(request: AppRequest, context: RequestContext = requestCont
 }
 
 function requestContext(request: AppRequest): RequestContext {
+  if (request.ctx) {
+    return request.ctx;
+  }
+  const context = resolveRequestContext(request);
+  request.ctx = context;
+  return context;
+}
+
+function resolveRequestContext(request: AppRequest): RequestContext {
   const requestId = headerValue(request.headers["x-request-id"]) ?? request.id ?? randomUUID();
   const correlationId = headerValue(request.headers["x-correlation-id"]) ?? `corr-${randomUUID()}`;
   return { requestId, correlationId };
 }
 
-type AppRequest = FastifyRequest;
+type AppRequest = FastifyRequest & { ctx?: RequestContext };
 type AppReply = FastifyReply;
 
 function headerValue(value: string | string[] | undefined): string | undefined {
@@ -344,4 +358,17 @@ function assertOptionalString(value: unknown, field: string): void {
 
 function accountIdParam(request: FastifyRequest): string {
   return requiredString((request.params as { accountId?: unknown }).accountId, "accountId");
+}
+
+function isUuidV7(value: string): boolean {
+  const parsed = parseUuid(value);
+  return parsed?.version === 7;
+}
+
+function parseUuid(value: string): { version: number } | undefined {
+  const match = /^(?<timeLow>[0-9a-f]{8})-(?<timeMid>[0-9a-f]{4})-(?<version>[0-9a-f])(?<timeHigh>[0-9a-f]{3})-(?<variant>[0-9a-f]{4})-(?<node>[0-9a-f]{12})$/iu.exec(value);
+  if (!match?.groups) {
+    return undefined;
+  }
+  return { version: Number.parseInt(match.groups.version, 16) };
 }

--- a/services/account/src/application.ts
+++ b/services/account/src/application.ts
@@ -1,0 +1,268 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import {
+  AccountClosureSaga,
+  DomainError,
+  Preference,
+  UserAccount,
+  type AccountDomainEvent,
+  type AccountId,
+  type PreferenceSnapshot,
+  type UserAccountSnapshot,
+} from "./domain.js";
+import { toEventEnvelope, type EventEnvelope, type EventPublisher } from "./ports.js";
+
+export type AccountStatusDto = "ACTIVE" | "FROZEN" | "CLOSURE_PENDING" | "CLOSED";
+
+export type AccountDetailsDto = Readonly<{
+  accountId: string;
+  status: AccountStatusDto;
+  createdAt: string;
+  frozenAt?: string;
+  frozenReason?: string;
+  frozenOperator?: string;
+  frozenCaseRef?: string;
+  closureRequestId?: string;
+  closureStartedAt?: string;
+  closedAt?: string;
+  preferences: Record<string, string>;
+}>;
+
+export type AccountRepository = Readonly<{
+  findAccount(accountId: AccountId): Promise<UserAccount | undefined>;
+  saveAccount(account: UserAccount): Promise<void>;
+  findPreference(accountId: AccountId, key: string): Promise<PreferenceSnapshot | undefined>;
+  savePreference(preference: Preference): Promise<void>;
+  preferencesFor(accountId: AccountId): Promise<PreferenceSnapshot[]>;
+}>;
+
+export class InMemoryAccountRepository implements AccountRepository {
+  private readonly accounts = new Map<AccountId, UserAccount>();
+  private readonly preferences = new Map<string, PreferenceSnapshot>();
+
+  async findAccount(accountId: AccountId): Promise<UserAccount | undefined> {
+    return this.accounts.get(accountId);
+  }
+
+  async saveAccount(account: UserAccount): Promise<void> {
+    this.accounts.set(account.id, account);
+  }
+
+  async findPreference(accountId: AccountId, key: string): Promise<PreferenceSnapshot | undefined> {
+    return this.preferences.get(preferenceStorageKey(accountId, key));
+  }
+
+  async savePreference(preference: Preference): Promise<void> {
+    const snapshot = preference.toSnapshot();
+    this.preferences.set(preferenceStorageKey(snapshot.accountId, snapshot.key), snapshot);
+  }
+
+  async preferencesFor(accountId: AccountId): Promise<PreferenceSnapshot[]> {
+    return [...this.preferences.values()].filter((preference) => preference.accountId === accountId);
+  }
+}
+
+export class InMemoryEventPublisher implements EventPublisher {
+  readonly envelopes: EventEnvelope[] = [];
+
+  async publish(envelope: EventEnvelope): Promise<void> {
+    this.envelopes.push(envelope);
+  }
+}
+
+export class AccountApplicationService {
+  constructor(
+    private readonly repository: AccountRepository,
+    private readonly publisher: EventPublisher,
+  ) {}
+
+  async createAccount(command: { accountId?: string; correlationId: string; causationId?: string }): Promise<AccountDetailsDto> {
+    const { account, event } = UserAccount.create({ accountId: command.accountId, correlationId: command.correlationId });
+    if (await this.repository.findAccount(account.id)) {
+      throw new ApplicationError("CONFLICT", `Account ${account.id} already exists`, 409);
+    }
+    await this.repository.saveAccount(account);
+    await this.publish(event, command);
+    return this.details(account);
+  }
+
+  async getAccount(accountId: string): Promise<AccountDetailsDto> {
+    return this.details(await this.requireAccount(accountId));
+  }
+
+  async freezeAccount(command: {
+    accountId: string;
+    reason: string;
+    operator: string;
+    caseRef?: string;
+    correlationId: string;
+    causationId?: string;
+  }): Promise<Readonly<{ accountId: string; status: "FROZEN"; frozenAt: string }>> {
+    const account = await this.requireAccount(command.accountId);
+    const { account: frozen, event } = account.freeze(command);
+    await this.repository.saveAccount(frozen);
+    await this.publish(event, command);
+    const snapshot = frozen.toSnapshot();
+    return { accountId: frozen.id, status: "FROZEN", frozenAt: requiredDate(snapshot.frozenAt).toISOString() };
+  }
+
+  async unfreezeAccount(command: {
+    accountId: string;
+    reason: string;
+    correlationId: string;
+    causationId?: string;
+  }): Promise<Readonly<{ accountId: string; status: "ACTIVE" }>> {
+    const account = await this.requireAccount(command.accountId);
+    const { account: active, event } = account.unfreeze(command);
+    await this.repository.saveAccount(active);
+    await this.publish(event, command);
+    return { accountId: active.id, status: "ACTIVE" };
+  }
+
+  async updatePreference(command: {
+    accountId: string;
+    preferenceKey: string;
+    value: string;
+    correlationId: string;
+    causationId?: string;
+  }): Promise<AccountDetailsDto> {
+    const account = await this.requireAccount(command.accountId);
+    const existing = await this.repository.findPreference(command.accountId, command.preferenceKey);
+    const { preference, event } = Preference.update(command, existing);
+    await this.repository.savePreference(preference);
+    await this.publish(event, command);
+    return this.details(account);
+  }
+
+  async startClosure(command: {
+    accountId: string;
+    correlationId: string;
+    causationId?: string;
+  }): Promise<Readonly<{ accountId: string; closureRequestId: string; status: "CLOSURE_INITIATED" }>> {
+    const account = await this.requireAccount(command.accountId);
+    const { account: pending, event } = account.startClosure(command);
+    AccountClosureSaga.start({ accountId: pending.id, closureRequestId: event.closureRequestId, correlationId: command.correlationId });
+    await this.repository.saveAccount(pending);
+    await this.publish(event, command);
+    return { accountId: pending.id, closureRequestId: event.closureRequestId, status: "CLOSURE_INITIATED" };
+  }
+
+  private async requireAccount(accountId: string): Promise<UserAccount> {
+    const account = await this.repository.findAccount(accountId);
+    if (!account) {
+      throw new ApplicationError("NOT_FOUND", `Account ${accountId} was not found`, 404);
+    }
+    return account;
+  }
+
+  private async details(account: UserAccount): Promise<AccountDetailsDto> {
+    const snapshot = account.toSnapshot();
+    const preferences = Object.fromEntries((await this.repository.preferencesFor(account.id)).map((preference) => [preference.key, preference.value]));
+    return accountDetails(snapshot, preferences);
+  }
+
+  private async publish(event: AccountDomainEvent, command: { correlationId: string; causationId?: string }): Promise<void> {
+    await this.publisher.publish(toEventEnvelope(event, command.correlationId, command.causationId));
+  }
+}
+
+export class ApplicationError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly statusCode: number,
+    public readonly details: Record<string, unknown> = {},
+  ) {
+    super(message);
+    this.name = "ApplicationError";
+  }
+}
+
+export type IdempotencyRecord = Readonly<{
+  fingerprint: string;
+  statusCode: number;
+  body: unknown;
+}>;
+
+export class InMemoryIdempotencyStore {
+  private readonly records = new Map<string, IdempotencyRecord>();
+
+  get(key: string): IdempotencyRecord | undefined {
+    return this.records.get(key);
+  }
+
+  set(key: string, record: IdempotencyRecord): void {
+    this.records.set(key, record);
+  }
+}
+
+export function fingerprintRequest(method: string, path: string, body: unknown): string {
+  return createHash("sha256").update(JSON.stringify({ method, path, body: normalizeJson(body) })).digest("hex");
+}
+
+export function mapError(error: unknown): ApplicationError {
+  if (error instanceof ApplicationError) {
+    return error;
+  }
+  if (error instanceof DomainError) {
+    if (error.code === "MISSING_REQUIRED_FIELD") {
+      return new ApplicationError("VALIDATION_FAILED", error.message, 400, { domainCode: error.code });
+    }
+    return new ApplicationError("DOMAIN_RULE_VIOLATION", error.message, 422, { domainCode: error.code });
+  }
+  return new ApplicationError("UNAVAILABLE", "The account service is temporarily unavailable", 503);
+}
+
+function accountDetails(snapshot: UserAccountSnapshot, preferences: Record<string, string>): AccountDetailsDto {
+  return {
+    accountId: snapshot.accountId,
+    status: accountStatusDto(snapshot.status),
+    createdAt: snapshot.createdAt.toISOString(),
+    frozenAt: snapshot.frozenAt?.toISOString(),
+    frozenReason: snapshot.frozenReason,
+    frozenOperator: snapshot.frozenOperator,
+    frozenCaseRef: snapshot.frozenCaseRef,
+    closureRequestId: snapshot.closureRequestId,
+    closureStartedAt: snapshot.closureStartedAt?.toISOString(),
+    closedAt: snapshot.closedAt?.toISOString(),
+    preferences,
+  };
+}
+
+function accountStatusDto(status: UserAccountSnapshot["status"]): AccountStatusDto {
+  switch (status) {
+    case "Active":
+      return "ACTIVE";
+    case "Frozen":
+      return "FROZEN";
+    case "ClosurePending":
+      return "CLOSURE_PENDING";
+    case "Closed":
+      return "CLOSED";
+  }
+}
+
+function preferenceStorageKey(accountId: string, key: string): string {
+  return `${accountId}:${key}`;
+}
+
+function requiredDate(value: Date | undefined): Date {
+  if (!value) {
+    throw new ApplicationError("UNAVAILABLE", "Expected timestamp was not recorded", 503);
+  }
+  return value;
+}
+
+function normalizeJson(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizeJson);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value).sort(([left], [right]) => left.localeCompare(right)).map(([key, nested]) => [key, normalizeJson(nested)]));
+  }
+  return value;
+}
+
+export function commandId(): string {
+  return `cmd-${randomUUID()}`;
+}

--- a/services/account/src/application.ts
+++ b/services/account/src/application.ts
@@ -200,7 +200,11 @@ export function fingerprintRequest(method: string, path: string, body: unknown):
   return createHash("sha256").update(JSON.stringify({ method, path, body: normalizeJson(body) })).digest("hex");
 }
 
-export function mapError(error: unknown): ApplicationError {
+export type DomainErrorMapping = Readonly<{
+  preconditionDomainCodes?: readonly string[] | "all";
+}>;
+
+export function mapError(error: unknown, mapping: DomainErrorMapping = {}): ApplicationError {
   if (error instanceof ApplicationError) {
     return error;
   }
@@ -208,9 +212,16 @@ export function mapError(error: unknown): ApplicationError {
     if (error.code === "MISSING_REQUIRED_FIELD") {
       return new ApplicationError("VALIDATION_FAILED", error.message, 400, { domainCode: error.code });
     }
+    if (isPreconditionFailure(error.code, mapping)) {
+      return new ApplicationError("PRECONDITION_FAILED", error.message, 412, { domainCode: error.code });
+    }
     return new ApplicationError("DOMAIN_RULE_VIOLATION", error.message, 422, { domainCode: error.code });
   }
   return new ApplicationError("UNAVAILABLE", "The account service is temporarily unavailable", 503);
+}
+
+function isPreconditionFailure(domainCode: string, mapping: DomainErrorMapping): boolean {
+  return mapping.preconditionDomainCodes === "all" || mapping.preconditionDomainCodes?.includes(domainCode) === true;
 }
 
 function accountDetails(snapshot: UserAccountSnapshot, preferences: Record<string, string>): AccountDetailsDto {

--- a/services/account/src/bootstrap.ts
+++ b/services/account/src/bootstrap.ts
@@ -1,4 +1,6 @@
 import { createApp, opentelemetryInstrumentationFromEnv, type InstrumentationHooks } from "./app.js";
+import { InMemoryAccountRepository } from "./application.js";
+import { RedisStreamEventPublisher } from "./adapters/messaging/publisher.js";
 
 export type BootstrapOptions = Readonly<{
   host?: string;
@@ -19,7 +21,15 @@ export function runtimePort(options: Pick<BootstrapOptions, "port"> = {}): numbe
 }
 
 export async function bootstrap(options: BootstrapOptions = {}) {
-  const app = createApp(options.instrumentation ?? opentelemetryInstrumentationFromEnv());
+  const publisher = new RedisStreamEventPublisher();
+  const app = createApp({
+    instrumentation: options.instrumentation ?? opentelemetryInstrumentationFromEnv(),
+    repository: new InMemoryAccountRepository(),
+    publisher,
+  });
+  app.addHook("onClose", async () => {
+    await publisher.close();
+  });
   await app.listen({ host: runtimeHost(options), port: runtimePort(options) });
   return app;
 }

--- a/services/account/src/fastify-context.d.ts
+++ b/services/account/src/fastify-context.d.ts
@@ -1,0 +1,7 @@
+import type { RequestContext } from "./app.js";
+
+declare module "fastify" {
+  interface FastifyRequest {
+    ctx?: RequestContext;
+  }
+}

--- a/services/account/src/index.ts
+++ b/services/account/src/index.ts
@@ -3,6 +3,7 @@ export {
   health,
   metadata,
   opentelemetryInstrumentationFromEnv,
+  type AppOptions,
   type ErrorEnvelope,
   type HealthStatus,
   type InstrumentationHooks,
@@ -14,6 +15,8 @@ export {
   type TraceSpan,
 } from "./app.js";
 export { bootstrap, runtimeHost, runtimePort, type BootstrapOptions } from "./bootstrap.js";
+export { InMemoryAccountRepository, InMemoryEventPublisher, InMemoryIdempotencyStore } from "./application.js";
+export type { EventEnvelope, EventPublisher, EventSubscriber, HandlerResult } from "./ports.js";
 export {
   DomainError,
   UserAccount,

--- a/services/account/src/messaging.test.ts
+++ b/services/account/src/messaging.test.ts
@@ -1,8 +1,45 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 
+import { RedisStreamEventSubscriber } from "./adapters/messaging/subscriber.js";
 import { UserAccount } from "./domain.js";
 import { toEventEnvelope, type EventEnvelope, type HandlerResult } from "./ports.js";
+
+class FakeRedisForSubscriber {
+  readonly acked: Array<{ stream: string; group: string; entryId: string }> = [];
+  readonly dlqEnvelopes: string[] = [];
+  private readonly reads: unknown[] = [];
+
+  constructor(reads: unknown[]) {
+    this.reads = [...reads];
+  }
+
+  async xgroup(): Promise<void> {}
+
+  async call(): Promise<unknown> {
+    const next = this.reads.shift();
+    if (next instanceof Error) {
+      throw next;
+    }
+    await delay(1);
+    return next ?? null;
+  }
+
+  async xack(stream: string, group: string, entryId: string): Promise<void> {
+    this.acked.push({ stream, group, entryId });
+  }
+
+  async xadd(stream: string, _maxlen: string, _approximate: string, _length: number, _id: string, _field: string, envelope: string): Promise<void> {
+    this.dlqEnvelopes.push(`${stream}:${envelope}`);
+  }
+
+  async xautoclaim(): Promise<[string, unknown[]]> {
+    return ["0-0", []];
+  }
+
+  disconnect(): void {}
+}
 
 class FakeSubscriber {
   private readonly seen = new Set<string>();
@@ -62,5 +99,44 @@ describe("account event ports", () => {
 
     assert.deepEqual(seen, [envelope.eventId]);
     assert.equal(subscriber.handled, 1);
+  });
+
+  it("continues polling after handler throws and dead-letters the fatal message", async () => {
+    const firstEnvelope = toEventEnvelope(UserAccount.create({ accountId: "acct_throw_1" }).event, "corr-loop", "cmd-loop-1");
+    const secondEnvelope = toEventEnvelope(UserAccount.create({ accountId: "acct_throw_2" }).event, "corr-loop", "cmd-loop-2");
+    const redis = new FakeRedisForSubscriber([
+      [["events:account", [["1-0", ["envelope", JSON.stringify(firstEnvelope)]]]]],
+      [["events:account", [["2-0", ["envelope", JSON.stringify(secondEnvelope)]]]]],
+    ]);
+    const subscriber = new RedisStreamEventSubscriber(redis as never);
+    const handled: string[] = [];
+    const loggedErrors: unknown[] = [];
+    const originalConsoleError = console.error;
+    console.error = (...args: unknown[]) => {
+      loggedErrors.push(args);
+    };
+
+    try {
+      await subscriber.subscribe(["events:account"], "account", "account-test", (envelope) => {
+        handled.push(envelope.eventId);
+        if (envelope.eventId === firstEnvelope.eventId) {
+          throw new Error("handler exploded");
+        }
+        return { ok: true };
+      });
+
+      for (let index = 0; index < 20 && redis.acked.length < 2; index += 1) {
+        await delay(10);
+      }
+    } finally {
+      await subscriber.close();
+      console.error = originalConsoleError;
+    }
+
+    assert.equal(loggedErrors.length, 1);
+    assert.deepEqual(handled, [firstEnvelope.eventId, secondEnvelope.eventId]);
+    assert.deepEqual(redis.acked.map((ack) => ack.entryId), ["1-0", "2-0"]);
+    assert.equal(redis.dlqEnvelopes.length, 1);
+    assert.ok(redis.dlqEnvelopes[0].includes(firstEnvelope.eventId));
   });
 });

--- a/services/account/src/messaging.test.ts
+++ b/services/account/src/messaging.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { UserAccount } from "./domain.js";
+import { toEventEnvelope, type EventEnvelope, type HandlerResult } from "./ports.js";
+
+class FakeSubscriber {
+  private readonly seen = new Set<string>();
+  handled = 0;
+
+  async deliver(envelope: EventEnvelope, handler: (envelope: EventEnvelope) => HandlerResult): Promise<void> {
+    if (this.seen.has(envelope.eventId)) {
+      return;
+    }
+    const result = handler(envelope);
+    if (result.ok) {
+      this.seen.add(envelope.eventId);
+      this.handled += 1;
+    }
+  }
+}
+
+describe("account event ports", () => {
+  it("wraps account domain events in the canonical event envelope", () => {
+    const { event } = UserAccount.create({ accountId: "acct_123", correlationId: "corr-test" });
+
+    const envelope = toEventEnvelope(event, "corr-test", "cmd-test");
+
+    assert.match(envelope.eventId, /^evt-[0-9a-f-]{36}$/);
+    assert.equal(envelope.eventType, "AccountCreated");
+    assert.equal(envelope.schemaVersion, 1);
+    assert.equal(envelope.producer, "account");
+    assert.equal(envelope.causationId, "cmd-test");
+    assert.equal(envelope.correlationId, "corr-test");
+    assert.match(envelope.occurredAt, /^\d{4}-\d{2}-\d{2}T.*Z$/);
+    assert.deepEqual(envelope.payload, { accountId: "acct_123" });
+    assert.deepEqual(Object.keys(envelope), [
+      "eventId",
+      "eventType",
+      "schemaVersion",
+      "producer",
+      "causationId",
+      "correlationId",
+      "occurredAt",
+      "payload",
+    ]);
+  });
+
+  it("deduplicates consumed events by eventId", async () => {
+    const subscriber = new FakeSubscriber();
+    const envelope = toEventEnvelope(UserAccount.create({ accountId: "acct_dup" }).event, "corr-dup", "cmd-dup");
+    const seen: string[] = [];
+
+    await subscriber.deliver(envelope, (message) => {
+      seen.push(message.eventId);
+      return { ok: true };
+    });
+    await subscriber.deliver(envelope, (message) => {
+      seen.push(message.eventId);
+      return { ok: true };
+    });
+
+    assert.deepEqual(seen, [envelope.eventId]);
+    assert.equal(subscriber.handled, 1);
+  });
+});

--- a/services/account/src/messaging.test.ts
+++ b/services/account/src/messaging.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { setTimeout as delay } from "node:timers/promises";
 
+import { ACCOUNT_STREAM } from "./adapters/messaging/stream-config.js";
 import { RedisStreamEventSubscriber } from "./adapters/messaging/subscriber.js";
 import { UserAccount } from "./domain.js";
 import { toEventEnvelope, type EventEnvelope, type HandlerResult } from "./ports.js";
@@ -105,8 +106,8 @@ describe("account event ports", () => {
     const firstEnvelope = toEventEnvelope(UserAccount.create({ accountId: "acct_throw_1" }).event, "corr-loop", "cmd-loop-1");
     const secondEnvelope = toEventEnvelope(UserAccount.create({ accountId: "acct_throw_2" }).event, "corr-loop", "cmd-loop-2");
     const redis = new FakeRedisForSubscriber([
-      [["events:account", [["1-0", ["envelope", JSON.stringify(firstEnvelope)]]]]],
-      [["events:account", [["2-0", ["envelope", JSON.stringify(secondEnvelope)]]]]],
+      [[ACCOUNT_STREAM, [["1-0", ["envelope", JSON.stringify(firstEnvelope)]]]]],
+      [[ACCOUNT_STREAM, [["2-0", ["envelope", JSON.stringify(secondEnvelope)]]]]],
     ]);
     const subscriber = new RedisStreamEventSubscriber(redis as never);
     const handled: string[] = [];
@@ -117,7 +118,7 @@ describe("account event ports", () => {
     };
 
     try {
-      await subscriber.subscribe(["events:account"], "account", "account-test", (envelope) => {
+      await subscriber.subscribe([ACCOUNT_STREAM], "account", "account-test", (envelope) => {
         handled.push(envelope.eventId);
         if (envelope.eventId === firstEnvelope.eventId) {
           throw new Error("handler exploded");

--- a/services/account/src/ports.ts
+++ b/services/account/src/ports.ts
@@ -1,0 +1,68 @@
+import { randomUUID } from "node:crypto";
+
+import type { AccountDomainEvent } from "./domain.js";
+
+export type EventEnvelope = Readonly<{
+  eventId: string;
+  eventType: string;
+  schemaVersion: 1;
+  producer: "account";
+  causationId: string;
+  correlationId: string;
+  occurredAt: string;
+  payload: Record<string, unknown>;
+}>;
+
+export type HandlerResult = Readonly<{ ok: true }> | Readonly<{ ok: false; errorType: "transient" | "fatal"; error?: Error }>;
+
+export interface EventPublisher {
+  publish(envelope: EventEnvelope): Promise<void>;
+}
+
+export interface EventSubscriber {
+  subscribe(
+    streams: readonly string[],
+    group: string,
+    consumerName: string,
+    handler: (envelope: EventEnvelope) => Promise<HandlerResult> | HandlerResult,
+  ): Promise<void>;
+  close(): Promise<void>;
+}
+
+export function toEventEnvelope(event: AccountDomainEvent, correlationId: string, causationId = `cmd-${randomUUID()}`): EventEnvelope {
+  return {
+    eventId: `evt-${randomUUID()}`,
+    eventType: event.type,
+    schemaVersion: 1,
+    producer: "account",
+    causationId,
+    correlationId: canonicalCorrelationId(correlationId),
+    occurredAt: event.occurredAt.toISOString(),
+    payload: eventPayload(event),
+  };
+}
+
+function canonicalCorrelationId(correlationId: string): string {
+  return correlationId.startsWith("corr-") ? correlationId : `corr-${correlationId}`;
+}
+
+function eventPayload(event: AccountDomainEvent): Record<string, unknown> {
+  switch (event.type) {
+    case "AccountCreated":
+      return { accountId: event.accountId };
+    case "AccountFrozen":
+      return { accountId: event.accountId, reason: event.reason, operator: event.operator, caseRef: event.caseRef };
+    case "AccountUnfrozen":
+      return { accountId: event.accountId, reason: event.reason };
+    case "AccountClosureStarted":
+      return { accountId: event.accountId, closureRequestId: event.closureRequestId };
+    case "AccountClosed":
+      return { accountId: event.accountId, closureRequestId: event.closureRequestId, final: event.final };
+    case "SessionOpened":
+      return { sessionId: event.sessionId, accountId: event.accountId };
+    case "SessionRevoked":
+      return { sessionId: event.sessionId, accountId: event.accountId, reason: event.reason };
+    case "PreferenceUpdated":
+      return { accountId: event.accountId, preferenceKey: event.preferenceKey, oldValue: event.oldValue, newValue: event.newValue };
+  }
+}


### PR DESCRIPTION
## Summary
- implement account HTTP API endpoints with idempotency and canonical errors
- add application ports plus Redis Streams publisher/subscriber adapter under adapters/messaging
- add endpoint and messaging port tests with in-memory fakes

## Validation
- cd services/account && npm install --silent && npm test
- ! grep -rl 'ioredis' services/account/src | grep -v adapters
- make check