### PR TITLE
REQ-067 ManualAction execution closure

### DIFF
--- a/deploy/e2e/09-manual-action.sh
+++ b/deploy/e2e/09-manual-action.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# ManualAction closure: customer-service request -> admin-audit approval/execution -> customer-service timeline.
+cd "$(dirname "$0")" && . ./lib.sh
+ensure_curl_pod
+
+if [ ! -f ./.refs.env ] || ! grep -q '^ORDER=' ./.refs.env; then
+  echo "== prerequisite purchase refs missing; running 02-purchase.sh"
+  bash ./02-purchase.sh
+fi
+. ./.refs.env
+
+retry() {
+  local description=$1 command=$2 attempts=${3:-4} delay=${4:-5}
+  for attempt in $(seq 1 "$attempts"); do
+    if eval "$command"; then ok "$description"; return 0; fi
+    sleep "$delay"
+  done
+  bad "$description"
+  return 1
+}
+
+stream_has_event() {
+  local stream=$1 event_type=$2 manual_action_id=$3
+  k exec "$(redis_pod)" -- redis-cli --no-raw XREVRANGE "$stream" + - COUNT 50 > /tmp/manual-action-stream.txt
+  EVENT_TYPE="$event_type" MANUAL_ACTION_ID="$manual_action_id" python3 - <<'PY'
+import json, os, re, sys
+raw = open('/tmp/manual-action-stream.txt').read()
+for match in re.finditer(r'\{.*\}', raw):
+    try:
+        envelope = json.loads(match.group(0).encode().decode('unicode_escape'))
+    except Exception:
+        continue
+    if envelope.get('eventType') == os.environ['EVENT_TYPE'] and envelope.get('payload', {}).get('manualActionId') == os.environ['MANUAL_ACTION_ID']:
+        sys.exit(0)
+sys.exit(1)
+PY
+}
+
+timeline_has_manual_result() {
+  req GET customer-service "/api/v1/support-cases/$CASE"
+  [ "$LAST_CODE" = 200 ] || return 1
+  tmp=/tmp/manual-action-case.json
+  printf '%s' "$RESP" > "$tmp"
+  MANUAL_ACTION_ID="$MA" python3 - <<'PY'
+import json, os, sys
+with open('/tmp/manual-action-case.json') as f:
+    case = json.load(f)
+for entry in case.get('timeline', []):
+    if entry.get('eventType') == 'ManualActionResultRecorded' and entry.get('payload', {}).get('manualActionId') == os.environ['MANUAL_ACTION_ID']:
+        sys.exit(0)
+sys.exit(1)
+PY
+}
+
+echo "== 1. open support case for purchased order"
+req POST customer-service /api/v1/support-cases "{\"requesterRef\":\"${TVL:-tvl-manual}\",\"channel\":\"APP\",\"priority\":\"NORMAL\",\"description\":\"Manual refund review\",\"businessReferences\":{\"journeyOrderId\":\"$ORDER\"}}"
+check_code 201 "open support case"
+CASE=$(jget "['caseId']")
+echo "  CASE=$CASE"
+
+echo "== 2. request manual action through customer-service"
+req POST customer-service "/api/v1/support-cases/$CASE/manual-action-requests" "{\"targetDomain\":\"post-sales\",\"commandType\":\"ManualRefundReviewRequested\",\"operatorRef\":\"op-manual-requester\",\"reason\":\"CUSTOMER_REQUEST\",\"description\":\"Review refund eligibility\",\"requiresApproval\":true}"
+[ "$LAST_CODE" = 202 ] && ok "request manual action [$LAST_CODE]" || bad "request manual action [got $LAST_CODE want 202]"
+MA=$(jget "['manualActionId']")
+echo "  MA=$MA"
+
+retry "admin-audit consumed pending request" "stream_has_event events:customer-service ManualActionRequested '$MA' && k exec \$(redis_pod) -- redis-cli --no-raw XREVRANGE events:admin-audit + - COUNT 50 >/tmp/admin-audit-stream.txt && grep -q '$MA' /tmp/admin-audit-stream.txt" 4 5
+
+echo "== 3. register approver and approve (admin-audit records execution fact in phase 1)"
+req POST admin-audit /api/v1/admin/operators '{"email":"manual-approver@example.com","role":"ADMIN","scopes":["OPERATOR_WRITE","AUDIT_READ"],"displayName":"Manual Approver"}'
+check_code 201 "register admin-audit approver"
+APPROVER=$(jget "['operatorId']")
+req POST admin-audit "/api/v1/admin/manual-actions/$MA/approve" "{"approvedByOperatorId":"$APPROVER"}"
+[ "$LAST_CODE" = 200 ] && ok "approve manual action [$LAST_CODE]" || bad "approve manual action [got $LAST_CODE want 200]"
+
+retry "ManualActionExecuted published" "stream_has_event events:admin-audit ManualActionExecuted '$MA'" 4 5
+retry "customer-service timeline records ManualActionResultRecorded" "timeline_has_manual_result" 4 5
+
+summary

--- a/deploy/e2e/09-manual-action.sh
+++ b/deploy/e2e/09-manual-action.sh
@@ -70,7 +70,7 @@ echo "== 3. register approver and approve (admin-audit records execution fact in
 req POST admin-audit /api/v1/admin/operators '{"email":"manual-approver@example.com","role":"ADMIN","scopes":["OPERATOR_WRITE","AUDIT_READ"],"displayName":"Manual Approver"}'
 check_code 201 "register admin-audit approver"
 APPROVER=$(jget "['operatorId']")
-req POST admin-audit "/api/v1/admin/manual-actions/$MA/approve" "{"approvedByOperatorId":"$APPROVER"}"
+req POST admin-audit "/api/v1/admin/manual-actions/$MA/approve" "{\"approvedByOperatorId\":\"$APPROVER\"}"
 [ "$LAST_CODE" = 200 ] && ok "approve manual action [$LAST_CODE]" || bad "approve manual action [got $LAST_CODE want 200]"
 
 retry "ManualActionExecuted published" "stream_has_event events:admin-audit ManualActionExecuted '$MA'" 4 5

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/http/AdminAuditController.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/http/AdminAuditController.java
@@ -81,7 +81,6 @@ public class AdminAuditController {
         )));
     }
 
