### PR TITLE
REQ-064 risk order assessment chain

### DIFF
--- a/deploy/e2e/06-risk.sh
+++ b/deploy/e2e/06-risk.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Risk chain: JourneyOrderCreated -> RiskAssessmentResult/RiskBlockApplied; manual lift permits a fresh order.
+cd "$(dirname "$0")" && . ./lib.sh
+. ./.refs.env
+ensure_curl_pod
+
+ACCT="acc-risk-$(uuid7)"
+
+find_risk_event() {
+  local type=$1 subject=$2 count=${3:-50}
+  k exec "$(redis_pod)" -- redis-cli XREVRANGE events:risk-compliance + - COUNT "$count" > /tmp/riskstream.txt
+  TYPE="$type" SUBJECT="$subject" python3 - << 'PY'
+import json, os, re
+raw = open('/tmp/riskstream.txt').read()
+for m in re.finditer(r'\{.*\}', raw):
+    try:
+        e = json.loads(m.group(0).encode().decode('unicode_escape'))
+    except Exception:
+        continue
+    payload = e.get('payload', {})
+    if e.get('eventType') == os.environ['TYPE'] and payload.get('subjectRef') == os.environ['SUBJECT']:
+        print(json.dumps(e)); break
+PY
+}
+
+wait_event() {
+  local type=$1 subject=$2 found=""
+  for attempt in 1 2 3 4 5 6; do
+    found=$(find_risk_event "$type" "$subject")
+    [ -n "$found" ] && break
+    sleep 3
+  done
+  [ -n "$found" ]
+}
+
+create_order() {
+  local label=$1
+  req POST journey-order /api/v1/journey-orders "{\"accountId\":\"$ACCT\",\"offerId\":\"$OFFER\",\"offerVersion\":${OFFERV:-1},\"travelerRefs\":[\"$TVL\"],\"segmentRefs\":[\"$SEG\"]}"
+  check_code 201 "$label" >&2
+  jget "['orderId']"
+}
+
+echo "== 0. normal order is risk-assessed ALLOW"
+NORMAL_ORDER=$(create_order "create normal risk-assessed order")
+echo "  normal=$NORMAL_ORDER"
+if wait_event RiskAssessmentResult "$NORMAL_ORDER"; then ok "RiskAssessmentResult for normal order"; else bad "missing RiskAssessmentResult for normal order"; fi
+
+echo "== 1. high-frequency order triggers risk block"
+SECOND_ORDER=$(create_order "create second order before threshold")
+echo "  second=$SECOND_ORDER"
+BLOCKED_ORDER=$(create_order "create high-frequency order")
+echo "  blockedCandidate=$BLOCKED_ORDER"
+if wait_event RiskBlockApplied "$BLOCKED_ORDER"; then ok "RiskBlockApplied for high-frequency order"; else bad "missing RiskBlockApplied for high-frequency order"; fi
+sleep 5
+req GET journey-order "/api/v1/journey-orders/$BLOCKED_ORDER"
+BLOCKED_STATUS=$(jget "['status']")
+echo "  blocked order status=$BLOCKED_STATUS [$LAST_CODE]"
+[ "$BLOCKED_STATUS" = "CANCELLED" ] && ok "RiskBlockApplied cancelled order" || bad "blocked order not CANCELLED ($BLOCKED_STATUS)"
+
+echo "== 2. lift block and create fresh order"
+req POST risk-compliance /api/v1/risk-blocks/lift "{\"subjectRef\":\"$BLOCKED_ORDER\",\"scope\":\"ORDER\",\"reasonCode\":\"MANUAL_REVIEW_CLEARED\"}"
+check_code 201 "lift risk block"
+if wait_event RiskBlockLifted "$BLOCKED_ORDER"; then ok "RiskBlockLifted published"; else bad "missing RiskBlockLifted"; fi
+
+ACCT="acc-risk-lifted-$(uuid7)"
+LIFTED_ORDER=$(create_order "create order after lift with fresh risk context")
+echo "  liftedFresh=$LIFTED_ORDER"
+if wait_event RiskAssessmentResult "$LIFTED_ORDER"; then ok "RiskAssessmentResult for post-lift order"; else bad "missing RiskAssessmentResult after lift"; fi
+sleep 3
+req GET journey-order "/api/v1/journey-orders/$LIFTED_ORDER"
+LIFTED_STATUS=$(jget "['status']")
+echo "  post-lift order status=$LIFTED_STATUS [$LAST_CODE]"
+[ "$LIFTED_STATUS" = "CREATED" ] && ok "post-lift fresh order not blocked" || bad "post-lift fresh order unexpected status ($LIFTED_STATUS)"
+
+summary

--- a/deploy/e2e/06-risk.sh
+++ b/deploy/e2e/06-risk.sh
@@ -51,9 +51,13 @@ echo "  second=$SECOND_ORDER"
 BLOCKED_ORDER=$(create_order "create high-frequency order")
 echo "  blockedCandidate=$BLOCKED_ORDER"
 if wait_event RiskBlockApplied "$BLOCKED_ORDER"; then ok "RiskBlockApplied for high-frequency order"; else bad "missing RiskBlockApplied for high-frequency order"; fi
-sleep 5
-req GET journey-order "/api/v1/journey-orders/$BLOCKED_ORDER"
-BLOCKED_STATUS=$(jget "['status']")
+BLOCKED_STATUS=""
+for attempt in 1 2 3 4; do
+  sleep 5
+  req GET journey-order "/api/v1/journey-orders/$BLOCKED_ORDER"
+  BLOCKED_STATUS=$(jget "['status']")
+  [ "$BLOCKED_STATUS" = "CANCELLED" ] && break
+done
 echo "  blocked order status=$BLOCKED_STATUS [$LAST_CODE]"
 [ "$BLOCKED_STATUS" = "CANCELLED" ] && ok "RiskBlockApplied cancelled order" || bad "blocked order not CANCELLED ($BLOCKED_STATUS)"
 

--- a/deploy/e2e/06-risk.sh
+++ b/deploy/e2e/06-risk.sh
@@ -57,19 +57,18 @@ BLOCKED_STATUS=$(jget "['status']")
 echo "  blocked order status=$BLOCKED_STATUS [$LAST_CODE]"
 [ "$BLOCKED_STATUS" = "CANCELLED" ] && ok "RiskBlockApplied cancelled order" || bad "blocked order not CANCELLED ($BLOCKED_STATUS)"
 
-echo "== 2. lift block and create fresh order"
+echo "== 2. lift block and create fresh order with same account"
 req POST risk-compliance /api/v1/risk-blocks/lift "{\"subjectRef\":\"$BLOCKED_ORDER\",\"scope\":\"ORDER\",\"reasonCode\":\"MANUAL_REVIEW_CLEARED\"}"
 check_code 201 "lift risk block"
 if wait_event RiskBlockLifted "$BLOCKED_ORDER"; then ok "RiskBlockLifted published"; else bad "missing RiskBlockLifted"; fi
 
-ACCT="acc-risk-lifted-$(uuid7)"
-LIFTED_ORDER=$(create_order "create order after lift with fresh risk context")
-echo "  liftedFresh=$LIFTED_ORDER"
+LIFTED_ORDER=$(create_order "create order after lift with same account")
+echo "  liftedSameAccount=$LIFTED_ORDER account=$ACCT"
 if wait_event RiskAssessmentResult "$LIFTED_ORDER"; then ok "RiskAssessmentResult for post-lift order"; else bad "missing RiskAssessmentResult after lift"; fi
 sleep 3
 req GET journey-order "/api/v1/journey-orders/$LIFTED_ORDER"
 LIFTED_STATUS=$(jget "['status']")
 echo "  post-lift order status=$LIFTED_STATUS [$LAST_CODE]"
-[ "$LIFTED_STATUS" = "CREATED" ] && ok "post-lift fresh order not blocked" || bad "post-lift fresh order unexpected status ($LIFTED_STATUS)"
+[ "$LIFTED_STATUS" = "CREATED" ] && ok "post-lift same-account order not blocked" || bad "post-lift same-account order unexpected status ($LIFTED_STATUS)"
 
 summary

--- a/docs/08-contracts/api/risk-compliance.md
+++ b/docs/08-contracts/api/risk-compliance.md
@@ -52,6 +52,36 @@ timestamps, and Money.
 
 **Error codes:** `NOT_FOUND`
 
