### PR TITLE
Close all post-联调 gaps: real refund pricing, contract alignment, subscriber self-healing

### DIFF
--- a/deploy/e2e/02-purchase.sh
+++ b/deploy/e2e/02-purchase.sh
@@ -103,10 +103,26 @@ sleep 6
 echo "== 8. saga completion + final states"
 echo "  entitlement stream:"; last_events events:entitlement-ticketing 2
 echo "  booking stream:"; last_events events:booking-orchestration 3
-req GET booking-orchestration "/api/v1/internal/booking-sagas/$SAGA"
+SAGA_STATUS=""
+for attempt in 1 2 3; do
+  req GET booking-orchestration "/api/v1/internal/booking-sagas/$SAGA"
+  SAGA_STATUS=$(jget "['status']")
+  [ "$SAGA_STATUS" = "COMPLETED" ] && break
+  sleep 4
+done
 echo "  saga: $(echo $RESP | head -c 220) [$LAST_CODE]"
-req GET journey-order "/api/v1/journey-orders/$ORDER"
-echo "  order status: $(jget "['status']") [$LAST_CODE]"
+[ "$SAGA_STATUS" = "COMPLETED" ] && ok "saga COMPLETED" || bad "saga not completed ($SAGA_STATUS)"
+STEP_STATES=$(echo "$RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); print(','.join(sorted(set(s['status'] for s in d.get('steps',[]))) or ['NONE']))" 2>/dev/null)
+[ "$STEP_STATES" = "SUCCEEDED" ] && ok "all saga steps SUCCEEDED" || bad "saga steps not all SUCCEEDED ($STEP_STATES)"
+ORDER_STATUS=""
+for attempt in 1 2 3; do
+  req GET journey-order "/api/v1/journey-orders/$ORDER"
+  ORDER_STATUS=$(jget "['status']")
+  [ "$ORDER_STATUS" = "CONFIRMED" ] && break
+  sleep 4
+done
+echo "  order status: $ORDER_STATUS [$LAST_CODE]"
+[ "$ORDER_STATUS" = "CONFIRMED" ] && ok "order CONFIRMED" || bad "order not confirmed ($ORDER_STATUS)"
 
 cat >> ./.refs.env << EOF
 ACCT=$ACCT

--- a/deploy/e2e/03-refund.sh
+++ b/deploy/e2e/03-refund.sh
@@ -15,7 +15,10 @@ echo "  CASE=$CASE status=$(jget "['status']")"
 echo "== 2. evaluate"
 req POST post-sales "/api/v1/post-sales-cases/$CASE/evaluate" '{}'
 check_code 200 "evaluate case"
+REFUNDABLE=$(jget "['refundableAmount']['minorUnits']")
 echo "  eligible=$(jget "['eligible']") refundable=$(jget "['refundableAmount']")"
+# fare 107.50 - refund fee 20.00 = 87.50 CNY (default rule set)
+[ "$REFUNDABLE" = "8750" ] && ok "refundable = 87.50 CNY (real adjustment quote)" || bad "refundable amount wrong ($REFUNDABLE, expected 8750)"
 
 echo "== 3. approve"
 req POST post-sales "/api/v1/post-sales-cases/$CASE/approve" '{}'
@@ -29,10 +32,53 @@ echo "  capacity stream:"; last_events events:capacity-availability 2
 echo "  entitlement stream:"; last_events events:entitlement-ticketing 2
 
 echo "== 5. final states"
-req GET post-sales "/api/v1/post-sales-cases/$CASE"
-echo "  case status: $(jget "['status']") [$LAST_CODE]"
-req GET journey-order "/api/v1/journey-orders/$ORDER"
-echo "  order status: $(jget "['status']") [$LAST_CODE]"
+CASE_STATUS=""
+for attempt in 1 2 3; do
+  req GET post-sales "/api/v1/post-sales-cases/$CASE"
+  CASE_STATUS=$(jget "['status']")
+  [ "$CASE_STATUS" = "APPLIED" ] && break
+  sleep 4
+done
+echo "  case status: $CASE_STATUS [$LAST_CODE]"
+[ "$CASE_STATUS" = "APPLIED" ] && ok "case APPLIED" || bad "case not applied ($CASE_STATUS)"
+ORDER_STATUS=""
+for attempt in 1 2 3; do
+  req GET journey-order "/api/v1/journey-orders/$ORDER"
+  ORDER_STATUS=$(jget "['status']")
+  [ "$ORDER_STATUS" = "ADJUSTED" ] && break
+  sleep 4
+done
+echo "  order status: $ORDER_STATUS [$LAST_CODE]"
+[ "$ORDER_STATUS" = "ADJUSTED" ] && ok "order ADJUSTED" || bad "order not adjusted ($ORDER_STATUS)"
 req GET entitlement-ticketing "/api/v1/entitlements/$ENT"
-echo "  entitlement status: $(jget "['status']") [$LAST_CODE]"
+ENT_STATUS=$(jget "['status']")
+echo "  entitlement status: $ENT_STATUS [$LAST_CODE]"
+[ "$ENT_STATUS" = "VOIDED" ] && ok "entitlement VOIDED" || bad "entitlement not voided ($ENT_STATUS)"
+
+echo "== 6. bystander side-effects (notification / finance-settlement / reporting)"
+stream_mentions() { # STREAM EVENT_TYPE NEEDLE -> yes/empty
+  k exec "$(redis_pod)" -- redis-cli XREVRANGE "$1" + - COUNT 60 > /tmp/bystander.txt 2>/dev/null
+  ET="$2" NEEDLE="$3" python3 - << 'PYEX'
+import re, os, json
+raw = open("/tmp/bystander.txt").read()
+for m in re.finditer(r'\{.*\}', raw):
+    try:
+        e = json.loads(m.group(0).encode().decode('unicode_escape'))
+        if e.get("eventType") == os.environ["ET"] and os.environ["NEEDLE"] in json.dumps(e.get("payload", {})):
+            print("yes"); break
+    except Exception:
+        pass
+PYEX
+}
+NOTIF_OK=$(stream_mentions events:notification NotificationScheduled "$TVL")
+[ "$NOTIF_OK" = "yes" ] && ok "notification scheduled for our traveler" || bad "no NotificationScheduled for traveler"
+FIN_OK=$(stream_mentions events:finance-settlement RevenueRecognized "$ORDER")
+[ "$FIN_OK" = "yes" ] && ok "RevenueRecognized for our order" || bad "no RevenueRecognized mentioning order"
+RPT_LEN=$(xlen events:reporting)
+[ "${RPT_LEN:-0}" -gt 0 ] 2>/dev/null && ok "reporting published ReadModelRebuilt facts (XLEN=$RPT_LEN)" || bad "reporting stream empty"
+req GET reporting /api/v1/dashboards/dash-revenue
+DASH_STATUS=$(jget "['status']")
+REBUILDS=$(echo "$RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('currentSnapshot',{}).get('rebuildId',''))" 2>/dev/null)
+echo "  dash-revenue status=$DASH_STATUS snapshot=$REBUILDS"
+case "$DASH_STATUS" in ready|stale) ok "dash-revenue read model live" ;; *) bad "dash-revenue status unexpected ($DASH_STATUS)" ;; esac
 summary

