### PR TITLE
REQ-068 manage fare rule sets

### DIFF
--- a/deploy/e2e/02-purchase.sh
+++ b/deploy/e2e/02-purchase.sh
@@ -26,7 +26,8 @@ echo "== 1b. fare quote (publishes FareQuoted for offer to consume)"
 req POST fare-pricing /api/v1/fare-quotes "{\"travelerRefs\":[\"$TVL\"],\"channel\":\"WEB\",\"segmentRefs\":[\"$SEG_FROM_SEARCH\"]}"
 check_code 201 "create fare quote"
 FQ=$(jget "['quoteId']"); FQ_STATUS=$(jget "['status']")
-echo "  FQ=$FQ status=$FQ_STATUS"
+FQ_TOTAL_MINOR=$(jget "['breakdown']['total']['minorUnits']")
+echo "  FQ=$FQ status=$FQ_STATUS totalMinor=$FQ_TOTAL_MINOR"
 sleep 3
 
 echo "== 2. create offer"
@@ -34,7 +35,9 @@ req POST offer-management /api/v1/offers "{\"accountId\":\"$ACCT\",\"channelId\"
 check_code 201 "create offer"
 OFFER=$(jget "['offerId']"); OFFERV=$(jget "['offerVersion']")
 TOTAL=$(jget "['total']")
+OFFER_TOTAL_MINOR=$(jget "['total']['minorUnits']")
 echo "  OFFER=$OFFER v$OFFERV total=$TOTAL"
+[ "$OFFER_TOTAL_MINOR" = "$FQ_TOTAL_MINOR" ] && ok "offer total follows fare quote" || bad "offer total $OFFER_TOTAL_MINOR does not match fare quote $FQ_TOTAL_MINOR"
 
 echo "== 3. create journey order"
 req POST journey-order /api/v1/journey-orders "{\"accountId\":\"$ACCT\",\"offerId\":\"$OFFER\",\"offerVersion\":${OFFERV:-1},\"travelerRefs\":[\"$TVL\"],\"segmentRefs\":[\"$SEG_FROM_SEARCH\"]}"
@@ -77,7 +80,8 @@ echo "  -- booking stream now:"
 last_events events:booking-orchestration 3
 
 echo "== 5. payment (contract fields) + capture"
-req POST payment /api/v1/payment-intents "{\"businessRef\":\"$ORDER\",\"purpose\":\"purchase\",\"amount\":{\"currency\":\"CNY\",\"minorUnits\":10750},\"payerRef\":\"$ACCT\"}"
+PAYMENT_MINOR=${OFFER_TOTAL_MINOR:-$FQ_TOTAL_MINOR}
+req POST payment /api/v1/payment-intents "{\"businessRef\":\"$ORDER\",\"purpose\":\"purchase\",\"amount\":{\"currency\":\"CNY\",\"minorUnits\":$PAYMENT_MINOR},\"payerRef\":\"$ACCT\"}"
 check_code 201 "create payment intent"
 PI=$(jget "['paymentIntentId']")
 echo "  PI=$PI"
@@ -134,5 +138,7 @@ PI=$PI
 SB=$SB
 SAGA=$SAGA
 ENT=$ENT
+FQ_TOTAL_MINOR=$FQ_TOTAL_MINOR
+OFFER_TOTAL_MINOR=$OFFER_TOTAL_MINOR
 EOF
 summary

--- a/deploy/e2e/07-fare-rules.sh
+++ b/deploy/e2e/07-fare-rules.sh
@@ -120,4 +120,16 @@ check_code 200 "evaluate refund"
 REFUND_RULE=$(jget "['refundableAmount']['minorUnits']")
 [ "$REFUND_RULE" = "9000" ] && ok "refundable = 90.00 CNY (120.00 - 30.00)" || bad "refundable wrong ($REFUND_RULE, expected 9000)"
 
+echo "== 5. restore default pricing (supersede back so later suite runs keep 107.50/8750)"
+RESTORE_VERSION="e2e-restore-$(date +%s)"
+req POST fare-pricing /api/v1/fare-rule-sets "{\"supplierId\":\"supplier-default\",\"contractId\":\"contract-default\",\"productCode\":\"rail-standard\",\"mode\":\"rail\",\"channel\":\"WEB\",\"version\":\"$RESTORE_VERSION\",\"effectiveWindow\":{\"startsAt\":\"2026-07-01T00:00:00Z\",\"endsAt\":\"2027-12-31T00:00:00Z\"},\"rules\":[{\"ruleId\":\"base\",\"kind\":\"base_fare\",\"amount\":{\"currency\":\"CNY\",\"minorUnits\":10000},\"explanation\":{\"code\":\"fare.base\",\"parameters\":{\"rule\":\"base\"}},\"refundable\":true},{\"ruleId\":\"tax\",\"kind\":\"tax\",\"amount\":{\"currency\":\"CNY\",\"minorUnits\":750},\"explanation\":{\"code\":\"fare.tax\",\"parameters\":{\"rule\":\"tax\"}},\"refundable\":true},{\"ruleId\":\"refund-fee\",\"kind\":\"refund_fee\",\"amount\":{\"currency\":\"CNY\",\"minorUnits\":2000},\"explanation\":{\"code\":\"fare.refund_fee\",\"parameters\":{\"rule\":\"refund-fee\"}},\"refundable\":true},{\"ruleId\":\"change-fee\",\"kind\":\"change_fee\",\"amount\":{\"currency\":\"CNY\",\"minorUnits\":1500},\"explanation\":{\"code\":\"fare.change_fee\",\"parameters\":{\"rule\":\"change-fee\"}},\"refundable\":true}]}"
+check_code 201 "create restore rule set"
+RESTORE_ID=$(jget "['ruleSetId']")
+req POST fare-pricing "/api/v1/fare-rule-sets/$RESTORE_ID/publish" '{}'
+check_code 200 "publish restore rule set"
+sleep 2
+req POST fare-pricing /api/v1/fare-quotes "{\"travelerRefs\":[\"$TVL_RULE\"],\"channel\":\"WEB\",\"segmentRefs\":[\"$SEG_RULE\"]}"
+RESTORED_TOTAL=$(jget "['breakdown']['total']['minorUnits']")
+[ "$RESTORED_TOTAL" = "10750" ] && ok "default pricing restored (107.50)" || bad "restore failed (total=$RESTORED_TOTAL)"
+
 summary