-
     @PostMapping("/manual-actions/{manualActionId}/reject")
     public ResponseEntity<Object> rejectManualAction(
         @PathVariable String manualActionId,
@@ -90,27 +89,11 @@ public class AdminAuditController {
         HttpServletRequest httpRequest
     ) {
         request.validate();
-        RejectFingerprint fingerprint = new RejectFingerprint(manualActionId, request.rejectedByOperatorId(), request.reason());
+        RejectFingerprint fingerprint = new RejectFingerprint(manualActionId, request.operatorRef(), request.reason());
         return idempotency.execute(idempotencyKey, fingerprint, 200, () -> ManualActionResponse.from(service.rejectManualAction(
             manualActionId,
-            request.rejectedByOperatorId(),
+            request.operatorRef(),
             request.reason(),
-            correlationId(httpRequest)
-        )));
-    }
-
-    @PostMapping("/manual-actions/{manualActionId}/execute")
-    public ResponseEntity<Object> executeManualAction(
-        @PathVariable String manualActionId,
-        @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
-        @RequestBody ExecuteManualActionRequest request,
-        HttpServletRequest httpRequest
-    ) {
-        request.validate();
-        ExecuteFingerprint fingerprint = new ExecuteFingerprint(manualActionId, request.resultSummary());
-        return idempotency.execute(idempotencyKey, fingerprint, 200, () -> ManualActionResponse.from(service.executeManualAction(
-            manualActionId,
-            request.resultSummary(),
             correlationId(httpRequest)
         )));
     }
@@ -183,23 +166,15 @@ public class AdminAuditController {
         }
     }
 
-
-    public record RejectManualActionRequest(String rejectedByOperatorId, String reason) {
+    public record RejectManualActionRequest(String operatorRef, String reason) {
         void validate() {
-            requireText(rejectedByOperatorId, "rejectedByOperatorId");
+            requireText(operatorRef, "operatorRef");
             requireText(reason, "reason");
         }
     }
 
-    public record ExecuteManualActionRequest(String resultSummary) {
-        void validate() {
-            requireText(resultSummary, "resultSummary");
-        }
-    }
-
     private record ApproveFingerprint(String manualActionId, String approvedByOperatorId) {}
-    private record RejectFingerprint(String manualActionId, String rejectedByOperatorId, String reason) {}
-    private record ExecuteFingerprint(String manualActionId, String resultSummary) {}
+    private record RejectFingerprint(String manualActionId, String operatorRef, String reason) {}
 
     public record OperatorResponse(String operatorId, String email, String role, List<String> scopes, String status) {
         static OperatorResponse from(OperatorIdentity operator) {

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/http/AdminAuditController.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/http/AdminAuditController.java
@@ -81,6 +81,40 @@ public class AdminAuditController {
         )));
     }
 
+
+    @PostMapping("/manual-actions/{manualActionId}/reject")
+    public ResponseEntity<Object> rejectManualAction(
+        @PathVariable String manualActionId,
+        @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
+        @RequestBody RejectManualActionRequest request,
+        HttpServletRequest httpRequest
+    ) {
+        request.validate();
+        RejectFingerprint fingerprint = new RejectFingerprint(manualActionId, request.rejectedByOperatorId(), request.reason());
+        return idempotency.execute(idempotencyKey, fingerprint, 200, () -> ManualActionResponse.from(service.rejectManualAction(
+            manualActionId,
+            request.rejectedByOperatorId(),
+            request.reason(),
+            correlationId(httpRequest)
+        )));
+    }
+
+    @PostMapping("/manual-actions/{manualActionId}/execute")
+    public ResponseEntity<Object> executeManualAction(
+        @PathVariable String manualActionId,
+        @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
+        @RequestBody ExecuteManualActionRequest request,
+        HttpServletRequest httpRequest
+    ) {
+        request.validate();
+        ExecuteFingerprint fingerprint = new ExecuteFingerprint(manualActionId, request.resultSummary());
+        return idempotency.execute(idempotencyKey, fingerprint, 200, () -> ManualActionResponse.from(service.executeManualAction(
+            manualActionId,
+            request.resultSummary(),
+            correlationId(httpRequest)
+        )));
+    }
+
     @GetMapping("/audit-trail")
     public AuditTrailPage listAuditTrail(
         @RequestParam(value = "businessRef", required = false) String businessRef,
@@ -149,7 +183,23 @@ public class AdminAuditController {
         }
     }
 
+
+    public record RejectManualActionRequest(String rejectedByOperatorId, String reason) {
+        void validate() {
+            requireText(rejectedByOperatorId, "rejectedByOperatorId");
+            requireText(reason, "reason");
+        }
+    }
+
+    public record ExecuteManualActionRequest(String resultSummary) {
+        void validate() {
+            requireText(resultSummary, "resultSummary");
+        }
+    }
+
     private record ApproveFingerprint(String manualActionId, String approvedByOperatorId) {}
