### PR TITLE
Contract ruling: revenue reversals are RevenueRecognitionReversed, not componentCode=refund

### DIFF
--- a/docs/08-contracts/events/finance-settlement-events.md
+++ b/docs/08-contracts/events/finance-settlement-events.md
@@ -16,6 +16,24 @@ event.
 | `sourceEventId` | string | The upstream event that triggered recognition. |
 | `metadata` | EventMetadata | Standard event envelope. |
 
+## RevenueRecognitionReversed
+
+Produced when previously recognized revenue is reversed (e.g. an approved
+refund). RULING (2026-07-06): reversals are a dedicated event — `componentCode`
+keeps its original enum (fare, tax, fee, ancillary, discount) and always names
+the component being reversed; there is no `refund` component.
+
+| Field | Type | Description |
+|---|---|---|
+| `revenueRecognitionId` | string | ID of the original recognition being reversed. |
+| `orderItemId` | string | The order item whose revenue is reversed. |
+| `orderId` | string | The parent order. |
+| `componentCode` | string | Original financial component (fare, tax, fee, ancillary, discount). |
+| `amount` | Money | Positive amount being reversed. |
+| `reversalReason` | string | Why the revenue was reversed (e.g. post-sales refund applied). |
+| `sourceEventId` | string | The upstream event that triggered the reversal. |
+| `metadata` | EventMetadata | Standard event envelope. |
+
 ## ReconciliationCaseOpened
 
 Produced when a reconciliation mismatch is detected.

--- a/docs/08-contracts/messaging.md
+++ b/docs/08-contracts/messaging.md
@@ -66,7 +66,7 @@ context.
 | 17 | `account` | `events:account` | AccountCreated, AccountSuspended, AccountClosed |
 | 18 | `admin-audit` | `events:admin-audit` | ManualActionCompleted, ApprovalGranted, ApprovalDenied |
 | 19 | `customer-service` | `events:customer-service` | SupportCaseOpened, SupportCaseResolved |
-| 20 | `finance-settlement` | `events:finance-settlement` | RevenueRecognized, ReconciliationCompleted, InvoiceGenerated |
+| 20 | `finance-settlement` | `events:finance-settlement` | RevenueRecognized, RevenueRecognitionReversed, ReconciliationCompleted, InvoiceGenerated |
 | 21 | `reporting` | `events:reporting` | MetricDefined, MetricVersionPublished, ReadModelRebuilt |
 | 22 | `supplier-catalog` | `events:supplier-catalog` | SupplierUpdated, ContractAmended, ProductCapabilityChanged |
 


### PR DESCRIPTION
REQ-065's last blocker was a contract question: refund reductions were emitted as RevenueRecognized(componentCode=refund), but refund is a direction, not a component. Ruling: dedicated RevenueRecognitionReversed event referencing the original recognition and its original componentCode — matching the reversal seam that already exists in the finance domain model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)