### PR TITLE
REQ-069 account gate for journey orders

### DIFF
--- a/deploy/e2e/10-account-gate.sh
+++ b/deploy/e2e/10-account-gate.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Account gate chain: registered account can buy, frozen account is rejected, unfreeze restores purchasing.
+# Requires 01-seed.sh to have run (reads .refs.env).
+cd "$(dirname "$0")" && . ./lib.sh
+. ./.refs.env
+ensure_curl_pod
+
+ACCT="acct_$(uuid7)"
+
+create_offer_for_account() {
+  local account_id=$1
+  local suffix=$2
+  local traveler itinerary segment quote offer version
+
+  req POST traveler-profile /api/v1/travelers "{\"accountId\":\"$account_id\",\"travelerType\":\"ADULT\",\"givenName\":\"Account\",\"familyName\":\"Gate$suffix\"}"
+  check_code 201 "register traveler $suffix"
+  traveler=$(jget "['travelerId']")
+  sleep 3
+
+  req POST trip-planning /api/v1/itineraries/search "{\"originRef\":\"$P_BJ\",\"destinationRef\":\"$P_SH\",\"departureDate\":\"2026-08-01\",\"travelerRefs\":[\"$traveler\"],\"channel\":\"WEB\"}"
+  check_code 200 "search itinerary $suffix"
+  itinerary=$(jget "['itineraries'][0]['itineraryRef']")
+  segment=$(jget "['itineraries'][0]['legs'][0]['serviceSegmentRef']")
+
+  req POST fare-pricing /api/v1/fare-quotes "{\"travelerRefs\":[\"$traveler\"],\"channel\":\"WEB\",\"segmentRefs\":[\"$segment\"]}"
+  check_code 201 "create fare quote $suffix"
+  quote=$(jget "['quoteId']")
+  echo "  quote=$quote traveler=$traveler segment=$segment"
+  sleep 3
+
+  req POST offer-management /api/v1/offers "{\"accountId\":\"$account_id\",\"channelId\":\"WEB\",\"itineraryRef\":\"$itinerary\",\"travelerRefs\":[\"$traveler\"]}"
+  check_code 201 "create offer $suffix"
+  offer=$(jget "['offerId']")
+  version=$(jget "['offerVersion']")
+
+  OFFER_ID=$offer
+  OFFER_VERSION=${version:-1}
+  TRAVELER_REF=$traveler
+  SEGMENT_REF=$segment
+}
+
+create_order_for_current_offer() {
+  local account_id=$1
+  req POST journey-order /api/v1/journey-orders "{\"accountId\":\"$account_id\",\"offerId\":\"$OFFER_ID\",\"offerVersion\":$OFFER_VERSION,\"travelerRefs\":[\"$TRAVELER_REF\"],\"segmentRefs\":[\"$SEGMENT_REF\"]}"
+}
+
+wait_for_account_event_projection() {
+  local account_id=$1
+  local expected_code=$2
+  local description=$3
+  local attempt
+  for attempt in 1 2 3 4 5 6 7 8; do
+    create_offer_for_account "$account_id" "projection-$attempt"
+    create_order_for_current_offer "$account_id"
+    [ "$LAST_CODE" = "$expected_code" ] && break
+    echo "  projection wait attempt $attempt got $LAST_CODE, retrying..."
+    sleep 4
+  done
+  check_code "$expected_code" "$description"
+}
+
+echo "== 0. register account"
+req POST account /api/v1/accounts "{\"accountId\":\"$ACCT\"}"
+check_code 201 "create account"
+echo "  ACCT=$ACCT"
+sleep 4
+
+echo "== 1. normal purchase is allowed"
+create_offer_for_account "$ACCT" "initial"
+create_order_for_current_offer "$ACCT"
+check_code 201 "create journey order before freeze"
+ORDER_BEFORE=$(jget "['orderId']")
+echo "  ORDER_BEFORE=$ORDER_BEFORE"
+
+echo "== 2. freeze account and wait until journey-order projection rejects new orders"
+req POST account "/api/v1/accounts/$ACCT/freeze" '{"reason":"account gate e2e","operator":"e2e"}'
+check_code 200 "freeze account"
+wait_for_account_event_projection "$ACCT" 422 "new journey order rejected while frozen"
+REJECT_CODE=$(jget "['code']")
+[ "$REJECT_CODE" = "DOMAIN_RULE_VIOLATION" ] && ok "frozen rejection error code DOMAIN_RULE_VIOLATION" || bad "frozen rejection code $REJECT_CODE"
+
+echo "== 3. unfreeze account and wait until purchases are allowed again"
+req POST account "/api/v1/accounts/$ACCT/unfreeze" '{"reason":"account gate e2e resolved"}'
+check_code 200 "unfreeze account"
+wait_for_account_event_projection "$ACCT" 201 "create journey order after unfreeze"
+ORDER_AFTER=$(jget "['orderId']")
+echo "  ORDER_AFTER=$ORDER_AFTER"
+
+summary

