### PR TITLE
REQ-065 add finance reconciliation and invoicing

### DIFF
--- a/deploy/e2e/03-refund.sh
+++ b/deploy/e2e/03-refund.sh
@@ -74,6 +74,17 @@ NOTIF_OK=$(stream_mentions events:notification NotificationScheduled "$TVL")
 [ "$NOTIF_OK" = "yes" ] && ok "notification scheduled for our traveler" || bad "no NotificationScheduled for traveler"
 FIN_OK=$(stream_mentions events:finance-settlement RevenueRecognized "$ORDER")
 [ "$FIN_OK" = "yes" ] && ok "RevenueRecognized for our order" || bad "no RevenueRecognized mentioning order"
+RECON_OK=$(stream_mentions events:finance-settlement ReconciliationCompleted "$ORDER")
+[ "$RECON_OK" = "yes" ] && ok "ReconciliationCompleted for our order" || bad "no ReconciliationCompleted mentioning order"
+REDUCTION_OK=$(stream_mentions events:finance-settlement RevenueRecognized '"minorUnits": -8750')
+[ "$REDUCTION_OK" = "yes" ] && ok "refund revenue reduction published" || bad "no -87.50 revenue reduction"
+req POST finance-settlement /api/v1/invoices "{\"orderId\":\"$ORDER\"}"
+INV_CODE_1=$LAST_CODE; INV_ID=$(jget "['invoiceId']")
+req POST finance-settlement /api/v1/invoices "{\"orderId\":\"$ORDER\"}"
+INV_ID_REPLAY=$(jget "['invoiceId']")
+[ "$INV_CODE_1" = "201" ] && [ "$LAST_CODE" = "201" ] && [ -n "$INV_ID" ] && [ "$INV_ID" = "$INV_ID_REPLAY" ] && ok "GenerateInvoice repeat returns invoice" || bad "GenerateInvoice repeat failed ($INV_CODE_1/$LAST_CODE $INV_ID/$INV_ID_REPLAY)"
+INV_EVT_OK=$(stream_mentions events:finance-settlement InvoiceGenerated "$ORDER")
+[ "$INV_EVT_OK" = "yes" ] && ok "InvoiceGenerated for our order" || bad "no InvoiceGenerated mentioning order"
 RPT_LEN=$(xlen events:reporting)
 [ "${RPT_LEN:-0}" -gt 0 ] 2>/dev/null && ok "reporting published ReadModelRebuilt facts (XLEN=$RPT_LEN)" || bad "reporting stream empty"
 req GET reporting /api/v1/dashboards/dash-revenue

--- a/deploy/e2e/03-refund.sh
+++ b/deploy/e2e/03-refund.sh
@@ -76,8 +76,8 @@ FIN_OK=$(stream_mentions events:finance-settlement RevenueRecognized "$ORDER")
 [ "$FIN_OK" = "yes" ] && ok "RevenueRecognized for our order" || bad "no RevenueRecognized mentioning order"
 RECON_OK=$(stream_mentions events:finance-settlement ReconciliationCompleted "$ORDER")
 [ "$RECON_OK" = "yes" ] && ok "ReconciliationCompleted for our order" || bad "no ReconciliationCompleted mentioning order"
-REDUCTION_OK=$(stream_mentions events:finance-settlement RevenueRecognized '"minorUnits": -8750')
-[ "$REDUCTION_OK" = "yes" ] && ok "refund revenue reduction published" || bad "no -87.50 revenue reduction"
+REDUCTION_OK=$(stream_mentions events:finance-settlement RevenueRecognitionReversed '"minorUnits": 8750')
+[ "$REDUCTION_OK" = "yes" ] && ok "refund revenue reversal published" || bad "no 87.50 revenue reversal"
 req POST finance-settlement /api/v1/invoices "{\"orderId\":\"$ORDER\"}"
 INV_CODE_1=$LAST_CODE; INV_ID=$(jget "['invoiceId']")
 req POST finance-settlement /api/v1/invoices "{\"orderId\":\"$ORDER\"}"