+    private record RejectFingerprint(String manualActionId, String rejectedByOperatorId, String reason) {}
+    private record ExecuteFingerprint(String manualActionId, String resultSummary) {}
 
     public record OperatorResponse(String operatorId, String email, String role, List<String> scopes, String status) {
         static OperatorResponse from(OperatorIdentity operator) {
@@ -191,7 +241,7 @@ public class AdminAuditController {
 
     public record ApprovalResponse(String manualActionId, String status) {
         static ApprovalResponse from(ManualAction action) {
-            return new ApprovalResponse(action.manualActionId(), action.state().name());
+            return new ApprovalResponse(action.manualActionId(), "APPROVED");
         }
     }
 

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/messaging/AdminAuditSubscriptionRunner.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/messaging/AdminAuditSubscriptionRunner.java
@@ -1,0 +1,40 @@
+package com.trainticket.adminaudit.adapters.messaging;
+
+import com.trainticket.adminaudit.application.AdminAuditInboundEventHandler;
+import com.trainticket.adminaudit.application.ports.EventSubscriber;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "ADMIN_AUDIT_REDIS_ENABLED", havingValue = "true", matchIfMissing = true)
+public class AdminAuditSubscriptionRunner implements CommandLineRunner {
+    static final List<String> SUBSCRIBED_STREAMS = List.of("events:customer-service");
+    static final String CONSUMER_GROUP = "admin-audit";
+
+    private final EventSubscriber subscriber;
+    private final ConsumedEventLog consumedEventLog;
+    private final AdminAuditInboundEventHandler handler;
+
+    public AdminAuditSubscriptionRunner(
+        EventSubscriber subscriber,
+        ConsumedEventLog consumedEventLog,
+        AdminAuditInboundEventHandler handler
+    ) {
+        this.subscriber = subscriber;
+        this.consumedEventLog = consumedEventLog;
+        this.handler = handler;
+    }
+
+    @Override
+    public void run(String... args) {
+        subscriber.subscribe(
+            SUBSCRIBED_STREAMS,
+            CONSUMER_GROUP,
+            CONSUMER_GROUP + "-" + UUID.randomUUID(),
+            new DeduplicatingEventHandler(consumedEventLog, handler)
+        );
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/AdminAuditInboundEventHandler.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/AdminAuditInboundEventHandler.java
@@ -1,0 +1,44 @@
+package com.trainticket.adminaudit.application;
+
+import com.trainticket.adminaudit.application.ports.EventSubscriber;
+import com.trainticket.adminaudit.domain.DomainRuleViolation;
+import com.trainticket.platformkit.messaging.EventEnvelope;
+import java.util.Objects;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AdminAuditInboundEventHandler implements EventSubscriber.EventHandler {
+    private final AdminAuditService service;
+
+    public AdminAuditInboundEventHandler(AdminAuditService service) {
+        this.service = Objects.requireNonNull(service, "service is required");
+    }
+
+    @Override
+    public EventSubscriber.HandlerResult handle(EventEnvelope envelope) {
+        if (!"customer-service".equals(envelope.producer()) || !"ManualActionRequested".equals(envelope.eventType())) {
+            return EventSubscriber.HandlerResult.SUCCESS;
+        }
+        try {
+            InboundEventPayload payload = InboundEventPayload.from(envelope);
+            service.recordCustomerManualActionRequest(
+                envelope.eventId(),
+                payload.requiredText("manualActionId"),
+                payload.requiredText("caseId"),
+                payload.requiredText("targetDomain"),
+                payload.requiredText("commandType"),
+                payload.requiredText("operatorRef"),
+                payload.requiredText("reason"),
+                payload.requiredText("description"),
+                payload.requiredBoolean("requiresApproval"),
+                envelope.occurredAt(),
+                envelope.correlationId()
+            );
+            return EventSubscriber.HandlerResult.SUCCESS;
+        } catch (ValidationException | DomainRuleViolation | IllegalArgumentException exception) {
+            return EventSubscriber.HandlerResult.FATAL_FAILURE;
+        } catch (RuntimeException exception) {
+            return EventSubscriber.HandlerResult.TRANSIENT_FAILURE;
+        }
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/AdminAuditService.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/AdminAuditService.java
@@ -3,6 +3,7 @@ package com.trainticket.adminaudit.application;
 import org.springframework.beans.factory.annotation.Autowired;
 import com.trainticket.adminaudit.application.ports.AdminAuditRepository;
 import com.trainticket.platformkit.messaging.EventEnvelope;
+import com.trainticket.platformkit.messaging.PrefixedIds;
 import com.trainticket.adminaudit.application.ports.EventPublisher;
 import com.trainticket.adminaudit.domain.AdminAuditEvent;
 import com.trainticket.adminaudit.domain.AuditEntry;
@@ -133,6 +134,124 @@ public class AdminAuditService {
             normalizeCorrelationId(correlationId),
             "Manual action approved: " + action.manualActionId()
         );
+
+        int afterApprovalPublished = action.domainEvents().size();
+        try {
+            action.execute(
+                "Manual action execution recorded",
+                Instant.now(clock),
+                newCommandId(),
+                normalizeCorrelationId(correlationId)
+            );
+        } catch (DomainRuleViolation violation) {
+            throw new PreconditionFailedException(violation.getMessage(), violation);
+        }
+        repository.saveManualAction(action);
+        publish(action.domainEvents().subList(afterApprovalPublished, action.domainEvents().size()));
+        recordAudit(
+            approver.operatorId(),
+            approver.email(),
+            "MANUAL_ACTION_EXECUTED",
+            action.businessRef(),
+            action.targetDomain(),
+            action.reasonCode(),
+            normalizeCorrelationId(correlationId),
+            action.resultSummary()
+        );
+        return action;
+    }
+
+    public ManualAction recordCustomerManualActionRequest(
+        String sourceEventId,
+        String manualActionId,
+        String caseId,
+        String targetDomain,
+        String commandType,
+        String operatorRef,
+        String reason,
+        String description,
+        boolean requiresApproval,
+        Instant requestedAt,
+        String correlationId
+    ) {
+        if (repository.findManualAction(manualActionId).isPresent()) {
+            return repository.findManualAction(manualActionId).orElseThrow();
+        }
+        ManualAction action = ManualAction.requestWithId(
+            manualActionId,
+            targetDomain,
+            commandType,
+            caseId,
+            reason,
+            description,
+            new OperatorRef(operatorRef, operatorRef),
+            requiresApproval,
+            requestedAt,
+            sourceEventId,
+            normalizeCorrelationId(correlationId)
+        );
+        repository.saveManualAction(action);
+        recordAudit(
+            operatorRef,
+            operatorRef,
+            "MANUAL_ACTION_REQUEST_INTAKEN",
+            caseId,
+            targetDomain,
+            reason,
+            normalizeCorrelationId(correlationId),
+            "Manual action intake recorded: " + manualActionId
+        );
+        return action;
+    }
+
+    public ManualAction rejectManualAction(String manualActionId, String rejectedByOperatorId, String reason, String correlationId) {
+        ManualAction action = repository.findManualAction(manualActionId)
+            .orElseThrow(() -> new NotFoundException("manual action not found"));
+        OperatorRef rejectedBy = repository.findOperator(rejectedByOperatorId)
+            .map(operator -> new OperatorRef(operator.operatorId(), operator.email()))
+            .orElseGet(() -> new OperatorRef(rejectedByOperatorId, rejectedByOperatorId));
+        int alreadyPublished = action.domainEvents().size();
+        try {
+            action.reject(rejectedBy, reason, Instant.now(clock), newCommandId(), normalizeCorrelationId(correlationId));
+        } catch (DomainRuleViolation violation) {
+            throw new PreconditionFailedException(violation.getMessage(), violation);
+        }
+        repository.saveManualAction(action);
+        publish(action.domainEvents().subList(alreadyPublished, action.domainEvents().size()));
+        recordAudit(
+            rejectedBy.operatorId(),
+            rejectedBy.displayName(),
+            "MANUAL_ACTION_REJECTED",
+            action.businessRef(),
+            action.targetDomain(),
+            action.reasonCode(),
+            normalizeCorrelationId(correlationId),
+            "Manual action rejected: " + action.manualActionId()
+        );
+        return action;
+    }
+
+    public ManualAction executeManualAction(String manualActionId, String resultSummary, String correlationId) {
+        ManualAction action = repository.findManualAction(manualActionId)
+            .orElseThrow(() -> new NotFoundException("manual action not found"));
+        int alreadyPublished = action.domainEvents().size();
+        try {
+            action.execute(resultSummary, Instant.now(clock), newCommandId(), normalizeCorrelationId(correlationId));
+        } catch (DomainRuleViolation violation) {
+            throw new PreconditionFailedException(violation.getMessage(), violation);
+        }
+        repository.saveManualAction(action);
+        publish(action.domainEvents().subList(alreadyPublished, action.domainEvents().size()));
+        recordAudit(
+            actorId(action),
+            actorDisplayName(action),
+            "MANUAL_ACTION_EXECUTED",
+            action.businessRef(),
+            action.targetDomain(),
+            action.reasonCode(),
+            normalizeCorrelationId(correlationId),
+            resultSummary
+        );
         return action;
     }
 
@@ -158,6 +277,7 @@ public class AdminAuditService {
         String correlationId,
         String resultSummary
     ) {
+        String sourceCommandId = newCommandId();
         AuditTrail trail = new AuditTrail();
         AuditEntry entry = trail.recordEntry(
             actorId,
@@ -173,6 +293,40 @@ public class AdminAuditService {
             newCommandId()
         );
         repository.saveAuditEntry(entry);
+        eventPublisher.publish(toContractEnvelope(new com.trainticket.adminaudit.domain.AuditEntryRecorded(
+            createAuditEnvelope(correlationId, sourceCommandId),
+            entry.entryId(),
+            entry.actorId(),
+            entry.actorDisplayName(),
+            entry.actionType(),
+            entry.resourceRef(),
+            entry.resourceDomain(),
+            entry.reasonCode(),
+            entry.correlationId(),
+            entry.resultSummary(),
+            entry.correctedEntryId()
+        )));
+    }
+
+    private EventEnvelope createAuditEnvelope(String correlationId, String causationId) {
+        return new EventEnvelope(
+            PrefixedIds.newEventId(),
+            "AuditEntryRecorded",
+            Instant.now(clock),
+            normalizeCorrelationId(correlationId),
+            ensureCausationPrefix(causationId),
+            PRODUCER,
+            1,
+            Map.of()
+        );
+    }
+
+    private static String actorId(ManualAction action) {
+        return action.approvedBy() != null ? action.approvedBy().operatorId() : action.requestedBy().operatorId();
+    }
+
+    private static String actorDisplayName(ManualAction action) {
+        return action.approvedBy() != null ? action.approvedBy().displayName() : action.requestedBy().displayName();
     }
 
     private void publish(List<AdminAuditEvent> events) {
@@ -202,7 +356,10 @@ public class AdminAuditService {
                 continue;
             }
             try {
-                payload.put(component.getName(), component.getAccessor().invoke(event));
+                Object value = component.getAccessor().invoke(event);
+                if (value != null) {
+                    payload.put(component.getName(), value);
+                }
             } catch (ReflectiveOperationException exception) {
                 throw new IllegalStateException("could not read event payload", exception);
             }
@@ -211,10 +368,10 @@ public class AdminAuditService {
     }
 
     private static String normalizeCorrelationId(String correlationId) {
-        if (correlationId == null || correlationId.isBlank()) {
-            return "corr-" + UUID.randomUUID();
+        if (PrefixedIds.isCorrelationId(correlationId)) {
+            return correlationId;
         }
-        return correlationId.startsWith("corr-") ? correlationId : "corr-" + correlationId;
+        return PrefixedIds.newCorrelationId();
     }
 
     private static String ensurePrefix(String value, String prefix) {
@@ -222,14 +379,14 @@ public class AdminAuditService {
     }
 
     private static String ensureCausationPrefix(String value) {
-        if (value.startsWith("cmd-") || value.startsWith("evt-")) {
+        if (PrefixedIds.isCausationId(value)) {
             return value;
         }
-        return "cmd-" + value;
+        return PrefixedIds.newCommandId();
     }
 
     private static String newCommandId() {
-        return "cmd-" + UUID.randomUUID();
+        return PrefixedIds.newCommandId();
     }
 
     public record Page<T>(List<T> items, int total, int limit, int offset) {}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/AdminAuditService.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/AdminAuditService.java
@@ -231,30 +231,6 @@ public class AdminAuditService {
         return action;
     }
 
-    public ManualAction executeManualAction(String manualActionId, String resultSummary, String correlationId) {
-        ManualAction action = repository.findManualAction(manualActionId)
-            .orElseThrow(() -> new NotFoundException("manual action not found"));
-        int alreadyPublished = action.domainEvents().size();
-        try {
-            action.execute(resultSummary, Instant.now(clock), newCommandId(), normalizeCorrelationId(correlationId));
-        } catch (DomainRuleViolation violation) {
-            throw new PreconditionFailedException(violation.getMessage(), violation);
-        }
-        repository.saveManualAction(action);
-        publish(action.domainEvents().subList(alreadyPublished, action.domainEvents().size()));
-        recordAudit(
-            actorId(action),
-            actorDisplayName(action),
-            "MANUAL_ACTION_EXECUTED",
-            action.businessRef(),
-            action.targetDomain(),
-            action.reasonCode(),
-            normalizeCorrelationId(correlationId),
-            resultSummary
-        );
-        return action;
-    }
-
     public OperatorIdentity getOperator(String operatorId) {
         return repository.findOperator(operatorId)
             .orElseThrow(() -> new NotFoundException("operator not found"));

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/InboundEventPayload.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/InboundEventPayload.java
@@ -1,0 +1,44 @@
+package com.trainticket.adminaudit.application;
+
+import com.trainticket.platformkit.messaging.EventEnvelope;
+import java.util.Map;
+
+final class InboundEventPayload {
+    private final Map<String, Object> payload;
+
+    private InboundEventPayload(Map<String, Object> payload) {
+        this.payload = payload;
+    }
+
+    @SuppressWarnings("unchecked")
+    static InboundEventPayload from(EventEnvelope envelope) {
+        if (envelope.payload() instanceof Map<?, ?> map) {
+            return new InboundEventPayload((Map<String, Object>) map);
+        }
+        throw new ValidationException("payload must be an object");
+    }
+
+    String requiredText(String field) {
+        Object value = payload.get(field);
+        if (value instanceof String text && !text.isBlank()) {
+            return text;
+        }
+        throw new ValidationException(field + " is required");
+    }
+
+    boolean requiredBoolean(String field) {
+        Object value = payload.get(field);
+        if (value instanceof Boolean bool) {
+            return bool;
+        }
+        throw new ValidationException(field + " is required");
+    }
+
+    String optionalText(String field) {
+        Object value = payload.get(field);
+        if (value instanceof String text && !text.isBlank()) {
+            return text;
+        }
+        return null;
+    }
+}

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/domain/ManualAction.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/domain/ManualAction.java
@@ -73,7 +73,39 @@ public final class ManualAction {
         String sourceCommandId,
         String correlationId
     ) {
-        String actionId = "ma-" + UUID.randomUUID().toString();
+        return requestWithId(
+            "ma-" + UUID.randomUUID(),
+            targetDomain,
+            targetCommand,
+            businessRef,
+            reasonCode,
+            description,
+            requestedBy,
+            requiresApproval,
+            now,
+            sourceCommandId,
+            correlationId
+        );
+    }
+
+    /**
+     * Rehydrate a manual action request from an upstream governance request fact.
+     * The caller supplies the canonical manualActionId so replay is deterministic.
+     */
+    public static ManualAction requestWithId(
+        String manualActionId,
+        String targetDomain,
+        String targetCommand,
+        String businessRef,
+        String reasonCode,
+        String description,
+        OperatorRef requestedBy,
+        boolean requiresApproval,
+        Instant now,
+        String sourceCommandId,
+        String correlationId
+    ) {
+        String actionId = requireText(manualActionId, "manualActionId");
         ManualAction action = new ManualAction(
             actionId,
             targetDomain,

--- a/services/admin-audit/src/test/java/com/trainticket/adminaudit/adapters/http/AdminAuditControllerTest.java
+++ b/services/admin-audit/src/test/java/com/trainticket/adminaudit/adapters/http/AdminAuditControllerTest.java
@@ -68,10 +68,48 @@ class AdminAuditControllerTest {
             .andExpect(jsonPath("$.manualActionId").value(manualActionId))
             .andExpect(jsonPath("$.status").value("APPROVED"));
 
+        mockMvc.perform(post("/api/v1/admin/manual-actions/{manualActionId}/execute", manualActionId)
+                .header("Idempotency-Key", "0194f2e0-7b3e-7610-8284-5c26e8b01120")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"resultSummary\":\"should not be exposed\"}"))
+            .andExpect(status().isNotFound());
+
         mockMvc.perform(get("/api/v1/admin/audit-trail").param("businessRef", "pi-1").param("limit", "20").param("offset", "0"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.total").value(3))
             .andExpect(jsonPath("$.items[0].resourceRef").value("pi-1"));
+    }
+
+    @Test
+    void rejectManualActionUsesOperatorRefContractAndIsIdempotent() throws Exception {
+        String requester = operatorId(register("reject-requester@example.com", "0194f2e0-7b3e-7610-8284-5c26e8b01118").andReturn());
+
+        MvcResult action = mockMvc.perform(post("/api/v1/admin/manual-actions")
+                .header("Idempotency-Key", "0194f2e0-7b3e-7610-8284-5c26e8b01119")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {"targetDomain":"payment","targetCommand":"RefundPayment","businessRef":"pi-reject","reasonCode":"CUSTOMER_REQUEST","description":"refund","requestedByOperatorId":"%s","requiresApproval":true}
+                    """.formatted(requester)))
+            .andExpect(status().isCreated())
+            .andReturn();
+
+        String manualActionId = actionId(action);
+        String body = "{\"operatorRef\":\"op-reviewer\",\"reason\":\"insufficient evidence\"}";
+
+        mockMvc.perform(post("/api/v1/admin/manual-actions/{manualActionId}/reject", manualActionId)
+                .header("Idempotency-Key", "0194f2e0-7b3e-7610-8284-5c26e8b01121")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.manualActionId").value(manualActionId))
+            .andExpect(jsonPath("$.status").value("REJECTED"));
+
+        mockMvc.perform(post("/api/v1/admin/manual-actions/{manualActionId}/reject", manualActionId)
+                .header("Idempotency-Key", "0194f2e0-7b3e-7610-8284-5c26e8b01121")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("REJECTED"));
     }
 
     @Test

--- a/services/admin-audit/src/test/java/com/trainticket/adminaudit/adapters/http/AdminAuditControllerTest.java
+++ b/services/admin-audit/src/test/java/com/trainticket/adminaudit/adapters/http/AdminAuditControllerTest.java
@@ -70,7 +70,7 @@ class AdminAuditControllerTest {
 
         mockMvc.perform(get("/api/v1/admin/audit-trail").param("businessRef", "pi-1").param("limit", "20").param("offset", "0"))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.total").value(2))
+            .andExpect(jsonPath("$.total").value(3))
             .andExpect(jsonPath("$.items[0].resourceRef").value("pi-1"));
     }
 

--- a/services/admin-audit/src/test/java/com/trainticket/adminaudit/adapters/messaging/MessagingAdapterTest.java
+++ b/services/admin-audit/src/test/java/com/trainticket/adminaudit/adapters/messaging/MessagingAdapterTest.java
@@ -6,7 +6,13 @@ import com.trainticket.adminaudit.application.AdminAuditService;
 import com.trainticket.platformkit.messaging.EventEnvelope;
 import com.trainticket.adminaudit.application.ports.EventSubscriber;
 import com.trainticket.adminaudit.domain.ManualActionRequested;
+import com.trainticket.adminaudit.application.AdminAuditInboundEventHandler;
+import com.trainticket.adminaudit.application.ports.EventPublisher;
+import com.trainticket.adminaudit.application.ports.AdminAuditRepository;
+import com.trainticket.adminaudit.application.ports.InMemoryAdminAuditRepository;
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -72,4 +78,44 @@ class MessagingAdapterTest {
 
         assertThat(handled).containsExactly("evt-0194f2e0-7b3e-7610-8284-5c26e8b0a444");
     }
+
+    @Test
+    void customerServiceManualActionRequestCreatesPendingActionWithSameIdAndAuditEvent() {
+        List<EventEnvelope> published = new ArrayList<>();
+        AdminAuditRepository repository = new InMemoryAdminAuditRepository();
+        AdminAuditService service = new AdminAuditService(
+            repository,
+            (EventPublisher) published::add,
+            Clock.fixed(Instant.parse("2026-07-05T10:30:00Z"), ZoneOffset.UTC)
+        );
+        AdminAuditInboundEventHandler handler = new AdminAuditInboundEventHandler(service);
+        EventEnvelope envelope = new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0a777",
+            "ManualActionRequested",
+            Instant.parse("2026-07-05T10:29:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0a555",
+            "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0a666",
+            "customer-service",
+            1,
+            java.util.Map.of(
+                "manualActionId", "ma-0194f2e0-7b3e-7610-8284-5c26e8b0a888",
+                "caseId", "sc-1",
+                "targetDomain", "post-sales",
+                "commandType", "ManualRefundReviewRequested",
+                "operatorRef", "op-1",
+                "reason", "CUSTOMER_REQUEST",
+                "description", "review refund",
+                "requiresApproval", true
+            )
+        );
+
+        assertThat(handler.handle(envelope)).isEqualTo(EventSubscriber.HandlerResult.SUCCESS);
+        assertThat(repository.findManualAction("ma-0194f2e0-7b3e-7610-8284-5c26e8b0a888")).isPresent();
+        assertThat(repository.findManualAction("ma-0194f2e0-7b3e-7610-8284-5c26e8b0a888").orElseThrow().businessRef()).isEqualTo("sc-1");
+        assertThat(published).extracting(EventEnvelope::eventType).contains("AuditEntryRecorded");
+
+        assertThat(handler.handle(envelope)).isEqualTo(EventSubscriber.HandlerResult.SUCCESS);
+        assertThat(repository.countAuditEntries("sc-1")).isEqualTo(1);
+    }
+
 }

--- a/services/customer-service/src/adapters/messaging/stream-config.ts
+++ b/services/customer-service/src/adapters/messaging/stream-config.ts
@@ -1,7 +1,7 @@
 import { dlqForStream as kitDlqForStream, streamForProducer } from "@trainticket/ts-kit";
 
 export const CUSTOMER_SERVICE_CONSUMER_GROUP = "customer-service";
-export const CUSTOMER_SERVICE_SUBSCRIPTIONS = Object.freeze(["events:journey-order", "events:post-sales"]);
+export const CUSTOMER_SERVICE_SUBSCRIPTIONS = Object.freeze(["events:journey-order", "events:post-sales", "events:admin-audit"]);
 export const DEFAULT_REDIS_URL = "redis://localhost:6379";
 export const STREAM_MAXLEN = 100_000;
 export const RECOVERY_MIN_IDLE_MS = 60_000;

--- a/services/customer-service/src/application/customer-service.ts
+++ b/services/customer-service/src/application/customer-service.ts
@@ -272,17 +272,16 @@ export class CustomerServiceApplication {
     return this.consumedIntegrationEvents.size;
   }
 
-
   private async recordAdminAuditManualActionOutcome(envelope: EventEnvelope): Promise<void> {
     const manualActionId = requiredPayloadString(envelope.payload, "manualActionId");
     const action = this.manualActions.get(manualActionId);
     if (!action) {
       return;
     }
-    const outcome = envelope.eventType === "ManualActionRejected" ? "Rejected" : "Succeeded";
     const resultSummary = envelope.eventType === "ManualActionRejected"
       ? requiredPayloadString(envelope.payload, "reason")
       : requiredPayloadString(envelope.payload, "resultSummary");
+    const outcome = manualActionOutcome(envelope.eventType, resultSummary);
     const { action: updated, event } = action.recordOutcome({
       manualActionId,
       outcome,
@@ -340,6 +339,13 @@ function requiredPayloadString(payload: Record<string, unknown>, field: string):
     throw new DomainError("MISSING_REQUIRED_FIELD", `${field} is required`);
   }
   return value;
+}
+
+function manualActionOutcome(eventType: string, resultSummary: string): "Succeeded" | "Failed" | "Rejected" {
+  if (eventType === "ManualActionRejected") {
+    return "Rejected";
+  }
+  return resultSummary.trim().toUpperCase().startsWith("FAILED:") ? "Failed" : "Succeeded";
 }
 
 function caseReferencesEnvelope(snapshot: SupportCaseSnapshot, envelope: EventEnvelope): boolean {

--- a/services/customer-service/src/application/customer-service.ts
+++ b/services/customer-service/src/application/customer-service.ts
@@ -241,30 +241,68 @@ export class CustomerServiceApplication {
     if (this.consumedIntegrationEvents.has(envelope.eventId)) {
       return;
     }
+
+    if (envelope.producer === "admin-audit" && (envelope.eventType === "ManualActionExecuted" || envelope.eventType === "ManualActionRejected")) {
+      await this.recordAdminAuditManualActionOutcome(envelope);
+    } else {
+      for (const supportCase of this.cases.values()) {
+        if (caseReferencesEnvelope(supportCase.toSnapshot(), envelope)) {
+          await this.appendTimelineEntry(
+            supportCase.id,
+            envelope.eventType,
+            { sourceEventId: envelope.eventId, producer: envelope.producer, payload: envelope.payload },
+            "INTERNAL_ONLY",
+            new Date(envelope.occurredAt),
+            envelope.correlationId,
+            envelope.causationId,
+          );
+        }
+      }
+    }
+
     this.consumedIntegrationEvents.set(envelope.eventId, Object.freeze({
       source: envelope.producer,
       eventType: envelope.eventType,
       consumedAt: new Date(),
       payload: envelope.payload,
     }));
-
-    for (const supportCase of this.cases.values()) {
-      if (caseReferencesEnvelope(supportCase.toSnapshot(), envelope)) {
-        await this.appendTimelineEntry(
-          supportCase.id,
-          envelope.eventType,
-          { sourceEventId: envelope.eventId, producer: envelope.producer, payload: envelope.payload },
-          "INTERNAL_ONLY",
-          new Date(envelope.occurredAt),
-          envelope.correlationId,
-          envelope.causationId,
-        );
-      }
-    }
   }
 
   consumedIntegrationEventCount(): number {
     return this.consumedIntegrationEvents.size;
+  }
+
+
+  private async recordAdminAuditManualActionOutcome(envelope: EventEnvelope): Promise<void> {
+    const manualActionId = requiredPayloadString(envelope.payload, "manualActionId");
+    const action = this.manualActions.get(manualActionId);
+    if (!action) {
+      return;
+    }
+    const outcome = envelope.eventType === "ManualActionRejected" ? "Rejected" : "Succeeded";
+    const resultSummary = envelope.eventType === "ManualActionRejected"
+      ? requiredPayloadString(envelope.payload, "reason")
+      : requiredPayloadString(envelope.payload, "resultSummary");
+    const { action: updated, event } = action.recordOutcome({
+      manualActionId,
+      outcome,
+      resultSummary,
+      recordedAt: new Date(envelope.occurredAt),
+      correlationId: envelope.correlationId,
+      causationId: envelope.eventId,
+    });
+    this.manualActions.set(manualActionId, updated);
+    const eventEnvelope = toEventEnvelope(event, envelope.eventId);
+    await this.publisher.publish(eventEnvelope);
+    await this.appendTimelineEntry(
+      updated.caseId,
+      "ManualActionResultRecorded",
+      eventEnvelope.payload,
+      "INTERNAL_ONLY",
+      event.occurredAt,
+      envelope.correlationId,
+      envelope.eventId,
+    );
   }
 
   private async appendTimelineEntry(caseId: string, eventType: string, payload: Readonly<Record<string, unknown>>, visibility: "CUSTOMER_VISIBLE" | "INTERNAL_ONLY", occurredAt: Date, correlationId: string, causationId?: string): Promise<void> {
@@ -294,6 +332,14 @@ export class CustomerServiceApplication {
 
 export function isDomainError(error: unknown): error is DomainError {
   return error instanceof DomainError;
+}
+
+function requiredPayloadString(payload: Record<string, unknown>, field: string): string {
+  const value = stringField(payload, field);
+  if (value === undefined) {
+    throw new DomainError("MISSING_REQUIRED_FIELD", `${field} is required`);
+  }
+  return value;
 }
 
 function caseReferencesEnvelope(snapshot: SupportCaseSnapshot, envelope: EventEnvelope): boolean {

--- a/services/customer-service/src/domain.test.ts
+++ b/services/customer-service/src/domain.test.ts
@@ -100,6 +100,8 @@ function recordOutcomeCommand(overrides: Partial<RecordActionOutcome> = {}): Rec
     outcome: "Succeeded",
     resultSummary: "Payment retry completed successfully",
     approvalRef: "aprv-test-001",
+    correlationId: testCorrelationId,
+    causationId: "evt-test-outcome",
     recordedAt: new Date("2026-07-03T10:10:00.000Z"),
     ...overrides,
   };

--- a/services/customer-service/src/domain.ts
+++ b/services/customer-service/src/domain.ts
@@ -218,6 +218,8 @@ export type RecordActionOutcome = Readonly<{
   outcome: "Succeeded" | "Failed" | "Rejected" | "Cancelled";
   resultSummary: string;
   approvalRef?: ApprovalRef;
+  correlationId: CorrelationId;
+  causationId?: CausationId;
   recordedAt: Date;
 }>;
 
@@ -1027,8 +1029,8 @@ export class ManualActionRequest {
       eventType: "ManualActionResultRecorded",
       schemaVersion: 1,
       occurredAt: new Date(command.recordedAt),
-      correlationId: this.snapshot.caseId, // use caseId as correlation for tracing
-      causationId: this.snapshot.manualActionId,
+      correlationId: command.correlationId,
+      causationId: command.causationId,
       producer: "customer-service",
       manualActionId: this.snapshot.manualActionId,
       caseId: this.snapshot.caseId,

--- a/services/customer-service/src/messaging.test.ts
+++ b/services/customer-service/src/messaging.test.ts
@@ -147,8 +147,6 @@ describe("customer-service messaging ports", () => {
     assert.equal(timelineEvents[0].causationId, "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c221");
   });
 
-
-
   it("records admin-audit manual action outcomes once and preserves event lineage", async () => {
     const publisher = new InMemoryEventPublisher();
     const application = new CustomerServiceApplication(publisher);
@@ -194,6 +192,40 @@ describe("customer-service messaging ports", () => {
     const details = application.getSupportCase(opened.caseId);
     assert.equal(details.timeline.at(-1)?.eventType, "ManualActionResultRecorded");
     assert.equal(application.consumedIntegrationEventCount(), 1);
+  });
+
+  it("records failed admin-audit execution summaries as failed outcomes", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const application = new CustomerServiceApplication(publisher);
+    const opened = await application.openSupportCase({
+      requesterRef: "tvl-doc",
+      channel: "APP",
+      priority: "NORMAL",
+      description: "Need manual help",
+    }, "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c224");
+    const action = await application.requestManualAction(opened.caseId, {
+      targetDomain: "post-sales",
+      commandType: "ManualRefundReviewRequested",
+      operatorRef: "op-doc",
+      reason: "needs manual review",
+      description: "Review refund",
+      requiresApproval: true,
+    }, "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c224");
+
+    await application.handleIntegrationEvent({
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c334",
+      eventType: "ManualActionExecuted",
+      occurredAt: "2026-07-05T10:35:00.000Z",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c224",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c334",
+      producer: "admin-audit",
+      schemaVersion: 1,
+      payload: { manualActionId: action.manualActionId, targetDomain: "post-sales", targetCommand: "ManualRefundReviewRequested", businessRef: opened.caseId, resultSummary: "FAILED: target domain rejected command" },
+    });
+
+    const resultEvents = publisher.findByEventType("ManualActionResultRecorded");
+    assert.equal(resultEvents.at(-1)?.payload.outcome, "Failed");
+    assert.equal(resultEvents.at(-1)?.payload.resultSummary, "FAILED: target domain rejected command");
   });
 
   it("Redis subscriber reports background loop failures", async () => {

--- a/services/customer-service/src/messaging.test.ts
+++ b/services/customer-service/src/messaging.test.ts
@@ -147,6 +147,55 @@ describe("customer-service messaging ports", () => {
     assert.equal(timelineEvents[0].causationId, "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c221");
   });
 
+
+
+  it("records admin-audit manual action outcomes once and preserves event lineage", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const application = new CustomerServiceApplication(publisher);
+    const opened = await application.openSupportCase({
+      requesterRef: "tvl-doc",
+      channel: "APP",
+      priority: "NORMAL",
+      description: "Need manual help",
+    }, "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222");
+    const action = await application.requestManualAction(opened.caseId, {
+      targetDomain: "post-sales",
+      commandType: "ManualRefundReviewRequested",
+      operatorRef: "op-doc",
+      reason: "needs manual review",
+      description: "Review refund",
+      requiresApproval: true,
+    }, "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222");
+
+    const upstream: EventEnvelope = {
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c333",
+      eventType: "ManualActionExecuted",
+      occurredAt: "2026-07-05T10:35:00.000Z",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c333",
+      producer: "admin-audit",
+      schemaVersion: 1,
+      payload: { manualActionId: action.manualActionId, targetDomain: "post-sales", targetCommand: "ManualRefundReviewRequested", businessRef: opened.caseId, resultSummary: "Manual action execution recorded" },
+    };
+
+    await application.handleIntegrationEvent(upstream);
+    await application.handleIntegrationEvent(upstream);
+
+    const resultEvents = publisher.findByEventType("ManualActionResultRecorded");
+    assert.equal(resultEvents.length, 1);
+    assert.equal(resultEvents[0].correlationId, upstream.correlationId);
+    assert.equal(resultEvents[0].causationId, upstream.eventId);
+    assert.deepEqual(resultEvents[0].payload, {
+      manualActionId: action.manualActionId,
+      caseId: opened.caseId,
+      outcome: "Succeeded",
+      resultSummary: "Manual action execution recorded",
+    });
+    const details = application.getSupportCase(opened.caseId);
+    assert.equal(details.timeline.at(-1)?.eventType, "ManualActionResultRecorded");
+    assert.equal(application.consumedIntegrationEventCount(), 1);
+  });
+
   it("Redis subscriber reports background loop failures", async () => {
     class FailingRedis {
       disconnect(): void {}


### PR DESCRIPTION
## Summary
- Wire customer-service ManualActionRequested consumption into admin-audit pending ManualAction intake with eventId deduplication and audit entry recording.
- Publish admin-audit ManualActionExecuted/ManualActionRejected after approval/rejection, and have customer-service record outcomes/timeline entries with upstream lineage.
- Apply contract rulings: reject endpoint uses `{operatorRef, reason}`, execute is internal/auto-on-approve only, and e2e approval JSON is valid.

## Validation
- `cd services/admin-audit && mvn test`
- `cd services/customer-service && npm test`
- `bash -n deploy/e2e/09-manual-action.sh`
- `make check`