--- a/deploy/e2e/04-change.sh
+++ b/deploy/e2e/04-change.sh
@@ -19,7 +19,10 @@ echo "  CASE=$CASE"
 echo "== 2. evaluate (fare adjustment quote path)"
 req POST post-sales "/api/v1/post-sales-cases/$CASE/evaluate" '{}'
 check_code 200 "evaluate CHANGE"
+AMOUNT_DUE=$(jget "['amountDue']['minorUnits']")
 echo "  eligible=$(jget "['eligible']") amountDue=$(jget "['amountDue']")"
+# same-fare change: fare diff 0 + change fee 15.00 CNY (default rule set)
+[ "$AMOUNT_DUE" = "1500" ] && ok "amountDue = 15.00 CNY change fee (real adjustment quote)" || bad "amountDue wrong ($AMOUNT_DUE, expected 1500)"
 
 echo "== 3. approve → old ticket teardown"
 req POST post-sales "/api/v1/post-sales-cases/$CASE/approve" '{}'

--- a/docs/08-contracts/events/service-plan.md
+++ b/docs/08-contracts/events/service-plan.md
@@ -1,0 +1,64 @@
+# Service Plan Event Contracts
+
+Service Plan owns scheduled services (运行计划) and their sellable service
+segments. It publishes plan facts to `events:service-plan`; Trip Planning
+consumes them to build itinerary candidates (see messaging.md subscription
+table row 2).
+
+Field shapes reference docs/08-contracts/shared-primitives.md for IDs and
+timestamps. All timestamps are RFC3339 UTC.
+
+## Published Events
+
+### ServicePlanPublished
+
+| Field | Description |
+|---|---|
+| **Producer** | service-plan |
+| **Consumers** | trip-planning |
+| **Trigger** | `CreateScheduledService` command processed — a scheduled service becomes part of the sellable plan. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `scheduledServiceRef` | string | yes | Canonical scheduled service ID (`ss-<uuid>`). |
+| `serviceNumber` | string | yes | Public service number (e.g. `G1234`). |
+| `status` | string | yes | Plan status of the scheduled service. |
+| `carrierId` | string | yes | Operating carrier reference. |
+| `departureTime` | RFC3339 UTC | yes | Scheduled departure of the full service. |
+| `arrivalTime` | RFC3339 UTC | yes | Scheduled arrival of the full service. |
+| `originNodeId` | string | yes | Origin transport node (`tnd-<uuid>`, place-network). |
+| `destinationNodeId` | string | yes | Destination transport node (`tnd-<uuid>`, place-network). |
+
+### ServicePlanChanged
+
+| Field | Description |
+|---|---|
+| **Producer** | service-plan |
+| **Consumers** | trip-planning |
+| **Trigger** | `CreateServiceSegment` command processed — a sellable segment is added to (or changed within) an already-published scheduled service. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `segmentRef` | string | yes | Canonical service segment ID (`seg-<uuid>`). |
+| `scheduledServiceRef` | string | yes | Parent scheduled service ID (`ss-<uuid>`). |
+| `originStopRef` | string | yes | Segment origin stop (transport node ref). |
+| `destinationStopRef` | string | yes | Segment destination stop (transport node ref). |
+| `departureTime` | RFC3339 UTC | yes | Segment departure time. |
+| `arrivalTime` | RFC3339 UTC | yes | Segment arrival time. |
+
+## Consumer Notes
+
+- Trip Planning treats these events as the authoritative plan feed: itinerary
+  search must only return segments observed on this stream (no synthetic
+  candidates once a plan exists).
+- `originStopRef`/`destinationStopRef` may arrive as transport node refs
+  (`tnd-*`); consumers that key by place must resolve node→place via the
+  place-network registration events they have already consumed.
+
+## Open Issues
+
+- None.

--- a/docs/08-contracts/messaging.md
+++ b/docs/08-contracts/messaging.md
@@ -47,7 +47,7 @@ context.
 
 | # | Producing Context | Stream Key | Produced Event Types (Phase 1) |
 |---|---|---|---|
-| 1 | `place-network` | `events:place-network` | PlaceUpdated, TransportNodeUpdated |
+| 1 | `place-network` | `events:place-network` | PlaceRegistered, TransportNodeRegistered |
 | 2 | `service-plan` | `events:service-plan` | ServicePlanPublished, ServicePlanChanged |
 | 3 | `capacity-availability` | `events:capacity-availability` | CapacityHeld, CapacityHoldConfirmed, CapacityHoldExpired, CapacityReleased, AvailabilityChanged |
 | 4 | `fare-pricing` | `events:fare-pricing` | FareRuleSetPublished, FareRuleSetSuperseded |
@@ -59,7 +59,7 @@ context.
 | 10 | `provider-integration` | `events:provider-integration` | ProviderReservationConfirmed, ProviderReservationFailed, ProviderReservationCancelled, ProviderBoardingAccepted |
 | 11 | `entitlement-ticketing` | `events:entitlement-ticketing` | EntitlementIssued, EntitlementVoided, EntitlementSuspended, EntitlementReinstated |
 | 12 | `fulfillment` | `events:fulfillment` | BoardingVerified, SegmentArrived, SegmentDelayed, NoShowRecorded, SegmentCompleted |
-| 13 | `post-sales` | `events:post-sales` | PostSalesRequested, PostSalesEvaluated, PostSalesApproved, PostSalesRejected, PostSalesApplied |
+| 13 | `post-sales` | `events:post-sales` | PostSalesCaseOpened, PostSalesRequested, PostSalesEligibilityEvaluated, PostSalesDecisionQuoted, PostSalesApproved, PostSalesRejected, PostSalesApplied |
 | 14 | `notification` | `events:notification` | NotificationScheduled, NotificationSent, NotificationFailed, NotificationSuppressed |
 | 15 | `traveler-profile` | `events:traveler-profile` | TravelerProfileUpdated, TravelerDocumentVerified, TravelerEligibilityChanged |
 | 16 | `risk-compliance` | `events:risk-compliance` | RiskAssessmentResult, RiskBlockApplied, RiskBlockLifted |