--- a/deploy/e2e/03-refund.sh
+++ b/deploy/e2e/03-refund.sh
@@ -78,11 +78,40 @@ RECON_OK=$(stream_mentions events:finance-settlement ReconciliationCompleted "$O
 [ "$RECON_OK" = "yes" ] && ok "ReconciliationCompleted for our order" || bad "no ReconciliationCompleted mentioning order"
 REDUCTION_OK=$(stream_mentions events:finance-settlement RevenueRecognitionReversed '"minorUnits": 8750')
 [ "$REDUCTION_OK" = "yes" ] && ok "refund revenue reversal published" || bad "no 87.50 revenue reversal"
-req POST finance-settlement /api/v1/invoices "{\"orderId\":\"$ORDER\"}"
+invoice_event_count() {
+  k exec "$(redis_pod)" -- redis-cli XREVRANGE events:finance-settlement + - COUNT 100 > /tmp/invoice-events.txt 2>/dev/null
+  ORDER_REF="$ORDER" python3 - << 'PYEX'
+import re, os, json
+count = 0
+raw = open("/tmp/invoice-events.txt").read()
+for m in re.finditer(r'\{.*\}', raw):
+    try:
+        e = json.loads(m.group(0).encode().decode('unicode_escape'))
+        if e.get("eventType") == "InvoiceGenerated" and e.get("payload", {}).get("orderId") == os.environ["ORDER_REF"]:
+            count += 1
+    except Exception:
+        pass
+print(count)
+PYEX
+}
+generate_invoice_fixed_key() {
+  local key=$1 body="{\"orderId\":\"$ORDER\"}" out
+  out=$(k exec -i e2e-curl -- curl -s -w $'\n%{http_code}' -X POST "http://finance-settlement:8080/api/v1/invoices" \
+    -H 'Content-Type: application/json' \
+    -H "Idempotency-Key: $key" \
+    -d "$body" 2>/dev/null)
+  LAST_CODE=$(echo "$out" | tail -1)
+  RESP=$(echo "$out" | sed '$d')
+}
+INV_EVT_BEFORE=$(invoice_event_count)
+INVOICE_KEY=$(uuid7)
+generate_invoice_fixed_key "$INVOICE_KEY"
 INV_CODE_1=$LAST_CODE; INV_ID=$(jget "['invoiceId']")
-req POST finance-settlement /api/v1/invoices "{\"orderId\":\"$ORDER\"}"
-INV_ID_REPLAY=$(jget "['invoiceId']")
-[ "$INV_CODE_1" = "201" ] && [ "$LAST_CODE" = "201" ] && [ -n "$INV_ID" ] && [ "$INV_ID" = "$INV_ID_REPLAY" ] && ok "GenerateInvoice repeat returns invoice" || bad "GenerateInvoice repeat failed ($INV_CODE_1/$LAST_CODE $INV_ID/$INV_ID_REPLAY)"
+generate_invoice_fixed_key "$INVOICE_KEY"
+INV_CODE_2=$LAST_CODE; INV_ID_REPLAY=$(jget "['invoiceId']")
+INV_EVT_AFTER=$(invoice_event_count)
+INV_EVT_DELTA=$((INV_EVT_AFTER - INV_EVT_BEFORE))
+[ "$INV_CODE_1" = "201" ] && [ "$INV_CODE_2" = "201" ] && [ -n "$INV_ID" ] && [ "$INV_ID" = "$INV_ID_REPLAY" ] && [ "$INV_EVT_DELTA" -eq 1 ] && ok "GenerateInvoice fixed-key replay returns same invoice without duplicate event" || bad "GenerateInvoice replay failed ($INV_CODE_1/$INV_CODE_2 $INV_ID/$INV_ID_REPLAY events+$INV_EVT_DELTA)"
 INV_EVT_OK=$(stream_mentions events:finance-settlement InvoiceGenerated "$ORDER")
 [ "$INV_EVT_OK" = "yes" ] && ok "InvoiceGenerated for our order" || bad "no InvoiceGenerated mentioning order"
 RPT_LEN=$(xlen events:reporting)

--- a/docs/08-contracts/api/finance-settlement.md
+++ b/docs/08-contracts/api/finance-settlement.md
@@ -9,8 +9,40 @@ timestamps, and Money.
 
 Finance & Settlement handles revenue recognition, reconciliation cases, and
 settlement views. It consumes upstream events and produces financial records.
-All commands are **bus-only** — there are no external HTTP endpoints for
-financial operations. Query endpoints are provided for reporting and audit.
+Commands are event-backed. `GenerateInvoice` is exposed as an HTTP command for
+idempotent invoice generation; other financial operations remain bus-only. Query
+endpoints are provided for reporting and audit.
+
+## Commands
+
+### Generate Invoice
+
+**POST** `/api/v1/invoices`
+
+Requires `Idempotency-Key` header (UUID v7). Replays with the same key and body
+return the original response; reusing a key with a different body returns
+`IDEMPOTENCY_KEY_REUSED`.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `orderId` | string | yes | Order whose recognized revenue should be invoiced. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `invoiceId` | string | Unique invoice ID. |
+| `orderId` | string | Invoiced order. |
+| `invoiceNumber` | string | Invoice number. |
+| `totalAmount` | object | Total amount (Money). |
+| `revenueRecognitionIds` | string[] | Included revenue recognitions. |
+| `generatedAt` | timestamp | Generation timestamp. |
+
+**Emits:** `InvoiceGenerated`
+
+**Error codes:** `VALIDATION_FAILED`, `DOMAIN_RULE_VIOLATION`, `IDEMPOTENCY_KEY_REUSED`, `UNAVAILABLE`
 
 ## Query Endpoints
 
@@ -46,11 +78,19 @@ financial operations. Query endpoints are provided for reporting and audit.
 
 **Response (200):** Paginated response.
 
+### Get Invoice
+
+**GET** `/api/v1/invoices/{invoiceId}`
+
+**Response (200):** Invoice details using the same shape as `GenerateInvoice`.
+
+**Error codes:** `NOT_FOUND`
+
 ## Bus-only commands
 
 | Command | Trigger | Description |
 |---|---|---|
-| `RecognizeRevenue` | `EntitlementIssued`, `BoardingVerified` | Recognize revenue from fulfillment events. |
+| `RecognizeRevenue` | `PaymentCaptured`, post-sales refund facts | Recognize revenue or refund reductions from event facts. |
 | `OpenReconciliationCase` | Mismatch detection | Open a reconciliation case. |
 | `ResolveReconciliationCase` | Manual or auto | Resolve a reconciliation case. |
 | `RebuildSettlementView` | Manual or scheduled | Rebuild a settlement view from event log. |

--- a/docs/08-contracts/api/finance-settlement.md
+++ b/docs/08-contracts/api/finance-settlement.md
@@ -90,7 +90,7 @@ return the original response; reusing a key with a different body returns
 
 | Command | Trigger | Description |
 |---|---|---|
-| `RecognizeRevenue` | `PaymentCaptured`, post-sales refund facts | Recognize revenue or refund reductions from event facts. |
+| `RecognizeRevenue` | `PaymentCaptured`, post-sales refund facts | Recognize revenue from capture facts and reverse previously recognized revenue from post-sales refund facts. |
 | `OpenReconciliationCase` | Mismatch detection | Open a reconciliation case. |
 | `ResolveReconciliationCase` | Manual or auto | Resolve a reconciliation case. |
 | `RebuildSettlementView` | Manual or scheduled | Rebuild a settlement view from event log. |

--- a/docs/08-contracts/events/finance-settlement-events.md
+++ b/docs/08-contracts/events/finance-settlement-events.md
@@ -8,7 +8,7 @@ event.
 | Field | Type | Description |
 |---|---|---|
 | `revenueRecognitionId` | string | Unique ID for this recognition. |
-| `orderItemId` | string | The order item being recognized. |
+| `orderItemId` | string | The order item/business revenue reference being recognized. For order-level payment facts that do not carry a line item, this is the payment `businessRef` (order ID), not the payment intent ID. |
 | `orderId` | string | The parent order. |
 | `componentCode` | string | Financial component (fare, tax, fee, ancillary, discount). |
 | `amount` | Money | Recognized revenue amount. |
@@ -58,6 +58,36 @@ Produced when a reconciliation case is resolved.
 | `reconciliationCaseId` | string | Unique ID for the case. |
 | `resolution` | string | Resolution: auto-resolved, manual-resolved, rejected. |
 | `resolutionNote` | string | Explanation of the resolution. |
+| `metadata` | EventMetadata | Standard event envelope. |
+
+## ReconciliationCompleted
+
+Produced when finance reconciliation completes for an order/payment fact.
+
+| Field | Type | Description |
+|---|---|---|
+| `reconciliationId` | string | Unique ID for this reconciliation result. |
+| `orderId` | string | The order reconciled. |
+| `paymentIntentId` | string | The payment intent involved, if available. |
+| `reconciliationStatus` | string | Result status (`MATCHED`). |
+| `expectedAmount` | Money | Amount expected by finance. |
+| `actualAmount` | Money | Amount observed from the matched upstream facts. |
+| `matchedRevenueRecognitionIds` | string[] | Revenue records included in the match. |
+| `sourceEventIds` | string[] | Upstream event IDs included in the match. |
+| `metadata` | EventMetadata | Standard event envelope. |
+
+## InvoiceGenerated
+
+Produced when an invoice is generated from recognized revenue.
+
+| Field | Type | Description |
+|---|---|---|
+| `invoiceId` | string | Unique invoice ID. |
+| `orderId` | string | The invoiced order. |
+| `invoiceNumber` | string | Human/business invoice number. |
+| `totalAmount` | Money | Total positive invoice amount. |
+| `revenueRecognitionIds` | string[] | Revenue records included in this invoice. |
+| `generatedAt` | timestamp | When the invoice was generated. |
 | `metadata` | EventMetadata | Standard event envelope. |
 
 ## SettlementViewRebuilt

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/adapters/http/FinanceSettlementController.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/adapters/http/FinanceSettlementController.java
@@ -1,16 +1,21 @@
 package com.trainticket.financesettlement.adapters.http;
 
-import com.trainticket.platformkit.messaging.EventEnvelope;
 import com.trainticket.financesettlement.application.DomainEventEnvelopeMapper;
 import com.trainticket.financesettlement.application.FinanceSettlementApplicationService;
 import com.trainticket.financesettlement.application.FinanceSettlementApplicationService.Page;
+import com.trainticket.financesettlement.domain.Invoice;
 import com.trainticket.financesettlement.domain.ReconciliationCase;
 import com.trainticket.financesettlement.domain.RevenueRecognition;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,6 +35,17 @@ public class FinanceSettlementController {
     @GetMapping("/api/v1/reconciliation-cases/{reconciliationCaseId}")
     public ReconciliationCaseResponse getReconciliationCase(@PathVariable String reconciliationCaseId) {
         return ReconciliationCaseResponse.from(service.getReconciliationCase(reconciliationCaseId));
+    }
+
+    @GetMapping("/api/v1/invoices/{invoiceId}")
+    public InvoiceResponse getInvoice(@PathVariable String invoiceId) {
+        return InvoiceResponse.from(service.getInvoice(invoiceId));
+    }
+
+    @PostMapping("/api/v1/invoices")
+    @ResponseStatus(HttpStatus.CREATED)
+    public InvoiceResponse generateInvoice(@RequestBody GenerateInvoiceRequest request, HttpServletRequest httpRequest) {
+        return InvoiceResponse.from(service.generateInvoice(request.orderId(), (String) httpRequest.getAttribute("X-Correlation-Id")));
     }
 
     @GetMapping("/api/v1/reconciliation-cases")
@@ -90,6 +106,28 @@ public class FinanceSettlementController {
                 reconciliationCase.status().name(),
                 reconciliationCase.resolution(),
                 reconciliationCase.resolutionNote()
+            );
+        }
+    }
+
+    public record GenerateInvoiceRequest(String orderId) {}
+
+    public record InvoiceResponse(
+        String invoiceId,
+        String orderId,
+        String invoiceNumber,
+        Map<String, Object> totalAmount,
+        List<String> revenueRecognitionIds,
+        Instant generatedAt
+    ) {
+        static InvoiceResponse from(Invoice invoice) {
+            return new InvoiceResponse(
+                invoice.invoiceId(),
+                invoice.orderId(),
+                invoice.invoiceNumber(),
+                DomainEventEnvelopeMapper.moneyPayload(invoice.totalAmount()),
+                invoice.revenueRecognitionIds(),
+                invoice.generatedAt()
             );
         }
     }

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/ApplicationConfiguration.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/ApplicationConfiguration.java
@@ -40,9 +40,10 @@ public class ApplicationConfiguration {
     FinanceSettlementEventHandler financeSettlementEventHandler(
         ConsumedEventLogRepository consumedEvents,
         PaymentIntentOrderReferenceRepository paymentIntentOrderReferences,
+        SegmentBookingOrderReferenceRepository segmentBookingOrderReferences,
         Clock clock,
         FinanceSettlementApplicationService service
     ) {
-        return new FinanceSettlementEventHandler(consumedEvents, paymentIntentOrderReferences, clock, service);
+        return new FinanceSettlementEventHandler(consumedEvents, paymentIntentOrderReferences, segmentBookingOrderReferences, clock, service);
     }
 }

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/ApplicationConfiguration.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/ApplicationConfiguration.java
@@ -1,6 +1,5 @@
 package com.trainticket.financesettlement.application;
 
-import com.trainticket.platformkit.messaging.EventEnvelope;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -29,10 +28,12 @@ public class ApplicationConfiguration {
     FinanceSettlementApplicationService financeSettlementApplicationService(
         RevenueRecognitionRepository revenueRecognitions,
         ReconciliationCaseRepository reconciliationCases,
+        InvoiceRepository invoices,
         EventPublisher eventPublisher,
-        DomainEventEnvelopeMapper envelopeMapper
+        DomainEventEnvelopeMapper envelopeMapper,
+        Clock clock
     ) {
-        return new FinanceSettlementApplicationService(revenueRecognitions, reconciliationCases, eventPublisher, envelopeMapper);
+        return new FinanceSettlementApplicationService(revenueRecognitions, reconciliationCases, invoices, eventPublisher, envelopeMapper, clock);
     }
 
     @Bean

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/DomainEventEnvelopeMapper.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/DomainEventEnvelopeMapper.java
@@ -4,8 +4,10 @@ import com.trainticket.platformkit.messaging.EventEnvelope;
 import com.trainticket.platformkit.messaging.PrefixedIds;
 import com.trainticket.financesettlement.domain.FinanceSettlementEvent;
 import com.trainticket.financesettlement.domain.Money;
+import com.trainticket.financesettlement.domain.InvoiceGenerated;
 import com.trainticket.financesettlement.domain.ReconciliationCaseOpened;
 import com.trainticket.financesettlement.domain.ReconciliationCaseResolved;
+import com.trainticket.financesettlement.domain.ReconciliationCompleted;
 import com.trainticket.financesettlement.domain.RevenueRecognized;
 import com.trainticket.financesettlement.domain.SettlementViewRebuilt;
 import java.util.LinkedHashMap;
@@ -32,6 +34,8 @@ public final class DomainEventEnvelopeMapper {
             case RevenueRecognized recognized -> revenueRecognizedPayload(recognized);
             case ReconciliationCaseOpened opened -> reconciliationCaseOpenedPayload(opened);
             case ReconciliationCaseResolved resolved -> reconciliationCaseResolvedPayload(resolved);
+            case ReconciliationCompleted completed -> reconciliationCompletedPayload(completed);
+            case InvoiceGenerated generated -> invoiceGeneratedPayload(generated);
             case SettlementViewRebuilt rebuilt -> settlementViewRebuiltPayload(rebuilt);
         };
     }
@@ -68,6 +72,30 @@ public final class DomainEventEnvelopeMapper {
         return payload;
     }
 
