### PR TITLE
REQ-070 Fare pricing product disambiguation and publish reliability

### DIFF
--- a/deploy/e2e/07-fare-rules.sh
+++ b/deploy/e2e/07-fare-rules.sh
@@ -31,10 +31,37 @@ retry_event() {
   [ "$ok_seen" = "yes" ] && ok "$event_type published" || bad "$event_type not observed for $rule_set_id"
 }
 
+quote_total_with_retry() {
+  local product_code=$1 traveler_ref=$2 segment_ref=$3 total_var=$4 rule_set_var=$5
+  local body total rule_set
+  if [ -n "$product_code" ]; then
+    body="{\"travelerRefs\":[\"$traveler_ref\"],\"channel\":\"WEB\",\"segmentRefs\":[\"$segment_ref\"],\"productCode\":\"$product_code\"}"
+  else
+    body="{\"travelerRefs\":[\"$traveler_ref\"],\"channel\":\"WEB\",\"segmentRefs\":[\"$segment_ref\"]}"
+  fi
+  total=""; rule_set=""
+  for attempt in 1 2 3 4 5 6; do
+    req POST fare-pricing /api/v1/fare-quotes "$body"
+    if [ "$LAST_CODE" = "201" ]; then
+      total=$(jget "['breakdown']['total']['minorUnits']")
+      rule_set=$(jget "['ruleSnapshot']['ruleSetId']")
+      [ -n "$total" ] && break
+    fi
+    sleep 2
+  done
+  eval "$total_var=\$total"
+  eval "$rule_set_var=\$rule_set"
+}
+
 ACCT_RULE="acc-$(uuid7)"
 RULE_VERSION="e2e-$(date -u +%Y%m%d%H%M%S)"
 RULE_BODY=$(cat <<JSON
 {"supplierId":"supplier-e2e","contractId":"contract-e2e","productCode":"rail-standard","mode":"rail","channel":"WEB","version":"$RULE_VERSION","effectiveWindow":{"startsAt":"2026-07-01T00:00:00Z","endsAt":"2026-12-31T00:00:00Z"},"rules":[{"ruleId":"base-e2e","kind":"base_fare","amount":{"currency":"CNY","minorUnits":12000},"explanation":{"code":"fare.base.e2e","parameters":{"source":"07-fare-rules"}},"refundable":true},{"ruleId":"refund-e2e","kind":"refund_fee","amount":{"currency":"CNY","minorUnits":3000},"explanation":{"code":"fare.refund.e2e","parameters":{"source":"07-fare-rules"}},"refundable":true},{"ruleId":"change-e2e","kind":"change_fee","amount":{"currency":"CNY","minorUnits":1500},"explanation":{"code":"fare.change.e2e","parameters":{"source":"07-fare-rules"}},"refundable":true}]}
+JSON
+)
+BUSINESS_VERSION="$RULE_VERSION-business"
+BUSINESS_BODY=$(cat <<JSON
+{"supplierId":"supplier-e2e","contractId":"contract-e2e-business","productCode":"rail-business","mode":"rail","channel":"WEB","version":"$BUSINESS_VERSION","effectiveWindow":{"startsAt":"2026-07-01T00:00:00Z","endsAt":"2026-12-31T00:00:00Z"},"rules":[{"ruleId":"base-business-e2e","kind":"base_fare","amount":{"currency":"CNY","minorUnits":18000},"explanation":{"code":"fare.base.business.e2e","parameters":{"source":"07-fare-rules"}},"refundable":true},{"ruleId":"refund-business-e2e","kind":"refund_fee","amount":{"currency":"CNY","minorUnits":4000},"explanation":{"code":"fare.refund.business.e2e","parameters":{"source":"07-fare-rules"}},"refundable":true},{"ruleId":"change-business-e2e","kind":"change_fee","amount":{"currency":"CNY","minorUnits":2000},"explanation":{"code":"fare.change.business.e2e","parameters":{"source":"07-fare-rules"}},"refundable":true}]}
 JSON
 )
 
@@ -46,6 +73,13 @@ echo "  RULE_SET=$RULE_SET"
 req POST fare-pricing "/api/v1/fare-rule-sets/$RULE_SET/publish" '{}'
 check_code 200 "publish fare rule set"
 retry_event FareRuleSetPublished "$RULE_SET"