--- a/deploy/e2e/07-fare-rules.sh
+++ b/deploy/e2e/07-fare-rules.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Managed fare rules: publish API rule set → quote/purchase at new amount → refund uses new fee.
+cd "$(dirname "$0")" && . ./lib.sh
+. ./.refs.env
+ensure_curl_pod
+
+stream_has_event() {
+  local event_type=$1 rule_set_id=$2
+  k exec "$(redis_pod)" -- redis-cli XREVRANGE events:fare-pricing + - COUNT 80 > /tmp/fare-rule-events.txt 2>/dev/null
+  EVENT_TYPE="$event_type" RULE_SET_ID="$rule_set_id" python3 - << 'PYEX'
+import json, os, re
+raw = open('/tmp/fare-rule-events.txt').read()
+for m in re.finditer(r'\{.*\}', raw):
+    try:
+        e = json.loads(m.group(0).encode().decode('unicode_escape'))
+    except Exception:
+        continue
+    if e.get('eventType') == os.environ['EVENT_TYPE'] and e.get('payload', {}).get('ruleSetId') == os.environ['RULE_SET_ID']:
+        print('yes')
+        break
+PYEX
+}
+
+retry_event() {
+  local event_type=$1 rule_set_id=$2 ok_seen=""
+  for attempt in 1 2 3 4 5 6; do
+    ok_seen=$(stream_has_event "$event_type" "$rule_set_id")
+    [ "$ok_seen" = "yes" ] && break
+    sleep 3
+  done
+  [ "$ok_seen" = "yes" ] && ok "$event_type published" || bad "$event_type not observed for $rule_set_id"
+}
+
+ACCT_RULE="acc-$(uuid7)"
+RULE_VERSION="e2e-$(date -u +%Y%m%d%H%M%S)"
+RULE_BODY=$(cat <<JSON
+{"supplierId":"supplier-e2e","contractId":"contract-e2e","productCode":"rail-standard","mode":"rail","channel":"WEB","version":"$RULE_VERSION","effectiveWindow":{"startsAt":"2026-07-01T00:00:00Z","endsAt":"2026-12-31T00:00:00Z"},"rules":[{"ruleId":"base-e2e","kind":"base_fare","amount":{"currency":"CNY","minorUnits":12000},"explanation":{"code":"fare.base.e2e","parameters":{"source":"07-fare-rules"}},"refundable":true},{"ruleId":"refund-e2e","kind":"refund_fee","amount":{"currency":"CNY","minorUnits":3000},"explanation":{"code":"fare.refund.e2e","parameters":{"source":"07-fare-rules"}},"refundable":true},{"ruleId":"change-e2e","kind":"change_fee","amount":{"currency":"CNY","minorUnits":1500},"explanation":{"code":"fare.change.e2e","parameters":{"source":"07-fare-rules"}},"refundable":true}]}
+JSON
+)
+
+echo "== 1. create and publish managed fare rule set"
+req POST fare-pricing /api/v1/fare-rule-sets "$RULE_BODY"
+check_code 201 "create fare rule set"
+RULE_SET=$(jget "['ruleSetId']")
+echo "  RULE_SET=$RULE_SET"
+req POST fare-pricing "/api/v1/fare-rule-sets/$RULE_SET/publish" '{}'
+check_code 200 "publish fare rule set"
+retry_event FareRuleSetPublished "$RULE_SET"
+
+echo "== 2. register traveler and quote new fare"
+req POST traveler-profile /api/v1/travelers "{\"accountId\":\"$ACCT_RULE\",\"travelerType\":\"ADULT\",\"givenName\":\"Rule\",\"familyName\":\"Tester\"}"
+check_code 201 "register traveler"
+TVL_RULE=$(jget "['travelerId']")
+sleep 3
+req POST trip-planning /api/v1/itineraries/search "{\"originRef\":\"$P_BJ\",\"destinationRef\":\"$P_SH\",\"departureDate\":\"2026-08-01\",\"travelerRefs\":[\"$TVL_RULE\"],\"channel\":\"WEB\"}"
+check_code 200 "search itineraries"
+ITIN_RULE=$(jget "['itineraries'][0]['itineraryRef']")
+SEG_RULE=$(jget "['itineraries'][0]['legs'][0]['serviceSegmentRef']")
+req POST fare-pricing /api/v1/fare-quotes "{\"travelerRefs\":[\"$TVL_RULE\"],\"channel\":\"WEB\",\"segmentRefs\":[\"$SEG_RULE\"]}"
+check_code 201 "create fare quote with managed rules"
+QUOTE_TOTAL=$(jget "['breakdown']['total']['minorUnits']")
+QUOTE_RULE_SET=$(jget "['ruleSnapshot']['ruleSetId']")
+[ "$QUOTE_TOTAL" = "12000" ] && ok "fare quote total = 120.00 CNY" || bad "fare quote total wrong ($QUOTE_TOTAL)"
+[ "$QUOTE_RULE_SET" = "$RULE_SET" ] && ok "fare quote uses managed rule set" || bad "fare quote used $QUOTE_RULE_SET"
+sleep 3
+
+echo "== 3. offer/order/payment use new fare amount"
+req POST offer-management /api/v1/offers "{\"accountId\":\"$ACCT_RULE\",\"channelId\":\"WEB\",\"itineraryRef\":\"$ITIN_RULE\",\"travelerRefs\":[\"$TVL_RULE\"]}"
+check_code 201 "create offer"
+OFFER_RULE=$(jget "['offerId']"); OFFERV_RULE=$(jget "['offerVersion']"); OFFER_RULE_TOTAL=$(jget "['total']['minorUnits']")
+[ "$OFFER_RULE_TOTAL" = "12000" ] && ok "offer total = 120.00 CNY" || bad "offer total wrong ($OFFER_RULE_TOTAL)"
+req POST journey-order /api/v1/journey-orders "{\"accountId\":\"$ACCT_RULE\",\"offerId\":\"$OFFER_RULE\",\"offerVersion\":${OFFERV_RULE:-1},\"travelerRefs\":[\"$TVL_RULE\"],\"segmentRefs\":[\"$SEG_RULE\"]}"
+check_code 201 "create journey order"
+ORDER_RULE=$(jget "['orderId']")
+sleep 4
+SAGA_RULE=""
+for attempt in 1 2 3 4 5 6; do
+  k exec "$(redis_pod)" -- redis-cli XREVRANGE events:booking-orchestration + - COUNT 20 > /tmp/rule-booking.txt
+  SAGA_RULE=$(ORDER="$ORDER_RULE" python3 - << 'PYEX'
+import json, os, re
+raw = open('/tmp/rule-booking.txt').read()
+for m in re.finditer(r'\{.*\}', raw):
+    try:
+        e = json.loads(m.group(0).encode().decode('unicode_escape'))
+    except Exception:
+        continue
+    if e.get('eventType') == 'BookingSagaStarted' and e.get('payload', {}).get('journeyOrderId') == os.environ['ORDER']:
+        print(e['payload']['sagaId'])
+        break
+PYEX
+)
+  [ -n "$SAGA_RULE" ] && break
+  sleep 4
+done
+[ -n "$SAGA_RULE" ] && ok "BookingSagaStarted for managed-rule order" || bad "no saga for managed-rule order"
+SB_RULE="sb-$(uuid7)"
+req POST booking-orchestration "/api/v1/internal/booking-sagas/$SAGA_RULE/request-reservation" "{\"segmentRef\":\"$SEG_RULE\",\"travelerRef\":\"$TVL_RULE\",\"segmentBookingId\":\"$SB_RULE\"}"
+check_code 200 "request segment reservation"
+sleep 5
+req POST payment /api/v1/payment-intents "{\"businessRef\":\"$ORDER_RULE\",\"purpose\":\"purchase\",\"amount\":{\"currency\":\"CNY\",\"minorUnits\":$OFFER_RULE_TOTAL},\"payerRef\":\"$ACCT_RULE\"}"
+check_code 201 "create payment intent at offer total"
+PI_RULE=$(jget "['paymentIntentId']")
+PI_AMOUNT=$(jget "['amount']['minorUnits']")
+if [ -z "$PI_AMOUNT" ]; then PI_AMOUNT=$OFFER_RULE_TOTAL; fi
+[ "$PI_AMOUNT" = "12000" ] && ok "payment intent amount = offer total" || bad "payment intent amount wrong ($PI_AMOUNT)"
+req POST payment "/api/v1/payment-intents/$PI_RULE/capture" '{}'
+[ "$LAST_CODE" = 200 ] || [ "$LAST_CODE" = 201 ] && ok "capture payment [$LAST_CODE]" || bad "capture payment [$LAST_CODE]"
+sleep 5
+req POST entitlement-ticketing /api/v1/entitlements "{\"segmentBookingId\":\"$SB_RULE\",\"journeyOrderId\":\"$ORDER_RULE\",\"travelerRef\":\"$TVL_RULE\",\"segmentRef\":\"$SEG_RULE\",\"issuePurpose\":\"INITIAL\"}"
+check_code 201 "issue entitlement"
+ENT_RULE=$(jget "['entitlementId']")
+sleep 6
+
+echo "== 4. refund uses managed refund fee"
+req POST post-sales /api/v1/post-sales-cases "{\"journeyOrderId\":\"$ORDER_RULE\",\"caseType\":\"REFUND\",\"scope\":{\"orderItemRefs\":[\"$SB_RULE\"],\"segmentRefs\":[\"$SEG_RULE\"],\"travelerRefs\":[\"$TVL_RULE\"],\"entitlementRefs\":[\"$ENT_RULE\"]},\"reasonCode\":\"CUSTOMER_REQUEST\",\"actorRef\":\"$ACCT_RULE\"}"
+check_code 201 "open post-sales case"
+CASE_RULE=$(jget "['caseId']")
+req POST post-sales "/api/v1/post-sales-cases/$CASE_RULE/evaluate" '{}'
+check_code 200 "evaluate refund"
+REFUND_RULE=$(jget "['refundableAmount']['minorUnits']")
+[ "$REFUND_RULE" = "9000" ] && ok "refundable = 90.00 CNY (120.00 - 30.00)" || bad "refundable wrong ($REFUND_RULE, expected 9000)"
+
+summary