+    private static Map<String, Object> reconciliationCompletedPayload(ReconciliationCompleted event) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("reconciliationId", event.reconciliationId());
+        payload.put("orderId", event.orderId());
+        payload.put("paymentIntentId", event.paymentIntentId());
+        payload.put("reconciliationStatus", event.reconciliationStatus());
+        payload.put("expectedAmount", moneyPayload(event.expectedAmount()));
+        payload.put("actualAmount", moneyPayload(event.actualAmount()));
+        payload.put("matchedRevenueRecognitionIds", event.matchedRevenueRecognitionIds());
+        payload.put("sourceEventIds", event.sourceEventIds());
+        return payload;
+    }
+
+    private static Map<String, Object> invoiceGeneratedPayload(InvoiceGenerated event) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("invoiceId", event.invoiceId());
+        payload.put("orderId", event.orderId());
+        payload.put("invoiceNumber", event.invoiceNumber());
+        payload.put("totalAmount", moneyPayload(event.totalAmount()));
+        payload.put("revenueRecognitionIds", event.revenueRecognitionIds());
+        payload.put("generatedAt", event.generatedAt().toString());
+        return payload;
+    }
+
     private static Map<String, Object> settlementViewRebuiltPayload(SettlementViewRebuilt event) {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("settlementViewId", event.settlementViewId());
@@ -94,6 +122,9 @@ public final class DomainEventEnvelopeMapper {
     }
 
     private static String canonicalCausationId(String causationId) {
+        if (causationId == null || causationId.isBlank()) {
+            return PrefixedIds.newCommandId();
+        }
         String prefixed = (causationId.startsWith("cmd-") || causationId.startsWith("evt-")) ? causationId : "cmd-" + causationId;
         return PrefixedIds.isCausationId(prefixed) ? prefixed : PrefixedIds.newCommandId();
     }

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/DomainEventEnvelopeMapper.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/DomainEventEnvelopeMapper.java
@@ -9,6 +9,7 @@ import com.trainticket.financesettlement.domain.ReconciliationCaseOpened;
 import com.trainticket.financesettlement.domain.ReconciliationCaseResolved;
 import com.trainticket.financesettlement.domain.ReconciliationCompleted;
 import com.trainticket.financesettlement.domain.RevenueRecognized;
+import com.trainticket.financesettlement.domain.RevenueRecognitionReversed;
 import com.trainticket.financesettlement.domain.SettlementViewRebuilt;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -32,6 +33,7 @@ public final class DomainEventEnvelopeMapper {
     private static Map<String, Object> payload(FinanceSettlementEvent event) {
         return switch (event) {
             case RevenueRecognized recognized -> revenueRecognizedPayload(recognized);
+            case RevenueRecognitionReversed reversed -> revenueRecognitionReversedPayload(reversed);
             case ReconciliationCaseOpened opened -> reconciliationCaseOpenedPayload(opened);
             case ReconciliationCaseResolved resolved -> reconciliationCaseResolvedPayload(resolved);
             case ReconciliationCompleted completed -> reconciliationCompletedPayload(completed);
@@ -48,6 +50,18 @@ public final class DomainEventEnvelopeMapper {
         payload.put("componentCode", event.componentCode());
         payload.put("amount", moneyPayload(event.amount()));
         payload.put("recognitionPolicyVersion", event.recognitionPolicyVersion());
+        payload.put("sourceEventId", event.sourceEventId());
+        return payload;
+    }
+
+    private static Map<String, Object> revenueRecognitionReversedPayload(RevenueRecognitionReversed event) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("revenueRecognitionId", event.revenueRecognitionId());
+        payload.put("orderItemId", event.orderItemId());
+        payload.put("orderId", event.orderId());
+        payload.put("componentCode", event.componentCode());
+        payload.put("amount", moneyPayload(event.amount()));
+        payload.put("reversalReason", event.reversalReason());
         payload.put("sourceEventId", event.sourceEventId());
         return payload;
     }

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementApplicationService.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementApplicationService.java
@@ -1,17 +1,26 @@
 package com.trainticket.financesettlement.application;
 
-import com.trainticket.platformkit.messaging.EventEnvelope;
 import com.trainticket.financesettlement.domain.DomainRuleViolation;
+import com.trainticket.financesettlement.domain.EventMetadata;
 import com.trainticket.financesettlement.domain.FinanceSettlementEvent;
+import com.trainticket.financesettlement.domain.Invoice;
+import com.trainticket.financesettlement.domain.Money;
 import com.trainticket.financesettlement.domain.ReconciliationCase;
+import com.trainticket.financesettlement.domain.ReconciliationCompleted;
 import com.trainticket.financesettlement.domain.RevenueRecognition;
+import com.trainticket.platformkit.messaging.PrefixedIds;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 public class FinanceSettlementApplicationService {
     private final RevenueRecognitionRepository revenueRecognitions;
     private final ReconciliationCaseRepository reconciliationCases;
+    private final InvoiceRepository invoices;
     private final EventPublisher eventPublisher;
     private final DomainEventEnvelopeMapper envelopeMapper;
+    private final Clock clock;
 
     public FinanceSettlementApplicationService(
         RevenueRecognitionRepository revenueRecognitions,
@@ -19,10 +28,23 @@ public class FinanceSettlementApplicationService {
         EventPublisher eventPublisher,
         DomainEventEnvelopeMapper envelopeMapper
     ) {
+        this(revenueRecognitions, reconciliationCases, new InMemoryInvoiceRepository(), eventPublisher, envelopeMapper, Clock.systemUTC());
+    }
+
+    public FinanceSettlementApplicationService(
+        RevenueRecognitionRepository revenueRecognitions,
+        ReconciliationCaseRepository reconciliationCases,
+        InvoiceRepository invoices,
+        EventPublisher eventPublisher,
+        DomainEventEnvelopeMapper envelopeMapper,
+        Clock clock
+    ) {
         this.revenueRecognitions = revenueRecognitions;
         this.reconciliationCases = reconciliationCases;
+        this.invoices = invoices;
         this.eventPublisher = eventPublisher;
         this.envelopeMapper = envelopeMapper;
+        this.clock = clock;
     }
 
     public RevenueRecognition getRevenueRecognition(String revenueRecognitionId) {
@@ -33,6 +55,15 @@ public class FinanceSettlementApplicationService {
     public ReconciliationCase getReconciliationCase(String reconciliationCaseId) {
         return reconciliationCases.findById(reconciliationCaseId)
             .orElseThrow(() -> new ResourceNotFoundException("reconciliation case not found"));
+    }
+
+    public Invoice getInvoice(String invoiceId) {
+        return invoices.findById(invoiceId)
+            .orElseThrow(() -> new ResourceNotFoundException("invoice not found"));
+    }
+
+    List<RevenueRecognition> findRevenueRecognitionsByOrderId(String orderId) {
+        return revenueRecognitions.findByOrderId(orderId);
     }
 
     public Page<ReconciliationCase> listReconciliationCases(String orderId, int limit, int offset) {
@@ -46,6 +77,31 @@ public class FinanceSettlementApplicationService {
         return new Page<>(items, reconciliationCases.count(orderId), limit, offset);
     }
 
+    public Invoice generateInvoice(String orderId, String correlationId) {
+        requireText(orderId, "orderId");
+        return invoices.findByOrderId(orderId).orElseGet(() -> {
+            List<RevenueRecognition> recognitions = revenueRecognitions.findByOrderId(orderId);
+            if (recognitions.isEmpty()) {
+                throw new DomainRuleViolation("invoice requires recognized revenue for order");
+            }
+            Money total = recognitions.stream()
+                .map(RevenueRecognition::amount)
+                .reduce(Money::plus)
+                .orElseThrow();
+            Invoice invoice = Invoice.generate(
+                orderId,
+                total,
+                recognitions.stream().map(RevenueRecognition::revenueRecognitionId).toList(),
+                clock.instant(),
+                PrefixedIds.newCommandId(),
+                canonicalCorrelationId(correlationId)
+            );
+            invoices.save(invoice);
+            publish(invoice.domainEvents());
+            return invoice;
+        });
+    }
+
     public void saveAndPublish(RevenueRecognition recognition) {
         revenueRecognitions.save(recognition);
         publish(recognition.domainEvents());
@@ -56,16 +112,43 @@ public class FinanceSettlementApplicationService {
         publish(reconciliationCase.domainEvents());
     }
 
+    public void publishReconciliationCompleted(String orderId, String paymentIntentId, Money expectedAmount, Money actualAmount,
+                                               List<String> matchedRevenueRecognitionIds, List<String> sourceEventIds,
+                                               String status, Instant now, String causationId, String correlationId) {
+        ReconciliationCompleted completed = new ReconciliationCompleted(
+            "rec-" + com.trainticket.platformkit.idempotency.UuidV7.generate(),
+            orderId,
+            paymentIntentId == null ? "" : paymentIntentId,
+            status,
+            expectedAmount,
+            actualAmount,
+            matchedRevenueRecognitionIds,
+            sourceEventIds,
+            EventMetadata.create(now, PrefixedIds.newCommandId(), causationId, canonicalCorrelationId(correlationId),
+                Map.of("orderId", orderId, "reconciliationStatus", status))
+        );
+        publish(List.of(completed));
+    }
+
     private void publish(List<FinanceSettlementEvent> events) {
         for (FinanceSettlementEvent event : events) {
             try {
                 eventPublisher.publish(envelopeMapper.toEnvelope(event));
-            } catch (PublishFailedException ex) {
-                throw ex;
-            } catch (DomainRuleViolation ex) {
+            } catch (PublishFailedException | DomainRuleViolation ex) {
                 throw ex;
             }
         }
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new ValidationException(name + " is required");
+        }
+        return value;
+    }
+
+    private static String canonicalCorrelationId(String correlationId) {
+        return PrefixedIds.isCorrelationId(correlationId) ? correlationId : PrefixedIds.newCorrelationId();
     }
 
     public record Page<T>(List<T> items, long total, int limit, int offset) {}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementApplicationService.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementApplicationService.java
@@ -85,7 +85,7 @@ public class FinanceSettlementApplicationService {
                 throw new DomainRuleViolation("invoice requires recognized revenue for order");
             }
             Money total = recognitions.stream()
-                .map(RevenueRecognition::amount)
+                .map(RevenueRecognition::netAmount)
                 .reduce(Money::plus)
                 .orElseThrow();
             Invoice invoice = Invoice.generate(
@@ -103,8 +103,12 @@ public class FinanceSettlementApplicationService {
     }
 
     public void saveAndPublish(RevenueRecognition recognition) {
+        saveAndPublish(recognition, 0);
+    }
+
+    public void saveAndPublish(RevenueRecognition recognition, int firstUnpublishedEventIndex) {
         revenueRecognitions.save(recognition);
-        publish(recognition.domainEvents());
+        publish(recognition.domainEvents().subList(firstUnpublishedEventIndex, recognition.domainEvents().size()));
     }
 
     public void saveAndPublish(ReconciliationCase reconciliationCase) {

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementEventHandler.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementEventHandler.java
@@ -18,13 +18,14 @@ import java.util.concurrent.ConcurrentMap;
 public class FinanceSettlementEventHandler implements EventSubscriber.EventHandler {
     private final ConsumedEventLogRepository consumedEvents;
     private final PaymentIntentOrderReferenceRepository paymentIntentOrderReferences;
+    private final SegmentBookingOrderReferenceRepository segmentBookingOrderReferences;
     private final ConcurrentMap<String, PaymentCaptureFact> capturesByOrderId = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, Money> approvedRefundsByCaseId = new ConcurrentHashMap<>();
     private final Clock clock;
     private final FinanceSettlementApplicationService service;
 
     public FinanceSettlementEventHandler(ConsumedEventLogRepository consumedEvents, Clock clock) {
-        this(consumedEvents, new InMemoryPaymentIntentOrderReferenceRepository(), clock, null);
+        this(consumedEvents, new InMemoryPaymentIntentOrderReferenceRepository(), new InMemorySegmentBookingOrderReferenceRepository(), clock, null);
     }
 
     public FinanceSettlementEventHandler(
@@ -33,8 +34,19 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
         Clock clock,
         FinanceSettlementApplicationService service
     ) {
+        this(consumedEvents, paymentIntentOrderReferences, new InMemorySegmentBookingOrderReferenceRepository(), clock, service);
+    }
+
+    public FinanceSettlementEventHandler(
+        ConsumedEventLogRepository consumedEvents,
+        PaymentIntentOrderReferenceRepository paymentIntentOrderReferences,
+        SegmentBookingOrderReferenceRepository segmentBookingOrderReferences,
+        Clock clock,
+        FinanceSettlementApplicationService service
+    ) {
         this.consumedEvents = consumedEvents;
         this.paymentIntentOrderReferences = paymentIntentOrderReferences;
+        this.segmentBookingOrderReferences = segmentBookingOrderReferences;
         this.clock = clock;
         this.service = service;
     }
@@ -65,6 +77,7 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
         Map<String, Object> payload = (Map<String, Object>) envelope.payload();
         switch (envelope.eventType()) {
             case "PaymentIntentCreated" -> rememberPaymentIntentOrderReference(payload);
+            case "SegmentReservationRequested" -> rememberSegmentBookingOrderReference(payload);
             case "PaymentCaptured" -> {
                 if (service != null) recognizeCapturedPayment(envelope, payload);
             }
@@ -81,6 +94,10 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
 
     private void rememberPaymentIntentOrderReference(Map<String, Object> payload) {
         paymentIntentOrderReferences.save(text(payload, "paymentIntentId"), text(payload, "businessRef"));
+    }
+
+    private void rememberSegmentBookingOrderReference(Map<String, Object> payload) {
+        segmentBookingOrderReferences.save(text(payload, "segmentBookingId"), text(payload, "journeyOrderId"));
     }
 
     private void recognizeCapturedPayment(EventEnvelope envelope, Map<String, Object> payload) {
@@ -107,9 +124,25 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
     }
 
     private void reconcileOperationalFact(EventEnvelope envelope, Map<String, Object> payload) {
-        String orderId = optionalText(payload, "journeyOrderId")
-            .or(() -> optionalText(payload, "orderId"))
-            .orElse(optionalText(payload, "businessRef").orElse("order-unknown-for-" + text(payload, "segmentBookingId")));
+        String segmentBookingId = optionalText(payload, "segmentBookingId").orElse("");
+        Optional<String> orderReference = orderReferenceForOperationalFact(payload, segmentBookingId);
+        if (orderReference.isEmpty()) {
+            ReconciliationCase open = ReconciliationCase.open(
+                "",
+                "",
+                "missing-in-platform",
+                Money.zero(Currency.getInstance("CNY")),
+                Money.zero(Currency.getInstance("CNY")),
+                envelope.eventType() + " could not be assigned to an order; missing SegmentReservationRequested index for segmentBookingId " + segmentBookingId,
+                clock.instant(),
+                causationIdOrEventId(envelope),
+                envelope.correlationId()
+            );
+            service.saveAndPublish(open);
+            return;
+        }
+
+        String orderId = orderReference.get();
         PaymentCaptureFact capture = capturesByOrderId.get(orderId);
         Money actual = capture == null ? Money.zero(Currency.getInstance("CNY")) : capture.amount();
         List<RevenueRecognition> recognitions = serviceRevenue(orderId);
@@ -141,6 +174,19 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
             causationIdOrEventId(envelope),
             envelope.correlationId()
         );
+    }
+
+    private Optional<String> orderReferenceForOperationalFact(Map<String, Object> payload, String segmentBookingId) {
+        Optional<String> explicitOrderReference = optionalText(payload, "journeyOrderId")
+            .or(() -> optionalText(payload, "orderId"))
+            .or(() -> optionalText(payload, "businessRef"));
+        if (explicitOrderReference.isPresent()) {
+            return explicitOrderReference;
+        }
+        if (segmentBookingId.isBlank()) {
+            return Optional.empty();
+        }
+        return segmentBookingOrderReferences.findOrderReference(segmentBookingId);
     }
 
     private void rememberApprovedRefund(Map<String, Object> payload) {

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementEventHandler.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementEventHandler.java
@@ -204,11 +204,26 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
         Money refund = Optional.ofNullable(approvedRefundsByCaseId.get(caseId))
             .or(() -> Optional.ofNullable(approvedRefundsByCaseId.get(orderId)))
             .orElseThrow(() -> new OutOfOrderEventException("PostSalesApplied received before PostSalesApproved refund amount"));
-        RevenueRecognition originalRecognition = serviceRevenue(orderId).stream()
+        Optional<RevenueRecognition> matchingRecognition = serviceRevenue(orderId).stream()
             .filter(recognition -> !recognition.reversed())
             .filter(recognition -> sameMoney(recognition.amount(), refund) || recognition.amount().compareTo(refund) >= 0)
-            .findFirst()
-            .orElseThrow(() -> new OutOfOrderEventException("PostSalesApplied received before matching recognized revenue"));
+            .findFirst();
+        if (matchingRecognition.isEmpty()) {
+            ReconciliationCase open = ReconciliationCase.open(
+                orderId,
+                "",
+                "refund-lag",
+                refund.negate(),
+                Money.zero(refund.currency()),
+                "PostSalesApplied refund could not be matched to recognized revenue",
+                clock.instant(),
+                causationIdOrEventId(envelope),
+                envelope.correlationId()
+            );
+            service.saveAndPublish(open);
+            return;
+        }
+        RevenueRecognition originalRecognition = matchingRecognition.get();
         int firstUnpublishedEventIndex = originalRecognition.domainEvents().size();
         originalRecognition.reverse(
             "post-sales refund applied",

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementEventHandler.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementEventHandler.java
@@ -1,18 +1,25 @@
 package com.trainticket.financesettlement.application;
 
-import com.trainticket.platformkit.messaging.EventEnvelope;
 import com.trainticket.financesettlement.domain.ConsumedEventLog;
 import com.trainticket.financesettlement.domain.DomainRuleViolation;
 import com.trainticket.financesettlement.domain.Money;
+import com.trainticket.financesettlement.domain.ReconciliationCase;
 import com.trainticket.financesettlement.domain.RevenueRecognition;
+import com.trainticket.platformkit.messaging.EventEnvelope;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.util.Currency;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public class FinanceSettlementEventHandler implements EventSubscriber.EventHandler {
     private final ConsumedEventLogRepository consumedEvents;
     private final PaymentIntentOrderReferenceRepository paymentIntentOrderReferences;
+    private final ConcurrentMap<String, PaymentCaptureFact> capturesByOrderId = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Money> approvedRefundsByCaseId = new ConcurrentHashMap<>();
     private final Clock clock;
     private final FinanceSettlementApplicationService service;
 
@@ -53,13 +60,22 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
         }
     }
 
+    @SuppressWarnings("unchecked")
     private void dispatch(EventEnvelope envelope) {
-        if ("PaymentIntentCreated".equals(envelope.eventType())) {
-            rememberPaymentIntentOrderReference((Map<String, Object>) envelope.payload());
-            return;
-        }
-        if (service != null && "PaymentCaptured".equals(envelope.eventType())) {
-            recognizeCapturedPayment(envelope);
+        Map<String, Object> payload = (Map<String, Object>) envelope.payload();
+        switch (envelope.eventType()) {
+            case "PaymentIntentCreated" -> rememberPaymentIntentOrderReference(payload);
+            case "PaymentCaptured" -> {
+                if (service != null) recognizeCapturedPayment(envelope, payload);
+            }
+            case "ProviderReservationConfirmed", "SegmentBookingCancelled" -> {
+                if (service != null) reconcileOperationalFact(envelope, payload);
+            }
+            case "PostSalesApproved" -> rememberApprovedRefund(payload);
+            case "PostSalesApplied" -> {
+                if (service != null) applyPostSales(envelope, payload);
+            }
+            default -> { }
         }
     }
 
@@ -67,16 +83,19 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
         paymentIntentOrderReferences.save(text(payload, "paymentIntentId"), text(payload, "businessRef"));
     }
 
-    private void recognizeCapturedPayment(EventEnvelope envelope) {
-        Map<String, Object> payload = (Map<String, Object>) envelope.payload();
+    private void recognizeCapturedPayment(EventEnvelope envelope, Map<String, Object> payload) {
         String paymentIntentId = text(payload, "paymentIntentId");
-        String orderReference = paymentIntentOrderReferences.findOrderReference(paymentIntentId)
-            .orElseThrow(() -> new OutOfOrderEventException("PaymentCaptured received before PaymentIntentCreated"));
+        String orderId = optionalText(payload, "businessRef")
+            .or(() -> paymentIntentOrderReferences.findOrderReference(paymentIntentId))
+            .orElseThrow(() -> new OutOfOrderEventException("PaymentCaptured received before order reference"));
+        paymentIntentOrderReferences.save(paymentIntentId, orderId);
+        Money captured = money(payload.get("capturedAmount"), "capturedAmount");
+        capturesByOrderId.put(orderId, new PaymentCaptureFact(paymentIntentId, captured, envelope.eventId()));
         RevenueRecognition recognition = RevenueRecognition.recognize(
-            orderReference,
-            paymentIntentId,
+            orderId,
+            orderItemReference(payload, orderId),
             "fare",
-            money(payload.get("capturedAmount"), "capturedAmount"),
+            captured,
             "payment-capture-v1",
             envelope.eventId(),
             envelope.occurredAt(),
@@ -85,6 +104,103 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
             envelope.correlationId()
         );
         service.saveAndPublish(recognition);
+    }
+
+    private void reconcileOperationalFact(EventEnvelope envelope, Map<String, Object> payload) {
+        String orderId = optionalText(payload, "journeyOrderId")
+            .or(() -> optionalText(payload, "orderId"))
+            .orElse(optionalText(payload, "businessRef").orElse("order-unknown-for-" + text(payload, "segmentBookingId")));
+        PaymentCaptureFact capture = capturesByOrderId.get(orderId);
+        Money actual = capture == null ? Money.zero(Currency.getInstance("CNY")) : capture.amount();
+        List<RevenueRecognition> recognitions = serviceRevenue(orderId);
+        Money expected = sumOrZero(recognitions, actual.currency());
+        if (capture == null || !sameMoney(expected, actual)) {
+            ReconciliationCase open = ReconciliationCase.open(
+                orderId,
+                capture == null ? "" : capture.paymentIntentId(),
+                capture == null ? "missing-in-platform" : "amount-mismatch",
+                expected,
+                actual,
+                envelope.eventType() + " did not match recognized revenue",
+                clock.instant(),
+                causationIdOrEventId(envelope),
+                envelope.correlationId()
+            );
+            service.saveAndPublish(open);
+            return;
+        }
+        service.publishReconciliationCompleted(
+            orderId,
+            capture.paymentIntentId(),
+            expected,
+            actual,
+            recognitions.stream().map(RevenueRecognition::revenueRecognitionId).toList(),
+            List.of(capture.sourceEventId(), envelope.eventId()),
+            "MATCHED",
+            clock.instant(),
+            causationIdOrEventId(envelope),
+            envelope.correlationId()
+        );
+    }
+
+    private void rememberApprovedRefund(Map<String, Object> payload) {
+        String caseId = optionalText(payload, "caseId").orElse(optionalText(payload, "postSalesCaseId").orElse(null));
+        if (caseId == null) return;
+        Object approvedActions = payload.get("approvedActions");
+        if (approvedActions instanceof Map<?, ?> actions && actions.get("refund") instanceof Map<?, ?> refund) {
+            approvedRefundsByCaseId.put(caseId, money(((Map<?, ?>) refund).get("amount"), "approvedActions.refund.amount"));
+        }
+    }
+
+    private void applyPostSales(EventEnvelope envelope, Map<String, Object> payload) {
+        String orderId = text(payload, "orderId");
+        String caseId = optionalText(payload, "caseId").orElse(optionalText(payload, "postSalesCaseId").orElse(""));
+        Money refund = Optional.ofNullable(approvedRefundsByCaseId.get(caseId))
+            .or(() -> Optional.ofNullable(approvedRefundsByCaseId.get(orderId)))
+            .orElseThrow(() -> new OutOfOrderEventException("PostSalesApplied received before PostSalesApproved refund amount"));
+        RevenueRecognition reduction = RevenueRecognition.recognize(
+            orderId,
+            optionalText(payload, "orderItemId").orElse(orderId),
+            "refund",
+            refund.negate(),
+            "post-sales-refund-v1",
+            envelope.eventId(),
+            envelope.occurredAt(),
+            clock.instant(),
+            causationIdOrEventId(envelope),
+            envelope.correlationId()
+        );
+        service.saveAndPublish(reduction);
+        PaymentCaptureFact capture = capturesByOrderId.get(orderId);
+        Money expected = capture == null ? refund.negate() : capture.amount().minus(refund);
+        service.publishReconciliationCompleted(
+            orderId,
+            capture == null ? "" : capture.paymentIntentId(),
+            expected,
+            expected,
+            serviceRevenue(orderId).stream().map(RevenueRecognition::revenueRecognitionId).toList(),
+            capture == null ? List.of(envelope.eventId()) : List.of(capture.sourceEventId(), envelope.eventId()),
+            "MATCHED",
+            clock.instant(),
+            causationIdOrEventId(envelope),
+            envelope.correlationId()
+        );
+    }
+
+    private List<RevenueRecognition> serviceRevenue(String orderId) {
+        return service.findRevenueRecognitionsByOrderId(orderId);
+    }
+
+    private static Money sumOrZero(List<RevenueRecognition> recognitions, Currency currency) {
+        return recognitions.stream().map(RevenueRecognition::amount).reduce(Money.zero(currency), Money::plus);
+    }
+
+    private static boolean sameMoney(Money left, Money right) {
+        return left.currency().equals(right.currency()) && left.compareTo(right) == 0;
+    }
+
+    private static String orderItemReference(Map<String, Object> payload, String orderId) {
+        return optionalText(payload, "orderItemId").orElse(orderId);
     }
 
     private static String causationIdOrEventId(EventEnvelope envelope) {
@@ -97,6 +213,11 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
             throw new IllegalArgumentException(name + " is required");
         }
         return text;
+    }
+
+    private static Optional<String> optionalText(Map<String, Object> payload, String name) {
+        Object value = payload.get(name);
+        return value instanceof String text && !text.isBlank() ? Optional.of(text) : Optional.empty();
     }
 
     @SuppressWarnings("unchecked")
@@ -114,6 +235,8 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
         BigDecimal majorUnits = BigDecimal.valueOf(minorUnits.longValue()).movePointLeft(fractionDigits);
         return Money.of(currencyCode, majorUnits.toPlainString());
     }
+
+    private record PaymentCaptureFact(String paymentIntentId, Money amount, String sourceEventId) {}
 
     private static final class OutOfOrderEventException extends RuntimeException {
         private OutOfOrderEventException(String message) {

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementEventHandler.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementEventHandler.java
@@ -204,19 +204,22 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
         Money refund = Optional.ofNullable(approvedRefundsByCaseId.get(caseId))
             .or(() -> Optional.ofNullable(approvedRefundsByCaseId.get(orderId)))
             .orElseThrow(() -> new OutOfOrderEventException("PostSalesApplied received before PostSalesApproved refund amount"));
-        RevenueRecognition reduction = RevenueRecognition.recognize(
-            orderId,
-            optionalText(payload, "orderItemId").orElse(orderId),
-            "refund",
-            refund.negate(),
-            "post-sales-refund-v1",
+        RevenueRecognition originalRecognition = serviceRevenue(orderId).stream()
+            .filter(recognition -> !recognition.reversed())
+            .filter(recognition -> sameMoney(recognition.amount(), refund) || recognition.amount().compareTo(refund) >= 0)
+            .findFirst()
+            .orElseThrow(() -> new OutOfOrderEventException("PostSalesApplied received before matching recognized revenue"));
+        int firstUnpublishedEventIndex = originalRecognition.domainEvents().size();
+        originalRecognition.reverse(
+            "post-sales refund applied",
             envelope.eventId(),
-            envelope.occurredAt(),
+            refund,
             clock.instant(),
+            causationIdOrEventId(envelope),
             causationIdOrEventId(envelope),
             envelope.correlationId()
         );
-        service.saveAndPublish(reduction);
+        service.saveAndPublish(originalRecognition, firstUnpublishedEventIndex);
         PaymentCaptureFact capture = capturesByOrderId.get(orderId);
         Money expected = capture == null ? refund.negate() : capture.amount().minus(refund);
         service.publishReconciliationCompleted(
@@ -238,7 +241,7 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
     }
 
     private static Money sumOrZero(List<RevenueRecognition> recognitions, Currency currency) {
-        return recognitions.stream().map(RevenueRecognition::amount).reduce(Money.zero(currency), Money::plus);
+        return recognitions.stream().map(RevenueRecognition::netAmount).reduce(Money.zero(currency), Money::plus);
     }
 
     private static boolean sameMoney(Money left, Money right) {

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemoryInvoiceRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemoryInvoiceRepository.java
@@ -1,0 +1,29 @@
+package com.trainticket.financesettlement.application;
+
+import com.trainticket.financesettlement.domain.Invoice;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryInvoiceRepository implements InvoiceRepository {
+    private final ConcurrentMap<String, Invoice> invoices = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, String> invoiceIdsByOrderId = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<Invoice> findById(String invoiceId) {
+        return Optional.ofNullable(invoices.get(invoiceId));
+    }
+
+    @Override
+    public Optional<Invoice> findByOrderId(String orderId) {
+        return Optional.ofNullable(invoiceIdsByOrderId.get(orderId)).flatMap(this::findById);
+    }
+
+    @Override
+    public void save(Invoice invoice) {
+        invoices.put(invoice.invoiceId(), invoice);
+        invoiceIdsByOrderId.putIfAbsent(invoice.orderId(), invoice.invoiceId());
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemoryRevenueRecognitionRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemoryRevenueRecognitionRepository.java
@@ -1,6 +1,8 @@
 package com.trainticket.financesettlement.application;
 
 import com.trainticket.financesettlement.domain.RevenueRecognition;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -13,6 +15,14 @@ public class InMemoryRevenueRecognitionRepository implements RevenueRecognitionR
     @Override
     public Optional<RevenueRecognition> findById(String revenueRecognitionId) {
         return Optional.ofNullable(revenueRecognitions.get(revenueRecognitionId));
+    }
+
+    @Override
+    public List<RevenueRecognition> findByOrderId(String orderId) {
+        return revenueRecognitions.values().stream()
+            .filter(recognition -> recognition.orderId().equals(orderId))
+            .sorted(Comparator.comparing(RevenueRecognition::recognizedAt).thenComparing(RevenueRecognition::revenueRecognitionId))
+            .toList();
     }
 
     @Override

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemorySegmentBookingOrderReferenceRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemorySegmentBookingOrderReferenceRepository.java
@@ -1,0 +1,29 @@
+package com.trainticket.financesettlement.application;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemorySegmentBookingOrderReferenceRepository implements SegmentBookingOrderReferenceRepository {
+    private final ConcurrentMap<String, String> orderReferencesBySegmentBookingId = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(String segmentBookingId, String orderReference) {
+        orderReferencesBySegmentBookingId.put(requireText(segmentBookingId, "segmentBookingId"), requireText(orderReference, "orderReference"));
+    }
+
+    @Override
+    public Optional<String> findOrderReference(String segmentBookingId) {
+        return Optional.ofNullable(orderReferencesBySegmentBookingId.get(segmentBookingId));
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InvoiceRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InvoiceRepository.java
@@ -1,0 +1,10 @@
+package com.trainticket.financesettlement.application;
+
+import com.trainticket.financesettlement.domain.Invoice;
+import java.util.Optional;
+
+public interface InvoiceRepository {
+    Optional<Invoice> findById(String invoiceId);
+    Optional<Invoice> findByOrderId(String orderId);
+    void save(Invoice invoice);
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/RevenueRecognitionRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/RevenueRecognitionRepository.java
@@ -1,9 +1,11 @@
 package com.trainticket.financesettlement.application;
 
 import com.trainticket.financesettlement.domain.RevenueRecognition;
+import java.util.List;
 import java.util.Optional;
 
 public interface RevenueRecognitionRepository {
     Optional<RevenueRecognition> findById(String revenueRecognitionId);
+    List<RevenueRecognition> findByOrderId(String orderId);
     void save(RevenueRecognition recognition);
 }

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/SegmentBookingOrderReferenceRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/SegmentBookingOrderReferenceRepository.java
@@ -1,0 +1,8 @@
+package com.trainticket.financesettlement.application;
+
+import java.util.Optional;
+
+public interface SegmentBookingOrderReferenceRepository {
+    void save(String segmentBookingId, String orderReference);
+    Optional<String> findOrderReference(String segmentBookingId);
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/EventMetadata.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/EventMetadata.java
@@ -3,7 +3,7 @@ package com.trainticket.financesettlement.domain;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
+import com.trainticket.platformkit.messaging.PrefixedIds;
 
 public record EventMetadata(
     String eventId,
@@ -25,7 +25,7 @@ public record EventMetadata(
     }
 
     public static EventMetadata create(Instant occurredAt, String sourceCommandId, String causationId, String correlationId, Map<String, String> attributes) {
-        return new EventMetadata(UUID.randomUUID().toString(), occurredAt, sourceCommandId, causationId, correlationId, 1, attributes);
+        return new EventMetadata(PrefixedIds.newEventId(), occurredAt, sourceCommandId, causationId, correlationId, 1, attributes);
     }
 
     private static String requireText(String value, String name) {

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/FinanceSettlementEvent.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/FinanceSettlementEvent.java
@@ -7,6 +7,8 @@ public sealed interface FinanceSettlementEvent permits
     RevenueRecognized,
     ReconciliationCaseOpened,
     ReconciliationCaseResolved,
+    ReconciliationCompleted,
+    InvoiceGenerated,
     SettlementViewRebuilt {
     String eventId();
     Instant occurredAt();

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/FinanceSettlementEvent.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/FinanceSettlementEvent.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 public sealed interface FinanceSettlementEvent permits
     RevenueRecognized,
+    RevenueRecognitionReversed,
     ReconciliationCaseOpened,
     ReconciliationCaseResolved,
     ReconciliationCompleted,

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/Invoice.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/Invoice.java
@@ -1,0 +1,68 @@
+package com.trainticket.financesettlement.domain;
+
+import com.trainticket.platformkit.idempotency.UuidV7;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class Invoice {
+    private final String invoiceId;
+    private final String orderId;
+    private final String invoiceNumber;
+    private final Money totalAmount;
+    private final List<String> revenueRecognitionIds;
+    private final Instant generatedAt;
+    private final List<FinanceSettlementEvent> domainEvents;
+
+    private Invoice(String invoiceId, String orderId, String invoiceNumber, Money totalAmount, List<String> revenueRecognitionIds, Instant generatedAt) {
+        this.invoiceId = requireText(invoiceId, "invoiceId");
+        this.orderId = requireText(orderId, "orderId");
+        this.invoiceNumber = requireText(invoiceNumber, "invoiceNumber");
+        this.totalAmount = Objects.requireNonNull(totalAmount, "totalAmount is required");
+        if (totalAmount.isNegative() || totalAmount.isZero()) {
+            throw new DomainRuleViolation("invoice total amount must be positive");
+        }
+        this.revenueRecognitionIds = List.copyOf(Objects.requireNonNull(revenueRecognitionIds, "revenueRecognitionIds are required"));
+        if (this.revenueRecognitionIds.isEmpty()) {
+            throw new DomainRuleViolation("invoice requires at least one revenue recognition");
+        }
+        this.generatedAt = Objects.requireNonNull(generatedAt, "generatedAt is required");
+        this.domainEvents = new ArrayList<>();
+    }
+
+    public static Invoice generate(String orderId, Money totalAmount, List<String> revenueRecognitionIds, Instant now, String sourceCommandId, String correlationId) {
+        Invoice invoice = new Invoice(
+            "inv-" + UuidV7.generate(),
+            orderId,
+            "INV-" + UuidV7.generate(),
+            totalAmount,
+            revenueRecognitionIds,
+            now
+        );
+        invoice.domainEvents.add(new InvoiceGenerated(
+            invoice.invoiceId, invoice.orderId, invoice.invoiceNumber, invoice.totalAmount,
+            invoice.revenueRecognitionIds, invoice.generatedAt,
+            EventMetadata.create(now, sourceCommandId, sourceCommandId, correlationId,
+                Map.of("invoiceId", invoice.invoiceId, "orderId", invoice.orderId))
+        ));
+        return invoice;
+    }
+
+    public String invoiceId() { return invoiceId; }
+    public String orderId() { return orderId; }
+    public String invoiceNumber() { return invoiceNumber; }
+    public Money totalAmount() { return totalAmount; }
+    public List<String> revenueRecognitionIds() { return revenueRecognitionIds; }
+    public Instant generatedAt() { return generatedAt; }
+    public List<FinanceSettlementEvent> domainEvents() { return Collections.unmodifiableList(domainEvents); }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/InvoiceGenerated.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/InvoiceGenerated.java
@@ -1,0 +1,40 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public record InvoiceGenerated(
+    String invoiceId,
+    String orderId,
+    String invoiceNumber,
+    Money totalAmount,
+    List<String> revenueRecognitionIds,
+    Instant generatedAt,
+    EventMetadata metadata
+) implements FinanceSettlementEvent {
+    public InvoiceGenerated {
+        requireText(invoiceId, "invoiceId");
+        requireText(orderId, "orderId");
+        requireText(invoiceNumber, "invoiceNumber");
+        Objects.requireNonNull(totalAmount, "totalAmount is required");
+        Objects.requireNonNull(generatedAt, "generatedAt is required");
+        Objects.requireNonNull(metadata, "metadata is required");
+        revenueRecognitionIds = List.copyOf(revenueRecognitionIds);
+    }
+
+    private static void requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+    }
+
+    public String eventId() { return metadata.eventId(); }
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    public String causationId() { return metadata.causationId(); }
+    public String correlationId() { return metadata.correlationId(); }
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationCase.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationCase.java
@@ -50,8 +50,10 @@ public final class ReconciliationCase {
     ) {
         Objects.requireNonNull(expectedAmount);
         Objects.requireNonNull(actualAmount);
-        if (expectedAmount.currency().equals(actualAmount.currency()) && expectedAmount.compareTo(actualAmount) == 0)
+        if (expectedAmount.currency().equals(actualAmount.currency()) && expectedAmount.compareTo(actualAmount) == 0
+            && !("missing-in-platform".equals(differenceType) || "missing-in-channel".equals(differenceType) || "refund-lag".equals(differenceType))) {
             throw new DomainRuleViolation("cannot open reconciliation case with matching amounts");
+        }
 
         ReconciliationCase rc = new ReconciliationCase(
             UUID.randomUUID().toString(), orderId, paymentIntentId,

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationCompleted.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/ReconciliationCompleted.java
@@ -1,0 +1,43 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public record ReconciliationCompleted(
+    String reconciliationId,
+    String orderId,
+    String paymentIntentId,
+    String reconciliationStatus,
+    Money expectedAmount,
+    Money actualAmount,
+    List<String> matchedRevenueRecognitionIds,
+    List<String> sourceEventIds,
+    EventMetadata metadata
+) implements FinanceSettlementEvent {
+    public ReconciliationCompleted {
+        requireText(reconciliationId, "reconciliationId");
+        requireText(orderId, "orderId");
+        requireText(reconciliationStatus, "reconciliationStatus");
+        Objects.requireNonNull(expectedAmount, "expectedAmount is required");
+        Objects.requireNonNull(actualAmount, "actualAmount is required");
+        Objects.requireNonNull(metadata, "metadata is required");
+        matchedRevenueRecognitionIds = List.copyOf(matchedRevenueRecognitionIds);
+        sourceEventIds = List.copyOf(sourceEventIds);
+    }
+
+    private static void requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+    }
+
+    public String eventId() { return metadata.eventId(); }
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    public String causationId() { return metadata.causationId(); }
+    public String correlationId() { return metadata.correlationId(); }
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RevenueRecognition.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RevenueRecognition.java
@@ -18,6 +18,7 @@ public final class RevenueRecognition {
     private final Instant recognizedAt;
     private final List<FinanceSettlementEvent> domainEvents;
     private boolean reversed;
+    private Money reversedAmount;
     private String reversalReason;
 
     private RevenueRecognition(
@@ -35,6 +36,7 @@ public final class RevenueRecognition {
         this.recognizedAt = Objects.requireNonNull(recognizedAt, "recognizedAt is required");
         this.domainEvents = new ArrayList<>();
         this.reversed = false;
+        this.reversedAmount = Money.zero(amount.currency());
         this.reversalReason = null;
     }
 
@@ -44,7 +46,7 @@ public final class RevenueRecognition {
         String sourceEventId, Instant recognizedAt,
         Instant now, String sourceCommandId, String correlationId
     ) {
-        if (amount.isNegative() && !("discount".equals(componentCode) || "refund".equals(componentCode)))
+        if (amount.isNegative() && !("discount".equals(componentCode)))
             throw new DomainRuleViolation("revenue recognition amount must not be negative for component: " + componentCode);
         if (amount.isZero())
             throw new DomainRuleViolation("revenue recognition amount must not be zero");
@@ -63,17 +65,28 @@ public final class RevenueRecognition {
         return recognition;
     }
 
-    public void reverse(String reason, Instant now, String sourceCommandId, String causationId, String correlationId) {
+    public void reverse(String reason, String sourceEventId, Money reversalAmount, Instant now, String sourceCommandId, String causationId, String correlationId) {
         if (reversed) return;
+        if (reversalAmount.isZero() || reversalAmount.isNegative()) {
+            throw new DomainRuleViolation("reversal amount must be positive");
+        }
+        if (reversedAmount.plus(reversalAmount).compareTo(amount) > 0) {
+            throw new DomainRuleViolation("reversal amount must not exceed recognized amount");
+        }
         this.reversed = true;
+        this.reversedAmount = reversedAmount.plus(reversalAmount);
         this.reversalReason = requireText(reason, "reason");
-        domainEvents.add(new RevenueRecognized(
+        domainEvents.add(new RevenueRecognitionReversed(
             revenueRecognitionId, orderItemId, orderId, componentCode,
-            amount.negate(), recognitionPolicyVersion + "-reversed", sourceEventId,
+            reversalAmount, reason, requireText(sourceEventId, "sourceEventId"),
             EventMetadata.create(now, sourceCommandId, causationId, correlationId,
                 Map.of("revenueRecognitionId", revenueRecognitionId, "reversalReason", reason,
-                       "originalSourceEventId", sourceEventId))
+                       "originalSourceEventId", this.sourceEventId))
         ));
+    }
+
+    public void reverse(String reason, Instant now, String sourceCommandId, String causationId, String correlationId) {
+        reverse(reason, sourceEventId, amount, now, sourceCommandId, causationId, correlationId);
     }
 
     public String revenueRecognitionId() { return revenueRecognitionId; }
@@ -85,6 +98,8 @@ public final class RevenueRecognition {
     public String sourceEventId() { return sourceEventId; }
     public Instant recognizedAt() { return recognizedAt; }
     public boolean reversed() { return reversed; }
+    public Money reversedAmount() { return reversedAmount; }
+    public Money netAmount() { return amount.minus(reversedAmount); }
     public String reversalReason() { return reversalReason; }
     public List<FinanceSettlementEvent> domainEvents() { return Collections.unmodifiableList(domainEvents); }
 

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RevenueRecognition.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RevenueRecognition.java
@@ -44,7 +44,7 @@ public final class RevenueRecognition {
         String sourceEventId, Instant recognizedAt,
         Instant now, String sourceCommandId, String correlationId
     ) {
-        if (amount.isNegative() && !"discount".equals(componentCode))
+        if (amount.isNegative() && !("discount".equals(componentCode) || "refund".equals(componentCode)))
             throw new DomainRuleViolation("revenue recognition amount must not be negative for component: " + componentCode);
         if (amount.isZero())
             throw new DomainRuleViolation("revenue recognition amount must not be zero");

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RevenueRecognitionReversed.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/domain/RevenueRecognitionReversed.java
@@ -1,0 +1,23 @@
+package com.trainticket.financesettlement.domain;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record RevenueRecognitionReversed(
+    String revenueRecognitionId,
+    String orderItemId,
+    String orderId,
+    String componentCode,
+    Money amount,
+    String reversalReason,
+    String sourceEventId,
+    EventMetadata metadata
+) implements FinanceSettlementEvent {
+    public String eventId() { return metadata.eventId(); }
+    public Instant occurredAt() { return metadata.occurredAt(); }
+    public String sourceCommandId() { return metadata.sourceCommandId(); }
+    public String causationId() { return metadata.causationId(); }
+    public String correlationId() { return metadata.correlationId(); }
+    public int schemaVersion() { return metadata.schemaVersion(); }
+    public Map<String, String> attributes() { return metadata.attributes(); }
+}

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/adapters/http/FinanceSettlementControllerTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/adapters/http/FinanceSettlementControllerTest.java
@@ -2,6 +2,7 @@ package com.trainticket.financesettlement.adapters.http;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -11,6 +12,7 @@ import com.trainticket.financesettlement.domain.Money;
 import com.trainticket.financesettlement.domain.ReconciliationCase;
 import com.trainticket.financesettlement.domain.RevenueRecognition;
 import java.time.Instant;
+import com.trainticket.platformkit.idempotency.UuidV7;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -94,5 +96,44 @@ class FinanceSettlementControllerTest {
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.code").value("NOT_FOUND"))
             .andExpect(jsonPath("$.correlationId").value("corr-0194f2e0-7b3e-7610-8284-5c26e8b0f002"));
+    }
+
+    @Test
+    void generateInvoiceIsIdempotent() throws Exception {
+        String key = UuidV7.generate();
+        mockMvc.perform(post("/api/v1/invoices")
+                .header("Idempotency-Key", key)
+                .contentType("application/json")
+                .content("{\"orderId\":\"" + orderId + "\"}"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.orderId").value(orderId))
+            .andExpect(jsonPath("$.totalAmount.minorUnits").value(12000));
+
+        mockMvc.perform(post("/api/v1/invoices")
+                .header("Idempotency-Key", key)
+                .contentType("application/json")
+                .content("{\"orderId\":\"" + orderId + "\"}"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.orderId").value(orderId))
+            .andExpect(jsonPath("$.totalAmount.minorUnits").value(12000));
+    }
+
+    @Test
+    void generateInvoiceRejectsMissingIdempotencyKey() throws Exception {
+        mockMvc.perform(post("/api/v1/invoices")
+                .contentType("application/json")
+                .content("{\"orderId\":\"" + orderId + "\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"));
+    }
+
+    @Test
+    void generateInvoiceRejectsNonUuidV7IdempotencyKey() throws Exception {
+        mockMvc.perform(post("/api/v1/invoices")
+                .header("Idempotency-Key", "550e8400-e29b-41d4-a716-446655440000")
+                .contentType("application/json")
+                .content("{\"orderId\":\"" + orderId + "\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"));
     }
 }

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/InMemoryRevenueRepository.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/InMemoryRevenueRepository.java
@@ -1,6 +1,8 @@
 package com.trainticket.financesettlement.application;
 
 import com.trainticket.financesettlement.domain.RevenueRecognition;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -11,6 +13,14 @@ final class InMemoryRevenueRepository implements RevenueRecognitionRepository {
     @Override
     public Optional<RevenueRecognition> findById(String revenueRecognitionId) {
         return Optional.ofNullable(recognitions.get(revenueRecognitionId));
+    }
+
+    @Override
+    public List<RevenueRecognition> findByOrderId(String orderId) {
+        return recognitions.values().stream()
+            .filter(recognition -> recognition.orderId().equals(orderId))
+            .sorted(Comparator.comparing(RevenueRecognition::recognizedAt).thenComparing(RevenueRecognition::revenueRecognitionId))
+            .toList();
     }
 
     @Override

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/MessagingTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/MessagingTest.java
@@ -122,7 +122,7 @@ class MessagingTest {
         EventEnvelope published = publisher.published.getFirst();
         assertEquals("RevenueRecognized", published.eventType());
         assertEquals("ord-0194f2e0-7b3e-7610-0284-5c26e8b0c321", ((Map<?, ?>) published.payload()).get("orderId"));
-        assertEquals("pi-0194f2e0-7b3e-7610-0284-5c26e8b0c789", ((Map<?, ?>) published.payload()).get("orderItemId"));
+        assertEquals("ord-0194f2e0-7b3e-7610-0284-5c26e8b0c321", ((Map<?, ?>) published.payload()).get("orderItemId"));
         assertEquals(35000L, ((Map<?, ?>) ((Map<?, ?>) published.payload()).get("amount")).get("minorUnits"));
     }
 
@@ -149,6 +149,47 @@ class MessagingTest {
 
         assertEquals(HandlerResult.TRANSIENT_FAILURE, handler.handle(captured));
         assertEquals(0, consumedEvents.saveCount);
+    }
+
+    @Test
+    void postSalesAppliedUsesApprovedRefundAmountForRevenueReductionAndReconciliation() {
+        InMemoryConsumedEventLogRepository consumedEvents = new InMemoryConsumedEventLogRepository();
+        RecordingPublisher publisher = new RecordingPublisher();
+        FinanceSettlementApplicationService service = new FinanceSettlementApplicationService(
+            new InMemoryRevenueRepository(), new InMemoryReconciliationRepository(), publisher, new DomainEventEnvelopeMapper());
+        FinanceSettlementEventHandler handler = new FinanceSettlementEventHandler(
+            consumedEvents, new InMemoryPaymentIntentOrderReferenceRepository(),
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC), service);
+
+        handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e107", "PaymentCaptured", Instant.parse("2026-07-03T10:30:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e105", null, "payment", 1, Map.of(
+                "paymentIntentId", "pi-0194f2e0-7b3e-7610-0284-5c26e8b0c789",
+                "businessRef", "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c321",
+                "capturedAmount", Map.of("currency", "CNY", "minorUnits", 35000),
+                "channel", "wechat_pay",
+                "channelTransactionId", "wx_txn_20260703_a1b2c3")));
+        handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e108", "PostSalesApproved", Instant.parse("2026-07-03T10:31:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e105", null, "post-sales", 1, Map.of(
+                "caseId", "psc-1",
+                "orderId", "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c321",
+                "approvedActions", Map.of(
+                    "decisionKind", "REFUND",
+                    "approvalRef", "approval-1",
+                    "refund", Map.of("orderId", "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c321", "amount", Map.of("currency", "CNY", "minorUnits", 8750)),
+                    "steps", List.of()))));
+        HandlerResult applied = handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e109", "PostSalesApplied", Instant.parse("2026-07-03T10:32:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e105", null, "post-sales", 1, Map.of(
+                "caseId", "psc-1",
+                "orderId", "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c321",
+                "resultSummary", Map.of("description", "applied"))));
+
+        assertEquals(HandlerResult.SUCCESS, applied);
+        EventEnvelope reduction = publisher.published.stream().filter(e -> "RevenueRecognized".equals(e.eventType()) && "refund".equals(((Map<?, ?>) e.payload()).get("componentCode"))).findFirst().orElseThrow();
+        assertEquals(-8750L, ((Map<?, ?>) ((Map<?, ?>) reduction.payload()).get("amount")).get("minorUnits"));
+        assertTrue(publisher.published.stream().anyMatch(e -> "ReconciliationCompleted".equals(e.eventType())));
     }
 
     private static final class RecordingPublisher implements EventPublisher {

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/MessagingTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/MessagingTest.java
@@ -4,6 +4,7 @@ import com.trainticket.platformkit.messaging.EventEnvelope;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -190,6 +191,68 @@ class MessagingTest {
         EventEnvelope reduction = publisher.published.stream().filter(e -> "RevenueRecognized".equals(e.eventType()) && "refund".equals(((Map<?, ?>) e.payload()).get("componentCode"))).findFirst().orElseThrow();
         assertEquals(-8750L, ((Map<?, ?>) ((Map<?, ?>) reduction.payload()).get("amount")).get("minorUnits"));
         assertTrue(publisher.published.stream().anyMatch(e -> "ReconciliationCompleted".equals(e.eventType())));
+    }
+
+    @Test
+    void operationalFactUsesSegmentReservationRequestedIndexForOrderReference() {
+        InMemoryConsumedEventLogRepository consumedEvents = new InMemoryConsumedEventLogRepository();
+        RecordingPublisher publisher = new RecordingPublisher();
+        FinanceSettlementApplicationService service = new FinanceSettlementApplicationService(
+            new InMemoryRevenueRepository(), new InMemoryReconciliationRepository(), publisher, new DomainEventEnvelopeMapper());
+        FinanceSettlementEventHandler handler = new FinanceSettlementEventHandler(
+            consumedEvents, new InMemoryPaymentIntentOrderReferenceRepository(), new InMemorySegmentBookingOrderReferenceRepository(),
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC), service);
+
+        handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e207", "SegmentReservationRequested", Instant.parse("2026-07-03T10:28:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e105", null, "booking-orchestration", 1, Map.of(
+                "segmentBookingId", "sb-0194f2e0-7b3e-7610-0284-5c26e8b0c111",
+                "journeyOrderId", "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c321",
+                "segmentRef", "seg-1",
+                "travelerRef", "trav-1",
+                "idempotencyKey", "idem-1")));
+        handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e208", "PaymentCaptured", Instant.parse("2026-07-03T10:30:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e105", null, "payment", 1, Map.of(
+                "paymentIntentId", "pi-0194f2e0-7b3e-7610-0284-5c26e8b0c789",
+                "businessRef", "ord-0194f2e0-7b3e-7610-0284-5c26e8b0c321",
+                "capturedAmount", Map.of("currency", "CNY", "minorUnits", 35000),
+                "channel", "wechat_pay",
+                "channelTransactionId", "wx_txn_20260703_a1b2c3")));
+        HandlerResult confirmed = handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e209", "ProviderReservationConfirmed", Instant.parse("2026-07-03T10:31:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e105", null, "provider-integration", 1, Map.of(
+                "segmentBookingId", "sb-0194f2e0-7b3e-7610-0284-5c26e8b0c111",
+                "providerReference", "pr-1",
+                "normalizedEvidence", "confirmed")));
+
+        assertEquals(HandlerResult.SUCCESS, confirmed);
+        EventEnvelope completed = publisher.published.stream().filter(e -> "ReconciliationCompleted".equals(e.eventType())).findFirst().orElseThrow();
+        assertEquals("ord-0194f2e0-7b3e-7610-0284-5c26e8b0c321", ((Map<?, ?>) completed.payload()).get("orderId"));
+        assertFalse(((String) ((Map<?, ?>) completed.payload()).get("orderId")).startsWith("order-unknown-for-"));
+    }
+
+    @Test
+    void operationalFactWithoutSegmentIndexOpensUnassignedCaseWithoutSyntheticOrderKey() {
+        InMemoryConsumedEventLogRepository consumedEvents = new InMemoryConsumedEventLogRepository();
+        RecordingPublisher publisher = new RecordingPublisher();
+        FinanceSettlementApplicationService service = new FinanceSettlementApplicationService(
+            new InMemoryRevenueRepository(), new InMemoryReconciliationRepository(), publisher, new DomainEventEnvelopeMapper());
+        FinanceSettlementEventHandler handler = new FinanceSettlementEventHandler(
+            consumedEvents, new InMemoryPaymentIntentOrderReferenceRepository(), new InMemorySegmentBookingOrderReferenceRepository(),
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC), service);
+
+        HandlerResult result = handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e210", "SegmentBookingCancelled", Instant.parse("2026-07-03T10:31:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e105", null, "booking-orchestration", 1, Map.of(
+                "segmentBookingId", "sb-0194f2e0-7b3e-7610-0284-5c26e8b0c222",
+                "reason", "refund")));
+
+        assertEquals(HandlerResult.SUCCESS, result);
+        EventEnvelope opened = publisher.published.stream().filter(e -> "ReconciliationCaseOpened".equals(e.eventType())).findFirst().orElseThrow();
+        assertEquals("", ((Map<?, ?>) opened.payload()).get("orderId"));
+        assertTrue(((String) ((Map<?, ?>) opened.payload()).get("description")).contains("missing SegmentReservationRequested index"));
+        assertFalse(((String) ((Map<?, ?>) opened.payload()).get("description")).contains("order-unknown-for-"));
     }
 
     private static final class RecordingPublisher implements EventPublisher {

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/MessagingTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/MessagingTest.java
@@ -196,6 +196,43 @@ class MessagingTest {
     }
 
     @Test
+    void postSalesAppliedWithApprovedRefundButNoRecognizedRevenueOpensCaseAndConsumesEvent() {
+        InMemoryConsumedEventLogRepository consumedEvents = new InMemoryConsumedEventLogRepository();
+        RecordingPublisher publisher = new RecordingPublisher();
+        FinanceSettlementApplicationService service = new FinanceSettlementApplicationService(
+            new InMemoryRevenueRepository(), new InMemoryReconciliationRepository(), publisher, new DomainEventEnvelopeMapper());
+        FinanceSettlementEventHandler handler = new FinanceSettlementEventHandler(
+            consumedEvents, new InMemoryPaymentIntentOrderReferenceRepository(),
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC), service);
+
+        handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e111", "PostSalesApproved", Instant.parse("2026-07-03T10:31:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e105", null, "post-sales", 1, Map.of(
+                "caseId", "psc-lag",
+                "orderId", "ord-refund-lag",
+                "approvedActions", Map.of(
+                    "decisionKind", "REFUND",
+                    "approvalRef", "approval-lag",
+                    "refund", Map.of("orderId", "ord-refund-lag", "amount", Map.of("currency", "CNY", "minorUnits", 8750)),
+                    "steps", List.of()))));
+
+        HandlerResult applied = handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e112", "PostSalesApplied", Instant.parse("2026-07-03T10:32:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e105", null, "post-sales", 1, Map.of(
+                "caseId", "psc-lag",
+                "orderId", "ord-refund-lag",
+                "resultSummary", Map.of("description", "applied"))));
+
+        assertEquals(HandlerResult.SUCCESS, applied);
+        assertEquals(2, consumedEvents.saveCount);
+        EventEnvelope opened = publisher.published.stream().filter(e -> "ReconciliationCaseOpened".equals(e.eventType())).findFirst().orElseThrow();
+        assertEquals("refund-lag", ((Map<?, ?>) opened.payload()).get("differenceType"));
+        assertEquals("ord-refund-lag", ((Map<?, ?>) opened.payload()).get("orderId"));
+        assertEquals(-8750L, ((Map<?, ?>) ((Map<?, ?>) opened.payload()).get("expectedAmount")).get("minorUnits"));
+        assertFalse(publisher.published.stream().anyMatch(e -> "RevenueRecognitionReversed".equals(e.eventType())));
+    }
+
+    @Test
     void operationalFactUsesSegmentReservationRequestedIndexForOrderReference() {
         InMemoryConsumedEventLogRepository consumedEvents = new InMemoryConsumedEventLogRepository();
         RecordingPublisher publisher = new RecordingPublisher();

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/MessagingTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/MessagingTest.java
@@ -188,8 +188,10 @@ class MessagingTest {
                 "resultSummary", Map.of("description", "applied"))));
 
         assertEquals(HandlerResult.SUCCESS, applied);
-        EventEnvelope reduction = publisher.published.stream().filter(e -> "RevenueRecognized".equals(e.eventType()) && "refund".equals(((Map<?, ?>) e.payload()).get("componentCode"))).findFirst().orElseThrow();
-        assertEquals(-8750L, ((Map<?, ?>) ((Map<?, ?>) reduction.payload()).get("amount")).get("minorUnits"));
+        EventEnvelope reduction = publisher.published.stream().filter(e -> "RevenueRecognitionReversed".equals(e.eventType())).findFirst().orElseThrow();
+        assertEquals("fare", ((Map<?, ?>) reduction.payload()).get("componentCode"));
+        assertEquals(8750L, ((Map<?, ?>) ((Map<?, ?>) reduction.payload()).get("amount")).get("minorUnits"));
+        assertEquals("post-sales refund applied", ((Map<?, ?>) reduction.payload()).get("reversalReason"));
         assertTrue(publisher.published.stream().anyMatch(e -> "ReconciliationCompleted".equals(e.eventType())));
     }
 

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/RevenueRecognitionTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/domain/RevenueRecognitionTest.java
@@ -55,9 +55,10 @@ class RevenueRecognitionTest {
         assertTrue(recognition.reversed());
         assertEquals("order cancelled", recognition.reversalReason());
         assertEquals(2, recognition.domainEvents().size());
-        RevenueRecognized reversalEvent = (RevenueRecognized) recognition.domainEvents().get(1);
-        assertTrue(reversalEvent.amount().isNegative());
-        assertEquals("policy-v1-reversed", reversalEvent.recognitionPolicyVersion());
+        RevenueRecognitionReversed reversalEvent = (RevenueRecognitionReversed) recognition.domainEvents().get(1);
+        assertEquals(amount, reversalEvent.amount());
+        assertEquals("fare", reversalEvent.componentCode());
+        assertEquals("order cancelled", reversalEvent.reversalReason());
     }
 
     @Test

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/http/TravelerController.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/http/TravelerController.java
@@ -1,6 +1,6 @@
 package com.trainticket.travelerprofile.adapters.http;
 
-import tools.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.trainticket.travelerprofile.application.ApiDocumentType;
 import com.trainticket.travelerprofile.application.CreateTravelerCommand;
 import com.trainticket.travelerprofile.application.EligibilityResult;

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/http/TravelerController.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/http/TravelerController.java
@@ -1,6 +1,6 @@
 package com.trainticket.travelerprofile.adapters.http;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.trainticket.travelerprofile.application.ApiDocumentType;
 import com.trainticket.travelerprofile.application.CreateTravelerCommand;
 import com.trainticket.travelerprofile.application.EligibilityResult;

--- a/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/RequestContextFilter.java
+++ b/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/RequestContextFilter.java
@@ -1,7 +1,5 @@
 package com.trainticket.walletpromotion;
 
-import com.trainticket.platformkit.messaging.PrefixedIds;
-
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -31,7 +29,7 @@ public class RequestContextFilter extends OncePerRequestFilter {
         FilterChain filterChain
     ) throws ServletException, IOException {
         String requestId = headerOrGenerated(request, REQUEST_ID_HEADER);
-        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, PrefixedIds.newCorrelationId());
+        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, requestId);
         RequestTraceContext context = new RequestTraceContext(
             requestId,
             correlationId,

--- a/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/RequestContextFilter.java
+++ b/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/RequestContextFilter.java
@@ -1,5 +1,7 @@
 package com.trainticket.walletpromotion;
 
+import com.trainticket.platformkit.messaging.PrefixedIds;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,7 +31,7 @@ public class RequestContextFilter extends OncePerRequestFilter {
         FilterChain filterChain
     ) throws ServletException, IOException {
         String requestId = headerOrGenerated(request, REQUEST_ID_HEADER);
-        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, requestId);
+        String correlationId = headerOrDefault(request, CORRELATION_ID_HEADER, PrefixedIds.newCorrelationId());
         RequestTraceContext context = new RequestTraceContext(
             requestId,
             correlationId,


### PR DESCRIPTION
## Summary
- Complete finance reconciliation/invoice flow for REQ-065: provider/post-sales facts reconcile against recognized revenue; unknown segment bookings open cases via SegmentReservationRequested indexing.
- GenerateInvoice HTTP command is idempotent and publishes InvoiceGenerated.
- Refund application now emits RevenueRecognitionReversed per contract ruling, preserving original componentCode (fare) and using approvedActions.refund.amount.

## Validation
- mvn test (services/finance-settlement): passed
- make check: passed
- e2e: not run in sandbox (requires live kind cluster; orchestrator will run)