+req POST fare-pricing /api/v1/fare-rule-sets "$BUSINESS_BODY"
+check_code 201 "create business fare rule set"
+BUSINESS_RULE_SET=$(jget "['ruleSetId']")
+echo "  BUSINESS_RULE_SET=$BUSINESS_RULE_SET"
+req POST fare-pricing "/api/v1/fare-rule-sets/$BUSINESS_RULE_SET/publish" '{}'
+check_code 200 "publish business fare rule set"
+retry_event FareRuleSetPublished "$BUSINESS_RULE_SET"
 
 echo "== 2. register traveler and quote new fare"
 req POST traveler-profile /api/v1/travelers "{\"accountId\":\"$ACCT_RULE\",\"travelerType\":\"ADULT\",\"givenName\":\"Rule\",\"familyName\":\"Tester\"}"
@@ -56,12 +90,15 @@ req POST trip-planning /api/v1/itineraries/search "{\"originRef\":\"$P_BJ\",\"de
 check_code 200 "search itineraries"
 ITIN_RULE=$(jget "['itineraries'][0]['itineraryRef']")
 SEG_RULE=$(jget "['itineraries'][0]['legs'][0]['serviceSegmentRef']")
-req POST fare-pricing /api/v1/fare-quotes "{\"travelerRefs\":[\"$TVL_RULE\"],\"channel\":\"WEB\",\"segmentRefs\":[\"$SEG_RULE\"]}"
-check_code 201 "create fare quote with managed rules"
-QUOTE_TOTAL=$(jget "['breakdown']['total']['minorUnits']")
-QUOTE_RULE_SET=$(jget "['ruleSnapshot']['ruleSetId']")
+quote_total_with_retry "" "$TVL_RULE" "$SEG_RULE" QUOTE_TOTAL QUOTE_RULE_SET
 [ "$QUOTE_TOTAL" = "12000" ] && ok "fare quote total = 120.00 CNY" || bad "fare quote total wrong ($QUOTE_TOTAL)"
 [ "$QUOTE_RULE_SET" = "$RULE_SET" ] && ok "fare quote uses managed rule set" || bad "fare quote used $QUOTE_RULE_SET"
+quote_total_with_retry "rail-business" "$TVL_RULE" "$SEG_RULE" BUSINESS_QUOTE_TOTAL BUSINESS_QUOTE_RULE_SET
+[ "$BUSINESS_QUOTE_TOTAL" = "18000" ] && ok "business fare quote total = 180.00 CNY" || bad "business fare quote total wrong ($BUSINESS_QUOTE_TOTAL)"
+[ "$BUSINESS_QUOTE_RULE_SET" = "$BUSINESS_RULE_SET" ] && ok "business fare quote uses business rule set" || bad "business fare quote used $BUSINESS_QUOTE_RULE_SET"
+quote_total_with_retry "" "$TVL_RULE" "$SEG_RULE" STANDARD_RECHECK_TOTAL STANDARD_RECHECK_RULE_SET
+[ "$STANDARD_RECHECK_TOTAL" = "12000" ] && ok "standard fare unaffected by business publish" || bad "standard fare changed ($STANDARD_RECHECK_TOTAL)"
+[ "$STANDARD_RECHECK_RULE_SET" = "$RULE_SET" ] && ok "standard fare still uses standard rule set" || bad "standard fare used $STANDARD_RECHECK_RULE_SET"
 sleep 3
 
 echo "== 3. offer/order/payment use new fare amount"

--- a/services/fare-pricing/src/fare_pricing/adapters/messaging/fake.py
+++ b/services/fare-pricing/src/fare_pricing/adapters/messaging/fake.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 from fare_pricing.ports import EventEnvelope
 from fare_pricing.ports.messaging import PublishFailed
 from train_ticket_platform.messaging import InMemoryEventSubscriber as FakeEventSubscriber
@@ -11,19 +9,28 @@ class FakeEventPublisher:
     def __init__(self) -> None:
         self.published_events: list[EventEnvelope] = []
         self._fail_next = False