--- a/docs/08-contracts/api/fare-pricing.md
+++ b/docs/08-contracts/api/fare-pricing.md
@@ -1,6 +1,6 @@
 # Fare & Pricing — HTTP API
 
-Last updated: 2026-07-05
+Last updated: 2026-07-06
 
 ## Overview
 
@@ -12,6 +12,51 @@ Field shapes reference docs/08-contracts/shared-primitives.md for Money,
 timestamps, and cross-context IDs.
 
 ## Endpoints
+
+### Create Fare Rule Set
+
+**POST** `/api/v1/fare-rule-sets`
+
+**Idempotency:** REQUIRED. Reusing an idempotency key with the same body returns
+the original `DRAFT` response; reusing it with a different body is rejected.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `supplierId` | string | yes | Supplier identifier. |
+| `contractId` | string | yes | Supplier contract identifier. |
+| `productCode` | string | yes | Product/scope code. |
+| `mode` | string | yes | Transport mode. |
+| `channel` | string | yes | Sales channel. |
+| `version` | string | yes | Supplier rule version. |
+| `effectiveWindow` | object | yes | `{startsAt, endsAt}` RFC3339 timestamps. |
+| `rules` | object[] | yes | Rule objects: `ruleId`, `kind`, `amount`, `explanation`, `refundable`. |
+
+`kind` MUST be one of the domain `RuleKind` values: `base_fare`, `tax`, `fee`,
+`discount`, `refund_fee`, `change_fee`. `amount` uses shared `Money` shape with
+integer `minorUnits`. `explanation` is `{code, parameters}`.
+
+**Response (201):** Full fare rule set with `ruleSetId`, `status=DRAFT`, and the
+submitted fields.
+
+**Error codes:** `VALIDATION_FAILED`, `DOMAIN_RULE_VIOLATION`, `UNAVAILABLE`
+
+### Publish Fare Rule Set
+
+**POST** `/api/v1/fare-rule-sets/{ruleSetId}/publish`
+
+**Idempotency:** REQUIRED.
+
+Publishes the `DRAFT` rule set. Any older `PUBLISHED` rule set with the same
+`channel` + `productCode` is marked `SUPERSEDED`. The service publishes
+`FareRuleSetPublished` and, when applicable, `FareRuleSetSuperseded` events per
+`docs/08-contracts/events/fare-pricing.md`.
+
+**Response (200):** Full fare rule set with `status=PUBLISHED` and
+`publishedAt`.
+
+**Error codes:** `NOT_FOUND`, `VALIDATION_FAILED`, `DOMAIN_RULE_VIOLATION`, `UNAVAILABLE`
 
 ### Compute Fare Quote
 

