### PR TITLE
REQ-055 Add Java platform kit library

### DIFF
--- a/platform/java-kit/pom.xml
+++ b/platform/java-kit/pom.xml
@@ -1,0 +1,57 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>4.1.0</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>com.trainticket</groupId>
+  <artifactId>java-kit</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <name>Train Ticket Java Platform Kit</name>
+  <description>Canonical HTTP idempotency, error, and Redis Streams integration primitives for Java services.</description>
+
+  <properties>
+    <java.version>25</java.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.lettuce</groupId>
+      <artifactId>lettuce-core</artifactId>
+      <version>6.4.2.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/PlatformKitConfiguration.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/PlatformKitConfiguration.java
@@ -2,6 +2,7 @@ package com.trainticket.platformkit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trainticket.platformkit.http.CanonicalErrorWriter;
+import com.trainticket.platformkit.http.PlatformKitExceptionHandler;
 import com.trainticket.platformkit.idempotency.IdempotencyFilter;
 import com.trainticket.platformkit.idempotency.IdempotencyStore;
 import com.trainticket.platformkit.idempotency.InMemoryIdempotencyStore;
@@ -18,8 +19,20 @@ import org.springframework.context.annotation.Configuration;
 public class PlatformKitConfiguration {
     @Bean
     @ConditionalOnMissingBean
+    ObjectMapper objectMapper() {
+        return new ObjectMapper().findAndRegisterModules();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
     CanonicalErrorWriter canonicalErrorWriter(ObjectMapper objectMapper) {
         return new CanonicalErrorWriter(objectMapper);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    PlatformKitExceptionHandler platformKitExceptionHandler() {
+        return new PlatformKitExceptionHandler();
     }
 
     @Bean

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/PlatformKitConfiguration.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/PlatformKitConfiguration.java
@@ -1,0 +1,52 @@
+package com.trainticket.platformkit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.platformkit.http.CanonicalErrorWriter;
+import com.trainticket.platformkit.idempotency.IdempotencyFilter;
+import com.trainticket.platformkit.idempotency.IdempotencyStore;
+import com.trainticket.platformkit.idempotency.InMemoryIdempotencyStore;
+import com.trainticket.platformkit.messaging.RedisEventPublisher;
+import com.trainticket.platformkit.messaging.RedisEventSubscriber;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class PlatformKitConfiguration {
+    @Bean
+    @ConditionalOnMissingBean
+    CanonicalErrorWriter canonicalErrorWriter(ObjectMapper objectMapper) {
+        return new CanonicalErrorWriter(objectMapper);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    IdempotencyStore idempotencyStore() {
+        return new InMemoryIdempotencyStore();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    FilterRegistrationBean<IdempotencyFilter> idempotencyFilter(IdempotencyStore store, CanonicalErrorWriter errorWriter) {
+        FilterRegistrationBean<IdempotencyFilter> registration = new FilterRegistrationBean<>(new IdempotencyFilter(store, errorWriter));
+        registration.setOrder(-50);
+        return registration;
+    }
+
+    @Bean(destroyMethod = "close")
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(prefix = "platform.java-kit.redis", name = "enabled", havingValue = "true")
+    RedisEventPublisher redisEventPublisher(@Value("${REDIS_URL:redis://localhost:6379}") String redisUrl, ObjectMapper objectMapper) {
+        return RedisEventPublisher.fromUrl(redisUrl, objectMapper);
+    }
+
+    @Bean(destroyMethod = "close")
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(prefix = "platform.java-kit.redis", name = "enabled", havingValue = "true")
+    RedisEventSubscriber redisEventSubscriber(@Value("${REDIS_URL:redis://localhost:6379}") String redisUrl, ObjectMapper objectMapper) {
+        return RedisEventSubscriber.fromUrl(redisUrl, objectMapper);
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/http/ApiError.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/http/ApiError.java
@@ -1,0 +1,8 @@
+package com.trainticket.platformkit.http;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ApiError(String code, String message, String correlationId, Map<String, ?> details) {
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/http/ApiErrorCode.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/http/ApiErrorCode.java
@@ -1,0 +1,23 @@
+package com.trainticket.platformkit.http;
+
+import org.springframework.http.HttpStatus;
+
+public enum ApiErrorCode {
+    VALIDATION_FAILED(HttpStatus.BAD_REQUEST),
+    NOT_FOUND(HttpStatus.NOT_FOUND),
+    CONFLICT(HttpStatus.CONFLICT),
+    IDEMPOTENCY_KEY_REUSED(HttpStatus.UNPROCESSABLE_ENTITY),
+    PRECONDITION_FAILED(HttpStatus.PRECONDITION_FAILED),
+    DOMAIN_RULE_VIOLATION(HttpStatus.UNPROCESSABLE_ENTITY),
+    UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE);
+
+    private final HttpStatus status;
+
+    ApiErrorCode(HttpStatus status) {
+        this.status = status;
+    }
+
+    public HttpStatus status() {
+        return status;
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/http/ApiException.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/http/ApiException.java
@@ -1,0 +1,34 @@
+package com.trainticket.platformkit.http;
+
+import java.util.Map;
+
+public class ApiException extends RuntimeException {
+    private final ApiErrorCode code;
+    private final Map<String, ?> details;
+
+    public ApiException(ApiErrorCode code, String message) {
+        this(code, message, Map.of(), null);
+    }
+
+    public ApiException(ApiErrorCode code, String message, Map<String, ?> details) {
+        this(code, message, details, null);
+    }
+
+    public ApiException(ApiErrorCode code, String message, Throwable cause) {
+        this(code, message, Map.of(), cause);
+    }
+
+    public ApiException(ApiErrorCode code, String message, Map<String, ?> details, Throwable cause) {
+        super(message, cause);
+        this.code = code;
+        this.details = details == null ? Map.of() : Map.copyOf(details);
+    }
+
+    public ApiErrorCode code() {
+        return code;
+    }
+
+    public Map<String, ?> details() {
+        return details;
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/http/CanonicalErrorWriter.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/http/CanonicalErrorWriter.java
@@ -1,0 +1,25 @@
+package com.trainticket.platformkit.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import org.springframework.http.MediaType;
+
+public class CanonicalErrorWriter {
+    private final ObjectMapper objectMapper;
+
+    public CanonicalErrorWriter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public void write(HttpServletResponse response, ApiErrorCode code, String message, String correlationId) throws IOException {
+        write(response, code, message, correlationId, Map.of());
+    }
+
+    public void write(HttpServletResponse response, ApiErrorCode code, String message, String correlationId, Map<String, ?> details) throws IOException {
+        response.setStatus(code.status().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getOutputStream(), new ApiError(code.name(), message, correlationId, details));
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/http/CorrelationIds.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/http/CorrelationIds.java
@@ -1,0 +1,24 @@
+package com.trainticket.platformkit.http;
+
+import com.trainticket.platformkit.idempotency.UuidV7;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+
+public final class CorrelationIds {
+    public static final String CORRELATION_HEADER = "X-Correlation-Id";
+    public static final String REQUEST_HEADER = "X-Request-Id";
+    public static final String CORRELATION_ATTRIBUTE = CorrelationIds.class.getName() + ".correlationId";
+
+    private CorrelationIds() {
+    }
+
+    public static String from(HttpServletRequest request) {
+        Object attribute = request.getAttribute(CORRELATION_ATTRIBUTE);
+        if (attribute instanceof String value && !value.isBlank()) {
+            return value;
+        }
+        return Optional.ofNullable(request.getHeader(CORRELATION_HEADER))
+            .filter(UuidV7::isValid)
+            .orElseGet(UuidV7::generate);
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/http/PlatformKitExceptionHandler.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/http/PlatformKitExceptionHandler.java
@@ -1,0 +1,51 @@
+package com.trainticket.platformkit.http;
+
+import com.trainticket.platformkit.idempotency.IdempotencyKeyReusedException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+
+@RestControllerAdvice
+public class PlatformKitExceptionHandler {
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ApiError> handleApi(ApiException exception, HttpServletRequest request) {
+        return error(exception.code(), exception.getMessage(), request, exception.details());
+    }
+
+    @ExceptionHandler(IdempotencyKeyReusedException.class)
+    public ResponseEntity<ApiError> handleIdempotencyReuse(IdempotencyKeyReusedException exception, HttpServletRequest request) {
+        return error(ApiErrorCode.IDEMPOTENCY_KEY_REUSED, exception.getMessage(), request, Map.of());
+    }
+
+    @ExceptionHandler({IllegalArgumentException.class, MissingRequestHeaderException.class})
+    public ResponseEntity<ApiError> handleValidation(RuntimeException exception, HttpServletRequest request) {
+        return error(ApiErrorCode.VALIDATION_FAILED, exception.getMessage(), request, Map.of());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiError> handleBodyValidation(MethodArgumentNotValidException exception, HttpServletRequest request) {
+        Map<String, String> fieldErrors = new LinkedHashMap<>();
+        for (FieldError fieldError : exception.getBindingResult().getFieldErrors()) {
+            fieldErrors.put(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+        return error(ApiErrorCode.VALIDATION_FAILED, "Request validation failed", request, Map.of("fields", fieldErrors));
+    }
+
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    public ResponseEntity<ApiError> handleMethodValidation(HandlerMethodValidationException exception, HttpServletRequest request) {
+        return error(ApiErrorCode.VALIDATION_FAILED, "Request validation failed", request, Map.of("errors", exception.getAllErrors().stream()
+            .map(error -> error.getDefaultMessage() == null ? error.toString() : error.getDefaultMessage())
+            .toList()));
+    }
+
+    private ResponseEntity<ApiError> error(ApiErrorCode code, String message, HttpServletRequest request, Map<String, ?> details) {
+        return ResponseEntity.status(code.status()).body(new ApiError(code.name(), message, CorrelationIds.from(request), details));
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/idempotency/CachedBodyHttpServletRequest.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/idempotency/CachedBodyHttpServletRequest.java
@@ -1,0 +1,53 @@
+package com.trainticket.platformkit.idempotency;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+final class CachedBodyHttpServletRequest extends HttpServletRequestWrapper {
+    private final byte[] body;
+
+    CachedBodyHttpServletRequest(HttpServletRequest request, byte[] body) {
+        super(request);
+        this.body = body == null ? new byte[0] : body.clone();
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        ByteArrayInputStream delegate = new ByteArrayInputStream(body);
+        return new ServletInputStream() {
+            @Override
+            public boolean isFinished() {
+                return delegate.available() == 0;
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener) {
+                throw new UnsupportedOperationException("asynchronous reads are not supported");
+            }
+
+            @Override
+            public int read() {
+                return delegate.read();
+            }
+        };
+    }
+
+    @Override
+    public BufferedReader getReader() throws IOException {
+        Charset charset = getCharacterEncoding() == null ? StandardCharsets.UTF_8 : Charset.forName(getCharacterEncoding());
+        return new BufferedReader(new InputStreamReader(getInputStream(), charset));
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/idempotency/IdempotencyFilter.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/idempotency/IdempotencyFilter.java
@@ -8,6 +8,10 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingResponseWrapper;
@@ -53,11 +57,12 @@ public class IdempotencyFilter extends OncePerRequestFilter {
             fingerprint,
             wrappedResponse.getStatus(),
             wrappedResponse.getContentType(),
+            responseHeaders(wrappedResponse),
             wrappedResponse.getContentAsByteArray()
         );
         IdempotencyStore.StoredResponse visible = store.saveIfAbsent(idempotencyKey, stored);
         if (visible != stored) {
-            wrappedResponse.resetBuffer();
+            wrappedResponse.reset();
             replayOrReject(request, wrappedResponse, fingerprint, visible);
         }
         wrappedResponse.copyBodyToResponse();
@@ -69,9 +74,26 @@ public class IdempotencyFilter extends OncePerRequestFilter {
             return;
         }
         response.setStatus(stored.status());
+        for (Map.Entry<String, List<String>> header : stored.headers().entrySet()) {
+            if ("Content-Type".equalsIgnoreCase(header.getKey()) || "Content-Length".equalsIgnoreCase(header.getKey())) {
+                continue;
+            }
+            for (String value : header.getValue()) {
+                response.addHeader(header.getKey(), value);
+            }
+        }
         if (stored.contentType() != null) {
             response.setContentType(stored.contentType());
         }
         response.getOutputStream().write(stored.body());
+    }
+
+    private static Map<String, List<String>> responseHeaders(HttpServletResponse response) {
+        Map<String, List<String>> headers = new LinkedHashMap<>();
+        for (String headerName : response.getHeaderNames()) {
+            Collection<String> values = response.getHeaders(headerName);
+            headers.put(headerName, List.copyOf(values));
+        }
+        return headers;
     }
 }

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/idempotency/IdempotencyFilter.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/idempotency/IdempotencyFilter.java
@@ -1,0 +1,77 @@
+package com.trainticket.platformkit.idempotency;
+
+import com.trainticket.platformkit.http.ApiErrorCode;
+import com.trainticket.platformkit.http.CanonicalErrorWriter;
+import com.trainticket.platformkit.http.CorrelationIds;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+public class IdempotencyFilter extends OncePerRequestFilter {
+    public static final String IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
+
+    private final IdempotencyStore store;
+    private final CanonicalErrorWriter errorWriter;
+
+    public IdempotencyFilter(IdempotencyStore store, CanonicalErrorWriter errorWriter) {
+        this.store = store;
+        this.errorWriter = errorWriter;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !"POST".equalsIgnoreCase(request.getMethod()) || !request.getRequestURI().startsWith("/api/v1/");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String idempotencyKey = Optional.ofNullable(request.getHeader(IDEMPOTENCY_KEY_HEADER))
+            .map(String::trim)
+            .filter(value -> !value.isEmpty())
+            .orElse(null);
+        if (!UuidV7.isValid(idempotencyKey)) {
+            errorWriter.write(response, ApiErrorCode.VALIDATION_FAILED, "Idempotency-Key header must be a UUID v7", CorrelationIds.from(request));
+            return;
+        }
+
+        byte[] body = request.getInputStream().readAllBytes();
+        String fingerprint = RequestFingerprint.of(request, body);
+        Optional<IdempotencyStore.StoredResponse> existing = store.find(idempotencyKey);
+        if (existing.isPresent()) {
+            replayOrReject(request, response, fingerprint, existing.get());
+            return;
+        }
+
+        ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(response);
+        filterChain.doFilter(new CachedBodyHttpServletRequest(request, body), wrappedResponse);
+        IdempotencyStore.StoredResponse stored = new IdempotencyStore.StoredResponse(
+            fingerprint,
+            wrappedResponse.getStatus(),
+            wrappedResponse.getContentType(),
+            wrappedResponse.getContentAsByteArray()
+        );
+        IdempotencyStore.StoredResponse visible = store.saveIfAbsent(idempotencyKey, stored);
+        if (visible != stored) {
+            wrappedResponse.resetBuffer();
+            replayOrReject(request, wrappedResponse, fingerprint, visible);
+        }
+        wrappedResponse.copyBodyToResponse();
+    }
+
+    private void replayOrReject(HttpServletRequest request, HttpServletResponse response, String fingerprint, IdempotencyStore.StoredResponse stored) throws IOException {
+        if (!stored.fingerprint().equals(fingerprint)) {
+            errorWriter.write(response, ApiErrorCode.IDEMPOTENCY_KEY_REUSED, "Idempotency-Key was reused with a different request body", CorrelationIds.from(request));
+            return;
+        }
+        response.setStatus(stored.status());
+        if (stored.contentType() != null) {
+            response.setContentType(stored.contentType());
+        }
+        response.getOutputStream().write(stored.body());
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/idempotency/IdempotencyKeyReusedException.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/idempotency/IdempotencyKeyReusedException.java
@@ -1,0 +1,7 @@
+package com.trainticket.platformkit.idempotency;
+
+public class IdempotencyKeyReusedException extends RuntimeException {
+    public IdempotencyKeyReusedException() {
+        super("Idempotency-Key was reused with a different request body");
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/idempotency/IdempotencyStore.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/idempotency/IdempotencyStore.java
@@ -1,0 +1,20 @@
+package com.trainticket.platformkit.idempotency;
+
+import java.util.Optional;
+
+public interface IdempotencyStore {
+    Optional<StoredResponse> find(String key);
+
+    StoredResponse saveIfAbsent(String key, StoredResponse response);
+
+    record StoredResponse(String fingerprint, int status, String contentType, byte[] body) {
+        public StoredResponse {
+            body = body == null ? new byte[0] : body.clone();
+        }
+
+        @Override
+        public byte[] body() {
+            return body.clone();
+        }
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/idempotency/IdempotencyStore.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/idempotency/IdempotencyStore.java
@@ -1,5 +1,7 @@
 package com.trainticket.platformkit.idempotency;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface IdempotencyStore {
@@ -7,8 +9,13 @@ public interface IdempotencyStore {
 
     StoredResponse saveIfAbsent(String key, StoredResponse response);
 
-    record StoredResponse(String fingerprint, int status, String contentType, byte[] body) {
+    record StoredResponse(String fingerprint, int status, String contentType, Map<String, List<String>> headers, byte[] body) {
         public StoredResponse {
+            headers = headers == null ? Map.of() : headers.entrySet().stream()
+                .collect(java.util.stream.Collectors.toUnmodifiableMap(
+                    Map.Entry::getKey,
+                    entry -> List.copyOf(entry.getValue())
+                ));
             body = body == null ? new byte[0] : body.clone();
         }
 

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/idempotency/InMemoryIdempotencyStore.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/idempotency/InMemoryIdempotencyStore.java
@@ -1,0 +1,24 @@
+package com.trainticket.platformkit.idempotency;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class InMemoryIdempotencyStore implements IdempotencyStore {
+    private final ConcurrentMap<String, StoredResponse> responses = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<StoredResponse> find(String key) {
+        return Optional.ofNullable(responses.get(key));
+    }
+
+    @Override
+    public StoredResponse saveIfAbsent(String key, StoredResponse response) {
+        StoredResponse existing = responses.putIfAbsent(key, response);
+        return existing == null ? response : existing;
+    }
+
+    public void clear() {
+        responses.clear();
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/idempotency/RequestFingerprint.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/idempotency/RequestFingerprint.java
@@ -1,0 +1,26 @@
+package com.trainticket.platformkit.idempotency;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Optional;
+
+public final class RequestFingerprint {
+    private RequestFingerprint() {
+    }
+
+    public static String of(HttpServletRequest request, byte[] body) {
+        String target = request.getMethod().toUpperCase() + " " + request.getRequestURI()
+            + "?" + Optional.ofNullable(request.getQueryString()).orElse("") + "\n";
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update(target.getBytes(StandardCharsets.UTF_8));
+            digest.update(body == null ? new byte[0] : body);
+            return HexFormat.of().formatHex(digest.digest());
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 is unavailable", exception);
+        }
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/idempotency/UuidV7.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/idempotency/UuidV7.java
@@ -1,0 +1,57 @@
+package com.trainticket.platformkit.idempotency;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class UuidV7 {
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private UuidV7() {
+    }
+
+    public static String generate() {
+        return generate(Instant.now());
+    }
+
+    public static String generate(Instant now) {
+        Objects.requireNonNull(now, "now is required");
+        long unixMillis = now.toEpochMilli();
+        byte[] random = new byte[10];
+        RANDOM.nextBytes(random);
+
+        long most = ((unixMillis & 0xFFFF_FFFF_FFFFL) << 16)
+            | 0x7000L
+            | (random[0] & 0x0FFFL);
+        long least = 0x8000_0000_0000_0000L
+            | ((long) (random[1] & 0x3F) << 56)
+            | ((long) (random[2] & 0xFF) << 48)
+            | ((long) (random[3] & 0xFF) << 40)
+            | ((long) (random[4] & 0xFF) << 32)
+            | ((long) (random[5] & 0xFF) << 24)
+            | ((long) (random[6] & 0xFF) << 16)
+            | ((long) (random[7] & 0xFF) << 8)
+            | ((long) (random[8] & 0xFF));
+        return new UUID(most, least).toString();
+    }
+
+    public static boolean isValid(String value) {
+        if (value == null) {
+            return false;
+        }
+        try {
+            UUID uuid = UUID.fromString(value.toLowerCase(Locale.ROOT));
+            return uuid.version() == 7 && uuid.variant() == 2 && uuid.toString().equals(value.toLowerCase(Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            return false;
+        }
+    }
+
+    public static void requireValid(String value, String name) {
+        if (!isValid(value)) {
+            throw new IllegalArgumentException(name + " must be a UUID v7");
+        }
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/ConsumedEventStore.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/ConsumedEventStore.java
@@ -1,0 +1,7 @@
+package com.trainticket.platformkit.messaging;
+
+public interface ConsumedEventStore {
+    boolean alreadyConsumed(String consumerGroup, String eventId);
+
+    void recordConsumed(String consumerGroup, String eventId);
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/EventEnvelope.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/EventEnvelope.java
@@ -1,0 +1,52 @@
+package com.trainticket.platformkit.messaging;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.Objects;
+
+public record EventEnvelope(
+    String eventId,
+    String eventType,
+    @JsonFormat(shape = JsonFormat.Shape.STRING) Instant occurredAt,
+    String correlationId,
+    String causationId,
+    String producer,
+    int schemaVersion,
+    Object payload
+) {
+    @JsonCreator
+    public EventEnvelope(
+        @JsonProperty("eventId") String eventId,
+        @JsonProperty("eventType") String eventType,
+        @JsonProperty("occurredAt") Instant occurredAt,
+        @JsonProperty("correlationId") String correlationId,
+        @JsonProperty("causationId") String causationId,
+        @JsonProperty("producer") String producer,
+        @JsonProperty("schemaVersion") int schemaVersion,
+        @JsonProperty("payload") Object payload
+    ) {
+        PrefixedIds.requireEventId(eventId);
+        PrefixedIds.requireCorrelationId(correlationId);
+        PrefixedIds.requireCausationId(causationId);
+        this.eventId = eventId;
+        this.eventType = requireText(eventType, "eventType");
+        this.occurredAt = Objects.requireNonNull(occurredAt, "occurredAt is required");
+        this.correlationId = correlationId;
+        this.causationId = causationId;
+        this.producer = requireText(producer, "producer");
+        if (schemaVersion < 1) {
+            throw new IllegalArgumentException("schemaVersion must be positive");
+        }
+        this.schemaVersion = schemaVersion;
+        this.payload = Objects.requireNonNull(payload, "payload is required");
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " is required");
+        }
+        return value;
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/EventEnvelope.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/EventEnvelope.java
@@ -2,6 +2,7 @@ package com.trainticket.platformkit.messaging;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.util.Objects;
@@ -11,7 +12,7 @@ public record EventEnvelope(
     String eventType,
     @JsonFormat(shape = JsonFormat.Shape.STRING) Instant occurredAt,
     String correlationId,
-    String causationId,
+    @JsonInclude(JsonInclude.Include.NON_NULL) String causationId,
     String producer,
     int schemaVersion,
     Object payload
@@ -29,7 +30,9 @@ public record EventEnvelope(
     ) {
         PrefixedIds.requireEventId(eventId);
         PrefixedIds.requireCorrelationId(correlationId);
-        PrefixedIds.requireCausationId(causationId);
+        if (causationId != null) {
+            PrefixedIds.requireCausationId(causationId);
+        }
         this.eventId = eventId;
         this.eventType = requireText(eventType, "eventType");
         this.occurredAt = Objects.requireNonNull(occurredAt, "occurredAt is required");

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/EventEnvelopeFactory.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/EventEnvelopeFactory.java
@@ -22,7 +22,9 @@ public class EventEnvelopeFactory {
 
     public EventEnvelope create(String eventType, String correlationId, String causationId, Object payload) {
         PrefixedIds.requireCorrelationId(correlationId);
-        PrefixedIds.requireCausationId(causationId);
+        if (causationId != null) {
+            PrefixedIds.requireCausationId(causationId);
+        }
         return new EventEnvelope(
             PrefixedIds.newEventId(),
             eventType,

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/EventEnvelopeFactory.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/EventEnvelopeFactory.java
@@ -1,0 +1,44 @@
+package com.trainticket.platformkit.messaging;
+
+import java.time.Clock;
+import java.util.Objects;
+
+public class EventEnvelopeFactory {
+    private final Clock clock;
+    private final String producer;
+
+    public EventEnvelopeFactory(String producer) {
+        this(producer, Clock.systemUTC());
+    }
+
+    public EventEnvelopeFactory(String producer, Clock clock) {
+        this.producer = requireText(producer, "producer");
+        this.clock = Objects.requireNonNull(clock, "clock is required");
+    }
+
+    public EventEnvelope create(String eventType, Object payload) {
+        return create(eventType, PrefixedIds.newCorrelationId(), PrefixedIds.newCommandId(), payload);
+    }
+
+    public EventEnvelope create(String eventType, String correlationId, String causationId, Object payload) {
+        PrefixedIds.requireCorrelationId(correlationId);
+        PrefixedIds.requireCausationId(causationId);
+        return new EventEnvelope(
+            PrefixedIds.newEventId(),
+            eventType,
+            clock.instant(),
+            correlationId,
+            causationId,
+            producer,
+            1,
+            payload
+        );
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " is required");
+        }
+        return value;
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/EventHandler.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/EventHandler.java
@@ -1,0 +1,6 @@
+package com.trainticket.platformkit.messaging;
+
+@FunctionalInterface
+public interface EventHandler {
+    HandlerResult handle(EventEnvelope envelope);
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/EventPublisher.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/EventPublisher.java
@@ -1,0 +1,5 @@
+package com.trainticket.platformkit.messaging;
+
+public interface EventPublisher {
+    void publish(EventEnvelope envelope) throws PublishFailedException;
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/EventSubscriber.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/EventSubscriber.java
@@ -1,0 +1,10 @@
+package com.trainticket.platformkit.messaging;
+
+import java.util.List;
+
+public interface EventSubscriber extends AutoCloseable {
+    void subscribe(List<String> streams, String group, String consumerName, EventHandler handler) throws SubscribeFailedException;
+
+    @Override
+    void close();
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/HandlerResult.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/HandlerResult.java
@@ -1,0 +1,7 @@
+package com.trainticket.platformkit.messaging;
+
+public enum HandlerResult {
+    SUCCESS,
+    TRANSIENT_FAILURE,
+    FATAL_FAILURE
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/InMemoryConsumedEventStore.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/InMemoryConsumedEventStore.java
@@ -1,0 +1,19 @@
+package com.trainticket.platformkit.messaging;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class InMemoryConsumedEventStore implements ConsumedEventStore {
+    private final ConcurrentMap<String, Set<String>> consumed = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean alreadyConsumed(String consumerGroup, String eventId) {
+        return consumed.computeIfAbsent(consumerGroup, ignored -> ConcurrentHashMap.newKeySet()).contains(eventId);
+    }
+
+    @Override
+    public void recordConsumed(String consumerGroup, String eventId) {
+        consumed.computeIfAbsent(consumerGroup, ignored -> ConcurrentHashMap.newKeySet()).add(eventId);
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/InMemoryEventBus.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/InMemoryEventBus.java
@@ -1,0 +1,119 @@
+package com.trainticket.platformkit.messaging;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class InMemoryEventBus {
+    private final AtomicLong sequence = new AtomicLong();
+    private final Map<String, Queue<Entry>> streams = new HashMap<>();
+    private final Map<String, List<Entry>> dlqs = new HashMap<>();
+    private final Map<GroupKey, Map<String, Pending>> pending = new HashMap<>();
+    private final Map<GroupKey, Set<String>> consumedEventIds = new HashMap<>();
+
+    public synchronized String publish(String stream, EventEnvelope envelope) {
+        String id = sequence.incrementAndGet() + "-0";
+        streams.computeIfAbsent(stream, ignored -> new ArrayDeque<>()).add(new Entry(id, envelope));
+        return id;
+    }
+
+    synchronized List<Delivery> read(String stream, String group, int count) {
+        GroupKey key = new GroupKey(stream, group);
+        Queue<Entry> entries = streams.computeIfAbsent(stream, ignored -> new ArrayDeque<>());
+        List<Delivery> deliveries = new ArrayList<>();
+        while (!entries.isEmpty() && deliveries.size() < count) {
+            Entry entry = entries.poll();
+            Pending pendingEntry = new Pending(entry, 1);
+            pending.computeIfAbsent(key, ignored -> new HashMap<>()).put(entry.id(), pendingEntry);
+            deliveries.add(new Delivery(entry.id(), entry.envelope(), pendingEntry.deliveryCount()));
+        }
+        return deliveries;
+    }
+
+    synchronized List<Delivery> claimPending(String stream, String group, int count) {
+        GroupKey key = new GroupKey(stream, group);
+        List<Delivery> deliveries = new ArrayList<>();
+        for (Pending pendingEntry : pending.computeIfAbsent(key, ignored -> new HashMap<>()).values()) {
+            if (deliveries.size() >= count) {
+                break;
+            }
+            pendingEntry.incrementDeliveryCount();
+            deliveries.add(new Delivery(pendingEntry.entry().id(), pendingEntry.entry().envelope(), pendingEntry.deliveryCount()));
+        }
+        return deliveries;
+    }
+
+    synchronized void ack(String stream, String group, String messageId) {
+        Map<String, Pending> groupPending = pending.get(new GroupKey(stream, group));
+        if (groupPending != null) {
+            groupPending.remove(messageId);
+        }
+    }
+
+    synchronized void moveToDlq(String stream, String group, String messageId) {
+        Map<String, Pending> groupPending = pending.get(new GroupKey(stream, group));
+        if (groupPending == null) {
+            return;
+        }
+        Pending entry = groupPending.remove(messageId);
+        if (entry != null) {
+            dlqs.computeIfAbsent(RedisStreamNames.dlqFor(stream), ignored -> new ArrayList<>()).add(entry.entry());
+        }
+    }
+
+    synchronized boolean wasConsumed(String stream, String group, String eventId) {
+        return consumedEventIds.computeIfAbsent(new GroupKey(stream, group), ignored -> new HashSet<>()).contains(eventId);
+    }
+
+    synchronized void recordConsumed(String stream, String group, String eventId) {
+        consumedEventIds.computeIfAbsent(new GroupKey(stream, group), ignored -> new HashSet<>()).add(eventId);
+    }
+
+    public synchronized List<EventEnvelope> dlq(String stream) {
+        return dlqs.getOrDefault(RedisStreamNames.dlqFor(stream), List.of()).stream().map(Entry::envelope).toList();
+    }
+
+    public synchronized Optional<Integer> pendingDeliveryCount(String stream, String group, String messageId) {
+        return Optional.ofNullable(pending.get(new GroupKey(stream, group)))
+            .map(messages -> messages.get(messageId))
+            .map(Pending::deliveryCount);
+    }
+
+    record Delivery(String messageId, EventEnvelope envelope, int deliveryCount) {
+    }
+
+    private record GroupKey(String stream, String group) {
+    }
+
+    private record Entry(String id, EventEnvelope envelope) {
+    }
+
+    private static final class Pending {
+        private final Entry entry;
+        private int deliveryCount;
+
+        Pending(Entry entry, int deliveryCount) {
+            this.entry = entry;
+            this.deliveryCount = deliveryCount;
+        }
+
+        Entry entry() {
+            return entry;
+        }
+
+        int deliveryCount() {
+            return deliveryCount;
+        }
+
+        void incrementDeliveryCount() {
+            deliveryCount++;
+        }
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/InMemoryEventPublisher.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/InMemoryEventPublisher.java
@@ -1,0 +1,14 @@
+package com.trainticket.platformkit.messaging;
+
+public class InMemoryEventPublisher implements EventPublisher {
+    private final InMemoryEventBus bus;
+
+    public InMemoryEventPublisher(InMemoryEventBus bus) {
+        this.bus = bus;
+    }
+
+    @Override
+    public void publish(EventEnvelope envelope) {
+        bus.publish(RedisStreamNames.streamForProducer(envelope.producer()), envelope);
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/InMemoryEventSubscriber.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/InMemoryEventSubscriber.java
@@ -1,0 +1,61 @@
+package com.trainticket.platformkit.messaging;
+
+import java.util.List;
+import java.util.Objects;
+
+public class InMemoryEventSubscriber implements EventSubscriber {
+    private final InMemoryEventBus bus;
+    private volatile boolean running;
+
+    public InMemoryEventSubscriber(InMemoryEventBus bus) {
+        this.bus = Objects.requireNonNull(bus, "bus is required");
+    }
+
+    @Override
+    public void subscribe(List<String> streams, String group, String consumerName, EventHandler handler) {
+        running = true;
+        pollOnce(streams, group, handler);
+    }
+
+    public void pollOnce(List<String> streams, String group, EventHandler handler) {
+        for (String stream : streams) {
+            for (InMemoryEventBus.Delivery delivery : bus.read(stream, group, 10)) {
+                handle(stream, group, delivery, handler);
+            }
+        }
+    }
+
+    public void recoverOnce(String stream, String group, EventHandler handler) {
+        for (InMemoryEventBus.Delivery delivery : bus.claimPending(stream, group, 100)) {
+            handle(stream, group, delivery, handler);
+        }
+    }
+
+    private void handle(String stream, String group, InMemoryEventBus.Delivery delivery, EventHandler handler) {
+        if (delivery.deliveryCount() >= RedisEventSubscriber.MAX_DELIVERY_ATTEMPTS) {
+            bus.moveToDlq(stream, group, delivery.messageId());
+            return;
+        }
+        EventEnvelope envelope = delivery.envelope();
+        if (bus.wasConsumed(stream, group, envelope.eventId())) {
+            bus.ack(stream, group, delivery.messageId());
+            return;
+        }
+        HandlerResult result = handler.handle(envelope);
+        if (result == HandlerResult.SUCCESS) {
+            bus.recordConsumed(stream, group, envelope.eventId());
+            bus.ack(stream, group, delivery.messageId());
+        } else if (result == HandlerResult.FATAL_FAILURE) {
+            bus.moveToDlq(stream, group, delivery.messageId());
+        }
+    }
+
+    public boolean running() {
+        return running;
+    }
+
+    @Override
+    public void close() {
+        running = false;
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/InMemoryEventSubscriber.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/InMemoryEventSubscriber.java
@@ -41,7 +41,12 @@ public class InMemoryEventSubscriber implements EventSubscriber {
             bus.ack(stream, group, delivery.messageId());
             return;
         }
-        HandlerResult result = handler.handle(envelope);
+        HandlerResult result;
+        try {
+            result = handler.handle(envelope);
+        } catch (RuntimeException exception) {
+            return;
+        }
         if (result == HandlerResult.SUCCESS) {
             bus.recordConsumed(stream, group, envelope.eventId());
             bus.ack(stream, group, delivery.messageId());

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/LettuceRedisStreamOperations.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/LettuceRedisStreamOperations.java
@@ -1,0 +1,85 @@
+package com.trainticket.platformkit.messaging;
+
+import io.lettuce.core.Consumer;
+import io.lettuce.core.Limit;
+import io.lettuce.core.Range;
+import io.lettuce.core.RedisBusyException;
+import io.lettuce.core.StreamMessage;
+import io.lettuce.core.XAddArgs;
+import io.lettuce.core.XAutoClaimArgs;
+import io.lettuce.core.XGroupCreateArgs;
+import io.lettuce.core.XReadArgs;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.models.stream.PendingMessage;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+final class LettuceRedisStreamOperations implements RedisStreamOperations {
+    private final StatefulRedisConnection<String, String> connection;
+
+    LettuceRedisStreamOperations(StatefulRedisConnection<String, String> connection) {
+        this.connection = Objects.requireNonNull(connection, "connection is required");
+    }
+
+    @Override
+    public void createGroup(String stream, String group) {
+        try {
+            connection.sync().xgroupCreate(XReadArgs.StreamOffset.from(stream, "$"), group, XGroupCreateArgs.Builder.mkstream());
+        } catch (RedisBusyException ignored) {
+            // Existing group is safe on restart.
+        }
+    }
+
+    @Override
+    public String publish(String stream, String envelopeJson) {
+        return connection.sync().xadd(stream, XAddArgs.Builder.maxlen(100_000).approximateTrimming(), Map.of("envelope", envelopeJson));
+    }
+
+    @Override
+    public List<StreamEntry> readGroup(String stream, String group, String consumerName) {
+        return connection.sync()
+            .xreadgroup(Consumer.from(group, consumerName), XReadArgs.Builder.block(Duration.ofSeconds(2)).count(10), XReadArgs.StreamOffset.lastConsumed(stream))
+            .stream()
+            .map(LettuceRedisStreamOperations::toEntry)
+            .toList();
+    }
+
+    @Override
+    public List<StreamEntry> autoClaim(String stream, String group, String consumerName) {
+        return connection.sync()
+            .xautoclaim(stream, XAutoClaimArgs.Builder.xautoclaim(Consumer.from(group, consumerName), Duration.ofSeconds(60), "0-0").count(100))
+            .getMessages()
+            .stream()
+            .map(LettuceRedisStreamOperations::toEntry)
+            .toList();
+    }
+
+    @Override
+    public int deliveryCount(String stream, String group, String messageId) {
+        List<PendingMessage> messages = connection.sync().xpending(stream, group, Range.create(messageId, messageId), Limit.create(0, 1));
+        if (messages.isEmpty()) {
+            return 1;
+        }
+        long redeliveryCount = messages.getFirst().getRedeliveryCount();
+        if (redeliveryCount >= Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return Math.max(1, (int) redeliveryCount);
+    }
+
+    @Override
+    public void ack(String stream, String group, String messageId) {
+        connection.sync().xack(stream, group, messageId);
+    }
+
+    @Override
+    public void moveToDlq(String stream, String envelopeJson) {
+        connection.sync().xadd(RedisStreamNames.dlqFor(stream), XAddArgs.Builder.maxlen(100_000).approximateTrimming(), Map.of("envelope", envelopeJson));
+    }
+
+    private static StreamEntry toEntry(StreamMessage<String, String> message) {
+        return new StreamEntry(message.getId(), message.getBody().get("envelope"));
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/PrefixedIds.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/PrefixedIds.java
@@ -1,0 +1,54 @@
+package com.trainticket.platformkit.messaging;
+
+import com.trainticket.platformkit.idempotency.UuidV7;
+
+public final class PrefixedIds {
+    private PrefixedIds() {
+    }
+
+    public static String newEventId() {
+        return "evt-" + UuidV7.generate();
+    }
+
+    public static String newCorrelationId() {
+        return "corr-" + UuidV7.generate();
+    }
+
+    public static String newCommandId() {
+        return "cmd-" + UuidV7.generate();
+    }
+
+    public static boolean isEventId(String value) {
+        return hasValidUuidWithPrefix(value, "evt-");
+    }
+
+    public static boolean isCorrelationId(String value) {
+        return hasValidUuidWithPrefix(value, "corr-");
+    }
+
+    public static boolean isCausationId(String value) {
+        return hasValidUuidWithPrefix(value, "cmd-") || hasValidUuidWithPrefix(value, "evt-");
+    }
+
+    public static void requireEventId(String value) {
+        if (!isEventId(value)) {
+            throw new IllegalArgumentException("eventId must be evt- + UUID v7");
+        }
+    }
+
+    public static void requireCorrelationId(String value) {
+        if (!isCorrelationId(value)) {
+            throw new IllegalArgumentException("correlationId must be corr- + UUID v7");
+        }
+    }
+
+    public static void requireCausationId(String value) {
+        if (!isCausationId(value)) {
+            throw new IllegalArgumentException("causationId must be cmd-/evt- + UUID v7");
+        }
+    }
+
+    private static boolean hasValidUuidWithPrefix(String value, String prefix) {
+        return value != null && value.startsWith(prefix) && UuidV7.isValid(value.substring(prefix.length()));
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/PublishAfterCommit.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/PublishAfterCommit.java
@@ -1,0 +1,22 @@
+package com.trainticket.platformkit.messaging;
+
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public final class PublishAfterCommit {
+    private PublishAfterCommit() {
+    }
+
+    public static void publish(EventPublisher publisher, EventEnvelope envelope) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    publisher.publish(envelope);
+                }
+            });
+        } else {
+            publisher.publish(envelope);
+        }
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/PublishFailedException.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/PublishFailedException.java
@@ -1,0 +1,7 @@
+package com.trainticket.platformkit.messaging;
+
+public class PublishFailedException extends RuntimeException {
+    public PublishFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventPublisher.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventPublisher.java
@@ -1,0 +1,79 @@
+package com.trainticket.platformkit.messaging;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import java.time.Duration;
+import java.util.Objects;
+
+public class RedisEventPublisher implements EventPublisher, AutoCloseable {
+    private static final int MAX_ATTEMPTS = 3;
+
+    private final RedisStreamOperations streams;
+    private final ObjectMapper objectMapper;
+    private final AutoCloseable closeable;
+
+    public RedisEventPublisher(StatefulRedisConnection<String, String> connection, ObjectMapper objectMapper) {
+        this(new LettuceRedisStreamOperations(connection), objectMapper, connection::close);
+    }
+
+    public static RedisEventPublisher fromUrl(String redisUrl, ObjectMapper objectMapper) {
+        RedisClient client = RedisClient.create(redisUrl == null || redisUrl.isBlank() ? "redis://localhost:6379" : redisUrl);
+        StatefulRedisConnection<String, String> connection = client.connect();
+        return new RedisEventPublisher(new LettuceRedisStreamOperations(connection), objectMapper, () -> {
+            connection.close();
+            client.shutdown();
+        });
+    }
+
+    RedisEventPublisher(RedisStreamOperations streams, ObjectMapper objectMapper, AutoCloseable closeable) {
+        this.streams = Objects.requireNonNull(streams, "streams are required");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper is required");
+        this.closeable = closeable;
+    }
+
+    @Override
+    public void publish(EventEnvelope envelope) throws PublishFailedException {
+        String json = serialize(envelope);
+        String stream = RedisStreamNames.streamForProducer(envelope.producer());
+        RuntimeException last = null;
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            try {
+                streams.publish(stream, json);
+                return;
+            } catch (RuntimeException exception) {
+                last = exception;
+                backoff(attempt);
+            }
+        }
+        throw new PublishFailedException("event was not published", last);
+    }
+
+    private String serialize(EventEnvelope envelope) {
+        try {
+            return objectMapper.writeValueAsString(envelope);
+        } catch (JsonProcessingException exception) {
+            throw new PublishFailedException("event envelope could not be serialized", exception);
+        }
+    }
+
+    private static void backoff(int attempt) {
+        if (attempt >= MAX_ATTEMPTS) {
+            return;
+        }
+        try {
+            Thread.sleep(Duration.ofMillis(50L * attempt).toMillis());
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new PublishFailedException("publish retry interrupted", exception);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (closeable != null) {
+            closeable.close();
+        }
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
@@ -1,0 +1,151 @@
+package com.trainticket.platformkit.messaging;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class RedisEventSubscriber implements EventSubscriber {
+    public static final int MAX_DELIVERY_ATTEMPTS = 5;
+
+    private final RedisStreamOperations streams;
+    private final ObjectMapper objectMapper;
+    private final ExecutorService executor;
+    private final AtomicBoolean running = new AtomicBoolean();
+    private final AutoCloseable closeable;
+    private final ConsumedEventStore consumedEvents;
+
+    public RedisEventSubscriber(StatefulRedisConnection<String, String> connection, ObjectMapper objectMapper) {
+        this(new LettuceRedisStreamOperations(connection), objectMapper, connection::close);
+    }
+
+    public static RedisEventSubscriber fromUrl(String redisUrl, ObjectMapper objectMapper) {
+        RedisClient client = RedisClient.create(redisUrl == null || redisUrl.isBlank() ? "redis://localhost:6379" : redisUrl);
+        StatefulRedisConnection<String, String> connection = client.connect();
+        return new RedisEventSubscriber(new LettuceRedisStreamOperations(connection), objectMapper, () -> {
+            connection.close();
+            client.shutdown();
+        });
+    }
+
+    RedisEventSubscriber(RedisStreamOperations streams, ObjectMapper objectMapper, AutoCloseable closeable) {
+        this(streams, objectMapper, closeable, new InMemoryConsumedEventStore());
+    }
+
+    RedisEventSubscriber(RedisStreamOperations streams, ObjectMapper objectMapper, AutoCloseable closeable, ConsumedEventStore consumedEvents) {
+        this.streams = Objects.requireNonNull(streams, "streams are required");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper is required");
+        this.closeable = closeable;
+        this.consumedEvents = Objects.requireNonNull(consumedEvents, "consumedEvents is required");
+        this.executor = Executors.newSingleThreadExecutor();
+    }
+
+    @Override
+    public void subscribe(List<String> streamNames, String group, String consumerName, EventHandler handler) throws SubscribeFailedException {
+        Objects.requireNonNull(streamNames, "streams are required");
+        Objects.requireNonNull(handler, "handler is required");
+        if (streamNames.isEmpty()) {
+            throw new SubscribeFailedException("at least one stream is required", null);
+        }
+        createGroups(streamNames, group);
+        running.set(true);
+        executor.submit(() -> poll(streamNames, group, consumerName, handler));
+    }
+
+    public void recoverOnce(String stream, String group, String consumerName, EventHandler handler) {
+        recover(stream, group, consumerName, handler);
+    }
+
+    private void createGroups(List<String> streamNames, String group) {
+        for (String stream : streamNames) {
+            try {
+                streams.createGroup(stream, group);
+            } catch (RuntimeException exception) {
+                throw new SubscribeFailedException("consumer group could not be created", exception);
+            }
+        }
+    }
+
+    private void poll(List<String> streamNames, String group, String consumerName, EventHandler handler) {
+        while (running.get()) {
+            for (String stream : streamNames) {
+                recover(stream, group, consumerName, handler);
+                for (RedisStreamOperations.StreamEntry message : streams.readGroup(stream, group, consumerName)) {
+                    handle(stream, group, message, handler, streams.deliveryCount(stream, group, message.id()));
+                }
+            }
+        }
+    }
+
+    private void recover(String stream, String group, String consumerName, EventHandler handler) {
+        for (RedisStreamOperations.StreamEntry message : streams.autoClaim(stream, group, consumerName)) {
+            handle(stream, group, message, handler, streams.deliveryCount(stream, group, message.id()));
+        }
+    }
+
+    private void handle(String stream, String group, RedisStreamOperations.StreamEntry message, EventHandler handler, int deliveryAttempts) {
+        String json = message.envelopeJson();
+        if (json == null) {
+            streams.moveToDlq(stream, "{}");
+            streams.ack(stream, group, message.id());
+            return;
+        }
+        if (deliveryAttempts >= MAX_DELIVERY_ATTEMPTS) {
+            streams.moveToDlq(stream, json);
+            streams.ack(stream, group, message.id());
+            return;
+        }
+        EventEnvelope envelope;
+        try {
+            envelope = deserialize(json);
+        } catch (SubscribeFailedException exception) {
+            streams.moveToDlq(stream, json);
+            streams.ack(stream, group, message.id());
+            return;
+        }
+        if (consumedEvents.alreadyConsumed(group, envelope.eventId())) {
+            streams.ack(stream, group, message.id());
+            return;
+        }
+        HandlerResult result = handler.handle(envelope);
+        if (result == HandlerResult.SUCCESS) {
+            consumedEvents.recordConsumed(group, envelope.eventId());
+            streams.ack(stream, group, message.id());
+        } else if (result == HandlerResult.FATAL_FAILURE) {
+            streams.moveToDlq(stream, json);
+            streams.ack(stream, group, message.id());
+        }
+    }
+
+    private EventEnvelope deserialize(String json) {
+        try {
+            return objectMapper.readValue(json, EventEnvelope.class);
+        } catch (JsonProcessingException exception) {
+            throw new SubscribeFailedException("event envelope could not be deserialized", exception);
+        }
+    }
+
+    @Override
+    public void close() {
+        running.set(false);
+        executor.shutdown();
+        try {
+            executor.awaitTermination(5, TimeUnit.SECONDS);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+        }
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (Exception exception) {
+                throw new SubscribeFailedException("subscriber could not close", exception);
+            }
+        }
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
@@ -75,9 +75,13 @@ public class RedisEventSubscriber implements EventSubscriber {
     private void poll(List<String> streamNames, String group, String consumerName, EventHandler handler) {
         while (running.get()) {
             for (String stream : streamNames) {
-                recover(stream, group, consumerName, handler);
-                for (RedisStreamOperations.StreamEntry message : streams.readGroup(stream, group, consumerName)) {
-                    handle(stream, group, message, handler, streams.deliveryCount(stream, group, message.id()));
+                try {
+                    recover(stream, group, consumerName, handler);
+                    for (RedisStreamOperations.StreamEntry message : streams.readGroup(stream, group, consumerName)) {
+                        handle(stream, group, message, handler, streams.deliveryCount(stream, group, message.id()));
+                    }
+                } catch (RuntimeException exception) {
+                    // Keep the subscriber alive; messages read but not acked remain in the Redis PEL for recovery/DLQ policy.
                 }
             }
         }
@@ -113,7 +117,12 @@ public class RedisEventSubscriber implements EventSubscriber {
             streams.ack(stream, group, message.id());
             return;
         }
-        HandlerResult result = handler.handle(envelope);
+        HandlerResult result;
+        try {
+            result = handler.handle(envelope);
+        } catch (RuntimeException exception) {
+            return;
+        }
         if (result == HandlerResult.SUCCESS) {
             consumedEvents.recordConsumed(group, envelope.eventId());
             streams.ack(stream, group, message.id());

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisStreamNames.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisStreamNames.java
@@ -1,0 +1,20 @@
+package com.trainticket.platformkit.messaging;
+
+public final class RedisStreamNames {
+    private RedisStreamNames() {
+    }
+
+    public static String streamForProducer(String producer) {
+        if (producer == null || producer.isBlank()) {
+            throw new IllegalArgumentException("producer is required");
+        }
+        return "events:" + producer;
+    }
+
+    public static String dlqFor(String stream) {
+        if (stream == null || stream.isBlank()) {
+            throw new IllegalArgumentException("stream is required");
+        }
+        return stream.endsWith(":dlq") ? stream : stream + ":dlq";
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisStreamOperations.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisStreamOperations.java
@@ -1,0 +1,22 @@
+package com.trainticket.platformkit.messaging;
+
+import java.util.List;
+
+interface RedisStreamOperations {
+    void createGroup(String stream, String group);
+
+    String publish(String stream, String envelopeJson);
+
+    List<StreamEntry> readGroup(String stream, String group, String consumerName);
+
+    List<StreamEntry> autoClaim(String stream, String group, String consumerName);
+
+    int deliveryCount(String stream, String group, String messageId);
+
+    void ack(String stream, String group, String messageId);
+
+    void moveToDlq(String stream, String envelopeJson);
+
+    record StreamEntry(String id, String envelopeJson) {
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/SubscribeFailedException.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/SubscribeFailedException.java
@@ -1,0 +1,7 @@
+package com.trainticket.platformkit.messaging;
+
+public class SubscribeFailedException extends RuntimeException {
+    public SubscribeFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/platform/java-kit/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/platform/java-kit/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.trainticket.platformkit.PlatformKitConfiguration

--- a/platform/java-kit/src/test/java/com/trainticket/platformkit/http/PlatformKitExceptionHandlerTest.java
+++ b/platform/java-kit/src/test/java/com/trainticket/platformkit/http/PlatformKitExceptionHandlerTest.java
@@ -2,12 +2,18 @@ package com.trainticket.platformkit.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.trainticket.platformkit.PlatformKitConfiguration;
 import com.trainticket.platformkit.idempotency.IdempotencyKeyReusedException;
 import org.junit.jupiter.api.Test;
-import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
 
 class PlatformKitExceptionHandlerTest {
+    private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(PlatformKitConfiguration.class));
+
     @Test
     void mapsIdempotencyReuseToCanonical422() {
         PlatformKitExceptionHandler handler = new PlatformKitExceptionHandler();
@@ -19,4 +25,21 @@ class PlatformKitExceptionHandlerTest {
         assertThat(response.getBody().code()).isEqualTo("IDEMPOTENCY_KEY_REUSED");
         assertThat(response.getBody().correlationId()).isNotBlank();
     }
+
+    @Test
+    void platformConfigurationRegistersExceptionHandlerBean() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(PlatformKitExceptionHandler.class);
+
+            PlatformKitExceptionHandler handler = context.getBean(PlatformKitExceptionHandler.class);
+            ResponseEntity<ApiError> response = handler.handleIdempotencyReuse(
+                new IdempotencyKeyReusedException(),
+                new MockHttpServletRequest()
+            );
+
+            assertThat(response.getStatusCode().value()).isEqualTo(422);
+            assertThat(response.getBody().code()).isEqualTo("IDEMPOTENCY_KEY_REUSED");
+        });
+    }
 }
+

--- a/platform/java-kit/src/test/java/com/trainticket/platformkit/http/PlatformKitExceptionHandlerTest.java
+++ b/platform/java-kit/src/test/java/com/trainticket/platformkit/http/PlatformKitExceptionHandlerTest.java
@@ -1,0 +1,22 @@
+package com.trainticket.platformkit.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.trainticket.platformkit.idempotency.IdempotencyKeyReusedException;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.http.ResponseEntity;
+
+class PlatformKitExceptionHandlerTest {
+    @Test
+    void mapsIdempotencyReuseToCanonical422() {
+        PlatformKitExceptionHandler handler = new PlatformKitExceptionHandler();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        ResponseEntity<ApiError> response = handler.handleIdempotencyReuse(new IdempotencyKeyReusedException(), request);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(422);
+        assertThat(response.getBody().code()).isEqualTo("IDEMPOTENCY_KEY_REUSED");
+        assertThat(response.getBody().correlationId()).isNotBlank();
+    }
+}

--- a/platform/java-kit/src/test/java/com/trainticket/platformkit/idempotency/IdempotencyFilterTest.java
+++ b/platform/java-kit/src/test/java/com/trainticket/platformkit/idempotency/IdempotencyFilterTest.java
@@ -41,6 +41,7 @@ class IdempotencyFilterTest {
         assertThat(first.getContentAsString()).isEqualTo("created");
         assertThat(replay.getStatus()).isEqualTo(201);
         assertThat(replay.getContentAsString()).isEqualTo("created");
+        assertThat(replay.getHeader("Location")).isEqualTo("/api/v1/payments/pi-1");
         assertThat(reused.getStatus()).isEqualTo(422);
         assertThat(reused.getContentAsString()).contains("IDEMPOTENCY_KEY_REUSED");
     }
@@ -61,6 +62,7 @@ class IdempotencyFilterTest {
             HttpServletResponse httpResponse = (HttpServletResponse) response;
             httpResponse.setStatus(201);
             httpResponse.setContentType("application/json");
+            httpResponse.setHeader("Location", "/api/v1/payments/pi-1");
             httpResponse.getOutputStream().write(body.getBytes(StandardCharsets.UTF_8));
         };
     }

--- a/platform/java-kit/src/test/java/com/trainticket/platformkit/idempotency/IdempotencyFilterTest.java
+++ b/platform/java-kit/src/test/java/com/trainticket/platformkit/idempotency/IdempotencyFilterTest.java
@@ -1,0 +1,67 @@
+package com.trainticket.platformkit.idempotency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.platformkit.http.CanonicalErrorWriter;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class IdempotencyFilterTest {
+    private final InMemoryIdempotencyStore store = new InMemoryIdempotencyStore();
+    private final IdempotencyFilter filter = new IdempotencyFilter(store, new CanonicalErrorWriter(new ObjectMapper()));
+
+    @Test
+    void rejectsMissingOrNonV7Key() throws Exception {
+        MockHttpServletResponse response = execute("not-a-v7", "{\"a\":1}", okChain("created"));
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(response.getContentAsString()).contains("VALIDATION_FAILED");
+
+        MockHttpServletResponse v4 = execute("550e8400-e29b-41d4-a716-446655440000", "{\"a\":1}", okChain("created"));
+        assertThat(v4.getStatus()).isEqualTo(400);
+        assertThat(v4.getContentAsString()).contains("VALIDATION_FAILED");
+    }
+
+    @Test
+    void replaysOriginalResponseAndRejectsDifferentBody() throws Exception {
+        String key = UuidV7.generate();
+
+        MockHttpServletResponse first = execute(key, "{\"a\":1}", okChain("created"));
+        MockHttpServletResponse replay = execute(key, "{\"a\":1}", okChain("different"));
+        MockHttpServletResponse reused = execute(key, "{\"a\":2}", okChain("different"));
+
+        assertThat(first.getStatus()).isEqualTo(201);
+        assertThat(first.getContentAsString()).isEqualTo("created");
+        assertThat(replay.getStatus()).isEqualTo(201);
+        assertThat(replay.getContentAsString()).isEqualTo("created");
+        assertThat(reused.getStatus()).isEqualTo(422);
+        assertThat(reused.getContentAsString()).contains("IDEMPOTENCY_KEY_REUSED");
+    }
+
+    private MockHttpServletResponse execute(String key, String body, FilterChain chain) throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/payments");
+        if (key != null) {
+            request.addHeader(IdempotencyFilter.IDEMPOTENCY_KEY_HEADER, key);
+        }
+        request.setContent(body.getBytes(StandardCharsets.UTF_8));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilter(request, response, chain);
+        return response;
+    }
+
+    private static FilterChain okChain(String body) {
+        return (request, response) -> {
+            HttpServletResponse httpResponse = (HttpServletResponse) response;
+            httpResponse.setStatus(201);
+            httpResponse.setContentType("application/json");
+            httpResponse.getOutputStream().write(body.getBytes(StandardCharsets.UTF_8));
+        };
+    }
+}

--- a/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/EventEnvelopeFactoryTest.java
+++ b/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/EventEnvelopeFactoryTest.java
@@ -1,0 +1,45 @@
+package com.trainticket.platformkit.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class EventEnvelopeFactoryTest {
+    @Test
+    void createsStrictCanonicalEnvelope() throws Exception {
+        EventEnvelopeFactory factory = new EventEnvelopeFactory("payment", Clock.fixed(Instant.parse("2026-07-05T10:30:00Z"), ZoneOffset.UTC));
+        String correlationId = PrefixedIds.newCorrelationId();
+        String causationId = PrefixedIds.newCommandId();
+
+        EventEnvelope envelope = factory.create("PaymentCaptured", correlationId, causationId, Map.of("paymentIntentId", "pi-1"));
+
+        assertThat(PrefixedIds.isEventId(envelope.eventId())).isTrue();
+        assertThat(envelope.correlationId()).isEqualTo(correlationId);
+        assertThat(envelope.causationId()).isEqualTo(causationId);
+        assertThat(envelope.occurredAt()).isEqualTo(Instant.parse("2026-07-05T10:30:00Z"));
+        String json = new ObjectMapper().registerModule(new JavaTimeModule()).writeValueAsString(envelope);
+        assertThat(new ObjectMapper().readValue(json, Map.class).keySet())
+            .containsExactlyInAnyOrder("eventId", "eventType", "occurredAt", "correlationId", "causationId", "producer", "schemaVersion", "payload");
+    }
+
+    @Test
+    void rejectsInvalidProvidedIdsInsteadOfRegenerating() {
+        EventEnvelopeFactory factory = new EventEnvelopeFactory("payment");
+        assertThatThrownBy(() -> factory.create("PaymentCaptured", "corr-not-a-uuid", PrefixedIds.newCommandId(), Map.of()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("correlationId");
+        assertThatThrownBy(() -> factory.create("PaymentCaptured", PrefixedIds.newCorrelationId(), "cmd-not-a-uuid", Map.of()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("causationId");
+        assertThatThrownBy(() -> new EventEnvelope("evt-not-a-uuid", "Type", Instant.now(), PrefixedIds.newCorrelationId(), PrefixedIds.newCommandId(), "producer", 1, Map.of()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("eventId");
+    }
+}

--- a/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/EventEnvelopeFactoryTest.java
+++ b/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/EventEnvelopeFactoryTest.java
@@ -30,6 +30,29 @@ class EventEnvelopeFactoryTest {
     }
 
     @Test
+    void omitsAbsentOptionalCausationId() throws Exception {
+        EventEnvelopeFactory factory = new EventEnvelopeFactory("payment", Clock.fixed(Instant.parse("2026-07-05T10:30:00Z"), ZoneOffset.UTC));
+        String correlationId = PrefixedIds.newCorrelationId();
+
+        EventEnvelope envelope = factory.create("PaymentCaptured", correlationId, null, Map.of("paymentIntentId", "pi-1"));
+
+        assertThat(envelope.causationId()).isNull();
+        String json = new ObjectMapper().registerModule(new JavaTimeModule()).writeValueAsString(envelope);
+        assertThat(new ObjectMapper().readValue(json, Map.class).keySet())
+            .containsExactlyInAnyOrder("eventId", "eventType", "occurredAt", "correlationId", "producer", "schemaVersion", "payload");
+    }
+
+    @Test
+    void acceptsEventCausationId() {
+        EventEnvelopeFactory factory = new EventEnvelopeFactory("payment");
+        String eventCausationId = PrefixedIds.newEventId();
+
+        EventEnvelope envelope = factory.create("PaymentCaptured", PrefixedIds.newCorrelationId(), eventCausationId, Map.of());
+
+        assertThat(envelope.causationId()).isEqualTo(eventCausationId);
+    }
+
+    @Test
     void rejectsInvalidProvidedIdsInsteadOfRegenerating() {
         EventEnvelopeFactory factory = new EventEnvelopeFactory("payment");
         assertThatThrownBy(() -> factory.create("PaymentCaptured", "corr-not-a-uuid", PrefixedIds.newCommandId(), Map.of()))

--- a/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/InMemoryEventSubscriberTest.java
+++ b/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/InMemoryEventSubscriberTest.java
@@ -1,0 +1,42 @@
+package com.trainticket.platformkit.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class InMemoryEventSubscriberTest {
+    @Test
+    void transientFailuresUseDeliveryCountsAndDlqOnFifthAttempt() {
+        InMemoryEventBus bus = new InMemoryEventBus();
+        EventEnvelope envelope = new EventEnvelopeFactory("payment").create("PaymentCaptured", Map.of("id", "1"));
+        bus.publish("events:payment", envelope);
+        InMemoryEventSubscriber subscriber = new InMemoryEventSubscriber(bus);
+
+        subscriber.pollOnce(List.of("events:payment"), "journey-order", ignored -> HandlerResult.TRANSIENT_FAILURE);
+        for (int i = 0; i < 4; i++) {
+            subscriber.recoverOnce("events:payment", "journey-order", ignored -> HandlerResult.TRANSIENT_FAILURE);
+        }
+
+        assertThat(bus.dlq("events:payment")).containsExactly(envelope);
+    }
+
+    @Test
+    void deduplicatesAfterSuccessPerConsumerGroup() {
+        InMemoryEventBus bus = new InMemoryEventBus();
+        EventEnvelope envelope = new EventEnvelopeFactory("payment").create("PaymentCaptured", Map.of("id", "1"));
+        bus.publish("events:payment", envelope);
+        bus.publish("events:payment", envelope);
+        InMemoryEventSubscriber subscriber = new InMemoryEventSubscriber(bus);
+        int[] calls = {0};
+
+        subscriber.pollOnce(List.of("events:payment"), "journey-order", ignored -> {
+            calls[0]++;
+            return HandlerResult.SUCCESS;
+        });
+
+        assertThat(calls[0]).isEqualTo(1);
+        assertThat(bus.dlq("events:payment")).isEmpty();
+    }
+}

--- a/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/InMemoryEventSubscriberTest.java
+++ b/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/InMemoryEventSubscriberTest.java
@@ -23,6 +23,30 @@ class InMemoryEventSubscriberTest {
     }
 
     @Test
+    void handlerExceptionsLeavePendingAndRecoveryContinues() {
+        InMemoryEventBus bus = new InMemoryEventBus();
+        EventEnvelope first = new EventEnvelopeFactory("payment").create("PaymentCaptured", Map.of("id", "1"));
+        EventEnvelope second = new EventEnvelopeFactory("payment").create("PaymentCaptured", Map.of("id", "2"));
+        bus.publish("events:payment", first);
+        bus.publish("events:payment", second);
+        InMemoryEventSubscriber subscriber = new InMemoryEventSubscriber(bus);
+        int[] successes = {0};
+
+        subscriber.pollOnce(List.of("events:payment"), "journey-order", envelope -> {
+            if (envelope.eventId().equals(first.eventId())) {
+                throw new IllegalStateException("boom");
+            }
+            successes[0]++;
+            return HandlerResult.SUCCESS;
+        });
+        subscriber.recoverOnce("events:payment", "journey-order", ignored -> HandlerResult.SUCCESS);
+
+        assertThat(successes[0]).isEqualTo(1);
+        assertThat(bus.pendingDeliveryCount("events:payment", "journey-order", "1-0")).isEmpty();
+        assertThat(bus.dlq("events:payment")).isEmpty();
+    }
+
+    @Test
     void deduplicatesAfterSuccessPerConsumerGroup() {
         InMemoryEventBus bus = new InMemoryEventBus();
         EventEnvelope envelope = new EventEnvelopeFactory("payment").create("PaymentCaptured", Map.of("id", "1"));

--- a/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/PublishAfterCommitTest.java
+++ b/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/PublishAfterCommitTest.java
@@ -1,0 +1,36 @@
+package com.trainticket.platformkit.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+class PublishAfterCommitTest {
+    @Test
+    void publishesOnlyAfterCommitWhenTransactionSynchronizationIsActive() {
+        EventEnvelope envelope = new EventEnvelopeFactory("payment").create("PaymentCaptured", Map.of());
+        List<EventEnvelope> published = new ArrayList<>();
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            PublishAfterCommit.publish(published::add, envelope);
+            assertThat(published).isEmpty();
+            TransactionSynchronizationManager.getSynchronizations().forEach(TransactionSynchronization::afterCommit);
+            assertThat(published).containsExactly(envelope);
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    @Test
+    void doesNotSwallowPublishErrors() {
+        EventEnvelope envelope = new EventEnvelopeFactory("payment").create("PaymentCaptured", Map.of());
+        assertThatThrownBy(() -> PublishAfterCommit.publish(event -> {
+            throw new PublishFailedException("boom", null);
+        }, envelope)).isInstanceOf(PublishFailedException.class);
+    }
+}

--- a/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/RedisEventSubscriberTest.java
+++ b/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/RedisEventSubscriberTest.java
@@ -1,0 +1,87 @@
+package com.trainticket.platformkit.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class RedisEventSubscriberTest {
+    @Test
+    void handlerExceptionLeavesMessagePendingAndLoopContinues() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        EventEnvelope first = new EventEnvelopeFactory("payment").create("PaymentCaptured", Map.of("id", "1"));
+        EventEnvelope second = new EventEnvelopeFactory("payment").create("PaymentCaptured", Map.of("id", "2"));
+        FakeRedisStreams streams = new FakeRedisStreams(List.of(
+            new RedisStreamOperations.StreamEntry("1-0", objectMapper.writeValueAsString(first)),
+            new RedisStreamOperations.StreamEntry("2-0", objectMapper.writeValueAsString(second))
+        ));
+        RedisEventSubscriber subscriber = new RedisEventSubscriber(streams, objectMapper, null);
+        CountDownLatch secondHandled = new CountDownLatch(1);
+
+        subscriber.subscribe(List.of("events:payment"), "journey-order", "consumer-1", envelope -> {
+            if (envelope.eventId().equals(first.eventId())) {
+                throw new IllegalStateException("boom");
+            }
+            secondHandled.countDown();
+            return HandlerResult.SUCCESS;
+        });
+
+        assertThat(secondHandled.await(2, TimeUnit.SECONDS)).isTrue();
+        subscriber.close();
+        assertThat(streams.acked).containsExactly("2-0");
+        assertThat(streams.acked).doesNotContain("1-0");
+    }
+
+    private static final class FakeRedisStreams implements RedisStreamOperations {
+        private final List<StreamEntry> firstBatch;
+        private final List<String> acked = new ArrayList<>();
+        private boolean delivered;
+
+        private FakeRedisStreams(List<StreamEntry> firstBatch) {
+            this.firstBatch = firstBatch;
+        }
+
+        @Override
+        public void createGroup(String stream, String group) {
+        }
+
+        @Override
+        public String publish(String stream, String envelopeJson) {
+            return "1-0";
+        }
+
+        @Override
+        public synchronized List<StreamEntry> readGroup(String stream, String group, String consumerName) {
+            if (delivered) {
+                return List.of();
+            }
+            delivered = true;
+            return firstBatch;
+        }
+
+        @Override
+        public List<StreamEntry> autoClaim(String stream, String group, String consumerName) {
+            return List.of();
+        }
+
+        @Override
+        public int deliveryCount(String stream, String group, String messageId) {
+            return 1;
+        }
+
+        @Override
+        public void ack(String stream, String group, String messageId) {
+            acked.add(messageId);
+        }
+
+        @Override
+        public void moveToDlq(String stream, String envelopeJson) {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add standalone platform/java-kit Maven module for shared Java integration primitives
- Provide canonical error handling and idempotency filter/store with UUID v7 validation and replay semantics
- Add strict event envelope factory plus Redis/in-memory publisher/subscriber runtime with DLQ and dedup semantics

## Validation
- cd platform/java-kit && mvn -q test
- git diff origin/refactor/greenfield-ddd...HEAD --name-only | grep -v '^platform/java-kit' | wc -l
- make check
- make contract-lint