### PR TITLE
e2e: make 08-notify-support self-contained

### DIFF
--- a/deploy/e2e/08-notify-support.sh
+++ b/deploy/e2e/08-notify-support.sh
@@ -4,7 +4,9 @@
 # verify the PostSalesApplied fact is attached to the support timeline and resolving
 # the case publishes SupportCaseResolved.
 cd "$(dirname "$0")" && . ./lib.sh
-[ -f ./.refs.env ] || ./02-purchase.sh
+# Always purchase fresh: earlier suite scripts leave used/refunded orders
+# in .refs.env, and this chain needs a refundable, un-fulfilled ticket.
+bash ./02-purchase.sh > /tmp/notify-support-base.log 2>&1 || true
 . ./.refs.env
 ensure_curl_pod
 


### PR DESCRIPTION
Running the full suite in order, 08 inherited 05/06's used or bare orders from .refs.env and the refund choreography could not complete. Now always runs a fresh purchase first, like 04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)