+        self._publish_attempts = 0
+        self._fail_on_publish_numbers: set[int] = set()
 
     @property
     def published_event_count(self) -> int:
         return len(self.published_events)
 
     def publish(self, envelope: EventEnvelope) -> None:
+        self._publish_attempts += 1
         if self._fail_next:
             self._fail_next = False
+            raise PublishFailed("configured publish failure")
+        if self._publish_attempts in self._fail_on_publish_numbers:
+            self._fail_on_publish_numbers.remove(self._publish_attempts)
             raise PublishFailed("configured publish failure")
         self.published_events.append(envelope)
 
     def fail_next_publish(self) -> None:
         self._fail_next = True
+
+    def fail_on_publish_number(self, publish_number: int) -> None:
+        self._fail_on_publish_numbers.add(publish_number)
 
     def last_event(self) -> EventEnvelope | None:
         return self.published_events[-1] if self.published_events else None

--- a/services/fare-pricing/src/fare_pricing/application/__init__.py
+++ b/services/fare-pricing/src/fare_pricing/application/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from typing import Any
+from uuid import NAMESPACE_URL, uuid5
 
 from ..ids import prefixed_uuid7
 from ..ports import EventEnvelope
@@ -34,3 +35,17 @@ class DomainEventService:
             payload=payload or {},
         )
         self._publisher.publish(envelope)
+
+
+def deterministic_uuid(value: str) -> str:
+    uuid = uuid5(NAMESPACE_URL, f"train-ticket:fare-pricing:{value}")
+    uuid_int = (uuid.int & ~(0xF << 76)) | (0x7 << 76)
+    return str(uuid.__class__(int=uuid_int))
+
+
+def deterministic_prefixed_id(prefix: str, *parts: str) -> str:
+    return f"{prefix}-{deterministic_uuid(':'.join(parts))}"
+
+
+def deterministic_rule_set_event_id(rule_set_id: str, version: str, action: str) -> str:
+    return deterministic_prefixed_id("evt", rule_set_id, version, action)

--- a/services/fare-pricing/src/fare_pricing/application/service.py
+++ b/services/fare-pricing/src/fare_pricing/application/service.py
@@ -151,14 +151,17 @@ class FarePricingService:
         self._store.save_rule_set(rule_set)
         return rule_set
 
-    def publish_rule_set(self, rule_set_id: str, published_at: datetime | None = None) -> tuple[FareRuleSet, tuple[FareRuleSet, ...], bool]:
+    def publish_rule_set(
+        self, rule_set_id: str, published_at: datetime | None = None
+    ) -> tuple[FareRuleSet, tuple[FareRuleSet, ...], bool, tuple[FareRuleSet, ...]]:
         now = published_at or datetime.now(UTC)
         rule_set = self._store.get_rule_set(rule_set_id)
         if rule_set.status == RuleSetStatus.PUBLISHED:
-            return rule_set, (), False
+            return rule_set, (), False, ()
         if rule_set.status not in {RuleSetStatus.DRAFT, RuleSetStatus.VALIDATED}:
             raise PricingError(f"fare rule set cannot be published from status {rule_set.status.value}")
         published = rule_set.publish(now)
+        originals: list[FareRuleSet] = [rule_set]
         superseded: list[FareRuleSet] = []
         for existing in list(self._store.fare_rule_sets.values()):
             if (
@@ -167,13 +170,18 @@ class FarePricingService:
                 and existing.channel == published.channel
                 and existing.product_code == published.product_code
             ):
+                originals.append(existing)
                 old = existing.supersede()
                 self._store.save_rule_set(old)
                 superseded.append(old)
         self._store.save_rule_set(published)
-        return published, tuple(superseded), True
+        return published, tuple(superseded), True, tuple(originals)
 
-    def find_published_rule_set_id(self, channel: str, at: datetime | None = None, product_code: str | None = None) -> str | None:
+    def restore_rule_sets(self, rule_sets: tuple[FareRuleSet, ...]) -> None:
+        for rule_set in rule_sets:
+            self._store.save_rule_set(rule_set)
+
+    def find_published_rule_set_id(self, channel: str, product_code: str, at: datetime | None = None) -> str | None:
         when = at or datetime.now(UTC)
         candidates = [
             rule_set
@@ -181,7 +189,7 @@ class FarePricingService:
             if rule_set.status == RuleSetStatus.PUBLISHED
             and rule_set.channel == channel
             and rule_set.is_effective(when)
-            and (product_code is None or rule_set.product_code == product_code)
+            and rule_set.product_code == product_code
         ]
         if not candidates:
             return None