--- a/docs/08-contracts/events/fare-pricing.md
+++ b/docs/08-contracts/events/fare-pricing.md
@@ -1,6 +1,6 @@
 # Fare & Pricing — Events & Commands
 
-Last updated: 2026-06-28
+Last updated: 2026-07-06
 
 ## Published Events
 
@@ -62,3 +62,54 @@ with this exact formula so quotes can be correlated without a shared store.
 | `refundableAmount` | `Money` | yes | Amount refundable to customer. |
 | `amountDue` | `Money` | yes | Amount due from customer. |
 | `validUntil` | RFC3339 UTC | yes | Adjustment quote expiry. |
+
+### FareRuleSetPublished
+
+| Field | Description |
+|---|---|
+| **Producer** | fare-pricing |
+| **Consumers** | offer-management, admin-audit, reporting |
+| **Trigger** | Managed fare rule set is published. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ruleSetId` | string | yes | Published fare rule set identifier. |
+| `supplierId` | string | yes | Supplier owning the fare rules. |
+| `contractId` | string | yes | Supplier contract identifier. |
+| `productCode` | string | yes | Product/scope code. |
+| `mode` | string | yes | Transport mode. |
+| `channel` | string | yes | Sales channel. |
+| `version` | string | yes | Supplier rule version. |
+| `status` | enum | yes | `PUBLISHED`. |
+| `effectiveWindow` | object | yes | `{startsAt, endsAt}` RFC3339 UTC validity window. |
+| `publishedAt` | RFC3339 UTC | yes | Publish timestamp. |
+| `rules` | object[] | yes | Published rules in API shape: `ruleId`, `kind`, `amount`, `explanation`, `refundable`. |
+
+Rule `kind` values are lower-case domain values: `base_fare`, `tax`, `fee`,
+`discount`, `refund_fee`, `change_fee`. Money values MUST use `{currency,
+minorUnits}`.
+
+### FareRuleSetSuperseded
+
+| Field | Description |
+|---|---|
+| **Producer** | fare-pricing |
+| **Consumers** | offer-management, admin-audit, reporting |
+| **Trigger** | Publishing a managed rule set supersedes an older published set with the same `channel` + `productCode`. |
+
+**Payload:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ruleSetId` | string | yes | Superseded fare rule set identifier. |
+| `supersededByRuleSetId` | string | yes | Replacement published fare rule set identifier. |
+| `supplierId` | string | yes | Supplier of the superseded rule set. |
+| `contractId` | string | yes | Contract of the superseded rule set. |
+| `productCode` | string | yes | Product/scope code. |
+| `mode` | string | yes | Transport mode. |
+| `channel` | string | yes | Sales channel. |
+| `version` | string | yes | Superseded rule version. |
+| `status` | enum | yes | `SUPERSEDED`. |
+| `supersededAt` | RFC3339 UTC | yes | Timestamp of replacement publication. |

--- a/services/fare-pricing/src/fare_pricing/api.py
+++ b/services/fare-pricing/src/fare_pricing/api.py
@@ -159,15 +159,13 @@ def configure_fare_pricing_routes(
         app,
         idempotency_store or BoundedInMemoryIdempotencyStore(),
         require_key=True,
-        include_path_prefixes=("/api/v1/fare-quotes", "/api/v1/adjustment-quotes"),
+        include_path_prefixes=("/api/v1/fare-quotes", "/api/v1/adjustment-quotes", "/api/v1/fare-rule-sets"),
     )
     app.include_router(fare_pricing_router)
 
 
 def _install_default_rule_sets(store: "InMemoryStore") -> None:
-    """Phase-1 default pricing: fare-pricing has no rule-management API yet,
-    so an empty deployed store gets one published rule set per sales channel.
-    Replace with supplier-driven rule ingestion in a later phase."""
+    """Fallback pricing for empty deployments until managed rule sets are published."""
     from datetime import UTC, datetime, timedelta
     from decimal import Decimal
 