--- a/services/account/src/app.test.ts
+++ b/services/account/src/app.test.ts
@@ -177,6 +177,58 @@ describe("account HTTP API", () => {
   });
 
 
+
+  it("publishes account lifecycle event payloads with contract fields", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const app = createApp({ publisher });
+
+    await app.inject({
+      method: "POST",
+      url: "/api/v1/accounts",
+      headers: { "idempotency-key": "0194f2e0-7b3e-7610-8284-5c26e8b0c021", "x-correlation-id": "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c321" },
+      payload: { accountId: "acct_contract" },
+    });
+    await app.inject({
+      method: "POST",
+      url: "/api/v1/accounts/acct_contract/freeze",
+      headers: { "idempotency-key": "0194f2e0-7b3e-7610-8284-5c26e8b0c022", "x-correlation-id": "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c321" },
+      payload: { reason: "risk", operator: "ops", caseRef: "case-1" },
+    });
+    await app.inject({
+      method: "POST",
+      url: "/api/v1/accounts/acct_contract/unfreeze",
+      headers: { "idempotency-key": "0194f2e0-7b3e-7610-8284-5c26e8b0c023", "x-correlation-id": "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c321" },
+      payload: { reason: "resolved" },
+    });
+    await app.inject({
+      method: "POST",
+      url: "/api/v1/accounts/acct_contract/start-closure",
+      headers: { "idempotency-key": "0194f2e0-7b3e-7610-8284-5c26e8b0c024", "x-correlation-id": "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c321" },
+      payload: {},
+    });
+
+    const created = publisher.findByEventType("AccountCreated")[0];
+    assert.deepEqual(Object.keys(created.payload).sort(), ["accountId", "correlationId", "occurredAt"]);
+    assert.equal(created.payload.accountId, "acct_contract");
+    assert.equal(created.payload.correlationId, created.correlationId);
+    assert.equal(created.payload.occurredAt, created.occurredAt);
+
+    const frozen = publisher.findByEventType("AccountFrozen")[0];
+    assert.deepEqual(Object.keys(frozen.payload).sort(), ["accountId", "caseRef", "correlationId", "occurredAt", "operator", "reason"]);
+    assert.equal(frozen.payload.reason, "risk");
+    assert.equal(frozen.payload.operator, "ops");
+    assert.equal(frozen.payload.caseRef, "case-1");
+    assert.equal(frozen.payload.occurredAt, frozen.occurredAt);
+
+    const unfrozen = publisher.findByEventType("AccountUnfrozen")[0];
+    assert.deepEqual(Object.keys(unfrozen.payload).sort(), ["accountId", "correlationId", "occurredAt", "reason"]);
+    assert.equal(unfrozen.payload.reason, "resolved");
+
+    const closureStarted = publisher.findByEventType("AccountClosureStarted")[0];
+    assert.deepEqual(Object.keys(closureStarted.payload).sort(), ["accountId", "closureRequestId", "correlationId", "occurredAt"]);
+    assert.match(String(closureStarted.payload.closureRequestId), /^clr_/);
+  });
+
   it("uses one resolved correlation id for response headers, errors, and published events", async () => {
     const publisher = new InMemoryEventPublisher();
     const app = createApp({ publisher });

--- a/services/account/src/messaging.test.ts
+++ b/services/account/src/messaging.test.ts
@@ -74,7 +74,11 @@ describe("account event ports", () => {
     assert.equal(envelope.correlationId, "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222");
     assert.equal(isPrefixedUuidV7(envelope.correlationId, ["corr"]), true);
     assert.match(envelope.occurredAt, /^\d{4}-\d{2}-\d{2}T.*Z$/);
-    assert.deepEqual(envelope.payload, { accountId: "acct_123" });
+    assert.deepEqual(envelope.payload, {
+      accountId: "acct_123",
+      occurredAt: envelope.occurredAt,
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+    });
     assert.deepEqual(Object.keys(envelope), [
       "eventId",
       "eventType",

--- a/services/account/src/ports.ts
+++ b/services/account/src/ports.ts
@@ -18,15 +18,24 @@ export function toEventEnvelope(event: AccountDomainEvent, correlationId: string
 function eventPayload(event: AccountDomainEvent): Record<string, unknown> {
   switch (event.type) {
     case "AccountCreated":
-      return { accountId: event.accountId };
+      return withEventMetadata(event, { accountId: event.accountId });
     case "AccountFrozen":
-      return { accountId: event.accountId, reason: event.reason, operator: event.operator, caseRef: event.caseRef };
+      return withEventMetadata(event, {
+        accountId: event.accountId,
+        reason: event.reason,
+        operator: event.operator,
+        caseRef: event.caseRef,
+      });
     case "AccountUnfrozen":
-      return { accountId: event.accountId, reason: event.reason };
+      return withEventMetadata(event, { accountId: event.accountId, reason: event.reason });
     case "AccountClosureStarted":
-      return { accountId: event.accountId, closureRequestId: event.closureRequestId };
+      return withEventMetadata(event, { accountId: event.accountId, closureRequestId: event.closureRequestId });
     case "AccountClosed":
-      return { accountId: event.accountId, closureRequestId: event.closureRequestId, final: event.final };
+      return withEventMetadata(event, {
+        accountId: event.accountId,
+        closureRequestId: event.closureRequestId,
+        final: event.final,
+      });
     case "SessionOpened":
       return { sessionId: event.sessionId, accountId: event.accountId };
     case "SessionRevoked":
@@ -34,4 +43,15 @@ function eventPayload(event: AccountDomainEvent): Record<string, unknown> {
     case "PreferenceUpdated":
       return { accountId: event.accountId, preferenceKey: event.preferenceKey, oldValue: event.oldValue, newValue: event.newValue };
   }
+}
+
+function withEventMetadata(
+  event: Extract<AccountDomainEvent, { accountId: string }>,
+  payload: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    ...payload,
+    occurredAt: event.occurredAt.toISOString(),
+    correlationId: event.correlationId,
+  };
 }

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/adapters/messaging/RedisJourneyOrderSubscriptions.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/adapters/messaging/RedisJourneyOrderSubscriptions.java
@@ -9,6 +9,7 @@ public final class RedisJourneyOrderSubscriptions {
         "events:post-sales",
         "events:traveler-profile",
         "events:risk-compliance",
+        "events:account",
         "events:entitlement-ticketing"
     );
     private static final String GROUP = "journey-order";

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/application/service/OrderManagementService.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/application/service/OrderManagementService.java
@@ -13,6 +13,8 @@ import com.trainticket.journeyorder.application.port.out.JourneyOrderEventHandle
 import com.trainticket.platformkit.messaging.EventEnvelope;
 import com.trainticket.platformkit.http.ApiErrorCode;
 import com.trainticket.platformkit.http.ApiException;
+import com.trainticket.journeyorder.domain.AccountOrderGate;
+import com.trainticket.journeyorder.domain.AccountOrderState;
 import com.trainticket.journeyorder.domain.JourneyOrder;
 import com.trainticket.journeyorder.domain.JourneyOrderEvent;
 import com.trainticket.journeyorder.domain.Money;
@@ -40,6 +42,7 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
     private final Map<String, StoredOrder> orderStore = new LinkedHashMap<>();
     private final Map<String, IdempotencyEntry<JourneyOrderResult>> createIdempotencyStore = new LinkedHashMap<>();
     private final Map<String, IdempotencyEntry<CancelJourneyOrderResult>> cancelIdempotencyStore = new LinkedHashMap<>();
+    private final Map<String, AccountOrderState> accountStateProjection = new LinkedHashMap<>();
     private final EventPublisher eventPublisher;
     private final Set<String> consumedEventIds = new HashSet<>();
     private final Clock clock;
@@ -64,6 +67,8 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
             }
             return existing.result();
         }
+
+        AccountOrderGate.assertCanCreateOrder(request.accountId(), Optional.ofNullable(accountStateProjection.get(request.accountId())));
 
         Instant now = Instant.now(clock);
         String sourceCommandId = "cmd-" + UUID.randomUUID();
@@ -327,8 +332,15 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
                 case "RiskAssessmentResult" -> handleRiskAssessmentResult(envelope);
                 case "RiskBlockApplied" -> handleRiskBlockApplied(envelope);
                 case "RiskBlockLifted" -> handleRiskBlockLifted(envelope);
+                case "AccountCreated" -> handleAccountCreated(envelope);
+                case "AccountFrozen" -> handleAccountFrozen(envelope);
+                case "AccountUnfrozen" -> handleAccountUnfrozen(envelope);
+                case "AccountClosureStarted" -> handleAccountClosureStarted(envelope);
+                case "AccountClosed" -> handleAccountClosed(envelope);
                 case "EntitlementIssued" -> handleEntitlementIssued(envelope);
-                case "OfferExpired", "OfferQuoted", "TravelerProfileUpdated", "TravelerSnapshotUpdated", "TravelerDocumentVerified", "TravelerEligibilityChanged" -> new EventSubscriber.Success();
+                case "OfferExpired", "OfferQuoted",
+                    "TravelerProfileUpdated", "TravelerSnapshotUpdated", "TravelerDocumentVerified", "TravelerEligibilityChanged",
+                    "SessionOpened", "SessionRevoked", "PreferenceUpdated" -> new EventSubscriber.Success();
                 default -> new EventSubscriber.FatalError("unsupported event type for journey-order: " + envelope.eventType());
             };
         } catch (RuntimeException ex) {
@@ -352,6 +364,32 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
             order.confirm("payment-captured", envelope.occurredAt(), "cmd-consume-payment", envelope.eventId(), envelope.correlationId());
         }
         publishEvents(order.domainEvents().subList(eventCount, order.domainEvents().size()));
+        return new EventSubscriber.Success();
+    }
+
+    private EventSubscriber.HandlerResult handleAccountCreated(EventEnvelope envelope) {
+        String accountId = accountIdFromPayload(envelope);
+        accountStateProjection.putIfAbsent(accountId, AccountOrderState.ACTIVE);
+        return new EventSubscriber.Success();
+    }
+
+    private EventSubscriber.HandlerResult handleAccountFrozen(EventEnvelope envelope) {
+        accountStateProjection.put(accountIdFromPayload(envelope), AccountOrderState.FROZEN);
+        return new EventSubscriber.Success();
+    }
+
+    private EventSubscriber.HandlerResult handleAccountUnfrozen(EventEnvelope envelope) {
+        accountStateProjection.put(accountIdFromPayload(envelope), AccountOrderState.ACTIVE);
+        return new EventSubscriber.Success();
+    }
+
+    private EventSubscriber.HandlerResult handleAccountClosureStarted(EventEnvelope envelope) {
+        accountIdFromPayload(envelope);
+        return new EventSubscriber.Success();
+    }
+
+    private EventSubscriber.HandlerResult handleAccountClosed(EventEnvelope envelope) {
+        accountStateProjection.put(accountIdFromPayload(envelope), AccountOrderState.CLOSED);
         return new EventSubscriber.Success();
     }
 
@@ -430,6 +468,14 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
         }
         publishEvents(order.domainEvents().subList(eventCount, order.domainEvents().size()));
         return new EventSubscriber.Success();
+    }
+
+    private static String accountIdFromPayload(EventEnvelope envelope) {
+        String accountId = textPayload(envelope, "accountId", null);
+        if (accountId == null || accountId.isBlank()) {
+            throw new IllegalArgumentException("event payload missing accountId");
+        }
+        return accountId;
     }
 
     private JourneyOrder orderFromPayload(EventEnvelope envelope) {

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/AccountOrderGate.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/AccountOrderGate.java
@@ -1,0 +1,16 @@
+package com.trainticket.journeyorder.domain;
+
+import java.util.Optional;
+
+public final class AccountOrderGate {
+    private AccountOrderGate() {
+    }
+
+    public static void assertCanCreateOrder(String accountId, Optional<AccountOrderState> projectedState) {
+        projectedState.ifPresent(state -> {
+            if (!state.permitsOrderCreation()) {
+                throw new DomainRuleViolation("Account " + accountId + " is " + state.name() + " and cannot place new journey orders");
+            }
+        });
+    }
+}

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/AccountOrderState.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/AccountOrderState.java
@@ -1,0 +1,11 @@
+package com.trainticket.journeyorder.domain;
+
+public enum AccountOrderState {
+    ACTIVE,
+    FROZEN,
+    CLOSED;
+
+    public boolean permitsOrderCreation() {
+        return this == ACTIVE;
+    }
+}

--- a/services/journey-order/src/test/java/com/trainticket/journeyorder/api/JourneyOrderControllerTest.java
+++ b/services/journey-order/src/test/java/com/trainticket/journeyorder/api/JourneyOrderControllerTest.java
@@ -206,6 +206,31 @@ class JourneyOrderControllerTest {
             .andExpect(jsonPath("$.correlationId").value("corr-reused"));
     }
 
+
+    @Test
+    void frozenAccountCreateOrderViolationUsesCanonical422Body() throws Exception {
+        when(orderService.createOrder(any(JourneyOrderRequest.class), eq("0194f2e0-7b3e-7008-8284-5c26e8b0a008"), eq("corr-frozen")))
+            .thenThrow(new DomainRuleViolation("Account acct-frozen is FROZEN and cannot place new journey orders"));
+
+        mockMvc.perform(post("/api/v1/journey-orders")
+                .header("Idempotency-Key", "0194f2e0-7b3e-7008-8284-5c26e8b0a008")
+                .header("X-Correlation-Id", "corr-frozen")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "accountId": "acct-frozen",
+                      "offerId": "offer-1",
+                      "offerVersion": 1,
+                      "travelerRefs": ["tvl-1"],
+                      "segmentRefs": ["seg-1"]
+                    }
+                    """))
+            .andExpect(status().isUnprocessableEntity())
+            .andExpect(jsonPath("$.code").value("DOMAIN_RULE_VIOLATION"))
+            .andExpect(jsonPath("$.message").value("Account acct-frozen is FROZEN and cannot place new journey orders"))
+            .andExpect(jsonPath("$.correlationId").value("corr-frozen"));
+    }
+
     @Test
     void getOrderReturnsNotFoundThroughCanonicalHandler() throws Exception {
         when(orderService.getOrder("ord-missing")).thenReturn(Optional.empty());

--- a/services/journey-order/src/test/java/com/trainticket/journeyorder/application/OrderManagementServiceTest.java
+++ b/services/journey-order/src/test/java/com/trainticket/journeyorder/application/OrderManagementServiceTest.java
@@ -12,6 +12,7 @@ import com.trainticket.journeyorder.application.port.in.JourneyOrderRequest;
 import com.trainticket.journeyorder.application.port.in.JourneyOrderResult;
 import com.trainticket.journeyorder.application.port.in.OrderListResult;
 import com.trainticket.journeyorder.application.service.OrderManagementService;
+import com.trainticket.journeyorder.application.port.out.EventSubscriber;
 import com.trainticket.platformkit.messaging.EventEnvelope;
 import java.time.Clock;
 import java.time.Instant;
@@ -226,8 +227,89 @@ class OrderManagementServiceTest {
         assertEquals(1, published.stream().filter(event -> event.eventType().equals("JourneyOrderCancelled")).count());
     }
 
+
+    @Test
+    void unknownAccountProjectionAllowsOrderCreation() {
+        JourneyOrderResult result = service.createOrder(
+            new JourneyOrderRequest("acct-unknown", "offer-unknown", 1, List.of("tvl-1"), List.of("seg-1")),
+            "idem-account-unknown", "corr-1");
+
+        assertEquals("acct-unknown", result.accountId());
+        assertEquals("CREATED", result.status());
+    }
+
+    @Test
+    void frozenAndClosedAccountProjectionRejectsNewOrderCreationAndUnfreezeRestoresIt() {
+        service.handle(accountEvent("evt-0194f2e0-7b3e-7610-8284-5c26e8b0ca01", "AccountCreated", "acct-gated"));
+        service.createOrder(
+            new JourneyOrderRequest("acct-gated", "offer-before-freeze", 1, List.of("tvl-1"), List.of("seg-1")),
+            "idem-account-before-freeze", "corr-1");
+
+        service.handle(accountEvent("evt-0194f2e0-7b3e-7610-8284-5c26e8b0ca02", "AccountFrozen", "acct-gated"));
+        var frozen = assertThrows(com.trainticket.journeyorder.domain.DomainRuleViolation.class, () ->
+            service.createOrder(
+                new JourneyOrderRequest("acct-gated", "offer-frozen", 1, List.of("tvl-1"), List.of("seg-1")),
+                "idem-account-frozen", "corr-1"));
+        assertEquals(com.trainticket.platformkit.http.ApiErrorCode.DOMAIN_RULE_VIOLATION, frozen.code());
+
+        service.handle(accountEvent("evt-0194f2e0-7b3e-7610-8284-5c26e8b0ca03", "AccountUnfrozen", "acct-gated"));
+        JourneyOrderResult afterUnfreeze = service.createOrder(
+            new JourneyOrderRequest("acct-gated", "offer-after-unfreeze", 1, List.of("tvl-1"), List.of("seg-1")),
+            "idem-account-after-unfreeze", "corr-1");
+        assertEquals("CREATED", afterUnfreeze.status());
+
+        service.handle(accountEvent("evt-0194f2e0-7b3e-7610-8284-5c26e8b0ca04", "AccountClosed", "acct-gated"));
+        assertThrows(com.trainticket.journeyorder.domain.DomainRuleViolation.class, () ->
+            service.createOrder(
+                new JourneyOrderRequest("acct-gated", "offer-closed", 1, List.of("tvl-1"), List.of("seg-1")),
+                "idem-account-closed", "corr-1"));
+    }
+
+    @Test
+    void nonGatingAccountEventsAreIgnoredSuccessfully() {
+        List<String> eventIds = List.of(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0ca11",
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0ca12",
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0ca13"
+        );
+        List<String> eventTypes = List.of("SessionOpened", "SessionRevoked", "PreferenceUpdated");
+
+        for (int i = 0; i < eventTypes.size(); i++) {
+            EventSubscriber.HandlerResult result = service.handle(accountEvent(
+                eventIds.get(i),
+                eventTypes.get(i),
+                "acct-gated"));
+
+            assertEquals(new EventSubscriber.Success(), result);
+        }
+    }
+
+    @Test
+    void unknownEventTypeRemainsFatal() {
+        EventSubscriber.HandlerResult result = service.handle(accountEvent(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0cb01",
+            "UnknownAccountEvent",
+            "acct-gated"));
+
+        assertTrue(result instanceof EventSubscriber.FatalError);
+    }
+
     private static void assertNotNull(Object obj) {
         if (obj == null) throw new AssertionError("Expected non-null");
+    }
+
+
+    private static EventEnvelope accountEvent(String eventId, String eventType, String accountId) {
+        return new EventEnvelope(
+            eventId,
+            eventType,
+            Instant.parse("2026-07-05T10:01:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0ca99",
+            "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0ca98",
+            "account",
+            1,
+            Map.of("accountId", accountId, "occurredAt", "2026-07-05T10:01:00Z")
+        );
     }
 
     private List<EventEnvelope> published() {


### PR DESCRIPTION
## Summary
- add account command HTTP coverage and account lifecycle event publication checks
- subscribe journey-order to events:account and project account lifecycle state for create-order gating
- reject FROZEN/CLOSED projected accounts before new journey order creation while allowing unknown projections and ignoring non-gating account events
- add account gate e2e script

## Validation
- npm test (services/account): passed
- mvn test (services/journey-order): passed
- bash -n deploy/e2e/10-account-gate.sh: passed