### PR TITLE
Contract rulings: FulfillmentCompleted is normative; no USED ticket status

### DIFF
--- a/docs/08-contracts/api/entitlement-ticketing.md
+++ b/docs/08-contracts/api/entitlement-ticketing.md
@@ -37,7 +37,7 @@ timestamps, and Money.
 | `journeyOrderId` | string | Order ID. |
 | `credentialNo` | string | Unique credential/ticket number. |
 | `credentialType` | string | Type: `E_TICKET`, `PAPER_TICKET`, `PICKUP_CODE`, `BOARDING_PASS`, `FERRY_TICKET`, `COACH_E_TICKET`, `RIDE_CODE` |
-| `status` | enum | `ISSUED`, `VOIDED`, `BOARDED`, `NO_SHOW`, `SUSPENDED` |
+| `status` | enum | `ISSUED`, `VOIDED`, `BOARDED`, `NO_SHOW`, `SUSPENDED`. RULING (2026-07-06): there is no `USED` status — `FulfillmentCompleted` leaves the ticket `BOARDED`; `BOARDED`, `NO_SHOW`, and `VOIDED` are terminal. |
 | `issuedAt` | timestamp | Issue timestamp. |
 
 **Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `PRECONDITION_FAILED`, `CONFLICT`, `DOMAIN_RULE_VIOLATION`

--- a/docs/08-contracts/events/fulfillment.md
+++ b/docs/08-contracts/events/fulfillment.md
@@ -55,7 +55,7 @@ Last updated: 2026-07-05
 |---|---|
 | **Producer** | fulfillment |
 | **Consumers** | entitlement-ticketing, journey-order, notification, finance-settlement |
-| **Trigger** | Segment fulfillment completed (arrival confirmed or segment finished). |
+| **Trigger** | Segment fulfillment completed (arrival confirmed or segment finished). RULING (2026-07-06): a fulfillment record may only complete after `BoardingVerified` for that entitlement — un-boarded records take the `NoShowRecorded` path instead. Consumers treat a `FulfillmentCompleted` for a ticket they have not seen boarded as an idempotent no-op, not an error. |
 
 **Payload:**
 

--- a/docs/08-contracts/messaging.md
+++ b/docs/08-contracts/messaging.md
@@ -58,7 +58,7 @@ context.
 | 9 | `payment` | `events:payment` | PaymentIntentCreated, PaymentCaptured, PaymentIntentFailed, PaymentExpired, RefundRequested, RefundSettled, RefundFailed |
 | 10 | `provider-integration` | `events:provider-integration` | ProviderReservationConfirmed, ProviderReservationFailed, ProviderReservationCancelled, ProviderBoardingAccepted |
 | 11 | `entitlement-ticketing` | `events:entitlement-ticketing` | EntitlementIssued, EntitlementVoided, EntitlementSuspended, EntitlementReinstated |
-| 12 | `fulfillment` | `events:fulfillment` | BoardingVerified, SegmentArrived, SegmentDelayed, NoShowRecorded, SegmentCompleted |
+| 12 | `fulfillment` | `events:fulfillment` | BoardingVerified, NoShowRecorded, FulfillmentCompleted, EvidenceDisputeOpened, EvidenceDisputeResolved |
 | 13 | `post-sales` | `events:post-sales` | PostSalesCaseOpened, PostSalesRequested, PostSalesEligibilityEvaluated, PostSalesDecisionQuoted, PostSalesApproved, PostSalesRejected, PostSalesApplied |
 | 14 | `notification` | `events:notification` | NotificationScheduled, NotificationSent, NotificationFailed, NotificationSuppressed |
 | 15 | `traveler-profile` | `events:traveler-profile` | TravelerProfileUpdated, TravelerDocumentVerified, TravelerEligibilityChanged |
@@ -218,7 +218,7 @@ plus notification/finance/reporting fan-in.
 | 24 | `events:entitlement-ticketing` | `fulfillment` | EntitlementIssued to prepare for boarding verification |
 | 25 | `events:entitlement-ticketing` | `booking-orchestration` | EntitlementIssued to mark segment ticketed |
 | 26 | `events:entitlement-ticketing` | `notification` | Ticketing events for user notifications |
-| 27 | `events:fulfillment` | `transfer-management` | SegmentArrived/SegmentDelayed for connection risk |
+| 27 | `events:fulfillment` | `transfer-management` | future-scope; arrival/delay facts are not part of the phase-1 contract |
 | 28 | `events:fulfillment` | `entitlement-ticketing` | BoardingVerified for entitlement lifecycle |
 | 29 | `events:post-sales` | `payment` | PostSalesApproved to trigger refund |
 | 30 | `events:post-sales` | `capacity-availability` | PostSalesApplied to release capacity |


### PR DESCRIPTION
Rulings needed by REQ-063's fix round: (1) messaging.md row 12 was stale — events/fulfillment.md's BoardingVerified/NoShowRecorded/FulfillmentCompleted/EvidenceDispute* are the contract; SegmentArrived/SegmentCompleted never existed in the event contract. (2) Completion requires prior BoardingVerified; consumers treat unknown-boarding completion as idempotent no-op. (3) No USED status: FulfillmentCompleted leaves the ticket BOARDED (terminal with NO_SHOW/VOIDED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)