+### Lift Risk Block
+
+**POST** `/api/v1/risk-blocks/lift`
+
+**Idempotency:** REQUIRED
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `subjectRef` | string | yes | Blocked subject reference (order ID, payment ID, account ID). |
+| `scope` | enum | yes | `ORDER`, `PAYMENT`, `ACCOUNT`. |
+| `reasonCode` | string | yes | Machine-readable lift reason. |
+
+**Response (201):**
+
+| Field | Type | Description |
+|---|---|---|
+| `allowId` | string | Canonical allow ID (`alw-<uuid>`). |
+| `subjectRef` | string | Subject reference. |
+| `scope` | enum | `ORDER`, `PAYMENT`, `ACCOUNT`. |
+| `reasonCode` | string | Machine-readable lift reason. |
+| `policyVersion` | string | Policy version used. |
+| `evidenceRef` | string | Reference to the evidence bundle. |
+| `allowedAt` | timestamp | When the block was lifted. |
+
+**Published event:** `RiskBlockLifted` with the same payload shape as `SubjectAllowed`.
+
+**Error codes:** `VALIDATION_FAILED`, `IDEMPOTENCY_KEY_REUSED`, `NOT_FOUND`, `UNAVAILABLE`
+
 ## Bus-only commands
 
 The following commands are consumed from the event bus only and have no HTTP
@@ -62,7 +92,7 @@ endpoint:
 | `IssueChallenge` | Risk system (internal) | Issue a challenge when the risk decision is `CHALLENGE`. |
 | `ResolveChallenge` | Customer / Operator | Resolve a challenge with outcome (PASSED/FAILED). |
 | `BlockSubject` | Risk system (internal) | Block a subject (order, payment, account) from proceeding. |
-| `AllowSubject` | Risk system (internal) | Allow a previously blocked subject to proceed. |
+| `AllowSubject` | Risk system (internal) | Allow a previously blocked subject to proceed. HTTP lift is available for operator-driven ORDER blocks. |
 | `RecordEvidence` | Risk system (internal) | Record risk evidence for audit trail. |
 
 ## Open Issues

--- a/docs/08-contracts/events/risk-compliance.md
+++ b/docs/08-contracts/events/risk-compliance.md
@@ -4,13 +4,13 @@ Last updated: 2026-07-04
 
 ## Published Events
 
-### RiskAssessed
+### RiskAssessmentResult
 
 | Field | Description |
 |---|---|
 | **Producer** | risk-compliance |
 | **Consumers** | journey-order, payment, post-sales, account |
-| **Trigger** | `AssessRisk` command processed. |
+| **Trigger** | `AssessRisk` command or `JourneyOrderCreated` event processed. |
 
 **Payload:**
 
@@ -65,13 +65,13 @@ Last updated: 2026-07-04
 | `resolvedAt` | RFC3339 UTC | yes | When the challenge was resolved. |
 | `evidenceRef` | string | no | Reference to resolution evidence. |
 
-### SubjectBlocked
+### RiskBlockApplied
 
 | Field | Description |
 |---|---|
 | **Producer** | risk-compliance |
 | **Consumers** | journey-order, payment, account, booking-orchestration |
-| **Trigger** | `BlockSubject` command processed. |
+| **Trigger** | `BlockSubject` command processed or a blocking order-risk rule is hit. |
 
 **Payload:**
 
@@ -85,13 +85,13 @@ Last updated: 2026-07-04
 | `evidenceRef` | string | yes | Reference to evidence bundle. |
 | `blockedAt` | RFC3339 UTC | yes | When the block was applied. |
 
-### SubjectAllowed
+### RiskBlockLifted
 
 | Field | Description |
 |---|---|
 | **Producer** | risk-compliance |
 | **Consumers** | journey-order, payment, account, booking-orchestration |
-| **Trigger** | `AllowSubject` command processed. |
+| **Trigger** | `AllowSubject` command or HTTP risk-block lift command processed. |
 
 **Payload:**
 

--- a/docs/08-contracts/messaging.md
+++ b/docs/08-contracts/messaging.md
@@ -204,6 +204,7 @@ plus notification/finance/reporting fan-in.
 | 10 | `events:journey-order` | `post-sales` | JourneyOrderCancelled for post-sales initiation |
 | 11 | `events:journey-order` | `notification` | Order lifecycle events for user notifications |
 | 12 | `events:journey-order` | `customer-service` | Order events for support case context |
+| 12a | `events:journey-order` | `risk-compliance` | JourneyOrderCreated triggers order risk assessment and blocking decisions |
 | 13 | `events:booking-orchestration` | `payment` | SegmentReservationRequested to trigger payment intent creation |
 | 14 | `events:booking-orchestration` | `capacity-availability` | SegmentReservationConfirmed to confirm hold |
 | 15 | `events:booking-orchestration` | `entitlement-ticketing` | SegmentTicketed for entitlement readiness |

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/application/service/OrderManagementService.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/application/service/OrderManagementService.java
@@ -324,9 +324,11 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
                 case "PaymentCaptured" -> handlePaymentCaptured(envelope);
                 case "PaymentExpired" -> handlePaymentExpired(envelope);
                 case "PostSalesApplied" -> handlePostSalesApplied(envelope);
+                case "RiskAssessmentResult" -> handleRiskAssessmentResult(envelope);
                 case "RiskBlockApplied" -> handleRiskBlockApplied(envelope);
+                case "RiskBlockLifted" -> handleRiskBlockLifted(envelope);
                 case "EntitlementIssued" -> handleEntitlementIssued(envelope);
-                case "OfferExpired", "OfferQuoted", "TravelerProfileUpdated", "TravelerSnapshotUpdated", "TravelerDocumentVerified", "TravelerEligibilityChanged", "RiskAssessmentResult", "RiskBlockLifted" -> new EventSubscriber.Success();
+                case "OfferExpired", "OfferQuoted", "TravelerProfileUpdated", "TravelerSnapshotUpdated", "TravelerDocumentVerified", "TravelerEligibilityChanged" -> new EventSubscriber.Success();
                 default -> new EventSubscriber.FatalError("unsupported event type for journey-order: " + envelope.eventType());
             };
         } catch (RuntimeException ex) {
@@ -391,16 +393,50 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
         return new EventSubscriber.Success();
     }
 