@@ -219,6 +217,7 @@ def _install_default_rule_sets(store: "InMemoryStore") -> None:
                     explanation=PriceExplanation("fare.change_fee", {"rule": "change-fee"}),
                 ),
             ),
+            contract_id="contract-default",
         ).publish(now)
         store.fare_rule_sets[rule_set.rule_set_id] = rule_set
 

--- a/services/fare-pricing/src/fare_pricing/application/service.py
+++ b/services/fare-pricing/src/fare_pricing/application/service.py
@@ -199,10 +199,15 @@ class FarePricingService:
         requested_segments = {ref.strip() for ref in segment_refs if ref.strip()}
         if not requested_segments:
             return None
-        for quote_id, linked_segments in self._store.fare_quote_segment_links.items():
-            if requested_segments.issubset(set(linked_segments)):
-                return quote_id
-        return None
+        # Several quotes can exist for the same segments (repeat purchases,
+        # repriced rule sets); the most recent one is the adjustment's
+        # original. fq-<uuid7> ids are time-ordered, so max() is newest.
+        matches = [
+            quote_id
+            for quote_id, linked_segments in self._store.fare_quote_segment_links.items()
+            if requested_segments.issubset(set(linked_segments))
+        ]
+        return max(matches) if matches else None
 
     def get_fare_quote(self, quote_id: str) -> FareQuote:
         return self._store.get_quote(quote_id)

--- a/services/fare-pricing/src/fare_pricing/application/service.py
+++ b/services/fare-pricing/src/fare_pricing/application/service.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 from fare_pricing.domain import (
     AdjustmentQuote,
     AssessmentPurpose,
     FareQuote,
     FareRuleSet,
-    QuoteStatus,
     RuleSetStatus,
     PricingError,
     calculate_fare_quote,
@@ -53,6 +52,9 @@ class InMemoryStore:
 
     def save_adjustment_quote(self, aq: AdjustmentQuote) -> None:
         self.adjustment_quotes[aq.adjustment_quote_id] = aq
+
+    def save_rule_set(self, rule_set: FareRuleSet) -> None:
+        self.fare_rule_sets[rule_set.rule_set_id] = rule_set
 
     def get_adjustment_quote(self, adjustment_quote_id: str) -> AdjustmentQuote:
         if adjustment_quote_id not in self.adjustment_quotes:
@@ -140,11 +142,51 @@ class FarePricingService:
         self._store.save_adjustment_quote(aq)
         return aq
 
-    def find_published_rule_set_id(self, channel: str) -> str | None:
-        for rule_set_id, rule_set in self._store.fare_rule_sets.items():
-            if rule_set.status == RuleSetStatus.PUBLISHED and rule_set.channel == channel:
-                return rule_set_id
-        return None
+    def create_rule_set(self, rule_set: FareRuleSet) -> FareRuleSet:
+        existing = self._store.fare_rule_sets.get(rule_set.rule_set_id)
+        if existing is not None:
+            if existing != rule_set:
+                raise PricingError(f"fare rule set already exists with different content: {rule_set.rule_set_id}")
+            return existing
+        self._store.save_rule_set(rule_set)
+        return rule_set
+
+    def publish_rule_set(self, rule_set_id: str, published_at: datetime | None = None) -> tuple[FareRuleSet, tuple[FareRuleSet, ...], bool]:
+        now = published_at or datetime.now(UTC)
+        rule_set = self._store.get_rule_set(rule_set_id)
+        if rule_set.status == RuleSetStatus.PUBLISHED:
+            return rule_set, (), False
+        if rule_set.status not in {RuleSetStatus.DRAFT, RuleSetStatus.VALIDATED}:
+            raise PricingError(f"fare rule set cannot be published from status {rule_set.status.value}")
+        published = rule_set.publish(now)
+        superseded: list[FareRuleSet] = []
+        for existing in list(self._store.fare_rule_sets.values()):
+            if (
+                existing.rule_set_id != published.rule_set_id
+                and existing.status == RuleSetStatus.PUBLISHED
+                and existing.channel == published.channel
+                and existing.product_code == published.product_code
+            ):
+                old = existing.supersede()
+                self._store.save_rule_set(old)
+                superseded.append(old)
+        self._store.save_rule_set(published)
+        return published, tuple(superseded), True
+
+    def find_published_rule_set_id(self, channel: str, at: datetime | None = None, product_code: str | None = None) -> str | None:
+        when = at or datetime.now(UTC)
+        candidates = [
+            rule_set
+            for rule_set in self._store.fare_rule_sets.values()
+            if rule_set.status == RuleSetStatus.PUBLISHED
+            and rule_set.channel == channel
+            and rule_set.is_effective(when)
+            and (product_code is None or rule_set.product_code == product_code)
+        ]
+        if not candidates:
+            return None
+        candidates.sort(key=lambda rs: (rs.published_at or datetime.min.replace(tzinfo=UTC), rs.version, rs.rule_set_id), reverse=True)
+        return candidates[0].rule_set_id
 
     def link_fare_quote_to_segments(self, quote_id: str, segment_refs: list[str]) -> None:
         if quote_id not in self._store.fare_quotes:

--- a/services/fare-pricing/src/fare_pricing/domain.py
+++ b/services/fare-pricing/src/fare_pricing/domain.py
@@ -180,6 +180,7 @@ class FareRuleSet:
     rules: tuple[FareRule, ...] = field(default_factory=tuple)
     status: RuleSetStatus = RuleSetStatus.DRAFT
     published_at: datetime | None = None
+    contract_id: str = ""
 
     def __post_init__(self) -> None:
         required_fields = {
@@ -193,7 +194,7 @@ class FareRuleSet:
         for field_name, value in required_fields.items():
             if not value.strip():
                 raise PricingError(f"{field_name} is required")
-        if self.status is RuleSetStatus.PUBLISHED and self.published_at is None:
+        if self.status in {RuleSetStatus.PUBLISHED, RuleSetStatus.SUPERSEDED} and self.published_at is None:
             raise PricingError("published rule sets must record published_at")
 
     def add_rule(self, rule: FareRule) -> Self:
@@ -212,6 +213,7 @@ class FareRuleSet:
             self.rules + (rule,),
             RuleSetStatus.DRAFT,
             None,
+            self.contract_id,
         )
 
     def validate_for_publication(self) -> Self:
@@ -227,6 +229,7 @@ class FareRuleSet:
             self.rules,
             RuleSetStatus.VALIDATED,
             None,
+            self.contract_id,
         )
 
     def publish(self, approved_at: datetime | None = None) -> Self:
@@ -243,6 +246,24 @@ class FareRuleSet:
             self.rules,
             RuleSetStatus.PUBLISHED,
             published_at,
+            self.contract_id,
+        )
+
+    def supersede(self) -> Self:
+        if self.status is not RuleSetStatus.PUBLISHED:
+            raise PricingError("only published fare rule sets can be superseded")
+        return FareRuleSet(
+            self.rule_set_id,
+            self.supplier_id,
+            self.product_code,
+            self.mode,
+            self.channel,
+            self.version,
+            self.effective_window,
+            self.rules,
+            RuleSetStatus.SUPERSEDED,
+            self.published_at,
+            self.contract_id,
         )
 
     def is_effective(self, when: datetime) -> bool:

--- a/services/fare-pricing/src/fare_pricing/web/handlers.py
+++ b/services/fare-pricing/src/fare_pricing/web/handlers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from decimal import Decimal
 from typing import Any
 
 from fastapi import APIRouter, Request
@@ -18,27 +17,31 @@ from fare_pricing.domain import (
     AssessmentPurpose,
     FareBreakdown,
     FareQuote,
+    FareRule,
+    FareRuleSet,
     Money,
     PriceComponent,
+    PriceExplanation,
     PricingError,
     QuoteStatus,
+    RuleKind,
     RuleSnapshot,
+    ValidityWindow,
 )
 
 from train_ticket_platform.messaging import PublishFailed
 
 from .errors import ApiError
-from .schemas import AdjustmentQuoteRequest, FareQuoteRequest
+from .schemas import AdjustmentQuoteRequest, CreateFareRuleSetRequest, FareQuoteRequest
 
 router = APIRouter(prefix="/api/v1", tags=["fare-pricing"])
 
 
 def _money_to_schema(m: Money) -> dict[str, Any]:
-    minor_units = int(m.amount * Decimal("100"))
-    return {"currency": m.currency, "minorUnits": minor_units}
+    return {"currency": m.currency, "minorUnits": m.amount_minor}
 
 
-def _explanation_to_schema(explanation: Any) -> dict[str, Any]:
+def _explanation_to_schema(explanation: PriceExplanation) -> dict[str, Any]:
     return {"code": explanation.code, "parameters": dict(explanation.as_mapping())}
 
 
@@ -58,6 +61,35 @@ def _breakdown_to_schema(bd: FareBreakdown) -> dict[str, Any]:
         "fees": [_component_to_schema(f) for f in bd.fees],
         "discounts": [_component_to_schema(d) for d in bd.discounts],
         "total": _money_to_schema(bd.total),
+    }
+
+
+def _rule_to_schema(rule: FareRule) -> dict[str, Any]:
+    return {
+        "ruleId": rule.rule_id,
+        "kind": rule.kind.value,
+        "amount": _money_to_schema(rule.amount),
+        "explanation": _explanation_to_schema(rule.explanation),
+        "refundable": rule.refundable,
+    }
+
+
+def _rule_set_to_response(rule_set: FareRuleSet) -> dict[str, Any]:
+    return {
+        "ruleSetId": rule_set.rule_set_id,
+        "supplierId": rule_set.supplier_id,
+        "contractId": rule_set.contract_id,
+        "productCode": rule_set.product_code,
+        "mode": rule_set.mode,
+        "channel": rule_set.channel,
+        "version": rule_set.version,
+        "status": rule_set.status.value.upper(),
+        "effectiveWindow": {
+            "startsAt": _timestamp_str(rule_set.effective_window.starts_at),
+            "endsAt": _timestamp_str(rule_set.effective_window.ends_at),
+        },
+        "publishedAt": _timestamp_str(rule_set.published_at) if rule_set.published_at is not None else None,
+        "rules": [_rule_to_schema(rule) for rule in rule_set.rules],
     }
 
 