@@ -67,7 +67,7 @@ context.
 | 18 | `admin-audit` | `events:admin-audit` | ManualActionCompleted, ApprovalGranted, ApprovalDenied |
 | 19 | `customer-service` | `events:customer-service` | SupportCaseOpened, SupportCaseResolved |
 | 20 | `finance-settlement` | `events:finance-settlement` | RevenueRecognized, ReconciliationCompleted, InvoiceGenerated |
-| 21 | `reporting` | `events:reporting` | ReportGenerated, DashboardRefreshed |
+| 21 | `reporting` | `events:reporting` | MetricDefined, MetricVersionPublished, ReadModelRebuilt |
 | 22 | `supplier-catalog` | `events:supplier-catalog` | SupplierUpdated, ContractAmended, ProductCapabilityChanged |
 
 ### Dead-Letter Streams

--- a/platform/go-kit/messaging/redis.go
+++ b/platform/go-kit/messaging/redis.go
@@ -185,6 +185,19 @@ func (b *RedisEventBus) consumeLoop(ctx context.Context, streams []string, group
 			if errors.Is(err, redis.Nil) {
 				continue
 			}
+			// A non-persistent Redis loses consumer groups on restart:
+			// NOGROUP means "recreate and carry on". Every other error
+			// backs off so a dead connection never hot-spins this loop.
+			if strings.Contains(strings.ToUpper(err.Error()), "NOGROUP") {
+				for _, s := range streams {
+					_ = b.ensureGroup(ctx, s, group)
+				}
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Second):
+			}
 			continue
 		}
 		for _, stream := range result {

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class RedisEventSubscriber implements EventSubscriber {
     public static final int MAX_DELIVERY_ATTEMPTS = 5;
+    private static final long POLL_FAILURE_BACKOFF_MILLIS = 1_000;
 
     private final RedisStreamOperations streams;
     private final ObjectMapper objectMapper;
@@ -82,6 +83,17 @@ public class RedisEventSubscriber implements EventSubscriber {
                     }
                 } catch (RuntimeException exception) {
                     // Keep the subscriber alive; messages read but not acked remain in the Redis PEL for recovery/DLQ policy.
+                    // A non-persistent Redis loses consumer groups on restart: NOGROUP
+                    // means "recreate the group and carry on". Anything else backs off
+                    // so a dead connection never turns this loop into a hot spin.
+                    if (isNoGroup(exception)) {
+                        try {
+                            streams.createGroup(stream, group);
+                        } catch (RuntimeException ignored) {
+                            // Redis still down; the backoff below paces the retry.
+                        }
+                    }
+                    sleepQuietly(POLL_FAILURE_BACKOFF_MILLIS);
                 }
             }
         }
