### PR TITLE
Hotfix: place-network test event-name expectation (unbreaks make check on base)

### DIFF
--- a/services/place-network/internal/http/handler_test.go
+++ b/services/place-network/internal/http/handler_test.go
@@ -179,7 +179,7 @@ func TestPublisherWrapsEventsInEnvelope(t *testing.T) {
 	router := setupTestRouter(publisher)
 	createPlace(t, router, "Shanghai", "CITY", "0194f2e0-7b3e-700c-8284-5c26e8b0000c")
 	envelope := publisher.last()
-	if !ids.ValidPrefixedUUIDv7(envelope.EventID, "evt") || envelope.EventType != "PlaceUpdated" || envelope.SchemaVersion != 1 || envelope.Producer != "place-network" || envelope.CorrelationID != "corr-test" || envelope.OccurredAt != "2026-07-05T10:30:00Z" {
+	if !ids.ValidPrefixedUUIDv7(envelope.EventID, "evt") || envelope.EventType != "PlaceRegistered" || envelope.SchemaVersion != 1 || envelope.Producer != "place-network" || envelope.CorrelationID != "corr-test" || envelope.OccurredAt != "2026-07-05T10:30:00Z" {
 		t.Fatalf("unexpected envelope: %#v", envelope)
 	}
 	payload, ok := envelope.Payload.(domain.PlaceUpdatedEvent)


### PR DESCRIPTION
Base-red test: producer renamed PlaceUpdated→PlaceRegistered (contract name) in the 联调 rounds; this test kept the old literal. All four wave-7 verifier runs are currently failing make check on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)