+    private EventSubscriber.HandlerResult handleRiskAssessmentResult(EventEnvelope envelope) {
+        if (!"ALLOW".equals(textPayload(envelope, "decision", ""))) {
+            return new EventSubscriber.Success();
+        }
+        JourneyOrder order = orderFromPayload(envelope);
+        int eventCount = order.domainEvents().size();
+        order.recordRiskAssessmentAllowed(envelope.occurredAt(), "cmd-consume-risk", envelope.eventId(), envelope.correlationId());
+        if (order.state() == com.trainticket.journeyorder.domain.OrderLifecycleState.CONFIRMING
+            && order.confirmationConditions().canConfirm()) {
+            order.confirm("risk-assessment-allowed", envelope.occurredAt(), "cmd-consume-risk", envelope.eventId(), envelope.correlationId());
+        }
+        publishEvents(order.domainEvents().subList(eventCount, order.domainEvents().size()));
+        return new EventSubscriber.Success();
+    }
+
     private EventSubscriber.HandlerResult handleRiskBlockApplied(EventEnvelope envelope) {
         JourneyOrder order = orderFromPayload(envelope);
         int eventCount = order.domainEvents().size();
-        order.cancel(textPayload(envelope, "reason", "risk block applied"), envelope.occurredAt(), "cmd-consume-risk", envelope.eventId(), envelope.correlationId());
+        String reason = textPayload(envelope, "reasonCode", textPayload(envelope, "reason", "risk block applied"));
+        order.cancel(reason, envelope.occurredAt(), "cmd-consume-risk", envelope.eventId(), envelope.correlationId());
+        publishEvents(order.domainEvents().subList(eventCount, order.domainEvents().size()));
+        return new EventSubscriber.Success();
+    }
+
+    private EventSubscriber.HandlerResult handleRiskBlockLifted(EventEnvelope envelope) {
+        JourneyOrder order = orderFromPayload(envelope);
+        if (order.state() == com.trainticket.journeyorder.domain.OrderLifecycleState.CANCELLED) {
+            return new EventSubscriber.Success();
+        }
+        int eventCount = order.domainEvents().size();
+        order.recordRiskBlockLifted(envelope.occurredAt(), "cmd-consume-risk", envelope.eventId(), envelope.correlationId());
+        if (order.state() == com.trainticket.journeyorder.domain.OrderLifecycleState.CONFIRMING
+            && order.confirmationConditions().canConfirm()) {
+            order.confirm("risk-block-lifted", envelope.occurredAt(), "cmd-consume-risk", envelope.eventId(), envelope.correlationId());
+        }
         publishEvents(order.domainEvents().subList(eventCount, order.domainEvents().size()));
         return new EventSubscriber.Success();
     }
 
     private JourneyOrder orderFromPayload(EventEnvelope envelope) {
         String orderId = textPayload(envelope, "orderId", null);
+        if (orderId == null) {
+            orderId = textPayload(envelope, "subjectRef", null);
+        }
         if (orderId == null) {
             orderId = textPayload(envelope, "businessRef", null);
         }

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/ConfirmationConditions.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/ConfirmationConditions.java
@@ -8,7 +8,7 @@ public record ConfirmationConditions(
     boolean riskClear
 ) {
     public static ConfirmationConditions none() {
-        return new ConfirmationConditions(false, false, false, false, true);
+        return new ConfirmationConditions(false, false, false, false, false);
     }
 
     public ConfirmationConditions withBookingSummaryAccepted() {
@@ -25,6 +25,10 @@ public record ConfirmationConditions(
 
     public ConfirmationConditions withEntitlementSummaryAccepted() {
         return new ConfirmationConditions(bookingSummaryAccepted, capacitySummaryAccepted, paymentConditionSatisfied, true, riskClear);
+    }
+
+    public ConfirmationConditions withRiskCleared() {
+        return new ConfirmationConditions(bookingSummaryAccepted, capacitySummaryAccepted, paymentConditionSatisfied, entitlementSummaryAccepted, true);
     }
 
     public ConfirmationConditions withRiskBlocked() {

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrder.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrder.java
@@ -134,6 +134,18 @@ public final class JourneyOrder {
         ));
     }
 
+    public void recordRiskAssessmentAllowed(Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        requireState(OrderLifecycleState.PENDING_CONFIRMATION, OrderLifecycleState.PENDING_PAYMENT, OrderLifecycleState.CONFIRMING);
+        confirmationConditions = confirmationConditions.withRiskCleared();
+        recordTimeline("RiskAssessmentAllowed", occurredAt, "risk-compliance", "required risk assessment allowed order continuation", Map.of());
+    }
+
+    public void recordRiskBlockLifted(Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
+        requireState(OrderLifecycleState.PENDING_CONFIRMATION, OrderLifecycleState.PENDING_PAYMENT, OrderLifecycleState.CONFIRMING);
+        confirmationConditions = confirmationConditions.withRiskCleared();
+        recordTimeline("RiskBlockLifted", occurredAt, "risk-compliance", "risk block lifted for order", Map.of());
+    }
+
     public void recordEntitlementSummaryAccepted(Instant occurredAt, String sourceCommandId, String causationId, String correlationId) {
         // Streams are only ordered per-producer; the entitlement fact may
         // arrive before the payment fact, so accept it in any pre-confirmed state.

--- a/services/journey-order/src/test/java/com/trainticket/journeyorder/application/OrderManagementServiceTest.java
+++ b/services/journey-order/src/test/java/com/trainticket/journeyorder/application/OrderManagementServiceTest.java
@@ -166,6 +166,66 @@ class OrderManagementServiceTest {
                 "idem-nonexist", "corr-1"));
     }
 
+    @Test
+    void riskAssessmentAllowRecordsExplicitConfirmationCondition() {
+        JourneyOrderResult created = service.createOrder(
+            new JourneyOrderRequest("account-risk", "offer-risk", 1, List.of("tvl-1"), List.of("seg-1")),
+            "idem-risk-allow", "corr-1");
+        published.clear();
+
+        EventEnvelope envelope = new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c501",
+            "RiskAssessmentResult",
+            Instant.parse("2026-07-05T10:01:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c502",
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c503",
+            "risk-compliance",
+            1,
+            Map.of("subjectRef", created.orderId(), "decision", "ALLOW")
+        );
+
+        service.handle(envelope);
+
+        var order = service.getOrder(created.orderId());
+        assertTrue(order.isPresent());
+        assertEquals("CREATED", order.get().status());
+    }
+
+    @Test
+    void riskBlockAppliedCancelsOrderAndLiftedDoesNotReviveCancelledOrder() {
+        JourneyOrderResult created = service.createOrder(
+            new JourneyOrderRequest("account-risk", "offer-block", 1, List.of("tvl-1"), List.of("seg-1")),
+            "idem-risk-block", "corr-1");
+        published.clear();
+
+        EventEnvelope block = new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c601",
+            "RiskBlockApplied",
+            Instant.parse("2026-07-05T10:01:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c602",
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c603",
+            "risk-compliance",
+            1,
+            Map.of("subjectRef", created.orderId(), "reasonCode", "HIGH_RISK_SIGNAL")
+        );
+        EventEnvelope lifted = new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c604",
+            "RiskBlockLifted",
+            Instant.parse("2026-07-05T10:02:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c602",
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c601",
+            "risk-compliance",
+            1,
+            Map.of("subjectRef", created.orderId(), "reasonCode", "MANUAL_REVIEW_CLEARED")
+        );
+
+        service.handle(block);
+        service.handle(lifted);
+
+        assertEquals("CANCELLED", service.getOrder(created.orderId()).get().status());
+        assertEquals(1, published.stream().filter(event -> event.eventType().equals("JourneyOrderCancelled")).count());
+    }
+
     private static void assertNotNull(Object obj) {
         if (obj == null) throw new AssertionError("Expected non-null");
     }

--- a/services/journey-order/src/test/java/com/trainticket/journeyorder/domain/JourneyOrderTest.java
+++ b/services/journey-order/src/test/java/com/trainticket/journeyorder/domain/JourneyOrderTest.java
@@ -71,23 +71,26 @@ class JourneyOrderTest {
     }
 
     @Test
-    void confirmsOnlyAfterBookingCapacityPaymentAndEntitlementSummariesAccepted() {
+    void confirmsOnlyAfterBookingCapacityPaymentEntitlementAndRiskFactsAccepted() {
         JourneyOrder order = sampleOrder();
         order.markBookingAndCapacityAccepted(NOW.plusSeconds(1), "cmd-booking", "corr-1");
         order.markPendingPayment("initial-ticket-purchase", NOW.plusSeconds(2), "cmd-pay-request", "corr-1");
         order.recordPaymentCaptured("payment-intent-1", NOW.plusSeconds(3), "cmd-payment", "payment-event-1", "corr-1");
         order.recordEntitlementSummaryAccepted(NOW.plusSeconds(4), "cmd-entitlement", "entitlement-event-1", "corr-1");
-        order.confirm("attempt-1", NOW.plusSeconds(5), "cmd-confirm", "entitlement-event-1", "corr-1");
+        assertThrows(DomainRuleViolation.class, () -> order.confirm("attempt-before-risk", NOW.plusSeconds(5), "cmd-confirm", "entitlement-event-1", "corr-1"));
+        order.recordRiskAssessmentAllowed(NOW.plusSeconds(5), "cmd-risk", "risk-event-1", "corr-1");
+        order.confirm("attempt-1", NOW.plusSeconds(6), "cmd-confirm", "risk-event-1", "corr-1");
 
         assertEquals(OrderLifecycleState.CONFIRMED, order.state());
         JourneyOrderConfirmed confirmed = assertInstanceOf(JourneyOrderConfirmed.class, order.domainEvents().getLast());
-        assertEquals(NOW.plusSeconds(5), confirmed.confirmedAt());
+        assertEquals(NOW.plusSeconds(6), confirmed.confirmedAt());
         assertEquals(List.of(
             "JourneyOrderCreated",
             "BookingCapacitySummaryAccepted",
             "JourneyOrderPendingPayment",
             "PaymentCaptured",
             "EntitlementSummaryAccepted",
+            "RiskAssessmentAllowed",
             "JourneyOrderConfirmed"
         ), order.timeline().stream().map(TimelineFact::factType).toList());
     }
@@ -124,7 +127,8 @@ class JourneyOrderTest {
         order.markPendingPayment("initial-ticket-purchase", NOW.plusSeconds(2), "cmd-pay-request", "corr-1");
         order.recordPaymentCaptured("payment-intent-1", NOW.plusSeconds(3), "cmd-payment", "payment-event-1", "corr-1");
         order.recordEntitlementSummaryAccepted(NOW.plusSeconds(4), "cmd-entitlement", "entitlement-event-1", "corr-1");
-        order.confirm("attempt-1", NOW.plusSeconds(5), "cmd-confirm", "entitlement-event-1", "corr-1");
+        order.recordRiskAssessmentAllowed(NOW.plusSeconds(5), "cmd-risk", "risk-event-1", "corr-1");
+        order.confirm("attempt-1", NOW.plusSeconds(6), "cmd-confirm", "risk-event-1", "corr-1");
         return order;
     }
 

--- a/services/risk-compliance/src/risk_compliance/__init__.py
+++ b/services/risk-compliance/src/risk_compliance/__init__.py
@@ -33,6 +33,8 @@ from .application import (
     InMemoryEventPublisher,
     InMemoryEventSubscriber,
     PublishFailed,
+    RiskBlockApplied,
+    RiskBlockLifted,
     RiskComplianceService,
 )
 from .runtime import SERVICE_PROFILE, ServiceProfile, health, profile
@@ -75,6 +77,8 @@ __all__ = [
     "InMemoryEventPublisher",
     "InMemoryEventSubscriber",
     "PublishFailed",
+    "RiskBlockApplied",
+    "RiskBlockLifted",
     "RiskComplianceService",
     # Runtime
     "SERVICE_PROFILE",

--- a/services/risk-compliance/src/risk_compliance/adapters/messaging/redis_streams.py
+++ b/services/risk-compliance/src/risk_compliance/adapters/messaging/redis_streams.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from train_ticket_platform.messaging import RedisEventPublisher, RedisEventSubscriber, default_consumer_name
 
 RISK_COMPLIANCE_PRODUCER = "risk-compliance"
-RISK_COMPLIANCE_SUBSCRIPTIONS: tuple[str, ...] = ()
+RISK_COMPLIANCE_SUBSCRIPTIONS: tuple[str, ...] = ("events:journey-order",)
 RISK_COMPLIANCE_CONSUMER_GROUP = "risk-compliance"
 
 

--- a/services/risk-compliance/src/risk_compliance/api.py
+++ b/services/risk-compliance/src/risk_compliance/api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
-from contextlib import AbstractContextManager, nullcontext
+from collections.abc import AsyncIterator, Callable, Mapping
+from contextlib import AbstractContextManager, asynccontextmanager, nullcontext
 from typing import Any, Protocol
 
 from fastapi import FastAPI, Request
@@ -265,11 +265,34 @@ def create_app(
     service: RiskComplianceService | None = None,
     idempotency_store: IdempotencyStore | None = None,
 ) -> FastAPI:
-    app = FastAPI(title="Risk & Compliance", version="0.1.0")
-    app.state.assessment_repository = InMemoryAssessmentRepository()
     store = idempotency_store or BoundedInMemoryIdempotencyStore()
+    subscriber_config: dict[str, Any] | None = None
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        if subscriber_config is not None:
+            app.state.subscriber.start_in_background(
+                subscriber_config["subscriptions"],
+                subscriber_config["consumer_group"],
+                app.state.risk_service.handle_event,
+                consumer_name=subscriber_config["consumer_name"],
+            )
+        try:
+            yield
+        finally:
+            if subscriber_config is not None:
+                app.state.subscriber.stop()
+
+    app = FastAPI(title="Risk & Compliance", version="0.1.0", lifespan=lifespan)
+    app.state.assessment_repository = InMemoryAssessmentRepository()
     if service is None:
-        from .adapters.messaging.redis_streams import RedisEventPublisher
+        from .adapters.messaging.redis_streams import (
+            RISK_COMPLIANCE_CONSUMER_GROUP,
+            RISK_COMPLIANCE_SUBSCRIPTIONS,
+            RedisEventPublisher,
+            RedisEventSubscriber,
+            risk_compliance_consumer_name,
+        )
 
         app.state.publisher = RedisEventPublisher()
         app.state.risk_service = RiskComplianceService(
@@ -277,6 +300,12 @@ def create_app(
             repository=app.state.assessment_repository,
             idempotency_store=store,
         )
+        app.state.subscriber = RedisEventSubscriber()
+        subscriber_config = {
+            "subscriptions": RISK_COMPLIANCE_SUBSCRIPTIONS,
+            "consumer_group": RISK_COMPLIANCE_CONSUMER_GROUP,
+            "consumer_name": risk_compliance_consumer_name(),
+        }
     else:
         app.state.risk_service = service
         app.state.publisher = service.publisher
@@ -291,26 +320,4 @@ def create_app(
         error_body_factory=_risk_error_body,
     )
     configure_risk_endpoints(app, app.state.risk_service)
-    if service is None:
-        from .adapters.messaging.redis_streams import (
-            RISK_COMPLIANCE_CONSUMER_GROUP,
-            RISK_COMPLIANCE_SUBSCRIPTIONS,
-            RedisEventSubscriber,
-            risk_compliance_consumer_name,
-        )
-
-        app.state.subscriber = RedisEventSubscriber()
-
-        @app.on_event("startup")
-        def start_risk_subscriber() -> None:
-            app.state.subscriber.start_in_background(
-                RISK_COMPLIANCE_SUBSCRIPTIONS,
-                RISK_COMPLIANCE_CONSUMER_GROUP,
-                app.state.risk_service.handle_event,
-                consumer_name=risk_compliance_consumer_name(),
-            )
-
-        @app.on_event("shutdown")
-        def stop_risk_subscriber() -> None:
-            app.state.subscriber.stop()
     return app

--- a/services/risk-compliance/src/risk_compliance/api.py
+++ b/services/risk-compliance/src/risk_compliance/api.py
@@ -12,6 +12,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from .application import (
     AssessmentNotFoundError,
+    BlockNotFoundError,
     InMemoryAssessmentRepository,
     PublishFailed,
     RiskComplianceService,
@@ -45,6 +46,14 @@ class AssessRiskRequest(BaseModel):
     subjectRef: str = Field(min_length=1)
     scenario: str = Field(pattern="^(order_risk|payment_risk|post_sales_risk|account_risk)$")
     context: dict[str, Any]
+
+
+class LiftRiskBlockRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    subjectRef: str = Field(min_length=1)
+    scope: str = Field(pattern="^(ORDER|PAYMENT|ACCOUNT)$")
+    reasonCode: str = Field(min_length=1)
 
 
 class ErrorBody(BaseModel):
@@ -234,6 +243,21 @@ def configure_risk_endpoints(app: FastAPI, service: RiskComplianceService) -> No
         except AssessmentNotFoundError:
             return error_response(request, 404, "NOT_FOUND", "Risk assessment was not found")
 
+    @app.post("/api/v1/risk-blocks/lift", status_code=201, response_model=None)
+    def lift_risk_block(request: Request, payload: LiftRiskBlockRequest) -> JSONResponse:
+        try:
+            lifted = service.lift_block(
+                subject_ref=payload.subjectRef,
+                scope=payload.scope,
+                reason_code=payload.reasonCode,
+                correlation_id=request.state.correlation_id,
+            )
+        except BlockNotFoundError:
+            return error_response(request, 404, "NOT_FOUND", "Active risk block was not found")
+        except PublishFailed:
+            return error_response(request, 503, "UNAVAILABLE", "Risk block lift event could not be published")
+        return JSONResponse(status_code=201, content=lifted.to_dict())
+
 
 def create_app(
     tracer: TraceHook | None = None,
@@ -245,9 +269,9 @@ def create_app(
     app.state.assessment_repository = InMemoryAssessmentRepository()
     store = idempotency_store or BoundedInMemoryIdempotencyStore()
     if service is None:
-        from train_ticket_platform.messaging import InMemoryEventPublisher
+        from .adapters.messaging.redis_streams import RedisEventPublisher
 
-        app.state.publisher = InMemoryEventPublisher()
+        app.state.publisher = RedisEventPublisher()
         app.state.risk_service = RiskComplianceService(
             publisher=app.state.publisher,
             repository=app.state.assessment_repository,
@@ -263,8 +287,30 @@ def create_app(
         app,
         store,
         require_key=True,
-        include_path_prefixes=("/api/v1/risk-assessments",),
+        include_path_prefixes=("/api/v1/risk-assessments", "/api/v1/risk-blocks"),
         error_body_factory=_risk_error_body,
     )
     configure_risk_endpoints(app, app.state.risk_service)
+    if service is None:
+        from .adapters.messaging.redis_streams import (
+            RISK_COMPLIANCE_CONSUMER_GROUP,
+            RISK_COMPLIANCE_SUBSCRIPTIONS,
+            RedisEventSubscriber,
+            risk_compliance_consumer_name,
+        )
+
+        app.state.subscriber = RedisEventSubscriber()
+
+        @app.on_event("startup")
+        def start_risk_subscriber() -> None:
+            app.state.subscriber.start_in_background(
+                RISK_COMPLIANCE_SUBSCRIPTIONS,
+                RISK_COMPLIANCE_CONSUMER_GROUP,
+                app.state.risk_service.handle_event,
+                consumer_name=risk_compliance_consumer_name(),
+            )
+
+        @app.on_event("shutdown")
+        def stop_risk_subscriber() -> None:
+            app.state.subscriber.stop()
     return app

--- a/services/risk-compliance/src/risk_compliance/application.py
+++ b/services/risk-compliance/src/risk_compliance/application.py
@@ -131,6 +131,8 @@ class InMemoryAssessmentRepository:
         self._blocks: dict[str, RiskBlockApplied] = {}
         self._processed_event_ids: set[str] = set()
         self._account_order_times: dict[str, list[datetime]] = {}
+        self._account_lifted_at: dict[str, datetime] = {}
+        self._order_accounts: dict[str, str] = {}
 
     def get(self, assessment_id: str) -> RiskAssessmentResult:
         try:
@@ -159,10 +161,24 @@ class InMemoryAssessmentRepository:
     def remove_block(self, subject_ref: str) -> None:
         self._blocks.pop(subject_ref, None)
 
+    def remember_order_account(self, order_id: str, account_id: str) -> None:
+        self._order_accounts[order_id] = account_id
+
+    def account_for_order(self, order_id: str) -> str | None:
+        return self._order_accounts.get(order_id)
+
+    def record_account_lift(self, account_id: str, lifted_at: datetime) -> None:
+        self._account_lifted_at[account_id] = lifted_at
+        self._account_order_times[account_id] = [
+            seen_at for seen_at in self._account_order_times.get(account_id, [])
+            if seen_at > lifted_at
+        ]
+
     def record_order_attempt(self, account_id: str, occurred_at: datetime) -> int:
+        lifted_at = self._account_lifted_at.get(account_id)
         attempts = [
             seen_at for seen_at in self._account_order_times.get(account_id, [])
-            if occurred_at - seen_at <= FREQUENCY_WINDOW
+            if occurred_at - seen_at <= FREQUENCY_WINDOW and (lifted_at is None or seen_at > lifted_at)
         ]
         attempts.append(occurred_at)
         self._account_order_times[account_id] = attempts
@@ -241,6 +257,7 @@ class RiskComplianceService:
             return
         if self.repository.is_processed(envelope.eventId):
             return
+        self.repository.record_processed(envelope.eventId)
         result, block = self._assess_journey_order_created(envelope)
         self.repository.save(result)
         assessment_envelope = _assessment_envelope(result, envelope.correlationId, envelope.eventId)
@@ -248,7 +265,6 @@ class RiskComplianceService:
         if block is not None:
             self.repository.save_block(block)
             self.publisher.publish(_block_applied_envelope(block, envelope.correlationId, assessment_envelope.eventId))
-        self.repository.record_processed(envelope.eventId)
 
     def lift_block(self, *, subject_ref: str, scope: str, reason_code: str, correlation_id: str) -> RiskBlockLifted:
         previous = self.repository.active_block(subject_ref)
@@ -257,12 +273,17 @@ class RiskComplianceService:
         lifted = _lifted_from_previous(previous, reason_code)
         self.publisher.publish(_block_lifted_envelope(lifted, correlation_id, prefixed_id("cmd")))
         self.repository.remove_block(subject_ref)
+        if previous.scope == BlockScope.ORDER.value:
+            account_id = self.repository.account_for_order(subject_ref)
+            if account_id is not None:
+                self.repository.record_account_lift(account_id, _coerce_datetime(lifted.allowedAt))
         return lifted
 
     def _assess_journey_order_created(self, envelope: EventEnvelope) -> tuple[RiskAssessmentResult, RiskBlockApplied | None]:
         payload = envelope.payload
         order_id = _required_payload_text(payload, "orderId")
         account_id = _required_payload_text(payload, "accountId")
+        self.repository.remember_order_account(order_id, account_id)
         occurred_at = _coerce_datetime(envelope.occurredAt)
         context = dict(payload)
         context["orderAttemptCount10m"] = self.repository.record_order_attempt(account_id, occurred_at)

--- a/services/risk-compliance/src/risk_compliance/application.py
+++ b/services/risk-compliance/src/risk_compliance/application.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any, TypeAlias
+from uuid import NAMESPACE_URL, uuid5
 
 from train_ticket_platform.events import EventEnvelope, envelope_factory, rfc3339_utc
 from train_ticket_platform.idempotency import IdempotencyRecord, IdempotencyStore
@@ -28,6 +29,7 @@ DEFAULT_POLICY_VERSION = PolicyVersionRef(policy_set_id="risk-rules", version="1
 FREQUENCY_WINDOW = timedelta(minutes=10)
 FREQUENCY_THRESHOLD = 3
 BLOCKING_DECISIONS = {Decision.DENY, Decision.CHALLENGE}
+BLOCKING_DECISION_VALUES = {decision.value for decision in BLOCKING_DECISIONS}
 RiskScenario: TypeAlias = str
 EventHandler: TypeAlias = Callable[[EventEnvelope], None]
 InMemoryEventSubscriber = PlatformInMemoryEventSubscriber
@@ -139,6 +141,15 @@ class InMemoryAssessmentRepository:
             return self._assessments[assessment_id]
         except KeyError as exc:
             raise AssessmentNotFoundError(assessment_id) from exc
+
+    def find(self, assessment_id: str) -> RiskAssessmentResult | None:
+        return self._assessments.get(assessment_id)
+
+    def count(self) -> int:
+        return len(self._assessments)
+
+    def values(self) -> tuple[RiskAssessmentResult, ...]:
+        return tuple(self._assessments.values())
 
     def save(self, assessment: RiskAssessmentResult) -> None:
         self._assessments[assessment.assessmentId] = assessment
@@ -252,19 +263,30 @@ class RiskComplianceService:
     def get_assessment(self, assessment_id: str) -> RiskAssessmentResult:
         return self.repository.get(assessment_id)
 
+    def assessment_count(self) -> int:
+        return self.repository.count()
+
+    def assessments(self) -> tuple[RiskAssessmentResult, ...]:
+        return self.repository.values()
+
     def handle_event(self, envelope: EventEnvelope) -> None:
         if envelope.eventType != "JourneyOrderCreated":
             return
         if self.repository.is_processed(envelope.eventId):
             return
-        self.repository.record_processed(envelope.eventId)
         result, block = self._assess_journey_order_created(envelope)
         self.repository.save(result)
-        assessment_envelope = _assessment_envelope(result, envelope.correlationId, envelope.eventId)
+        assessment_envelope = _assessment_envelope(
+            result,
+            envelope.correlationId,
+            envelope.eventId,
+            event_id=deterministic_event_id(result.assessmentId),
+        )
         self.publisher.publish(assessment_envelope)
         if block is not None:
             self.repository.save_block(block)
             self.publisher.publish(_block_applied_envelope(block, envelope.correlationId, assessment_envelope.eventId))
+        self.repository.record_processed(envelope.eventId)
 
     def lift_block(self, *, subject_ref: str, scope: str, reason_code: str, correlation_id: str) -> RiskBlockLifted:
         previous = self.repository.active_block(subject_ref)
@@ -283,12 +305,17 @@ class RiskComplianceService:
         payload = envelope.payload
         order_id = _required_payload_text(payload, "orderId")
         account_id = _required_payload_text(payload, "accountId")
+        assessment_id = deterministic_prefixed_id("asmt", envelope.eventId, "assessment")
+        existing = self.repository.find(assessment_id)
+        if existing is not None:
+            block = _block_from_result(existing) if existing.decision in BLOCKING_DECISION_VALUES else None
+            return existing, block
         self.repository.remember_order_account(order_id, account_id)
         occurred_at = _coerce_datetime(envelope.occurredAt)
         context = dict(payload)
         context["orderAttemptCount10m"] = self.repository.record_order_attempt(account_id, occurred_at)
         assessment = assess_risk(
-            assessment_id=prefixed_id("asmt"),
+            assessment_id=assessment_id,
             subject_ref=order_id,
             scenario="order_risk",
             input_data=context,
@@ -302,6 +329,20 @@ class RiskComplianceService:
 
 def prefixed_id(prefix: str) -> str:
     return new_prefixed_uuid7(prefix)
+
+
+def deterministic_uuid(value: str) -> str:
+    uuid = uuid5(NAMESPACE_URL, f"train-ticket:risk-compliance:{value}")
+    uuid_int = (uuid.int & ~(0xF << 76)) | (0x7 << 76)
+    return str(uuid.__class__(int=uuid_int))
+
+
+def deterministic_prefixed_id(prefix: str, *parts: str) -> str:
+    return f"{prefix}-{deterministic_uuid(':'.join(parts))}"
+
+
+def deterministic_event_id(fact_id: str) -> str:
+    return deterministic_prefixed_id("evt", fact_id, "event")
 
 
 def uuid7() -> str:
@@ -444,7 +485,13 @@ def _to_result(assessment: RiskAssessment) -> RiskAssessmentResult:
     )
 
 
-def _assessment_envelope(result: RiskAssessmentResult, correlation_id: str, causation_id: str) -> EventEnvelope:
+def _assessment_envelope(
+    result: RiskAssessmentResult,
+    correlation_id: str,
+    causation_id: str,
+    *,
+    event_id: str | None = None,
+) -> EventEnvelope:
     return envelope_factory(
         event_type="RiskAssessmentResult",
         producer=PRODUCER,
@@ -453,12 +500,13 @@ def _assessment_envelope(result: RiskAssessmentResult, correlation_id: str, caus
         causation_id=causation_id,
         occurred_at=result.assessedAt,
         schema_version=SCHEMA_VERSION,
+        event_id=event_id,
     )
 
 
 def _block_from_result(result: RiskAssessmentResult) -> RiskBlockApplied:
     decision = block_subject(
-        decision_id=prefixed_id("blk"),
+        decision_id=deterministic_prefixed_id("blk", result.assessmentId, "block"),
         subject_ref=result.subjectRef,
         scope=BlockScope.ORDER,
         reason_code=result.reasonCode,
@@ -473,7 +521,7 @@ def _block_from_result(result: RiskAssessmentResult) -> RiskBlockApplied:
         reasonCode=decision.reason_code,
         policyVersion=decision.policy_version.version,
         evidenceRef=result.evidenceRef,
-        blockedAt=rfc3339_utc(decision.decided_at),
+        blockedAt=result.assessedAt,
     )
 
 
@@ -507,6 +555,7 @@ def _block_applied_envelope(block: RiskBlockApplied, correlation_id: str, causat
         causation_id=causation_id,
         occurred_at=block.blockedAt,
         schema_version=SCHEMA_VERSION,
+        event_id=deterministic_event_id(block.blockId),
     )
 
 

--- a/services/risk-compliance/src/risk_compliance/application.py
+++ b/services/risk-compliance/src/risk_compliance/application.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
 from typing import Any, TypeAlias
 
 from train_ticket_platform.events import EventEnvelope, envelope_factory, rfc3339_utc
@@ -19,11 +20,14 @@ from train_ticket_platform.messaging import (
     TransientHandlerError,
 )
 
-from .domain import Decision, PolicyVersionRef, RiskAssessment, RiskLevel, assess_risk
+from .domain import BlockScope, Decision, PolicyVersionRef, RiskAssessment, RiskLevel, allow_subject, assess_risk, block_subject
 
 PRODUCER = "risk-compliance"
 SCHEMA_VERSION = 1
 DEFAULT_POLICY_VERSION = PolicyVersionRef(policy_set_id="risk-rules", version="1.0.0")
+FREQUENCY_WINDOW = timedelta(minutes=10)
+FREQUENCY_THRESHOLD = 3
+BLOCKING_DECISIONS = {Decision.DENY, Decision.CHALLENGE}
 RiskScenario: TypeAlias = str
 EventHandler: TypeAlias = Callable[[EventEnvelope], None]
 InMemoryEventSubscriber = PlatformInMemoryEventSubscriber
@@ -66,13 +70,67 @@ class RiskAssessmentResult:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class RiskBlockApplied:
+    blockId: str
+    subjectRef: str
+    scope: str
+    reasonCode: str
+    policyVersion: str
+    evidenceRef: str
+    blockedAt: str
+
+    def to_event_payload(self) -> dict[str, Any]:
+        return {
+            "blockId": self.blockId,
+            "subjectRef": self.subjectRef,
+            "scope": self.scope,
+            "reasonCode": self.reasonCode,
+            "policyVersion": self.policyVersion,
+            "evidenceRef": self.evidenceRef,
+            "blockedAt": self.blockedAt,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RiskBlockLifted:
+    allowId: str
+    subjectRef: str
+    scope: str
+    reasonCode: str
+    policyVersion: str
+    evidenceRef: str
+    allowedAt: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "allowId": self.allowId,
+            "subjectRef": self.subjectRef,
+            "scope": self.scope,
+            "reasonCode": self.reasonCode,
+            "policyVersion": self.policyVersion,
+            "evidenceRef": self.evidenceRef,
+            "allowedAt": self.allowedAt,
+        }
+
+    def to_event_payload(self) -> dict[str, Any]:
+        return self.to_dict()
+
+
 class AssessmentNotFoundError(KeyError):
+    pass
+
+
+class BlockNotFoundError(KeyError):
     pass
 
 
 class InMemoryAssessmentRepository:
     def __init__(self) -> None:
         self._assessments: dict[str, RiskAssessmentResult] = {}
+        self._blocks: dict[str, RiskBlockApplied] = {}
+        self._processed_event_ids: set[str] = set()
+        self._account_order_times: dict[str, list[datetime]] = {}
 
     def get(self, assessment_id: str) -> RiskAssessmentResult:
         try:
@@ -82,6 +140,33 @@ class InMemoryAssessmentRepository:
 
     def save(self, assessment: RiskAssessmentResult) -> None:
         self._assessments[assessment.assessmentId] = assessment
+
+    def is_processed(self, event_id: str) -> bool:
+        return event_id in self._processed_event_ids
+
+    def record_processed(self, event_id: str) -> None:
+        self._processed_event_ids.add(event_id)
+
+    def save_block(self, block: RiskBlockApplied) -> None:
+        self._blocks[block.subjectRef] = block
+
+    def active_block(self, subject_ref: str) -> RiskBlockApplied:
+        try:
+            return self._blocks[subject_ref]
+        except KeyError as exc:
+            raise BlockNotFoundError(subject_ref) from exc
+
+    def remove_block(self, subject_ref: str) -> None:
+        self._blocks.pop(subject_ref, None)
+
+    def record_order_attempt(self, account_id: str, occurred_at: datetime) -> int:
+        attempts = [
+            seen_at for seen_at in self._account_order_times.get(account_id, [])
+            if occurred_at - seen_at <= FREQUENCY_WINDOW
+        ]
+        attempts.append(occurred_at)
+        self._account_order_times[account_id] = attempts
+        return len(attempts)
 
 
 @dataclass(slots=True)
@@ -151,6 +236,48 @@ class RiskComplianceService:
     def get_assessment(self, assessment_id: str) -> RiskAssessmentResult:
         return self.repository.get(assessment_id)
 
+    def handle_event(self, envelope: EventEnvelope) -> None:
+        if envelope.eventType != "JourneyOrderCreated":
+            return
+        if self.repository.is_processed(envelope.eventId):
+            return
+        result, block = self._assess_journey_order_created(envelope)
+        self.repository.save(result)
+        assessment_envelope = _assessment_envelope(result, envelope.correlationId, envelope.eventId)
+        self.publisher.publish(assessment_envelope)
+        if block is not None:
+            self.repository.save_block(block)
+            self.publisher.publish(_block_applied_envelope(block, envelope.correlationId, assessment_envelope.eventId))
+        self.repository.record_processed(envelope.eventId)
+
+    def lift_block(self, *, subject_ref: str, scope: str, reason_code: str, correlation_id: str) -> RiskBlockLifted:
+        previous = self.repository.active_block(subject_ref)
+        if previous.scope != scope:
+            raise BlockNotFoundError(subject_ref)
+        lifted = _lifted_from_previous(previous, reason_code)
+        self.publisher.publish(_block_lifted_envelope(lifted, correlation_id, prefixed_id("cmd")))
+        self.repository.remove_block(subject_ref)
+        return lifted
+
+    def _assess_journey_order_created(self, envelope: EventEnvelope) -> tuple[RiskAssessmentResult, RiskBlockApplied | None]:
+        payload = envelope.payload
+        order_id = _required_payload_text(payload, "orderId")
+        account_id = _required_payload_text(payload, "accountId")
+        occurred_at = _coerce_datetime(envelope.occurredAt)
+        context = dict(payload)
+        context["orderAttemptCount10m"] = self.repository.record_order_attempt(account_id, occurred_at)
+        assessment = assess_risk(
+            assessment_id=prefixed_id("asmt"),
+            subject_ref=order_id,
+            scenario="order_risk",
+            input_data=context,
+            idempotency_key=envelope.eventId,
+        )
+        completed = _evaluate(assessment)
+        result = _to_result(completed)
+        block = _block_from_result(result) if completed.decision in BLOCKING_DECISIONS else None
+        return result, block
+
 
 def prefixed_id(prefix: str) -> str:
     return new_prefixed_uuid7(prefix)
@@ -206,8 +333,54 @@ def _score(assessment: RiskAssessment) -> int:
     explicit = context["riskScore"] if "riskScore" in context else context.get("score")
     if isinstance(explicit, int) and 0 <= explicit <= 1000:
         return explicit
+    if _has_blacklisted_document(context):
+        return 950
+    attempt_count = context.get("orderAttemptCount10m")
+    if isinstance(attempt_count, int) and attempt_count >= FREQUENCY_THRESHOLD:
+        return 900
     digest = assessment.input_snapshot.digest
     return int(digest[:8], 16) % 350
+
+
+def _has_blacklisted_document(context: Mapping[str, Any]) -> bool:
+    document_refs = _document_refs(context)
+    if any("BLACKLIST" in ref.upper() or "***9999" in ref.upper() for ref in document_refs):
+        return True
+    configured = context.get("blacklistedDocumentRefs")
+    if isinstance(configured, list):
+        blacklist = {str(value) for value in configured}
+        return any(ref in blacklist for ref in document_refs)
+    return False
+
+
+def _document_refs(context: Mapping[str, Any]) -> list[str]:
+    refs: list[str] = []
+    travelers = context.get("travelerRefs")
+    if isinstance(travelers, list):
+        for traveler in travelers:
+            if isinstance(traveler, Mapping):
+                for field_name in ("maskedDocumentRef", "maskedDocumentNo", "documentRef"):
+                    value = traveler.get(field_name)
+                    if isinstance(value, str) and value.strip():
+                        refs.append(value)
+    for field_name in ("maskedDocumentRef", "maskedDocumentNo", "documentRef"):
+        value = context.get(field_name)
+        if isinstance(value, str) and value.strip():
+            refs.append(value)
+    return refs
+
+
+def _required_payload_text(payload: Mapping[str, Any], field_name: str) -> str:
+    value = payload.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"JourneyOrderCreated payload missing {field_name}")
+    return value
+
+
+def _coerce_datetime(value: datetime | str) -> datetime:
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
 
 
 def _result_from_response_body(body: Any) -> RiskAssessmentResult:
@@ -252,11 +425,77 @@ def _to_result(assessment: RiskAssessment) -> RiskAssessmentResult:
 
 def _assessment_envelope(result: RiskAssessmentResult, correlation_id: str, causation_id: str) -> EventEnvelope:
     return envelope_factory(
-        event_type="RiskAssessed",
+        event_type="RiskAssessmentResult",
         producer=PRODUCER,
         payload=result.to_event_payload(),
         correlation_id=correlation_id,
         causation_id=causation_id,
         occurred_at=result.assessedAt,
+        schema_version=SCHEMA_VERSION,
+    )
+
+
+def _block_from_result(result: RiskAssessmentResult) -> RiskBlockApplied:
+    decision = block_subject(
+        decision_id=prefixed_id("blk"),
+        subject_ref=result.subjectRef,
+        scope=BlockScope.ORDER,
+        reason_code=result.reasonCode,
+        policy_version=PolicyVersionRef("risk-rules", result.policyVersion),
+        assessment_id=result.assessmentId,
+        input_snapshot_digest=result.assessmentSnapshotHash,
+    )
+    return RiskBlockApplied(
+        blockId=decision.decision_id,
+        subjectRef=decision.subject_ref,
+        scope=decision.scope.value,
+        reasonCode=decision.reason_code,
+        policyVersion=decision.policy_version.version,
+        evidenceRef=result.evidenceRef,
+        blockedAt=rfc3339_utc(decision.decided_at),
+    )
+
+
+def _lifted_from_previous(previous: RiskBlockApplied, reason_code: str) -> RiskBlockLifted:
+    decision = allow_subject(
+        decision_id=prefixed_id("alw"),
+        subject_ref=previous.subjectRef,
+        scope=BlockScope(previous.scope),
+        reason_code=reason_code,
+        policy_version=PolicyVersionRef("risk-rules", previous.policyVersion),
+        assessment_id=previous.blockId,
+        input_snapshot_digest=previous.blockId,
+    )
+    return RiskBlockLifted(
+        allowId=decision.decision_id,
+        subjectRef=decision.subject_ref,
+        scope=decision.scope.value,
+        reasonCode=decision.reason_code,
+        policyVersion=decision.policy_version.version,
+        evidenceRef=previous.evidenceRef,
+        allowedAt=rfc3339_utc(decision.decided_at),
+    )
+
+
+def _block_applied_envelope(block: RiskBlockApplied, correlation_id: str, causation_id: str) -> EventEnvelope:
+    return envelope_factory(
+        event_type="RiskBlockApplied",
+        producer=PRODUCER,
+        payload=block.to_event_payload(),
+        correlation_id=correlation_id,
+        causation_id=causation_id,
+        occurred_at=block.blockedAt,
+        schema_version=SCHEMA_VERSION,
+    )
+
+
+def _block_lifted_envelope(lifted: RiskBlockLifted, correlation_id: str, causation_id: str) -> EventEnvelope:
+    return envelope_factory(
+        event_type="RiskBlockLifted",
+        producer=PRODUCER,
+        payload=lifted.to_event_payload(),
+        correlation_id=correlation_id,
+        causation_id=causation_id,
+        occurred_at=lifted.allowedAt,
         schema_version=SCHEMA_VERSION,
     )

--- a/services/risk-compliance/tests/test_api_and_messaging.py
+++ b/services/risk-compliance/tests/test_api_and_messaging.py
@@ -113,6 +113,26 @@ def test_missing_idempotency_key_is_validation_error() -> None:
     assert response.json()["code"] == "VALIDATION_FAILED"
 
 
+def journey_order_created_envelope(event_id: str, order_id: str, account_id: str, occurred_at: str = "2026-07-05T10:30:00.000Z") -> EventEnvelope:
+    return EventEnvelope(
+        eventId=event_id,
+        eventType="JourneyOrderCreated",
+        occurredAt=occurred_at,
+        correlationId=f"corr-{uuid7()}",
+        causationId=f"cmd-{uuid7()}",
+        producer="journey-order",
+        schemaVersion=1,
+        payload={
+            "orderId": order_id,
+            "accountId": account_id,
+            "offerId": "offer-1",
+            "travelerRefs": [{"travelerId": "tvl-1", "maskedDocumentRef": "11***0001", "travelerType": "ADULT"}],
+            "segmentRefs": ["seg-1"],
+            "createdAt": occurred_at,
+        },
+    )
+
+
 class FailingPublisher(InMemoryEventPublisher):
     def publish(self, envelope: EventEnvelope) -> None:
         raise PublishFailed("downstream unavailable")
@@ -382,6 +402,50 @@ def test_journey_order_created_is_assessed_and_blocked_idempotently() -> None:
     }
     assert block.payload["blockId"].startswith("blk-")
     assert block.causationId == publisher.envelopes[0].eventId
+
+
+def test_journey_order_replay_does_not_publish_second_assessment_after_partial_delivery_failure() -> None:
+    class FailsAfterAssessmentPublisher(InMemoryEventPublisher):
+        def publish(self, envelope: EventEnvelope) -> None:
+            super().publish(envelope)
+            if envelope.eventType == "RiskAssessmentResult":
+                raise PublishFailed("block publication failed after assessment delivery")
+
+    publisher = FailsAfterAssessmentPublisher()
+    service = RiskComplianceService(publisher, InMemoryAssessmentRepository())
+    envelope = journey_order_created_envelope(f"evt-{uuid7()}", "ord-partial", "acct-partial")
+
+    try:
+        service.handle_event(envelope)
+    except PublishFailed:
+        pass
+    service.handle_event(envelope)
+
+    assert [published.eventType for published in publisher.envelopes] == ["RiskAssessmentResult"]
+    assert len(service.repository._assessments) == 1
+
+
+def test_lift_block_clears_account_frequency_window_for_same_account() -> None:
+    publisher = InMemoryEventPublisher()
+    service = RiskComplianceService(publisher, InMemoryAssessmentRepository())
+    account_id = "acct-lift-frequency"
+    for index in range(3):
+        service.handle_event(journey_order_created_envelope(f"evt-{uuid7()}", f"ord-lift-frequency-{index}", account_id))
+    blocked_order_id = "ord-lift-frequency-2"
+
+    lifted = service.lift_block(
+        subject_ref=blocked_order_id,
+        scope="ORDER",
+        reason_code="MANUAL_REVIEW_CLEARED",
+        correlation_id=f"corr-{uuid7()}",
+    )
+    service.handle_event(journey_order_created_envelope(f"evt-{uuid7()}", "ord-after-lift", account_id, lifted.allowedAt))
+
+    post_lift_assessment = publisher.envelopes[-1]
+    assert post_lift_assessment.eventType == "RiskAssessmentResult"
+    assert post_lift_assessment.payload["subjectRef"] == "ord-after-lift"
+    assert post_lift_assessment.payload["decision"] == "ALLOW"
+    assert [event.eventType for event in publisher.envelopes].count("RiskBlockApplied") == 1
 
 
 def test_lift_block_endpoint_publishes_lift_event() -> None:

--- a/services/risk-compliance/tests/test_api_and_messaging.py
+++ b/services/risk-compliance/tests/test_api_and_messaging.py
@@ -11,7 +11,7 @@ from risk_compliance import (
     RiskComplianceService,
     create_app,
 )
-from risk_compliance.application import is_prefixed_uuid7, is_uuid7, uuid7
+from risk_compliance.application import deterministic_event_id, deterministic_prefixed_id, is_prefixed_uuid7, is_uuid7, uuid7
 
 
 def fake_app():
@@ -178,7 +178,7 @@ def test_publish_failure_returns_unavailable_body_after_save() -> None:
     assert response.status_code == 503
     assert response.json()["code"] == "UNAVAILABLE"
     assert response.json()["details"] == {"deliverySemantics": "AT_LEAST_ONCE"}
-    assert len(repository._assessments) == 1
+    assert repository.count() == 1
 
 
 def test_publish_failure_retry_same_key_publishes_and_returns_created() -> None:
@@ -194,9 +194,9 @@ def test_publish_failure_retry_same_key_publishes_and_returns_created() -> None:
 
     assert first.status_code == 503
     assert retry.status_code == 201
-    assert len(repository._assessments) == 1
+    assert repository.count() == 1
     assert len(publisher.envelopes) == 1
-    assert retry.json() == next(iter(repository._assessments.values())).to_dict()
+    assert retry.json() == repository.values()[0].to_dict()
 
 
 def test_idempotent_replay_returns_original_result() -> None:
@@ -400,7 +400,10 @@ def test_journey_order_created_is_assessed_and_blocked_idempotently() -> None:
         "evidenceRef": publisher.envelopes[0].payload["evidenceRef"],
         "blockedAt": block.payload["blockedAt"],
     }
-    assert block.payload["blockId"].startswith("blk-")
+    assert block.payload["blockId"] == deterministic_prefixed_id("blk", publisher.envelopes[0].payload["assessmentId"], "block")
+    assert block.payload["blockId"].split("-", 1)[1][14] == "7"
+    assert block.eventId == deterministic_event_id(block.payload["blockId"])
+    assert block.eventId.split("-", 1)[1][14] == "7"
     assert block.causationId == publisher.envelopes[0].eventId
 
 
@@ -415,14 +418,16 @@ def test_journey_order_replay_does_not_publish_second_assessment_after_partial_d
     service = RiskComplianceService(publisher, InMemoryAssessmentRepository())
     envelope = journey_order_created_envelope(f"evt-{uuid7()}", "ord-partial", "acct-partial")
 
-    try:
-        service.handle_event(envelope)
-    except PublishFailed:
-        pass
-    service.handle_event(envelope)
+    for _ in range(2):
+        try:
+            service.handle_event(envelope)
+        except PublishFailed:
+            pass
 
-    assert [published.eventType for published in publisher.envelopes] == ["RiskAssessmentResult"]
-    assert len(service.repository._assessments) == 1
+    assert [published.eventType for published in publisher.envelopes] == ["RiskAssessmentResult", "RiskAssessmentResult"]
+    assert publisher.envelopes[1].eventId == publisher.envelopes[0].eventId
+    assert publisher.envelopes[1].payload["assessmentId"] == publisher.envelopes[0].payload["assessmentId"]
+    assert service.assessment_count() == 1
 
 
 def test_lift_block_clears_account_frequency_window_for_same_account() -> None:

--- a/services/risk-compliance/tests/test_api_and_messaging.py
+++ b/services/risk-compliance/tests/test_api_and_messaging.py
@@ -50,8 +50,8 @@ def test_assess_risk_happy_path_and_get() -> None:
     assert fetched.json() == body
 
 
-def test_default_app_assess_risk_smoke_uses_platform_fake_publisher() -> None:
-    app = create_app()
+def test_injected_app_assess_risk_smoke_uses_platform_fake_publisher() -> None:
+    app = fake_app()
     client = TestClient(app)
 
     response = client.post(
@@ -64,8 +64,15 @@ def test_default_app_assess_risk_smoke_uses_platform_fake_publisher() -> None:
     body = response.json()
     assert body["subjectRef"] == "ord-default"
     [envelope] = app.state.publisher.envelopes
-    assert envelope.to_json_dict()["eventType"] == "RiskAssessed"
+    assert envelope.to_json_dict()["eventType"] == "RiskAssessmentResult"
     assert envelope.payload["assessmentId"] == body["assessmentId"]
+
+
+def test_default_app_wires_redis_publisher_and_journey_order_subscriber() -> None:
+    app = create_app()
+
+    assert app.state.publisher.__class__.__name__ == "RedisEventPublisher"
+    assert app.state.subscriber.__class__.__name__ == "RedisEventSubscriber"
 
 
 def test_get_unknown_assessment_returns_not_found_error_body() -> None:
@@ -216,7 +223,7 @@ def test_publisher_wraps_domain_event_in_contract_envelope() -> None:
     assert envelope.eventId.startswith("evt-")
     assert envelope.eventId.split("-", 1)[1][14] == "7"
     assert response.json()["assessmentId"].split("-", 1)[1][14] == "7"
-    assert envelope.eventType == "RiskAssessed"
+    assert envelope.eventType == "RiskAssessmentResult"
     assert envelope.producer == "risk-compliance"
     assert envelope.schemaVersion == 1
     assert envelope.correlationId == f"corr-{valid_correlation_id}"
@@ -236,7 +243,7 @@ def test_publisher_wraps_domain_event_in_contract_envelope() -> None:
         "assessmentSnapshotHash",
     }
     assert envelope.causationId is not None and is_prefixed_uuid7(envelope.causationId, "cmd")
-    assert envelope.occurredAt == response.json()["assessedAt"]
+    assert envelope.to_json_dict()["occurredAt"] == response.json()["assessedAt"]
     assert envelope.payload == {
         **response.json(),
         "evidenceRef": f"evid-{response.json()['assessmentId']}",
@@ -248,7 +255,7 @@ def test_publisher_wraps_domain_event_in_contract_envelope() -> None:
 def test_subscriber_deduplicates_duplicate_event_id() -> None:
     envelope = EventEnvelope(
         eventId="evt-duplicate",
-        eventType="RiskAssessed",
+        eventType="RiskAssessmentResult",
         occurredAt="2026-07-05T10:30:00.000Z",
         correlationId=str(uuid7()),
         causationId=f"cmd-{uuid7()}",
@@ -336,3 +343,72 @@ def test_request_id_is_server_assigned_and_caller_value_is_not_echoed() -> None:
     assert response.status_code == 201
     assert response.headers["X-Request-Id"] != caller_request_id
     assert is_uuid7(response.headers["X-Request-Id"])
+
+
+def test_journey_order_created_is_assessed_and_blocked_idempotently() -> None:
+    publisher = InMemoryEventPublisher()
+    service = RiskComplianceService(publisher, InMemoryAssessmentRepository())
+    envelope = EventEnvelope(
+        eventId=f"evt-{uuid7()}",
+        eventType="JourneyOrderCreated",
+        occurredAt="2026-07-05T10:30:00.000Z",
+        correlationId=f"corr-{uuid7()}",
+        causationId=f"cmd-{uuid7()}",
+        producer="journey-order",
+        schemaVersion=1,
+        payload={
+            "orderId": "ord-risky",
+            "accountId": "acct-risky",
+            "offerId": "offer-1",
+            "travelerRefs": [{"travelerId": "tvl-1", "maskedDocumentRef": "11***9999", "travelerType": "ADULT"}],
+            "segmentRefs": ["seg-1"],
+            "createdAt": "2026-07-05T10:30:00.000Z",
+        },
+    )
+
+    service.handle_event(envelope)
+    service.handle_event(envelope)
+
+    assert [published.eventType for published in publisher.envelopes] == ["RiskAssessmentResult", "RiskBlockApplied"]
+    block = publisher.envelopes[1]
+    assert block.payload == {
+        "blockId": block.payload["blockId"],
+        "subjectRef": "ord-risky",
+        "scope": "ORDER",
+        "reasonCode": "HIGH_RISK_SIGNAL",
+        "policyVersion": "1.0.0",
+        "evidenceRef": publisher.envelopes[0].payload["evidenceRef"],
+        "blockedAt": block.payload["blockedAt"],
+    }
+    assert block.payload["blockId"].startswith("blk-")
+    assert block.causationId == publisher.envelopes[0].eventId
+
+
+def test_lift_block_endpoint_publishes_lift_event() -> None:
+    app = fake_app()
+    service = app.state.risk_service
+    risky = EventEnvelope(
+        eventId=f"evt-{uuid7()}",
+        eventType="JourneyOrderCreated",
+        occurredAt="2026-07-05T10:30:00.000Z",
+        correlationId=f"corr-{uuid7()}",
+        causationId=f"cmd-{uuid7()}",
+        producer="journey-order",
+        schemaVersion=1,
+        payload={"orderId": "ord-lift", "accountId": "acct-lift", "travelerRefs": [{"maskedDocumentRef": "11***9999"}]},
+    )
+    service.handle_event(risky)
+
+    response = TestClient(app).post(
+        "/api/v1/risk-blocks/lift",
+        headers={"Idempotency-Key": str(uuid7()), "X-Correlation-Id": str(uuid7())},
+        json={"subjectRef": "ord-lift", "scope": "ORDER", "reasonCode": "MANUAL_REVIEW_CLEARED"},
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["allowId"].startswith("alw-")
+    assert body["subjectRef"] == "ord-lift"
+    assert body["scope"] == "ORDER"
+    assert app.state.publisher.envelopes[-1].eventType == "RiskBlockLifted"
+    assert app.state.publisher.envelopes[-1].payload == body


### PR DESCRIPTION
## Summary
- risk-compliance consumes JourneyOrderCreated, emits RiskAssessmentResult and RiskBlockApplied/RiskBlockLifted per contract
- journey-order consumes explicit risk assessment/lift semantics in confirmation conditions
- e2e risk script covers pass, block/cancel, lift, and same-account retry
- final fix derives JourneyOrderCreated assessment/block event fact IDs deterministically from the consumed event for safe replay after partial publication

## Validation
- `PYTHONPATH=platform/python-kit/src:services/risk-compliance/src services/risk-compliance/.venv/bin/pytest services/risk-compliance -q` ✅
- `(cd services/journey-order && mvn test)` ✅
- `make check` ⚠️ fails in existing traveler-profile tests with `HttpMessageConversionException: Type definition error: [simple type, class tools.jackson.databind.JsonNode]` while unrelated services before it pass
- `bash deploy/e2e/06-risk.sh` not run (requires live cluster)