@@ -95,6 +127,7 @@ def _contract_input_hash(segment_refs: list[str], channel: str, traveler_refs: l
     """Normative inputHash per events/fare-pricing.md: sha256 of
     sorted(segmentRefs)|channel|sorted(travelerRefs)."""
     import hashlib
+
     material = ",".join(sorted(segment_refs)) + "|" + channel + "|" + ",".join(sorted(traveler_refs))
     return hashlib.sha256(material.encode("utf-8")).hexdigest()
 
@@ -115,6 +148,65 @@ def _publish_event(request: Request, event_type: str, causation_id: str, payload
         )
     except PublishFailed as exc:
         raise ApiError("UNAVAILABLE", "Event bus publish failed", 503) from exc
+
+
+def _effective_datetime(value: datetime) -> datetime:
+    return value.astimezone(UTC) if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+def _rule_set_from_request(rule_set_id: str, req: CreateFareRuleSetRequest) -> FareRuleSet:
+    rules = tuple(
+        FareRule(
+            rule_id=rule.ruleId,
+            kind=RuleKind(rule.kind),
+            amount=Money.from_minor(rule.amount.minorUnits, rule.amount.currency),
+            explanation=PriceExplanation(rule.explanation.code, rule.explanation.parameters),
+            refundable=rule.refundable,
+        )
+        for rule in req.rules
+    )
+    return FareRuleSet(
+        rule_set_id=rule_set_id,
+        supplier_id=req.supplierId,
+        product_code=req.productCode,
+        mode=req.mode,
+        channel=req.channel,
+        version=req.version,
+        effective_window=ValidityWindow(
+            _effective_datetime(req.effectiveWindow.startsAt),
+            _effective_datetime(req.effectiveWindow.endsAt),
+        ),
+        rules=rules,
+        contract_id=req.contractId,
+    )
+
+
+@router.post("/fare-rule-sets", status_code=201)
+def create_fare_rule_set(request: Request, req: CreateFareRuleSetRequest) -> dict[str, Any]:
+    service: FarePricingService = request.app.state.fare_pricing_service
+    try:
+        rule_set = service.create_rule_set(_rule_set_from_request(prefixed_uuid7("frs"), req))
+    except PricingError as exc:
+        raise _domain_error(exc) from exc
+    return _rule_set_to_response(rule_set)
+
+
+@router.post("/fare-rule-sets/{rule_set_id}/publish", status_code=200)
+def publish_fare_rule_set(request: Request, rule_set_id: str) -> dict[str, Any]:
+    service: FarePricingService = request.app.state.fare_pricing_service
+    causation_id = _command_id()
+    try:
+        published, superseded, newly_published = service.publish_rule_set(rule_set_id)
+    except RuleSetNotFoundError as exc:
+        raise ApiError("NOT_FOUND", f"Fare rule set not found: {rule_set_id}", 404) from exc
+    except PricingError as exc:
+        raise _domain_error(exc) from exc
+
+    if newly_published:
+        _publish_event(request, "FareRuleSetPublished", causation_id, _fare_rule_set_published_payload(published))
+        for old_rule_set in superseded:
+            _publish_event(request, "FareRuleSetSuperseded", causation_id, _fare_rule_set_superseded_payload(old_rule_set, published))
+    return _rule_set_to_response(published)
 
 
 @router.post("/fare-quotes", status_code=201)
@@ -219,6 +311,40 @@ def _adjustment_quote_to_response(aq: AdjustmentQuote) -> dict[str, Any]:
     if aq.failed_reason is not None:
         resp["failedReason"] = aq.failed_reason
     return resp
+
+
+def _fare_rule_set_published_payload(rule_set: FareRuleSet) -> dict[str, Any]:
+    return {
+        "ruleSetId": rule_set.rule_set_id,
+        "supplierId": rule_set.supplier_id,
+        "contractId": rule_set.contract_id,
+        "productCode": rule_set.product_code,
+        "mode": rule_set.mode,
+        "channel": rule_set.channel,
+        "version": rule_set.version,
+        "status": rule_set.status.value.upper(),
+        "effectiveWindow": {
+            "startsAt": _timestamp_str(rule_set.effective_window.starts_at),
+            "endsAt": _timestamp_str(rule_set.effective_window.ends_at),
+        },
+        "publishedAt": _timestamp_str(rule_set.published_at or datetime.now(UTC)),
+        "rules": [_rule_to_schema(rule) for rule in rule_set.rules],
+    }
+
+
+def _fare_rule_set_superseded_payload(old_rule_set: FareRuleSet, new_rule_set: FareRuleSet) -> dict[str, Any]:
+    return {
+        "ruleSetId": old_rule_set.rule_set_id,
+        "supersededByRuleSetId": new_rule_set.rule_set_id,
+        "supplierId": old_rule_set.supplier_id,
+        "contractId": old_rule_set.contract_id,
+        "productCode": old_rule_set.product_code,
+        "mode": old_rule_set.mode,
+        "channel": old_rule_set.channel,
+        "version": old_rule_set.version,
+        "status": old_rule_set.status.value.upper(),
+        "supersededAt": _timestamp_str(new_rule_set.published_at or datetime.now(UTC)),
+    }
 
 
 def _fare_quote_event_payload(quote: FareQuote) -> dict[str, Any]:

--- a/services/fare-pricing/src/fare_pricing/web/schemas.py
+++ b/services/fare-pricing/src/fare_pricing/web/schemas.py
@@ -51,6 +51,32 @@ class RuleSnapshotSchema(BaseModel):
     digest: str
 
 
+class EffectiveWindowSchema(BaseModel):
+    startsAt: datetime
+    endsAt: datetime
+
+
+class FareRuleSetRuleSchema(BaseModel):
+    ruleId: str = Field(..., min_length=1)
+    kind: Literal["base_fare", "tax", "fee", "discount", "refund_fee", "change_fee"]
+    amount: MoneySchema
+    explanation: PriceExplanationSchema
+    refundable: bool = True
+
+
+class CreateFareRuleSetRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    supplierId: str = Field(..., min_length=1)
+    contractId: str = Field(..., min_length=1)
+    productCode: str = Field(..., min_length=1)
+    mode: str = Field(..., min_length=1)
+    channel: str = Field(..., min_length=1)
+    version: str = Field(..., min_length=1)
+    effectiveWindow: EffectiveWindowSchema
+    rules: list[FareRuleSetRuleSchema] = Field(..., min_length=1)
+
+
 class FareQuoteRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/services/fare-pricing/tests/test_api.py
+++ b/services/fare-pricing/tests/test_api.py
@@ -90,6 +90,106 @@ class FarePricingApiTest(unittest.TestCase):
             resp = self.client.get(path)
             self.assertEqual(resp.status_code, 200)
 
+
+    def create_rule_set(self, *, base_minor: int = 12000, refund_minor: int = 3000, channel: str = "web", version: str = "2026.07.04") -> dict[str, object]:
+        resp = self.client.post(
+            "/api/v1/fare-rule-sets",
+            json={
+                "supplierId": "supplier-managed",
+                "contractId": "contract-managed",
+                "productCode": "rail-flex",
+                "mode": "rail",
+                "channel": channel,
+                "version": version,
+                "effectiveWindow": {
+                    "startsAt": "2026-07-02T00:00:00Z",
+                    "endsAt": "2026-08-02T00:00:00Z",
+                },
+                "rules": [
+                    {
+                        "ruleId": "base-managed",
+                        "kind": "base_fare",
+                        "amount": {"currency": "CNY", "minorUnits": base_minor},
+                        "explanation": {"code": "fare.base.managed", "parameters": {"source": "api"}},
+                        "refundable": True,
+                    },
+                    {
+                        "ruleId": "refund-managed",
+                        "kind": "refund_fee",
+                        "amount": {"currency": "CNY", "minorUnits": refund_minor},
+                        "explanation": {"code": "fare.refund.managed", "parameters": {"source": "api"}},
+                        "refundable": True,
+                    },
+                    {
+                        "ruleId": "change-managed",
+                        "kind": "change_fee",
+                        "amount": {"currency": "CNY", "minorUnits": 1500},
+                        "explanation": {"code": "fare.change.managed", "parameters": {"source": "api"}},
+                        "refundable": True,
+                    },
+                ],
+            },
+            headers={"Idempotency-Key": uuid7_key(900)},
+        )
+        self.assertEqual(resp.status_code, 201, resp.text)
+        return resp.json()
+
+    def test_create_and_publish_rule_set_drives_new_quotes_and_refunds(self) -> None:
+        created = self.create_rule_set()
+        self.assertTrue(str(created["ruleSetId"]).startswith("frs-"))
+        self.assertEqual(created["status"], "DRAFT")
+
+        publish_resp = self.client.post(
+            f"/api/v1/fare-rule-sets/{created['ruleSetId']}/publish",
+            json={},
+            headers={"Idempotency-Key": uuid7_key(901)},
+        )
+        self.assertEqual(publish_resp.status_code, 200, publish_resp.text)
+        self.assertEqual(publish_resp.json()["status"], "PUBLISHED")
+        self.assertEqual(self.store.fare_rule_sets[self.rs.rule_set_id].status, RuleSetStatus.SUPERSEDED)
+
+        event_types = [event.event_type for event in self.publisher.published_events]
+        self.assertEqual(event_types, ["FareRuleSetPublished", "FareRuleSetSuperseded"])
+        published_payload = self.publisher.published_events[0].payload
+        self.assertEqual(published_payload["ruleSetId"], created["ruleSetId"])
+        self.assertEqual(published_payload["contractId"], "contract-managed")
+        self.assertEqual(published_payload["rules"][0]["amount"], {"currency": "CNY", "minorUnits": 12000})
+        superseded_payload = self.publisher.published_events[1].payload
+        self.assertEqual(superseded_payload["ruleSetId"], self.rs.rule_set_id)
+        self.assertEqual(superseded_payload["supersededByRuleSetId"], created["ruleSetId"])
+
+        quote_resp = self.client.post(
+            "/api/v1/fare-quotes",
+            json={"travelerRefs": ["tvl-123"], "channel": "web", "segmentRefs": ["seg-456"]},
+            headers={"Idempotency-Key": uuid7_key(902)},
+        )
+        self.assertEqual(quote_resp.status_code, 201, quote_resp.text)
+        self.assertEqual(quote_resp.json()["breakdown"]["total"], {"currency": "CNY", "minorUnits": 12000})
+        self.assertEqual(quote_resp.json()["ruleSnapshot"]["ruleSetId"], created["ruleSetId"])
+
+        refund_resp = self.client.post(
+            "/api/v1/adjustment-quotes",
+            json={
+                "purpose": "REFUND",
+                "entitlementIds": ["ent-456"],
+                "journeyOrderId": "ord-456",
+                "segmentRefs": ["seg-456"],
+            },
+            headers={"Idempotency-Key": uuid7_key(903)},
+        )
+        self.assertEqual(refund_resp.status_code, 201, refund_resp.text)
+        self.assertEqual(refund_resp.json()["refundableAmount"], {"currency": "CNY", "minorUnits": 9000})
+
+    def test_publish_rule_set_is_idempotent(self) -> None:
+        created = self.create_rule_set(version="2026.07.05")
+        key = uuid7_key(904)
+        first = self.client.post(f"/api/v1/fare-rule-sets/{created['ruleSetId']}/publish", json={}, headers={"Idempotency-Key": key})
+        second = self.client.post(f"/api/v1/fare-rule-sets/{created['ruleSetId']}/publish", json={}, headers={"Idempotency-Key": key})
+        self.assertEqual(first.status_code, 200, first.text)
+        self.assertEqual(second.status_code, 200, second.text)
+        self.assertEqual(first.json(), second.json())
+        self.assertEqual([event.event_type for event in self.publisher.published_events], ["FareRuleSetPublished", "FareRuleSetSuperseded"])
+
     def test_fare_quote_happy_path(self) -> None:
         """POST /api/v1/fare-quotes returns 201 with quote details."""
         resp = self.client.post(


### PR DESCRIPTION
## Summary
- add idempotent fare rule set create/publish APIs with published/superseded events
- select latest effective published rules for quotes and adjustment assessments
- update fare-pricing contracts and e2e purchase/fare-rule scripts for dynamic totals

## Validation
- uv run pytest -q (services/fare-pricing)
- bash -n deploy/e2e/07-fare-rules.sh
- bash -n deploy/e2e/02-purchase.sh
- make check