### PR TITLE
Hotfix: filter tests expect minted corr- ids (unbreaks make check again)

### DIFF
--- a/services/admin-audit/src/test/java/com/trainticket/adminaudit/ApplicationTest.java
+++ b/services/admin-audit/src/test/java/com/trainticket/adminaudit/ApplicationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.servlet.ServletException;
 import java.io.IOException;
@@ -72,7 +73,11 @@ class ApplicationTest {
         String requestId = response.getHeader(RequestContextFilter.REQUEST_ID_HEADER);
         assertNotNull(requestId);
         assertFalse(requestId.isBlank());
-        assertEquals(requestId, response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+        // A missing correlation header mints a canonical corr-<uuid7> id
+        // instead of reusing the request id (shared-primitives ruling).
+        String correlationId = response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER);
+        assertNotNull(correlationId);
+        assertTrue(correlationId.startsWith("corr-"));
     }
 
     private static final class RecordingTracer implements RuntimeTracer {

--- a/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/ApplicationTest.java
+++ b/services/booking-orchestration/src/test/java/com/trainticket/bookingorchestration/ApplicationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.servlet.ServletException;
 import java.io.IOException;
@@ -72,7 +73,11 @@ class ApplicationTest {
         String requestId = response.getHeader(RequestContextFilter.REQUEST_ID_HEADER);
         assertNotNull(requestId);
         assertFalse(requestId.isBlank());
-        assertEquals(requestId, response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+        // A missing correlation header mints a canonical corr-<uuid7> id
+        // instead of reusing the request id (shared-primitives ruling).
+        String correlationId = response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER);
+        assertNotNull(correlationId);
+        assertTrue(correlationId.startsWith("corr-"));
     }
 
     private static final class RecordingTracer implements RuntimeTracer {

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/ApplicationTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/ApplicationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.servlet.ServletException;
 import java.io.IOException;
@@ -72,7 +73,11 @@ class ApplicationTest {
         String requestId = response.getHeader(RequestContextFilter.REQUEST_ID_HEADER);
         assertNotNull(requestId);
         assertFalse(requestId.isBlank());
-        assertEquals(requestId, response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+        // A missing correlation header mints a canonical corr-<uuid7> id
+        // instead of reusing the request id (shared-primitives ruling).
+        String correlationId = response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER);
+        assertNotNull(correlationId);
+        assertTrue(correlationId.startsWith("corr-"));
     }
 
     private static final class RecordingTracer implements RuntimeTracer {

--- a/services/payment/src/test/java/com/trainticket/payment/ApplicationTest.java
+++ b/services/payment/src/test/java/com/trainticket/payment/ApplicationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.servlet.ServletException;
 import java.io.IOException;
@@ -72,7 +73,11 @@ class ApplicationTest {
         String requestId = response.getHeader(RequestContextFilter.REQUEST_ID_HEADER);
         assertNotNull(requestId);
         assertFalse(requestId.isBlank());
-        assertEquals(requestId, response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+        // A missing correlation header mints a canonical corr-<uuid7> id
+        // instead of reusing the request id (shared-primitives ruling).
+        String correlationId = response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER);
+        assertNotNull(correlationId);
+        assertTrue(correlationId.startsWith("corr-"));
     }
 
     private static final class RecordingTracer implements RuntimeTracer {

--- a/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/ApplicationTest.java
+++ b/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/ApplicationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.servlet.ServletException;
 import java.io.IOException;
@@ -72,7 +73,11 @@ class ApplicationTest {
         String requestId = response.getHeader(RequestContextFilter.REQUEST_ID_HEADER);
         assertNotNull(requestId);
         assertFalse(requestId.isBlank());
-        assertEquals(requestId, response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+        // A missing correlation header mints a canonical corr-<uuid7> id
+        // instead of reusing the request id (shared-primitives ruling).
+        String correlationId = response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER);
+        assertNotNull(correlationId);
+        assertTrue(correlationId.startsWith("corr-"));
     }
 
     private static final class RecordingTracer implements RuntimeTracer {

--- a/services/wallet-promotion/pom.xml
+++ b/services/wallet-promotion/pom.xml
@@ -18,6 +18,11 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.trainticket</groupId>
+      <artifactId>java-kit</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>

--- a/services/wallet-promotion/src/test/java/com/trainticket/walletpromotion/ApplicationTest.java
+++ b/services/wallet-promotion/src/test/java/com/trainticket/walletpromotion/ApplicationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.servlet.ServletException;
 import java.io.IOException;
@@ -72,7 +73,11 @@ class ApplicationTest {
         String requestId = response.getHeader(RequestContextFilter.REQUEST_ID_HEADER);
         assertNotNull(requestId);
         assertFalse(requestId.isBlank());
-        assertEquals(requestId, response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER));
+        // A missing correlation header mints a canonical corr-<uuid7> id
+        // instead of reusing the request id (shared-primitives ruling).
+        String correlationId = response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER);
+        assertNotNull(correlationId);
+        assertTrue(correlationId.startsWith("corr-"));
     }
 
     private static final class RecordingTracer implements RuntimeTracer {


### PR DESCRIPTION
Follow-up to #110: 6 copy-pasted ApplicationTests asserted requestId == correlationId; now assert corr- prefix. wallet-promotion gains the java-kit dependency its filter change needed (future-scope service, never built, so the compile break was invisible). All 6 tests verified green in the JDK25 maven container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)