@@ -129,6 +141,24 @@ public class RedisEventSubscriber implements EventSubscriber {
         } else if (result == HandlerResult.FATAL_FAILURE) {
             streams.moveToDlq(stream, json);
             streams.ack(stream, group, message.id());
+        }
+    }
+
+    private static boolean isNoGroup(RuntimeException exception) {
+        for (Throwable cause = exception; cause != null; cause = cause.getCause()) {
+            String message = cause.getMessage();
+            if (message != null && message.contains("NOGROUP")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void sleepQuietly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/platform/python-kit/src/train_ticket_platform/messaging.py
+++ b/platform/python-kit/src/train_ticket_platform/messaging.py
@@ -167,7 +167,13 @@ class RedisEventSubscriber(EventSubscriber):
                     break
                 if isinstance(exc, (TransientHandlerError, FatalHandlerError)):
                     raise
-                raise SubscribeFailed("subscriber could not poll Redis Streams") from exc
+                # Redis is non-persistent here: a restart drops consumer groups,
+                # so recreate them on NOGROUP instead of spinning on the error.
+                if "NOGROUP" in str(exc):
+                    for stream in streams_tuple:
+                        self._ensure_group(stream, group)
+                # Back off so a dead connection never hot-spins.
+                time.sleep(1)
 
     def start_in_background(
         self,

--- a/platform/rust-kit/src/messaging.rs
+++ b/platform/rust-kit/src/messaging.rs
@@ -682,6 +682,20 @@ pub mod redis_runtime {
             }
             Ok(())
         }
+        // A non-persistent Redis loses consumer groups on restart: a NOGROUP
+        // error means recreate the groups and carry on. Every consume error
+        // backs off so a dead connection never hot-spins the subscribe loop.
+        async fn handle_consume_error(
+            connection: &mut redis::aio::MultiplexedConnection,
+            streams: &[String],
+            group: &str,
+            error: &str,
+        ) {
+            if error.to_uppercase().contains("NOGROUP") {
+                let _ = Self::create_groups(connection, streams, group).await;
+            }
+            sleep(Duration::from_secs(1)).await;
+        }
         async fn recover_pending(
             &self,
             connection: &mut redis::aio::MultiplexedConnection,
@@ -772,15 +786,20 @@ pub mod redis_runtime {
                 .map_err(|error| SubscribeFailed(error.to_string()))?;
             Self::create_groups(&mut connection, &streams, &group).await?;
             while !self.stop.load(std::sync::atomic::Ordering::SeqCst) {
-                self.recover_pending(
-                    &mut connection,
-                    &streams,
-                    &group,
-                    &consumer_name,
-                    handler.as_ref(),
-                )
-                .await?;
-                let response: redis::Value = redis::cmd("XREADGROUP")
+                if let Err(error) = self
+                    .recover_pending(
+                        &mut connection,
+                        &streams,
+                        &group,
+                        &consumer_name,
+                        handler.as_ref(),
+                    )
+                    .await
+                {
+                    Self::handle_consume_error(&mut connection, &streams, &group, &error.0).await;
+                    continue;
+                }
+                let response: RedisResult<redis::Value> = redis::cmd("XREADGROUP")
                     .arg("GROUP")
                     .arg(&group)
                     .arg(&consumer_name)
@@ -792,8 +811,20 @@ pub mod redis_runtime {
                     .arg(&streams)
                     .arg(vec![">"; streams.len()])
                     .query_async(&mut connection)
-                    .await
-                    .map_err(|error| SubscribeFailed(error.to_string()))?;
+                    .await;
+                let response = match response {
+                    Ok(value) => value,
+                    Err(error) => {
+                        Self::handle_consume_error(
+                            &mut connection,
+                            &streams,
+                            &group,
+                            &error.to_string(),
+                        )
+                        .await;
+                        continue;
+                    }
+                };
                 for message in parse_stream_messages(response) {
                     self.process_message(&mut connection, &group, message, handler.as_ref())
                         .await?;

--- a/platform/ts-kit/dist/messaging.js
+++ b/platform/ts-kit/dist/messaging.js
@@ -245,8 +245,17 @@ export class RedisEventSubscriber {
             if (!read) {
                 throw new TypeError("Redis client does not support XREADGROUP");
             }
-            const messages = await read("XREADGROUP", "GROUP", group, consumerName, "BLOCK", READ_BLOCK_MS, "COUNT", READ_COUNT, "STREAMS", ...streams, ...streams.map(() => ">"));
-            await this.processMessages(messages, group, handler);
+            try {
+                const messages = await read("XREADGROUP", "GROUP", group, consumerName, "BLOCK", READ_BLOCK_MS, "COUNT", READ_COUNT, "STREAMS", ...streams, ...streams.map(() => ">"));
+                await this.processMessages(messages, group, handler);
+            }
+            catch (error) {
+                // Non-persistent redis loses consumer groups on restart; recreate then back off so a dead connection never hot-spins.
+                if (String(error).includes("NOGROUP")) {
+                    await Promise.all(streams.map((stream) => this.createGroup(stream, group)));
+                }
+                await sleep(1_000);
+            }
         }
     }
     async recover(streams, group, consumerName, handler, signal) {

--- a/platform/ts-kit/src/messaging.ts
+++ b/platform/ts-kit/src/messaging.ts
@@ -341,20 +341,28 @@ export class RedisEventSubscriber implements EventSubscriber {
       if (!read) {
         throw new TypeError("Redis client does not support XREADGROUP");
       }
-      const messages = await read(
-        "XREADGROUP",
-        "GROUP",
-        group,
-        consumerName,
-        "BLOCK",
-        READ_BLOCK_MS,
-        "COUNT",
-        READ_COUNT,
-        "STREAMS",
-        ...streams,
-        ...streams.map(() => ">"),
-      ) as StreamMessages[] | null;
-      await this.processMessages(messages, group, handler);
+      try {
+        const messages = await read(
+          "XREADGROUP",
+          "GROUP",
+          group,
+          consumerName,
+          "BLOCK",
+          READ_BLOCK_MS,
+          "COUNT",
+          READ_COUNT,
+          "STREAMS",
+          ...streams,
+          ...streams.map(() => ">"),
+        ) as StreamMessages[] | null;
+        await this.processMessages(messages, group, handler);
+      } catch (error) {
+        // Non-persistent redis loses consumer groups on restart; recreate then back off so a dead connection never hot-spins.
+        if (String(error).includes("NOGROUP")) {
+          await Promise.all(streams.map((stream) => this.createGroup(stream, group)));
+        }
+        await sleep(1_000);
+      }
     }
   }
 

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/RequestContextFilter.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/RequestContextFilter.java
@@ -1,6 +1,7 @@
 package com.trainticket.adminaudit;
 
 import com.trainticket.platformkit.http.CorrelationIds;
+import com.trainticket.platformkit.messaging.PrefixedIds;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -30,7 +31,7 @@ public class RequestContextFilter extends OncePerRequestFilter {
         FilterChain filterChain
     ) throws ServletException, IOException {
         String requestId = headerOrGenerated(request, REQUEST_ID_HEADER);
-        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, requestId);
+        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, PrefixedIds.newCorrelationId());
         RequestTraceContext context = new RequestTraceContext(
             requestId,
             correlationId,

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/RequestContextFilter.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/RequestContextFilter.java
@@ -1,5 +1,7 @@
 package com.trainticket.bookingorchestration;
 
+import com.trainticket.platformkit.messaging.PrefixedIds;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,7 +31,7 @@ public class RequestContextFilter extends OncePerRequestFilter {
         FilterChain filterChain
     ) throws ServletException, IOException {
         String requestId = headerOrGenerated(request, REQUEST_ID_HEADER);
-        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, requestId);
+        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, PrefixedIds.newCorrelationId());
         request.setAttribute(REQUEST_ID_HEADER, requestId);
         request.setAttribute(CORRELATION_ID_HEADER, correlationId);
         RequestTraceContext context = new RequestTraceContext(

--- a/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
+++ b/services/booking-orchestration/src/main/java/com/trainticket/bookingorchestration/application/BookingOrchestrationService.java
@@ -50,7 +50,7 @@ public class BookingOrchestrationService {
     }
 
     public StartSagaResult startSaga(StartSagaCommand command, String idempotencyKey, String correlationId) {
-        String sagaId = "saga-" + UUID.randomUUID();
+        String sagaId = "saga-" + com.trainticket.platformkit.idempotency.UuidV7.generate();
         BookingSaga saga = startSagaAggregate(sagaId, command.journeyOrderId(), command.segmentRefs());
         sagas.put(sagaId, saga);
         indexSagaCorrelation(correlationId, sagaId);
@@ -166,7 +166,7 @@ public class BookingOrchestrationService {
         if (segmentRefs.isEmpty()) {
             throw new IllegalArgumentException("JourneyOrderCreated payload requires segmentRefs or segments");
         }
-        String sagaId = "saga-" + UUID.randomUUID();
+        String sagaId = "saga-" + com.trainticket.platformkit.idempotency.UuidV7.generate();
         BookingSaga saga = startSagaAggregate(sagaId, journeyOrderId, segmentRefs);
         sagas.put(sagaId, saga);
         indexSagaCorrelation(correlationId, sagaId);

--- a/services/fare-pricing/src/fare_pricing/api.py
+++ b/services/fare-pricing/src/fare_pricing/api.py
@@ -206,6 +206,18 @@ def _install_default_rule_sets(store: "InMemoryStore") -> None:
                     amount=Money(Decimal("7.50"), "CNY"),
                     explanation=PriceExplanation("fare.tax", {"rule": "tax"}),
                 ),
+                FareRule(
+                    rule_id="refund-fee",
+                    kind=RuleKind.REFUND_FEE,
+                    amount=Money(Decimal("20.00"), "CNY"),
+                    explanation=PriceExplanation("fare.refund_fee", {"rule": "refund-fee"}),
+                ),
+                FareRule(
+                    rule_id="change-fee",
+                    kind=RuleKind.CHANGE_FEE,
+                    amount=Money(Decimal("15.00"), "CNY"),
+                    explanation=PriceExplanation("fare.change_fee", {"rule": "change-fee"}),
+                ),
             ),
         ).publish(now)
         store.fare_rule_sets[rule_set.rule_set_id] = rule_set

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/RequestContextFilter.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/RequestContextFilter.java
@@ -1,6 +1,7 @@
 package com.trainticket.financesettlement;
 
 import com.trainticket.platformkit.http.CorrelationIds;
+import com.trainticket.platformkit.messaging.PrefixedIds;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -34,7 +35,7 @@ public class RequestContextFilter extends OncePerRequestFilter {
         FilterChain filterChain
     ) throws ServletException, IOException {
         String requestId = headerOrGenerated(request, REQUEST_ID_HEADER);
-        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, requestId);
+        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, PrefixedIds.newCorrelationId());
         RequestTraceContext context = new RequestTraceContext(
             requestId,
             correlationId,

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RevenueRecognition.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RevenueRecognition.java
@@ -6,7 +6,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 
 public final class RevenueRecognition {
     private final String revenueRecognitionId;
@@ -51,7 +50,7 @@ public final class RevenueRecognition {
             throw new DomainRuleViolation("revenue recognition amount must not be zero");
 
         RevenueRecognition recognition = new RevenueRecognition(
-            UUID.randomUUID().toString(), orderId, orderItemId, componentCode,
+            com.trainticket.platformkit.idempotency.UuidV7.generate(), orderId, orderItemId, componentCode,
             amount, recognitionPolicyVersion, sourceEventId, recognizedAt
         );
 

--- a/services/payment/src/main/java/com/trainticket/payment/RequestContextFilter.java
+++ b/services/payment/src/main/java/com/trainticket/payment/RequestContextFilter.java
@@ -1,6 +1,7 @@
 package com.trainticket.payment;
 
 import com.trainticket.platformkit.http.CorrelationIds;
+import com.trainticket.platformkit.messaging.PrefixedIds;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,7 +33,7 @@ public class RequestContextFilter extends OncePerRequestFilter {
         FilterChain filterChain
     ) throws ServletException, IOException {
         String requestId = headerOrGenerated(request, REQUEST_ID_HEADER);
-        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, requestId);
+        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, PrefixedIds.newCorrelationId());
         RequestTraceContext context = new RequestTraceContext(
             requestId,
             correlationId,

--- a/services/place-network/internal/adapters/messaging/subscriber.go
+++ b/services/place-network/internal/adapters/messaging/subscriber.go
@@ -33,7 +33,7 @@ func (s *RedisSubscriber) Subscribe(streams []string, group string, consumerName
 	ctx := context.Background()
 	for _, stream := range streams {
 		err := s.client.XGroupCreateMkStream(ctx, stream, group, "$").Err()
-		if err != nil && !strings.Contains(err.Error(), "BUSYGROUP") {
+		if err != nil && !strings.Contains(strings.ToUpper(err.Error()), "BUSYGROUP") {
 			return fmt.Errorf("subscribe failed: %w", err)
 		}
 	}
@@ -67,14 +67,30 @@ func (s *RedisSubscriber) pollLoop(streams []string, group, consumerName string,
 			if errors.Is(err, redis.Nil) {
 				continue
 			}
+			// A non-persistent Redis loses consumer groups on restart:
+			// NOGROUP means recreate the groups and carry on. Every error
+			// backs off so a dead connection never hot-spins this loop.
+			if strings.Contains(strings.ToUpper(err.Error()), "NOGROUP") {
+				s.ensureGroups(streams, group)
+			}
 			log.Printf("place-network subscriber read error: %v", err)
-			time.Sleep(500 * time.Millisecond)
+			time.Sleep(time.Second)
 			continue
 		}
 		for _, stream := range results {
 			for _, msg := range stream.Messages {
 				s.processMessage(stream.Stream, group, msg, handler)
 			}
+		}
+	}
+}
+
+func (s *RedisSubscriber) ensureGroups(streams []string, group string) {
+	ctx := context.Background()
+	for _, stream := range streams {
+		err := s.client.XGroupCreateMkStream(ctx, stream, group, "$").Err()
+		if err != nil && !strings.Contains(strings.ToUpper(err.Error()), "BUSYGROUP") {
+			log.Printf("place-network subscriber recreate group error: %v", err)
 		}
 	}
 }

--- a/services/post-sales/README.md
+++ b/services/post-sales/README.md
@@ -13,7 +13,7 @@ Status: REQ-014 domain foundation
 - PostSalesCase lifecycle for cancellation, refund, change, rebook, and compensation case intake
 - Immutable PostSalesDecision snapshots referencing Fare & Pricing evaluation and rule snapshots
 - PostSalesExecutionPlan step ordering for entitlement, booking/segment, capacity, payment, and result-application requests
-- PostSales domain events: PostSalesRequested, PostSalesEvaluated, PostSalesApproved, PostSalesApplied
+- PostSales domain events: PostSalesRequested, PostSalesEligibilityEvaluated, PostSalesDecisionQuoted, PostSalesApproved, PostSalesApplied
 
 ## Boundary
 

--- a/services/post-sales/src/main/java/com/trainticket/postsales/adapters/http/FarePricingAdjustmentQuoteClient.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/adapters/http/FarePricingAdjustmentQuoteClient.java
@@ -1,0 +1,81 @@
+package com.trainticket.postsales.adapters.http;
+
+import com.trainticket.postsales.application.AdjustmentQuotePort;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class FarePricingAdjustmentQuoteClient implements AdjustmentQuotePort {
+    private static final Logger log = LoggerFactory.getLogger(FarePricingAdjustmentQuoteClient.class);
+    private static final ParameterizedTypeReference<Map<String, Object>> MAP_TYPE = new ParameterizedTypeReference<>() { };
+
+    private final RestClient restClient;
+
+    public FarePricingAdjustmentQuoteClient(@Value("${post-sales.fare-pricing.base-url}") String baseUrl) {
+        // Plain HTTP/1.1 factory: the JDK client's default h2c upgrade is
+        // rejected by fare-pricing's uvicorn/h11 with "Invalid HTTP request".
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(Duration.ofSeconds(3));
+        requestFactory.setReadTimeout(Duration.ofSeconds(10));
+        this.restClient = RestClient.builder().requestFactory(requestFactory).baseUrl(baseUrl).build();
+    }
+
+    @Override
+    public Optional<AdjustmentQuoteResult> compute(AdjustmentQuoteRequest request) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("purpose", request.purpose());
+        body.put("entitlementIds", request.entitlementIds());
+        body.put("journeyOrderId", request.journeyOrderId());
+        body.put("segmentRefs", request.segmentRefs());
+        try {
+            Map<String, Object> response = restClient.post()
+                .uri("/api/v1/adjustment-quotes")
+                .header("Idempotency-Key", request.idempotencyKey())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(body)
+                .retrieve()
+                .body(MAP_TYPE);
+            if (response == null || response.get("adjustmentQuoteId") == null) {
+                return Optional.empty();
+            }
+            Map<String, Object> refundable = asMap(response.get("refundableAmount"));
+            Map<String, Object> amountDue = asMap(response.get("amountDue"));
+            return Optional.of(new AdjustmentQuoteResult(
+                String.valueOf(response.get("adjustmentQuoteId")),
+                String.valueOf(response.get("status")),
+                minorUnits(refundable),
+                currency(refundable),
+                minorUnits(amountDue),
+                currency(amountDue)
+            ));
+        } catch (RuntimeException ex) {
+            log.warn("adjustment quote unavailable for case idempotency key {}: {}", request.idempotencyKey(), ex.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asMap(Object value) {
+        return value instanceof Map<?, ?> map ? (Map<String, Object>) map : Map.of();
+    }
+
+    private static long minorUnits(Map<String, Object> money) {
+        Object value = money.get("minorUnits");
+        return value instanceof Number number ? number.longValue() : 0L;
+    }
+
+    private static String currency(Map<String, Object> money) {
+        Object value = money.get("currency");
+        return value instanceof String code && !code.isBlank() ? code : "CNY";
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/AdjustmentQuotePort.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/AdjustmentQuotePort.java
@@ -1,0 +1,31 @@
+package com.trainticket.postsales.application;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Outbound port to Fare & Pricing's synchronous adjustment-quote API
+ * (docs/08-contracts/api/fare-pricing.md, POST /api/v1/adjustment-quotes).
+ * Empty result means the quote could not be computed (service unreachable
+ * or original fare quote unresolvable) — callers degrade, never fail the case.
+ */
+public interface AdjustmentQuotePort {
+    Optional<AdjustmentQuoteResult> compute(AdjustmentQuoteRequest request);
+
+    record AdjustmentQuoteRequest(
+        String purpose,
+        List<String> entitlementIds,
+        String journeyOrderId,
+        List<String> segmentRefs,
+        String idempotencyKey
+    ) { }
+
+    record AdjustmentQuoteResult(
+        String adjustmentQuoteId,
+        String status,
+        long refundableMinorUnits,
+        String refundableCurrency,
+        long amountDueMinorUnits,
+        String amountDueCurrency
+    ) { }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
@@ -23,12 +23,15 @@ import org.springframework.stereotype.Service;
 public class PostSalesApplicationService {
     private final PostSalesRepository repository;
     private final EventPublisher eventPublisher;
+    private final AdjustmentQuotePort adjustmentQuotePort;
     private final Clock clock;
     private final ConcurrentMap<String, Integer> publishedEventCounts = new ConcurrentHashMap<>();
 
-    public PostSalesApplicationService(PostSalesRepository repository, EventPublisher eventPublisher, Clock clock) {
+    public PostSalesApplicationService(PostSalesRepository repository, EventPublisher eventPublisher,
+            AdjustmentQuotePort adjustmentQuotePort, Clock clock) {
         this.repository = repository;
         this.eventPublisher = eventPublisher;
+        this.adjustmentQuotePort = adjustmentQuotePort;
         this.clock = clock;
     }
 
@@ -63,7 +66,12 @@ public class PostSalesApplicationService {
             postSalesCase.beginEvaluation(now, sourceCommandId, sourceCommandId, correlationId);
         }
         PostSalesDecision decision = decisionFor(postSalesCase, now);
-        postSalesCase.recordDecision(decision, false, false, now, sourceCommandId, sourceCommandId, correlationId);
+        postSalesCase.evaluateEligibility(decision.eligible(), decision.reasonCode(),
+            decision.ruleSnapshot().farePricingEvaluationRef(), decision.ruleSnapshot().fareRuleVersion(),
+            now, sourceCommandId, sourceCommandId, correlationId);
+        if (decision.eligible()) {
+            postSalesCase.recordDecision(decision, false, false, now, sourceCommandId, sourceCommandId, correlationId);
+        }
         repository.save(postSalesCase);
         publishNewEvents(postSalesCase);
         return postSalesCase;
@@ -90,23 +98,44 @@ public class PostSalesApplicationService {
     }
 
     private PostSalesDecision decisionFor(PostSalesCase postSalesCase, Instant now) {
+        DecisionKind kind = switch (postSalesCase.caseType()) {
+            case REFUND, CANCELLATION, REBOOK -> DecisionKind.REFUND;
+            case CHANGE -> DecisionKind.CHANGE;
+            case COMPENSATION -> DecisionKind.COMPENSATION;
+        };
+        String purpose = kind == DecisionKind.CHANGE ? "CHANGE" : "REFUND";
+        // Idempotency-Key must be a bare UUID v7 (fare-pricing contract); the
+        // case ID is one, and reusing it keys the quote to this case.
+        var quote = adjustmentQuotePort.compute(new AdjustmentQuotePort.AdjustmentQuoteRequest(
+            purpose,
+            postSalesCase.scope().entitlementRefs(),
+            postSalesCase.journeyOrderId(),
+            postSalesCase.scope().segmentRefs(),
+            PostSalesMapper.stripCasePrefix(postSalesCase.caseId())
+        ));
         RuleEvaluationSnapshot ruleSnapshot = new RuleEvaluationSnapshot(
-            "adjq-" + postSalesCase.caseId(),
+            quote.map(AdjustmentQuotePort.AdjustmentQuoteResult::adjustmentQuoteId)
+                .orElse("adjq-" + postSalesCase.caseId()),
             "offer-rule-snapshot-" + postSalesCase.caseId(),
             "rule-v1",
             now,
             Map.of("journeyOrderId", postSalesCase.journeyOrderId(), "postSalesCaseId", postSalesCase.caseId())
         );
         Money zero = Money.zero("CNY");
-        AmountDecisionSnapshot amount = switch (postSalesCase.caseType()) {
-            case REFUND, CANCELLATION, REBOOK -> AmountDecisionSnapshot.refund(zero, Money.fromMinorUnits(0, "CNY"), "HTTP eligibility evaluation");
-            case CHANGE -> AmountDecisionSnapshot.extraCharge(zero, Money.fromMinorUnits(0, "CNY"), "HTTP eligibility evaluation");
-            case COMPENSATION -> AmountDecisionSnapshot.refund(zero, Money.fromMinorUnits(0, "CNY"), "HTTP eligibility evaluation");
-        };
-        DecisionKind kind = switch (postSalesCase.caseType()) {
-            case REFUND, CANCELLATION, REBOOK -> DecisionKind.REFUND;
-            case CHANGE -> DecisionKind.CHANGE;
-            case COMPENSATION -> DecisionKind.COMPENSATION;
+        Money refundable = quote
+            .map(q -> Money.fromMinorUnits(q.refundableMinorUnits(), q.refundableCurrency()))
+            .orElse(zero);
+        Money amountDue = quote
+            .map(q -> Money.fromMinorUnits(q.amountDueMinorUnits(), q.amountDueCurrency()))
+            .orElse(zero);
+        String explanation = quote
+            .map(q -> "fare-pricing adjustment quote " + q.adjustmentQuoteId())
+            .orElse("fare-pricing unavailable; zero-amount fallback");
+        AmountDecisionSnapshot amount = switch (kind) {
+            case REFUND, CANCELLATION, COMPENSATION -> AmountDecisionSnapshot.refund(zero, refundable, explanation);
+            case CHANGE -> amountDue.isZero() && !refundable.isZero()
+                ? AmountDecisionSnapshot.refund(zero, refundable, explanation)
+                : AmountDecisionSnapshot.extraCharge(zero, amountDue, explanation);
         };
         ChangeFlowSnapshot changeFlowSnapshot = kind == DecisionKind.CHANGE
             ? new ChangeFlowSnapshot(

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesMapper.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesMapper.java
@@ -13,7 +13,8 @@ import com.trainticket.postsales.domain.PostSalesCaseOpened;
 import com.trainticket.postsales.domain.PostSalesCaseStatus;
 import com.trainticket.postsales.domain.PostSalesCaseType;
 import com.trainticket.postsales.domain.PostSalesDecision;
-import com.trainticket.postsales.domain.PostSalesEvaluated;
+import com.trainticket.postsales.domain.PostSalesDecisionQuoted;
+import com.trainticket.postsales.domain.PostSalesEligibilityEvaluated;
 import com.trainticket.postsales.domain.PostSalesEvent;
 import com.trainticket.postsales.domain.PostSalesRejected;
 import com.trainticket.postsales.domain.PostSalesRequested;
@@ -130,10 +131,19 @@ public final class PostSalesMapper {
             payload.put("orderId", requested.journeyOrderId());
             payload.put("requestType", requestType(requested.caseType()));
             payload.put("requestedAt", requested.metadata().occurredAt().toString());
-        } else if (event instanceof PostSalesEvaluated evaluated) {
-            payload.put("decisionKind", evaluated.decisionKind().name());
-            payload.put("eligible", evaluated.eligible());
-            payload.put("adjustmentQuoteId", evaluated.farePricingEvaluationRef());
+        } else if (event instanceof PostSalesEligibilityEvaluated eligibility) {
+            payload.put("eligible", eligibility.eligible());
+            payload.put("reasonCode", eligibility.reasonCode());
+            if (eligibility.ruleSnapshotRef() != null) {
+                payload.put("ruleSnapshotRef", eligibility.ruleSnapshotRef());
+            }
+            if (eligibility.ruleVersion() != null) {
+                payload.put("ruleVersion", eligibility.ruleVersion());
+            }
+        } else if (event instanceof PostSalesDecisionQuoted quoted) {
+            payload.put("decisionKind", quoted.decisionKind().name());
+            payload.put("eligible", quoted.eligible());
+            payload.put("ruleSnapshotRef", quoted.ruleSnapshotRef());
         } else if (event instanceof PostSalesApproved approved) {
             payload.put("orderId", approved.journeyOrderId());
             payload.put("approvedActions", approvedActions(approved, sourceCase));

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesCase.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesCase.java
@@ -125,8 +125,6 @@ public final class PostSalesCase {
         this.decision = decision;
         domainEvents.add(new PostSalesDecisionQuoted(caseId, decision.kind(), decision.eligible(), decision.ruleSnapshot().farePricingEvaluationRef(),
             metadata(occurredAt, sourceCommandId, causationId, correlationId, PostSalesCaseStatus.ELIGIBILITY_CHECKING)));
-        domainEvents.add(new PostSalesEvaluated(caseId, decision.kind(), decision.eligible(), decision.ruleSnapshot().farePricingEvaluationRef(),
-            metadata(occurredAt, sourceCommandId, causationId, correlationId, PostSalesCaseStatus.ELIGIBILITY_CHECKING)));
         if (!decision.eligible()) {
             reject(decision.reasonCode(), occurredAt, sourceCommandId, causationId, correlationId);
             return;

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesEvaluated.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesEvaluated.java
@@ -1,9 +1,0 @@
-package com.trainticket.postsales.domain;
-
-public record PostSalesEvaluated(
-    String caseId,
-    DecisionKind decisionKind,
-    boolean eligible,
-    String farePricingEvaluationRef,
-    EventMetadata metadata
-) implements PostSalesEvent { }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesEvent.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/PostSalesEvent.java
@@ -1,6 +1,6 @@
 package com.trainticket.postsales.domain;
 
-public sealed interface PostSalesEvent permits PostSalesRequested, PostSalesCaseOpened, PostSalesEvaluated, PostSalesEligibilityEvaluated, PostSalesDecisionQuoted, PostSalesApproved, PostSalesRejected, PostSalesExecutionRequested, PostSalesExecutionStarted, PostSalesStepSucceeded, PostSalesStepFailed, PostSalesManualReviewRequired, PostSalesApplied, PostSalesFailed, ChangeApplied {
+public sealed interface PostSalesEvent permits PostSalesRequested, PostSalesCaseOpened, PostSalesEligibilityEvaluated, PostSalesDecisionQuoted, PostSalesApproved, PostSalesRejected, PostSalesExecutionRequested, PostSalesExecutionStarted, PostSalesStepSucceeded, PostSalesStepFailed, PostSalesManualReviewRequired, PostSalesApplied, PostSalesFailed, ChangeApplied {
     String caseId();
     EventMetadata metadata();
 }

--- a/services/post-sales/src/main/resources/application.properties
+++ b/services/post-sales/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 post-sales.messaging.redis.enabled=${POST_SALES_REDIS_MESSAGING_ENABLED:true}
+post-sales.fare-pricing.base-url=${POST_SALES_FARE_PRICING_BASE_URL:http://fare-pricing:8080}

--- a/services/post-sales/src/test/java/com/trainticket/postsales/domain/PostSalesCaseDomainTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/domain/PostSalesCaseDomainTest.java
@@ -48,7 +48,7 @@ class PostSalesCaseDomainTest {
         assertEquals(PostSalesCaseStatus.APPLIED, postSalesCase.status());
         assertInstanceOf(PostSalesCaseOpened.class, postSalesCase.domainEvents().get(0));
         assertInstanceOf(PostSalesRequested.class, postSalesCase.domainEvents().get(1));
-        assertTrue(postSalesCase.domainEvents().stream().anyMatch(PostSalesEvaluated.class::isInstance));
+        assertTrue(postSalesCase.domainEvents().stream().anyMatch(PostSalesDecisionQuoted.class::isInstance));
         assertTrue(postSalesCase.domainEvents().stream().anyMatch(PostSalesApproved.class::isInstance));
         assertTrue(postSalesCase.domainEvents().stream().anyMatch(PostSalesApplied.class::isInstance));
     }

--- a/services/reporting/src/reporting/application/service.py
+++ b/services/reporting/src/reporting/application/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -16,11 +17,16 @@ from reporting.domain import (
     MetricRef,
     MetricStatus,
     ReadModelSnapshot,
+    ReadModelStatus,
 )
 
 from .ports import EventEnvelope, EventPublisher, HandlerResult
 
 PRODUCER = "reporting"
+
+# Minimum seconds between rebuilds of the same dashboard (inline scheduler
+# for the bus-only RebuildReadModel command, api/reporting.md).
+REBUILD_DEBOUNCE_SECONDS = 10.0
 
 
 def utc_now() -> datetime:
@@ -166,10 +172,45 @@ class ReportingApplicationService:
 
     def handle_event(self, envelope: EventEnvelope) -> HandlerResult:
         try:
-            self.repository.record_consumed_event(envelope)
+            if self.repository.record_consumed_event(envelope):
+                self._rebuild_stale_dashboards(envelope)
         except Exception as exc:  # pragma: no cover - defensive boundary for broker callback
             return HandlerResult.fatal_error(str(exc))
         return HandlerResult.success()
+
+    def _rebuild_stale_dashboards(self, envelope: EventEnvelope) -> None:
+        """RebuildReadModel is a bus-only command with a 'manual or scheduled'
+        trigger (api/reporting.md); phase 1 schedules it inline — a stale
+        dashboard is rebuilt once the debounce window since its last build
+        has elapsed, and each rebuild publishes the ReadModelRebuilt fact."""
+        now = utc_now()
+        for dashboard_id, dashboard in list(self.repository.dashboards.items()):
+            if dashboard.status is not ReadModelStatus.STALE:
+                continue
+            last_built = dashboard.last_built_at
+            if last_built is not None and (now - last_built).total_seconds() < REBUILD_DEBOUNCE_SECONDS:
+                continue
+            event_count = len(self.repository.consumed_events.records)
+            digest = "sha256-" + hashlib.sha256(
+                f"{dashboard_id}:{event_count}:{rfc3339_utc(now)}".encode()
+            ).hexdigest()[:16]
+            rebuild_id = prefixed_uuid7("rebuild")
+            self.repository.dashboards[dashboard_id] = dashboard.rebuild(rebuild_id, now, event_count, digest)
+            self.repository.rebuild_runs.setdefault(dashboard_id, []).append(
+                RebuildRun(rebuild_id, dashboard_id, now, "COMPLETED", event_count, digest)
+            )
+            self.publish_domain_event(
+                event_type="ReadModelRebuilt",
+                payload={
+                    "dashboardId": dashboard_id,
+                    "rebuildId": rebuild_id,
+                    "rebuiltAt": rfc3339_utc(now),
+                    "eventCount": event_count,
+                    "digest": digest,
+                },
+                correlation_id=envelope.correlationId,
+                causation_id=envelope.eventId,
+            )
 
     def publish_domain_event(
         self,

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/RequestContextFilter.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/RequestContextFilter.java
@@ -1,6 +1,7 @@
 package com.trainticket.travelerprofile;
 
 import com.trainticket.platformkit.http.CorrelationIds;
+import com.trainticket.platformkit.messaging.PrefixedIds;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -30,7 +31,7 @@ public class RequestContextFilter extends OncePerRequestFilter {
         FilterChain filterChain
     ) throws ServletException, IOException {
         String requestId = headerOrGenerated(request, REQUEST_ID_HEADER);
-        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, requestId);
+        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, PrefixedIds.newCorrelationId());
         RequestTraceContext context = new RequestTraceContext(
             requestId,
             correlationId,

--- a/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/RequestContextFilter.java
+++ b/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/RequestContextFilter.java
@@ -1,5 +1,7 @@
 package com.trainticket.walletpromotion;
 
+import com.trainticket.platformkit.messaging.PrefixedIds;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,7 +31,7 @@ public class RequestContextFilter extends OncePerRequestFilter {
         FilterChain filterChain
     ) throws ServletException, IOException {
         String requestId = headerOrGenerated(request, REQUEST_ID_HEADER);
-        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, requestId);
+        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, PrefixedIds.newCorrelationId());
         RequestTraceContext context = new RequestTraceContext(
             requestId,
             correlationId,


### PR DESCRIPTION
All remaining known gaps from the 联调 rounds, fixed and verified live (kind arl-test, full e2e 01–04 = 39 asserts, 0 failures).

## Fixes
- **Real adjustment pricing**: post-sales now calls fare-pricing `/adjustment-quotes` synchronously (new `AdjustmentQuotePort` + HTTP/1.1 RestClient adapter). Refund = 87.50 CNY (107.50 − 20.00 fee), change = 15.00 CNY fee — asserted in e2e. Fare default rule sets gained REFUND_FEE/CHANGE_FEE rules.
- **Event contract alignment**: non-contract `PostSalesEvaluated` removed; `PostSalesEligibilityEvaluated`/`PostSalesDecisionQuoted` carry normative payloads and fire on the main evaluate path. messaging.md rows for post-sales/place-network/reporting corrected to contract names. `events/service-plan.md` written (was missing).
- **Reporting produces facts**: inline scheduler for the bus-only `RebuildReadModel` command — stale dashboards rebuild after 10s debounce and publish `ReadModelRebuilt`; dash-revenue goes READY with real rebuild runs.
- **Subscriber self-healing (root cause)**: non-persistent redis loses consumer groups on restart; every consume loop (java-kit, go-kit, ts-kit, python-kit, rust-kit, place-network/trip-planning/reporting local loops) now recreates groups on NOGROUP and backs off 1s instead of spinning dead. rust-kit's loop previously died on any redis error.
- **ID conventions**: corr- prefix minted on fallback in 7 Java filters; sagaId + revenueRecognitionId now uuid7 per shared-primitives.
- **e2e hardening**: asserts for saga steps all SUCCEEDED, order CONFIRMED/ADJUSTED (with retry), real amounts, and bystander facts (NotificationScheduled for traveler, RevenueRecognized for order, ReadModelRebuilt published).

## Verification
Clean-slate 01-seed 6/6 → 02-purchase 14/14 → 03-refund 11/11 → 04-change 8/8 on rebuilt images (all 22 services).

🤖 Generated with [Claude Code](https://claude.com/claude-code)