--- a/services/fare-pricing/src/fare_pricing/domain.py
+++ b/services/fare-pricing/src/fare_pricing/domain.py
@@ -314,6 +314,7 @@ class FareQuote:
     input_hash: str
     traveler_refs: tuple[str, ...]
     channel: str
+    product_code: str
     currency: str
     status: QuoteStatus
     valid_from: datetime
@@ -349,6 +350,7 @@ class FareQuote:
             self.input_hash,
             self.traveler_refs,
             self.channel,
+            self.product_code,
             self.currency,
             QuoteStatus.EXPIRED,
             self.valid_from,
@@ -442,6 +444,7 @@ def calculate_fare_quote(
             input_hash,
             tuple(traveler_refs),
             channel,
+            rule_set.product_code,
             normalized_currency,
             QuoteStatus.FAILED,
             quoted_at,
@@ -460,6 +463,7 @@ def calculate_fare_quote(
         input_hash,
         tuple(traveler_refs),
         channel,
+        rule_set.product_code,
         normalized_currency,
         QuoteStatus.QUOTED,
         quoted_at,

--- a/services/fare-pricing/src/fare_pricing/web/handlers.py
+++ b/services/fare-pricing/src/fare_pricing/web/handlers.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from fastapi import APIRouter, Request
 
-from fare_pricing.application import DomainEventService
+from fare_pricing.application import DomainEventService, deterministic_rule_set_event_id
 from fare_pricing.ids import prefixed_uuid7
 from fare_pricing.application.service import (
     FarePricingService,
@@ -136,7 +136,7 @@ def _command_id() -> str:
     return prefixed_uuid7("cmd")
 
 
-def _publish_event(request: Request, event_type: str, causation_id: str, payload: dict[str, Any]) -> None:
+def _publish_event(request: Request, event_type: str, causation_id: str, payload: dict[str, Any], event_id: str | None = None) -> None:
     event_service: DomainEventService = request.app.state.domain_event_service
     try:
         event_service.publish_event(
@@ -145,6 +145,7 @@ def _publish_event(request: Request, event_type: str, causation_id: str, payload
             correlation_id=_correlation_id(request),
             payload=payload,
             occurred_at=datetime.now(UTC),
+            event_id=event_id,
         )
     except PublishFailed as exc:
         raise ApiError("UNAVAILABLE", "Event bus publish failed", 503) from exc
@@ -196,16 +197,32 @@ def publish_fare_rule_set(request: Request, rule_set_id: str) -> dict[str, Any]:
     service: FarePricingService = request.app.state.fare_pricing_service
     causation_id = _command_id()
     try:
-        published, superseded, newly_published = service.publish_rule_set(rule_set_id)
+        published, superseded, newly_published, originals = service.publish_rule_set(rule_set_id)
     except RuleSetNotFoundError as exc:
         raise ApiError("NOT_FOUND", f"Fare rule set not found: {rule_set_id}", 404) from exc
     except PricingError as exc:
         raise _domain_error(exc) from exc
 
     if newly_published:
-        _publish_event(request, "FareRuleSetPublished", causation_id, _fare_rule_set_published_payload(published))
-        for old_rule_set in superseded:
-            _publish_event(request, "FareRuleSetSuperseded", causation_id, _fare_rule_set_superseded_payload(old_rule_set, published))
+        try:
+            _publish_event(
+                request,
+                "FareRuleSetPublished",
+                causation_id,
+                _fare_rule_set_published_payload(published),
+                deterministic_rule_set_event_id(published.rule_set_id, published.version, "published"),
+            )
+            for old_rule_set in superseded:
+                _publish_event(
+                    request,
+                    "FareRuleSetSuperseded",
+                    causation_id,
+                    _fare_rule_set_superseded_payload(old_rule_set, published),
+                    deterministic_rule_set_event_id(old_rule_set.rule_set_id, old_rule_set.version, "superseded"),
+                )
+        except ApiError:
+            service.restore_rule_sets(originals)
+            raise
     return _rule_set_to_response(published)
 
 
@@ -215,7 +232,7 @@ def compute_fare_quote(
     req: FareQuoteRequest,
 ) -> dict[str, Any]:
     service: FarePricingService = request.app.state.fare_pricing_service
-    rule_set_id = service.find_published_rule_set_id(req.channel)
+    rule_set_id = service.find_published_rule_set_id(req.channel, req.productCode)
     if rule_set_id is None:
         raise _validation_error("No applicable fare rule set found")
 
@@ -259,7 +276,7 @@ def compute_adjustment_quote(
     if original_quote_id is None:
         raise ApiError("PRECONDITION_FAILED", "Original fare quote not found for requested segments", 412)
     original_quote = service.get_fare_quote(original_quote_id)
-    rule_set_id = service.find_published_rule_set_id(original_quote.channel)
+    rule_set_id = service.find_published_rule_set_id(original_quote.channel, original_quote.product_code)
     if rule_set_id is None:
         raise _validation_error("No applicable fare rule set found")
 

--- a/services/fare-pricing/src/fare_pricing/web/schemas.py
+++ b/services/fare-pricing/src/fare_pricing/web/schemas.py
@@ -83,6 +83,7 @@ class FareQuoteRequest(BaseModel):
     travelerRefs: list[str] = Field(..., min_length=1)
     channel: str = Field(..., min_length=1)
     segmentRefs: list[str] = Field(..., min_length=1)
+    productCode: str = Field(default="rail-standard", min_length=1)
     fareRuleRefs: list[str] | None = None
 
 

--- a/services/fare-pricing/tests/test_api.py
+++ b/services/fare-pricing/tests/test_api.py
@@ -23,6 +23,7 @@ from fare_pricing import (
     calculate_fare_quote,
 )
 from fare_pricing.api import create_app
+from fare_pricing.application import deterministic_rule_set_event_id
 from fare_pricing.ids import uuid7
 from fare_pricing.application.service import InMemoryStore
 from fare_pricing.ports import EventEnvelope
@@ -46,11 +47,11 @@ def rule(rule_id: str, kind: RuleKind, amount: str, *, refundable: bool = True) 
     )
 
 
-def published_rule_set(*extra_rules: FareRule) -> FareRuleSet:
+def published_rule_set(*extra_rules: FareRule, product_code: str = "rail-standard", rule_set_id: str = "ruleset-main") -> FareRuleSet:
     rs = FareRuleSet(
-        rule_set_id="ruleset-main",
+        rule_set_id=rule_set_id,
         supplier_id="supplier-a",
-        product_code="rail-flex",
+        product_code=product_code,
         mode="rail",
         channel="web",
         version="2026.07.03",
@@ -91,13 +92,21 @@ class FarePricingApiTest(unittest.TestCase):
             self.assertEqual(resp.status_code, 200)
 
 
-    def create_rule_set(self, *, base_minor: int = 12000, refund_minor: int = 3000, channel: str = "web", version: str = "2026.07.04") -> dict[str, object]:
+    def create_rule_set(
+        self,
+        *,
+        base_minor: int = 12000,
+        refund_minor: int = 3000,
+        channel: str = "web",
+        version: str = "2026.07.04",
+        product_code: str = "rail-standard",
+    ) -> dict[str, object]:
         resp = self.client.post(
             "/api/v1/fare-rule-sets",
             json={
                 "supplierId": "supplier-managed",
                 "contractId": "contract-managed",
-                "productCode": "rail-flex",
+                "productCode": product_code,
                 "mode": "rail",
                 "channel": channel,
                 "version": version,
@@ -180,6 +189,57 @@ class FarePricingApiTest(unittest.TestCase):
         self.assertEqual(refund_resp.status_code, 201, refund_resp.text)
         self.assertEqual(refund_resp.json()["refundableAmount"], {"currency": "CNY", "minorUnits": 9000})
 
+    def test_product_code_disambiguates_quotes_and_publish_supersede_scope(self) -> None:
+        business = self.create_rule_set(
+            base_minor=18000,
+            refund_minor=4000,
+            version="2026.07.business",
+            product_code="rail-business",
+        )
+        publish_resp = self.client.post(
+            f"/api/v1/fare-rule-sets/{business['ruleSetId']}/publish",
+            json={},
+            headers={"Idempotency-Key": uuid7_key(910)},
+        )
+        self.assertEqual(publish_resp.status_code, 200, publish_resp.text)
+        self.assertEqual(self.store.fare_rule_sets[self.rs.rule_set_id].status, RuleSetStatus.PUBLISHED)
+
+        standard_quote = self.client.post(
+            "/api/v1/fare-quotes",
+            json={"travelerRefs": ["tvl-standard"], "channel": "web", "segmentRefs": ["seg-standard"]},
+            headers={"Idempotency-Key": uuid7_key(911)},
+        )
+        self.assertEqual(standard_quote.status_code, 201, standard_quote.text)
+        self.assertEqual(standard_quote.json()["breakdown"]["total"], {"currency": "CNY", "minorUnits": 10000})
+        self.assertEqual(standard_quote.json()["ruleSnapshot"]["ruleSetId"], self.rs.rule_set_id)
+
+        business_quote = self.client.post(
+            "/api/v1/fare-quotes",
+            json={
+                "travelerRefs": ["tvl-business"],
+                "channel": "web",
+                "segmentRefs": ["seg-business"],
+                "productCode": "rail-business",
+            },
+            headers={"Idempotency-Key": uuid7_key(912)},
+        )
+        self.assertEqual(business_quote.status_code, 201, business_quote.text)
+        self.assertEqual(business_quote.json()["breakdown"]["total"], {"currency": "CNY", "minorUnits": 18000})
+        self.assertEqual(business_quote.json()["ruleSnapshot"]["ruleSetId"], business["ruleSetId"])
+
+        refund_resp = self.client.post(
+            "/api/v1/adjustment-quotes",
+            json={
+                "purpose": "REFUND",
+                "entitlementIds": ["ent-business"],
+                "journeyOrderId": "ord-business",
+                "segmentRefs": ["seg-business"],
+            },
+            headers={"Idempotency-Key": uuid7_key(913)},
+        )
+        self.assertEqual(refund_resp.status_code, 201, refund_resp.text)
+        self.assertEqual(refund_resp.json()["refundableAmount"], {"currency": "CNY", "minorUnits": 14000})
+
     def test_publish_rule_set_is_idempotent(self) -> None:
         created = self.create_rule_set(version="2026.07.05")
         key = uuid7_key(904)
@@ -189,6 +249,89 @@ class FarePricingApiTest(unittest.TestCase):
         self.assertEqual(second.status_code, 200, second.text)
         self.assertEqual(first.json(), second.json())
         self.assertEqual([event.event_type for event in self.publisher.published_events], ["FareRuleSetPublished", "FareRuleSetSuperseded"])
+        self.assertEqual(
+            self.publisher.published_events[0].event_id,
+            deterministic_rule_set_event_id(created["ruleSetId"], "2026.07.05", "published"),
+        )
+        self.assertEqual(
+            self.publisher.published_events[1].event_id,
+            deterministic_rule_set_event_id(self.rs.rule_set_id, self.rs.version, "superseded"),
+        )
+
+    def test_publish_event_failure_rolls_back_state_and_retry_uses_same_event_id(self) -> None:
+        created = self.create_rule_set(version="2026.07.rollback")
+        original = self.store.fare_rule_sets[self.rs.rule_set_id]
+        self.publisher.fail_next_publish()
+
+        failed = self.client.post(
+            f"/api/v1/fare-rule-sets/{created['ruleSetId']}/publish",
+            json={},
+            headers={"Idempotency-Key": uuid7_key(914)},
+        )
+
+        self.assertEqual(failed.status_code, 503, failed.text)
+        self.assertEqual(failed.json()["code"], "UNAVAILABLE")
+        self.assertEqual(self.store.fare_rule_sets[created["ruleSetId"]].status, RuleSetStatus.DRAFT)
+        self.assertEqual(self.store.fare_rule_sets[self.rs.rule_set_id], original)
+        self.assertEqual(self.publisher.published_event_count, 0)
+
+        retry = self.client.post(
+            f"/api/v1/fare-rule-sets/{created['ruleSetId']}/publish",
+            json={},
+            headers={"Idempotency-Key": uuid7_key(914)},
+        )
+        self.assertEqual(retry.status_code, 200, retry.text)
+        first_event_ids = [event.event_id for event in self.publisher.published_events]
+        self.assertEqual(len(first_event_ids), 2)
+        self.assertTrue(all(event_id.startswith("evt-") for event_id in first_event_ids))
+        self.assertEqual(uuid.UUID(first_event_ids[0].removeprefix("evt-")).version, 7)
+
+        replay = self.client.post(
+            f"/api/v1/fare-rule-sets/{created['ruleSetId']}/publish",
+            json={},
+            headers={"Idempotency-Key": uuid7_key(915)},
+        )
+        self.assertEqual(replay.status_code, 200, replay.text)
+        self.assertEqual([event.event_id for event in self.publisher.published_events], first_event_ids)
+
+    def test_superseded_event_failure_rolls_back_state_and_retry_uses_same_event_ids(self) -> None:
+        created = self.create_rule_set(version="2026.07.supersede-failure")
+        original = self.store.fare_rule_sets[self.rs.rule_set_id]
+        self.publisher.fail_on_publish_number(2)
+
+        failed = self.client.post(
+            f"/api/v1/fare-rule-sets/{created['ruleSetId']}/publish",
+            json={},
+            headers={"Idempotency-Key": uuid7_key(916)},
+        )
+
+        self.assertEqual(failed.status_code, 503, failed.text)
+        self.assertEqual(self.store.fare_rule_sets[created["ruleSetId"]].status, RuleSetStatus.DRAFT)
+        self.assertEqual(self.store.fare_rule_sets[self.rs.rule_set_id], original)
+        first_published_event_id = self.publisher.published_events[0].event_id
+        expected_published_event_id = deterministic_rule_set_event_id(
+            created["ruleSetId"], "2026.07.supersede-failure", "published"
+        )
+        expected_superseded_event_id = deterministic_rule_set_event_id(self.rs.rule_set_id, self.rs.version, "superseded")
+        self.assertEqual(first_published_event_id, expected_published_event_id)
+
+        retry = self.client.post(
+            f"/api/v1/fare-rule-sets/{created['ruleSetId']}/publish",
+            json={},
+            headers={"Idempotency-Key": uuid7_key(916)},
+        )
+        self.assertEqual(retry.status_code, 200, retry.text)
+        event_ids = [event.event_id for event in self.publisher.published_events]
+        self.assertEqual(event_ids[0], event_ids[1])
+        self.assertEqual(event_ids[0], first_published_event_id)
+        self.assertNotEqual(event_ids[1], event_ids[2])
+        self.assertEqual(event_ids[2], expected_superseded_event_id)
+        self.assertEqual(uuid.UUID(event_ids[2].removeprefix("evt-")).version, 7)
+        self.assertEqual([event.event_type for event in self.publisher.published_events], [
+            "FareRuleSetPublished",
+            "FareRuleSetPublished",
+            "FareRuleSetSuperseded",
+        ])
 
     def test_fare_quote_happy_path(self) -> None:
         """POST /api/v1/fare-quotes returns 201 with quote details."""

--- a/services/fare-pricing/tests/test_domain.py
+++ b/services/fare-pricing/tests/test_domain.py
@@ -148,6 +148,7 @@ class FarePricingDomainTest(unittest.TestCase):
                 input_hash="hash",
                 traveler_refs=("traveler-1",),
                 channel="web",
+                product_code="rail-flex",
                 currency="USD",
                 status=QuoteStatus.FAILED,
                 valid_from=NOW,


### PR DESCRIPTION
## Summary
- Add fare quote productCode defaulting and channel+product selection for quotes and adjustments
- Make rule-set publish/supersede events deterministic and rollback state on publish failures
- Extend fare-rule e2e coverage with rail-business disambiguation checks

## Validation
- uv run --project services/fare-pricing pytest services/fare-pricing -q
- bash -n deploy/e2e/07-fare-rules.sh
- make check

E2E live cluster run: not run in sandbox; orchestrator should execute 02/03/07 regression.