### PR TITLE
Contract rulings: notification event names; ManualAction request via HTTP

### DIFF
--- a/docs/08-contracts/api/customer-service.md
+++ b/docs/08-contracts/api/customer-service.md
@@ -178,6 +178,23 @@ timestamps, and Money.
 
 **Error codes:** `NOT_FOUND`, `VALIDATION_FAILED`
 
+### Request Manual Action
+
+**POST** `/api/v1/support-cases/{caseId}/manual-action-requests`
+
+**Idempotency:** REQUIRED
+
+**Request:** fields per `RequestManualAction` in events/customer-service.md
+(`targetDomain`, `commandType`, `operatorRef`, `reason`, `description`,
+`requiresApproval`, optional `evidenceRefs`).
+
+**Response (202):** `{ "manualActionId": "ma-<uuid>", "status": "REQUESTED" }` —
+publishes the `ManualActionRequested` fact. Customer Service only records the
+request; execution stays with Admin & Audit (WP-20 boundary: no business-state
+mutation from support).
+
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`
+
 ## Bus-only commands
 
 The following commands are consumed from the event bus only and have no HTTP
@@ -185,7 +202,7 @@ endpoint:
 
 | Command | Trigger | Description |
 |---|---|---|
-| `RequestManualAction` | Customer Service UI | Request a manual action against a target domain (e.g. payment, order). |
+| ~~`RequestManualAction`~~ | — | RULING (2026-07-06): promoted to an HTTP command — see `POST /api/v1/support-cases/{caseId}/manual-action-requests` above; there is no command-bus infrastructure in phase 1. |
 | `RecordActionOutcome` | Customer Service UI / Admin & Audit | Record the outcome of a manual action. |
 | `AppendTimelineEntry` | Customer Service UI / Internal | Append an event to the case timeline. |
 

--- a/docs/08-contracts/events/notification.md
+++ b/docs/08-contracts/events/notification.md
@@ -84,7 +84,7 @@ Last updated: 2026-07-04
 |---|---|
 | **Producer** | notification |
 | **Consumers** | none |
-| **Trigger** | `CancelNotification` command processed. |
+| **Trigger** | `CancelNotification` command processed. RULING (2026-07-06): preference-based suppression is expressed as this event with `reason` = `SUPPRESSED_BY_PREFERENCES` (never emitted for `transactionRequired` notifications, which bypass preferences). There are no `NotificationSent`/`NotificationSuppressed` events — successful delivery is `NotificationDispatched` then `NotificationDelivered`. |
 
 **Payload:**
 
@@ -96,9 +96,9 @@ Last updated: 2026-07-04
 
 ## Consumed Events
 
-None in this foundation phase. In future phases, the notification domain will
-consume events from Journey Order, Payment, Entitlement & Ticketing, Post Sales,
-and other upstream bounded contexts.
+Notification subscribes to `events:journey-order`, `events:booking-orchestration`,
+`events:payment`, `events:entitlement-ticketing`, and `events:post-sales`
+(messaging.md subscription table) and schedules notifications from those facts.
 
 ## Key Commands
 

--- a/docs/08-contracts/messaging.md
+++ b/docs/08-contracts/messaging.md
@@ -60,7 +60,7 @@ context.
 | 11 | `entitlement-ticketing` | `events:entitlement-ticketing` | EntitlementIssued, EntitlementVoided, EntitlementSuspended, EntitlementReinstated |
 | 12 | `fulfillment` | `events:fulfillment` | BoardingVerified, NoShowRecorded, FulfillmentCompleted, EvidenceDisputeOpened, EvidenceDisputeResolved |
 | 13 | `post-sales` | `events:post-sales` | PostSalesCaseOpened, PostSalesRequested, PostSalesEligibilityEvaluated, PostSalesDecisionQuoted, PostSalesApproved, PostSalesRejected, PostSalesApplied |
-| 14 | `notification` | `events:notification` | NotificationScheduled, NotificationSent, NotificationFailed, NotificationSuppressed |
+| 14 | `notification` | `events:notification` | NotificationScheduled, NotificationDispatched, NotificationDelivered, NotificationFailed, NotificationCancelled |
 | 15 | `traveler-profile` | `events:traveler-profile` | TravelerProfileUpdated, TravelerDocumentVerified, TravelerEligibilityChanged |
 | 16 | `risk-compliance` | `events:risk-compliance` | RiskAssessmentResult, RiskBlockApplied, RiskBlockLifted |
 | 17 | `account` | `events:account` | AccountCreated, AccountSuspended, AccountClosed |


### PR DESCRIPTION
Needed by REQ-066's fix round. (1) messaging.md row 14 was stale — NotificationSent/NotificationSuppressed never existed in events/notification.md; the normative set is Scheduled/Dispatched/Delivered/Failed/Cancelled, with preference suppression expressed as Cancelled(reason=SUPPRESSED_BY_PREFERENCES). (2) RequestManualAction promoted from bus-only to POST /api/v1/support-cases/{caseId}/manual-action-requests — no command-bus infra exists in phase 1 and the sender is a UI. (3) Notification's consumed-events section updated to the real subscription set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)