### PR TITLE
REQ-071 Legacy ACL strangler

### DIFF
--- a/deploy/build-images.sh
+++ b/deploy/build-images.sh
@@ -29,6 +29,7 @@ services=(
   finance-settlement
   reporting
   supplier-catalog
+  legacy-acl
 )
 
 for service in "${services[@]}"; do

--- a/deploy/docker/legacy-acl/Dockerfile
+++ b/deploy/docker/legacy-acl/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1.7
+FROM ghcr.io/astral-sh/uv:0.9-python3.12-bookworm-slim AS builder
+WORKDIR /src
+ENV UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
+COPY platform/python-kit ./platform/python-kit
+COPY services/legacy-acl/pyproject.toml ./services/legacy-acl/
+COPY services/legacy-acl/src ./services/legacy-acl/src
+RUN sed -i 's/editable = true/editable = false/' services/legacy-acl/pyproject.toml
+RUN --mount=type=cache,target=/root/.cache/uv uv venv /opt/venv &&     uv pip install --python /opt/venv/bin/python ./platform/python-kit ./services/legacy-acl "uvicorn[standard]"
+
+FROM python:3.12-slim
+RUN useradd --system --create-home --home-dir /home/app app
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH=/opt/venv/bin:$PATH PORT=8080 REDIS_URL=redis://localhost:6379
+USER app
+EXPOSE 8080
+CMD ["sh", "-c", "exec uvicorn legacy_acl.main:app --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/deploy/e2e/11-legacy-acl.sh
+++ b/deploy/e2e/11-legacy-acl.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Legacy ACL strangler: complete lifecycle through legacy endpoints only.
+cd "$(dirname "$0")" && . ./lib.sh
+. ./.refs.env
+ensure_curl_pod
+
+legacy_req() {
+  local p=$1 body=$2 key=${3:-$(uuid7)} out
+  out=$(k exec -i e2e-curl -- curl -s -w $'\n%{http_code}' -X POST "http://legacy-acl:8080$p" \
+    -H 'Content-Type: application/json' \
+    -H "Idempotency-Key: $key" \
+    -H 'X-Legacy-Operator: e2e-legacy-operator' \
+    -H 'X-Legacy-Reason: E2E_LEGACY_ACL' \
+    -d "$body" 2>/dev/null)
+  LAST_CODE=$(echo "$out" | tail -1)
+  RESP=$(echo "$out" | sed '$d')
+}
+
+assert_legacy_response() {
+  local expected_status=$1 description=$2
+  if [ "$LAST_CODE" = "200" ]; then ok "$description HTTP 200"; else bad "$description HTTP got $LAST_CODE"; fi
+  STATUS_FIELD=$(echo "$RESP" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("status", "")); assert "msg" in d and "data" in d' 2>/dev/null || true)
+  if [ "$STATUS_FIELD" = "$expected_status" ]; then ok "$description legacy status=$expected_status"; else bad "$description legacy status got $STATUS_FIELD want $expected_status"; fi
+}
+
+find_stream_event() {
+  local stream=$1 event_type=$2 field=$3 value=$4 count=${5:-120}
+  k exec "$(redis_pod)" -- redis-cli --no-raw XREVRANGE "$stream" + - COUNT "$count" 2>/dev/null > /tmp/legacy-acl-events.txt
+  EVENT_TYPE="$event_type" FIELD="$field" VALUE="$value" python3 - << 'PY'
+import json, os, re
+raw = open('/tmp/legacy-acl-events.txt').read()
+for m in re.finditer(r'\{.*\}', raw):
+    try:
+        e = json.loads(m.group(0).encode().decode('unicode_escape'))
+    except Exception:
+        continue
+    payload = e.get('payload', {})
+    if e.get('eventType') == os.environ['EVENT_TYPE'] and str(payload.get(os.environ['FIELD'], '')) == os.environ['VALUE']:
+        print(json.dumps(e)); break
+PY
+}
+
+wait_legacy_event() {
+  local operation=$1 key=$2 found=""
+  for attempt in 1 2 3 4 5 6; do
+    found=$(find_stream_event events:legacy-acl LegacyCommandMapped sourceRef "$key")
+    if [ -n "$found" ] && echo "$found" | OP="$operation" python3 -c 'import json,sys,os; e=json.load(sys.stdin); assert e["payload"]["legacyOperation"] == os.environ["OP"]' 2>/dev/null; then
+      break
+    fi
+    sleep 3
+  done
+  [ -n "$found" ] && ok "LegacyCommandMapped $operation" || bad "missing LegacyCommandMapped $operation"
+}
+
+wait_audit() {
+  local key=$1 found=""
+  for attempt in 1 2 3 4 5 6; do
+    req GET admin-audit "/api/v1/admin/audit-trail?businessRef=$key&limit=20&offset=0"
+    found=$(echo "$RESP" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("total", 0))' 2>/dev/null || echo 0)
+    [ "${found:-0}" -gt 0 ] 2>/dev/null && break
+    sleep 3
+  done
+  [ "${found:-0}" -gt 0 ] 2>/dev/null && ok "admin-audit recorded $key" || bad "admin-audit missing $key"
+}
+
+legacy_step() {
+  local op=$1 path=$2 body=$3 key
+  key=$(uuid7)
+  legacy_req "$path" "$body" "$key"
+  assert_legacy_response 1 "$op"
+  wait_legacy_event "$op" "$key"
+  wait_audit "$key"
+  LEGACY_KEY="$key"
+}
+
+ACCT="acc-$(uuid7)"
+echo "== 1. preserve through legacy ACL"
+legacy_step PRESERVE /api/v1/legacy/preserve "{\"accountId\":\"$ACCT\",\"contactsId\":\"$TVL\",\"tripId\":\"G1234\",\"seatType\":\"SECOND\",\"date\":\"2026-08-01\",\"from\":\"$P_BJ\",\"to\":\"$P_SH\"}"
+ORDER=$(jget "['data']['orderId']"); TOTAL=$(jget "['data']['total']['minorUnits']")
+echo "  ORDER=$ORDER totalMinor=$TOTAL"
+
+sleep 5
+echo "== 2. inside payment"
+legacy_step INSIDE_PAYMENT /api/v1/legacy/inside_payment "{\"orderId\":\"$ORDER\",\"price\":{\"currency\":\"CNY\",\"minorUnits\":${TOTAL:-10750}}}"
+PI=$(jget "['data']['paymentIntentId']")
+echo "  PI=$PI"
+
+sleep 5
+echo "== 3. ticket issue"
+# Allow booking-orchestration to process reservation confirmation before ticketing.
+sleep 8
+legacy_step TICKET_ISSUE /api/v1/legacy/ticket_issue "{\"orderId\":\"$ORDER\"}"
+ENT=$(jget "['data']['entitlementId']")
+echo "  ENT=$ENT"
+
+sleep 5
+echo "== 4. execute boarding"
+legacy_step EXECUTE /api/v1/legacy/execute "{\"orderId\":\"$ORDER\"}"
+FR=$(jget "['data']['fulfillmentRecordId']")
+echo "  FR=$FR"
+
+ACCT2="acc-$(uuid7)"
+echo "== 5. second order preserve"
+legacy_step PRESERVE /api/v1/legacy/preserve "{\"accountId\":\"$ACCT2\",\"contactsId\":\"$TVL\",\"tripId\":\"G1234\",\"seatType\":\"SECOND\",\"date\":\"2026-08-01\",\"from\":\"$P_BJ\",\"to\":\"$P_SH\"}"
+ORDER2=$(jget "['data']['orderId']"); TOTAL2=$(jget "['data']['total']['minorUnits']")
+legacy_step INSIDE_PAYMENT /api/v1/legacy/inside_payment "{\"orderId\":\"$ORDER2\",\"price\":{\"currency\":\"CNY\",\"minorUnits\":${TOTAL2:-10750}}}"
+sleep 8
+legacy_step TICKET_ISSUE /api/v1/legacy/ticket_issue "{\"orderId\":\"$ORDER2\"}"
+sleep 5
+
+legacy_step CANCEL /api/v1/legacy/cancel "{\"orderId\":\"$ORDER2\"}"
+REFUNDABLE=$(jget "['data']['refundAmount']['minorUnits']")
+[ "$REFUNDABLE" = "8750" ] && ok "legacy cancel refundable amount is 8750" || bad "legacy cancel refundable amount $REFUNDABLE, expected 8750"
+
+summary

--- a/deploy/e2e/11-legacy-acl.sh
+++ b/deploy/e2e/11-legacy-acl.sh
@@ -67,9 +67,13 @@ legacy_step() {
   local op=$1 path=$2 body=$3 key
   key=$(uuid7)
   legacy_req "$path" "$body" "$key"
+  # wait_* below overwrite $RESP with admin-audit queries; stash the
+  # legacy response so callers can extract data.* from it afterwards.
+  LEGACY_RESP="$RESP"
   assert_legacy_response 1 "$op"
   wait_legacy_event "$op" "$key"
   wait_audit "$key"
+  RESP="$LEGACY_RESP"
   LEGACY_KEY="$key"
 }
 

--- a/deploy/k8s/services.yaml
+++ b/deploy/k8s/services.yaml
@@ -1691,3 +1691,78 @@ spec:
       targetPort: http
   selector:
     app.kubernetes.io/name: supplier-catalog
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: legacy-acl
+  namespace: train-ticket
+  labels:
+    app.kubernetes.io/name: legacy-acl
+    app.kubernetes.io/part-of: train-ticket
+spec:
+  replicas: 1
+  # Stateless strangler facade; keep deployment strategy consistent with phase-1 services.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: legacy-acl
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: legacy-acl
+        app.kubernetes.io/part-of: train-ticket
+    spec:
+      containers:
+        - name: legacy-acl
+          image: train-ticket/legacy-acl:local
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"
+            - name: REDIS_URL
+              value: redis://redis.train-ticket.svc.cluster.local:6379
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: legacy-acl
+  namespace: train-ticket
+  labels:
+    app.kubernetes.io/name: legacy-acl
+    app.kubernetes.io/part-of: train-ticket
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+  selector:
+    app.kubernetes.io/name: legacy-acl

--- a/service-catalog.json
+++ b/service-catalog.json
@@ -718,6 +718,26 @@
         "Eta"
       ],
       "rationale": "Go fits real-time dispatch APIs, adapter calls, and low-latency state updates."
+    },
+    {
+      "id": "legacy-acl",
+      "path": "services/legacy-acl",
+      "domain": "Legacy ACL",
+      "language": "python",
+      "runtime": "python",
+      "phase": "phase-1-core",
+      "status": "integration-ready",
+      "priority": "P0",
+      "workPackages": [
+        "REQ-071",
+        "WP-23"
+      ],
+      "docs": [
+        "docs/08-contracts/api/legacy-acl.md",
+        "docs/08-contracts/events/legacy-acl.md"
+      ],
+      "owns": [],
+      "rationale": "Python/FastAPI strangler facade maps legacy entrypoints to bounded-context HTTP commands without owning state."
     }
   ]
 }

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/messaging/AdminAuditSubscriptionRunner.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/adapters/messaging/AdminAuditSubscriptionRunner.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 @Component
 @ConditionalOnProperty(name = "ADMIN_AUDIT_REDIS_ENABLED", havingValue = "true", matchIfMissing = true)
 public class AdminAuditSubscriptionRunner implements CommandLineRunner {
-    static final List<String> SUBSCRIBED_STREAMS = List.of("events:customer-service");
+    public static final List<String> SUBSCRIBED_STREAMS = List.of("events:customer-service", "events:legacy-acl");
     static final String CONSUMER_GROUP = "admin-audit";
 
     private final EventSubscriber subscriber;

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/AdminAuditInboundEventHandler.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/AdminAuditInboundEventHandler.java
@@ -16,24 +16,37 @@ public class AdminAuditInboundEventHandler implements EventSubscriber.EventHandl
 
     @Override
     public EventSubscriber.HandlerResult handle(EventEnvelope envelope) {
-        if (!"customer-service".equals(envelope.producer()) || !"ManualActionRequested".equals(envelope.eventType())) {
-            return EventSubscriber.HandlerResult.SUCCESS;
-        }
         try {
-            InboundEventPayload payload = InboundEventPayload.from(envelope);
-            service.recordCustomerManualActionRequest(
-                envelope.eventId(),
-                payload.requiredText("manualActionId"),
-                payload.requiredText("caseId"),
-                payload.requiredText("targetDomain"),
-                payload.requiredText("commandType"),
-                payload.requiredText("operatorRef"),
-                payload.requiredText("reason"),
-                payload.requiredText("description"),
-                payload.requiredBoolean("requiresApproval"),
-                envelope.occurredAt(),
-                envelope.correlationId()
-            );
+            if ("customer-service".equals(envelope.producer()) && "ManualActionRequested".equals(envelope.eventType())) {
+                InboundEventPayload payload = InboundEventPayload.from(envelope);
+                service.recordCustomerManualActionRequest(
+                    envelope.eventId(),
+                    payload.requiredText("manualActionId"),
+                    payload.requiredText("caseId"),
+                    payload.requiredText("targetDomain"),
+                    payload.requiredText("commandType"),
+                    payload.requiredText("operatorRef"),
+                    payload.requiredText("reason"),
+                    payload.requiredText("description"),
+                    payload.requiredBoolean("requiresApproval"),
+                    envelope.occurredAt(),
+                    envelope.correlationId()
+                );
+                return EventSubscriber.HandlerResult.SUCCESS;
+            }
+            if ("legacy-acl".equals(envelope.producer()) && "LegacyCommandMapped".equals(envelope.eventType())) {
+                InboundEventPayload payload = InboundEventPayload.from(envelope);
+                service.recordLegacyCommandMapped(
+                    envelope.eventId(),
+                    payload.requiredText("legacyOperation"),
+                    payload.requiredText("outcome"),
+                    payload.requiredText("operatorRef"),
+                    payload.optionalText("reason"),
+                    payload.requiredText("sourceRef"),
+                    envelope.correlationId()
+                );
+                return EventSubscriber.HandlerResult.SUCCESS;
+            }
             return EventSubscriber.HandlerResult.SUCCESS;
         } catch (ValidationException | DomainRuleViolation | IllegalArgumentException exception) {
             return EventSubscriber.HandlerResult.FATAL_FAILURE;

--- a/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/AdminAuditService.java
+++ b/services/admin-audit/src/main/java/com/trainticket/adminaudit/application/AdminAuditService.java
@@ -204,6 +204,28 @@ public class AdminAuditService {
         return action;
     }
 
+    public void recordLegacyCommandMapped(
+        String sourceEventId,
+        String legacyOperation,
+        String outcome,
+        String operatorRef,
+        String reason,
+        String sourceRef,
+        String correlationId
+    ) {
+        String resourceRef = sourceRef == null || sourceRef.isBlank() ? sourceEventId : sourceRef;
+        recordAudit(
+            operatorRef,
+            operatorRef,
+            "LEGACY_COMMAND_MAPPED",
+            resourceRef,
+            "legacy-acl",
+            reason == null || reason.isBlank() ? legacyOperation : reason,
+            normalizeCorrelationId(correlationId),
+            "Legacy command mapped: " + legacyOperation + " " + outcome
+        );
+    }
+
     public ManualAction rejectManualAction(String manualActionId, String rejectedByOperatorId, String reason, String correlationId) {
         ManualAction action = repository.findManualAction(manualActionId)
             .orElseThrow(() -> new NotFoundException("manual action not found"));

--- a/services/admin-audit/src/test/java/com/trainticket/adminaudit/ApplicationTest.java
+++ b/services/admin-audit/src/test/java/com/trainticket/adminaudit/ApplicationTest.java
@@ -7,6 +7,14 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.trainticket.adminaudit.adapters.messaging.AdminAuditSubscriptionRunner;
+import com.trainticket.adminaudit.application.AdminAuditInboundEventHandler;
+import com.trainticket.adminaudit.application.AdminAuditService;
+import com.trainticket.adminaudit.application.ports.EventSubscriber;
+import com.trainticket.adminaudit.application.ports.InMemoryAdminAuditRepository;
+import com.trainticket.adminaudit.application.ports.EventPublisher;
+import com.trainticket.platformkit.messaging.EventEnvelope;
+
 import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.time.Clock;
@@ -78,6 +86,41 @@ class ApplicationTest {
         String correlationId = response.getHeader(RequestContextFilter.CORRELATION_ID_HEADER);
         assertNotNull(correlationId);
         assertTrue(correlationId.startsWith("corr-"));
+    }
+
+    @Test
+    void legacyAclEventsAreAuditedAndDoNotPoisonHandler() {
+        InMemoryAdminAuditRepository repository = new InMemoryAdminAuditRepository();
+        List<EventEnvelope> published = new ArrayList<>();
+        EventPublisher publisher = published::add;
+        AdminAuditService service = new AdminAuditService(
+            repository,
+            publisher,
+            Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC)
+        );
+        AdminAuditInboundEventHandler handler = new AdminAuditInboundEventHandler(service);
+        EventEnvelope envelope = new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8000-000000000001",
+            "LegacyCommandMapped",
+            Instant.parse("2026-01-01T00:00:00Z"),
+            "corr-0194f2e0-7b3e-7610-8000-000000000002",
+            "cmd-0194f2e0-7b3e-7610-8000-000000000003",
+            "legacy-acl",
+            1,
+            Map.of(
+                "legacyOperation", "PRESERVE",
+                "outcome", "SUCCEEDED",
+                "operatorRef", "op-1",
+                "sourceRef", "0194f2e0-7b3e-7610-8000-000000000004"
+            )
+        );
+
+        EventSubscriber.HandlerResult result = handler.handle(envelope);
+
+        assertEquals(EventSubscriber.HandlerResult.SUCCESS, result);
+        assertEquals(1, repository.countAuditEntries("0194f2e0-7b3e-7610-8000-000000000004"));
+        assertEquals("AuditEntryRecorded", published.getFirst().eventType());
+        assertTrue(AdminAuditSubscriptionRunner.SUBSCRIBED_STREAMS.contains("events:legacy-acl"));
     }
 
     private static final class RecordingTracer implements RuntimeTracer {

--- a/services/legacy-acl/README.md
+++ b/services/legacy-acl/README.md
@@ -1,0 +1,3 @@
+# Legacy ACL
+
+FastAPI strangler facade for legacy Train Ticket entrypoints. It owns no domain state: every command resolves context through owning service APIs, invokes the new bounded-context HTTP commands, and emits `LegacyCommandMapped` to `events:legacy-acl` for audit ingestion.

--- a/services/legacy-acl/pyproject.toml
+++ b/services/legacy-acl/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "legacy-acl"
+version = "0.1.0"
+description = "Legacy ACL strangler facade"
+requires-python = ">=3.11"
+dependencies = [
+  "train-ticket-platform",
+]
+
+[dependency-groups]
+dev = [
+  "httpx2>=2.5.0",
+  "pytest==9.1.1",
+]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.uv.sources]
+train-ticket-platform = { path = "../../platform/python-kit", editable = true }

--- a/services/legacy-acl/src/legacy_acl/api.py
+++ b/services/legacy-acl/src/legacy_acl/api.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from contextlib import AbstractContextManager, nullcontext
+from typing import Any, Protocol
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from train_ticket_platform.idempotency import BoundedInMemoryIdempotencyStore, IdempotencyStore, configure_idempotency_middleware
+from train_ticket_platform.ids import is_uuid7
+
+from .application import LegacyAclService, LegacyContext
+from .downstream import DownstreamClient
+
+from .ids import prefixed_uuid7
+from .runtime import health, profile
+
+REQUEST_ID_HEADER = "X-Request-Id"
+CORRELATION_ID_HEADER = "X-Correlation-Id"
+LEGACY_OPERATOR_HEADER = "X-Legacy-Operator"
+LEGACY_REASON_HEADER = "X-Legacy-Reason"
+IDEMPOTENCY_KEY_HEADER = "Idempotency-Key"
+TraceHook = Callable[[str, Mapping[str, object]], None]
+
+
+class RuntimeSpan(AbstractContextManager["RuntimeSpan"], Protocol):
+    def set_attribute(self, key: str, value: object) -> None: ...
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool | None: ...
+
+
+class RuntimeTracer(Protocol):
+    def start_as_current_span(self, name: str) -> RuntimeSpan: ...
+
+
+def opentelemetry_tracer_from_env(service_name: str) -> RuntimeTracer | None:
+    import os
+
+    exporter = os.getenv("OTEL_TRACES_EXPORTER", "").strip().lower()
+    if not exporter or exporter == "none":
+        return None
+    configured_service = os.getenv("OTEL_SERVICE_NAME", "").strip() or service_name
+    try:
+        from opentelemetry import trace
+    except ImportError:  # pragma: no cover
+        return None
+    return trace.get_tracer(configured_service)
+
+
+def _span_context(tracer: RuntimeTracer | None, name: str) -> AbstractContextManager[RuntimeSpan | None]:
+    if tracer is None:
+        return nullcontext(None)
+    return tracer.start_as_current_span(name)
+
+
+def _set_span_attribute(span: RuntimeSpan | None, key: str, value: object) -> None:
+    if span is not None:
+        span.set_attribute(key, value)
+
+
+def _emit_trace(tracer: TraceHook | None, event: str, attributes: Mapping[str, object]) -> None:
+    if tracer is not None:
+        tracer(event, dict(attributes))
+
+
+def _canonical_correlation_id(value: str | None) -> str:
+    if not value or not value.strip():
+        return prefixed_uuid7("corr")
+    supplied = value.strip()
+    if supplied.startswith("corr-") and is_uuid7(supplied[5:]):
+        return supplied
+    if is_uuid7(supplied):
+        return f"corr-{supplied}"
+    return prefixed_uuid7("corr")
+
+
+def _request_identifiers(request: Request) -> tuple[str, str]:
+    request_id = request.headers.get(REQUEST_ID_HEADER) or prefixed_uuid7("req")
+    correlation_id = _canonical_correlation_id(request.headers.get(CORRELATION_ID_HEADER))
+    return request_id, correlation_id
+
+
+def legacy_body(status: int, msg: str, data: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    return {"status": status, "msg": msg, "data": dict(data or {})}
+
+
+def _legacy_idempotency_error(_request: Request, _code: str, message: str) -> Mapping[str, Any]:
+    return legacy_body(0, message)
+
+
+def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None) -> None:
+    @app.middleware("http")
+    async def request_context_middleware(request: Request, call_next: Any):
+        request_id, correlation_id = _request_identifiers(request)
+        request.state.request_id = request_id
+        request.state.correlation_id = correlation_id
+        attrs = {
+            "service.name": profile()["service_id"],
+            "request_id": request_id,
+            "correlation_id": correlation_id,
+            "http.request.method": request.method,
+            "http.method": request.method,
+            "url.path": request.url.path,
+            "http.route": request.url.path,
+        }
+        _emit_trace(tracer, "http.request.start", attrs)
+        with _span_context(otel_tracer, f"{request.method} {request.url.path}") as span:
+            for key, value in attrs.items():
+                _set_span_attribute(span, key, value)
+            response = await call_next(request)
+            response.headers[REQUEST_ID_HEADER] = request_id
+            response.headers[CORRELATION_ID_HEADER] = correlation_id
+            _set_span_attribute(span, "http.response.status_code", response.status_code)
+            _emit_trace(tracer, "http.request.complete", {**attrs, "status_code": response.status_code})
+            return response
+
+    @app.get("/healthz")
+    def healthz_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
+    @app.get("/readyz")
+    def readyz_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
+    @app.get("/health")
+    def health_endpoint() -> dict[str, object]:
+        return {"status": health(), "service": profile()}
+
+    @app.get("/live")
+    def live_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
+    @app.get("/ready")
+    def ready_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
+    @app.get("/metadata")
+    def metadata_endpoint() -> dict[str, object]:
+        return {"service": profile(), "observability": {"tracing": "opt-in", "default": "noop"}}
+
+
+def configure_legacy_routes(app: FastAPI, service: LegacyAclService) -> None:
+    app.state.legacy_acl_service = service
+
+    async def invoke(request: Request, operation: str) -> JSONResponse:
+        operator = request.headers.get(LEGACY_OPERATOR_HEADER)
+        if not operator or not operator.strip():
+            return JSONResponse(status_code=400, content=legacy_body(0, "X-Legacy-Operator header is required"))
+        source_ref = request.headers.get(IDEMPOTENCY_KEY_HEADER, "")
+        ctx = LegacyContext(
+            operator_ref=operator.strip(),
+            reason=request.headers.get(LEGACY_REASON_HEADER),
+            source_ref=source_ref,
+            correlation_id=str(getattr(request.state, "correlation_id", None) or prefixed_uuid7("corr")),
+        )
+        try:
+            payload = await request.json()
+        except Exception:
+            payload = {}
+        if not isinstance(payload, Mapping):
+            payload = {}
+        result = getattr(service, operation)(payload, ctx)
+        return JSONResponse(status_code=200, content=legacy_body(result.status, result.msg, result.data))
+
+    @app.post("/api/v1/legacy/preserve")
+    async def preserve(request: Request) -> JSONResponse:
+        return await invoke(request, "preserve")
+
+    @app.post("/api/v1/legacy/inside_payment")
+    async def inside_payment(request: Request) -> JSONResponse:
+        return await invoke(request, "inside_payment")
+
+    @app.post("/api/v1/legacy/ticket_issue")
+    async def ticket_issue(request: Request) -> JSONResponse:
+        return await invoke(request, "ticket_issue")
+
+    @app.post("/api/v1/legacy/execute")
+    async def execute(request: Request) -> JSONResponse:
+        return await invoke(request, "execute")
+
+    @app.post("/api/v1/legacy/cancel")
+    async def cancel(request: Request) -> JSONResponse:
+        return await invoke(request, "cancel")
+
+    @app.post("/api/v1/legacy/rebook")
+    async def rebook(request: Request) -> JSONResponse:
+        return await invoke(request, "rebook")
+
+
+def create_app(
+    tracer: TraceHook | None = None,
+    otel_tracer: RuntimeTracer | None = None,
+    client: DownstreamClient | None = None,
+    event_publisher: Any | None = None,
+    idempotency_store: IdempotencyStore | None = None,
+) -> FastAPI:
+    app = FastAPI(title="Legacy ACL", version="0.1.0")
+    configure_runtime_endpoints(app, tracer, otel_tracer or opentelemetry_tracer_from_env(profile()["service_id"]))
+    configure_idempotency_middleware(
+        app,
+        idempotency_store or BoundedInMemoryIdempotencyStore(),
+        require_key=True,
+        include_path_prefixes=("/api/v1/legacy/",),
+        error_body_factory=_legacy_idempotency_error,
+    )
+    configure_legacy_routes(app, LegacyAclService(client=client, publisher=event_publisher))
+    return app

--- a/services/legacy-acl/src/legacy_acl/application.py
+++ b/services/legacy-acl/src/legacy_acl/application.py
@@ -10,7 +10,7 @@ from train_ticket_platform.events import EventEnvelope, rfc3339_utc
 from train_ticket_platform.messaging import EventPublisher, RedisEventPublisher
 
 from .downstream import DownstreamClient, DownstreamError, quote
-from .ids import deterministic_event_id, deterministic_prefixed_uuid, prefixed_uuid7
+from .ids import deterministic_event_id, deterministic_prefixed_uuid, deterministic_uuid7
 
 
 class LegacyOperation(StrEnum):
@@ -235,10 +235,10 @@ class LegacyAclService:
             return self._failure(LegacyOperation.EXECUTE, ctx, commands, exc)
 
     def cancel(self, payload: Mapping[str, Any], ctx: LegacyContext) -> LegacyResult:
-        return self._post_sales(payload, ctx, LegacyOperation.CANCEL, "REFUND", "CUSTOMER_REQUEST", "refundAmount")
+        return self._post_sales(payload, ctx, LegacyOperation.CANCEL, "REFUND", "CUSTOMER_REQUEST", "refundableAmount", "refundAmount")
 
     def rebook(self, payload: Mapping[str, Any], ctx: LegacyContext) -> LegacyResult:
-        return self._post_sales(payload, ctx, LegacyOperation.REBOOK, "CHANGE", "CUSTOMER_CHANGE", "amountDue")
+        return self._post_sales(payload, ctx, LegacyOperation.REBOOK, "CHANGE", "CUSTOMER_CHANGE", "amountDue", "amountDue")
 
     def _post_sales(
         self,
@@ -247,7 +247,8 @@ class LegacyAclService:
         operation: LegacyOperation,
         case_type: str,
         reason_code: str,
-        result_amount_field: str,
+        evaluation_amount_field: str,
+        legacy_amount_field: str,
     ) -> LegacyResult:
         commands: list[str] = []
         try:
@@ -270,20 +271,20 @@ class LegacyAclService:
                     "reasonCode": reason_code,
                     "actorRef": _required_text(order, "accountId"),
                 },
-                _headers(ctx, "case"),
+                _headers(ctx, f"{operation.value.lower()}-case"),
             )
             commands.append("OpenPostSalesCase")
             case_id = _required_text(opened, "caseId")
-            evaluated = self.client.post("post-sales", f"/api/v1/post-sales-cases/{quote(case_id)}/evaluate", {}, _headers(ctx, "evaluate"))
+            evaluated = self.client.post("post-sales", f"/api/v1/post-sales-cases/{quote(case_id)}/evaluate", {}, _headers(ctx, f"{operation.value.lower()}-evaluate"))
             commands.append("EvaluatePostSalesEligibility")
-            self.client.post("post-sales", f"/api/v1/post-sales-cases/{quote(case_id)}/approve", {}, _headers(ctx, "approve"))
+            self.client.post("post-sales", f"/api/v1/post-sales-cases/{quote(case_id)}/approve", {}, _headers(ctx, f"{operation.value.lower()}-approve"))
             commands.append("ApprovePostSalesCase")
             return self._finish(
                 operation,
                 Outcome.SUCCEEDED,
                 ctx,
                 commands,
-                {"caseId": case_id, result_amount_field: evaluated.get(result_amount_field) or {"currency": "CNY", "minorUnits": 0}},
+                {"caseId": case_id, legacy_amount_field: _required_mapping(evaluated, evaluation_amount_field)},
                 None,
             )
         except Exception as exc:
@@ -434,7 +435,8 @@ class LegacyAclService:
 
 
 def _headers(ctx: LegacyContext, suffix: str) -> dict[str, str]:
-    return {"Idempotency-Key": ctx.source_ref, "X-Correlation-Id": ctx.correlation_id, "X-Request-Id": f"{ctx.source_ref}-{suffix}"}
+    downstream_key = deterministic_uuid7(ctx.source_ref, suffix)
+    return {"Idempotency-Key": downstream_key, "X-Correlation-Id": ctx.correlation_id, "X-Request-Id": f"{ctx.source_ref}-{suffix}"}
 
 
 def _required_text(payload: Mapping[str, Any], field: str) -> str:

--- a/services/legacy-acl/src/legacy_acl/application.py
+++ b/services/legacy-acl/src/legacy_acl/application.py
@@ -1,0 +1,479 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+from train_ticket_platform.events import EventEnvelope, rfc3339_utc
+from train_ticket_platform.messaging import EventPublisher, RedisEventPublisher
+
+from .downstream import DownstreamClient, DownstreamError, quote
+from .ids import deterministic_event_id, deterministic_prefixed_uuid, prefixed_uuid7
+
+
+class LegacyOperation(StrEnum):
+    PRESERVE = "PRESERVE"
+    INSIDE_PAYMENT = "INSIDE_PAYMENT"
+    TICKET_ISSUE = "TICKET_ISSUE"
+    EXECUTE = "EXECUTE"
+    CANCEL = "CANCEL"
+    REBOOK = "REBOOK"
+
+
+class Outcome(StrEnum):
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+
+
+@dataclass(frozen=True)
+class LegacyContext:
+    operator_ref: str
+    reason: str | None
+    source_ref: str
+    correlation_id: str
+
+
+@dataclass(frozen=True)
+class LegacyResult:
+    status: int
+    msg: str
+    data: Mapping[str, Any]
+
+
+class LegacyAclService:
+    def __init__(self, client: DownstreamClient | None = None, publisher: EventPublisher | None = None) -> None:
+        self.client = client or DownstreamClient()
+        self.publisher = publisher or RedisEventPublisher()
+
+    def preserve(self, payload: Mapping[str, Any], ctx: LegacyContext) -> LegacyResult:
+        commands: list[str] = []
+        try:
+            account_id = _required_text(payload, "accountId")
+            traveler_ref = self._traveler_ref(account_id, payload.get("contactsId"), ctx, commands)
+            search = self.client.post(
+                "trip-planning",
+                "/api/v1/itineraries/search",
+                {
+                    "originRef": _required_text(payload, "from"),
+                    "destinationRef": _required_text(payload, "to"),
+                    "departureDate": _required_text(payload, "date"),
+                    "travelerRefs": [traveler_ref],
+                    "channel": "WEB",
+                },
+                _headers(ctx, "search"),
+            )
+            commands.append("SearchItineraries")
+            itinerary = _first_mapping(search, "itineraries", "no itinerary found")
+            itinerary_ref = _required_text(itinerary, "itineraryRef")
+            leg = _first_mapping(itinerary, "legs", "itinerary contains no legs")
+            segment_ref = _required_text(leg, "serviceSegmentRef")
+
+            fare_quote = self.client.post(
+                "fare-pricing",
+                "/api/v1/fare-quotes",
+                {"travelerRefs": [traveler_ref], "channel": "WEB", "segmentRefs": [segment_ref]},
+                _headers(ctx, "fare-quote"),
+            )
+            commands.append("CreateFareQuote")
+
+            offer = self.client.post(
+                "offer-management",
+                "/api/v1/offers",
+                {
+                    "accountId": account_id,
+                    "channelId": "WEB",
+                    "itineraryRef": itinerary_ref,
+                    "travelerRefs": [traveler_ref],
+                    "quoteRequestId": str(fare_quote.get("quoteId", ctx.source_ref)),
+                },
+                _headers(ctx, "offer"),
+            )
+            commands.append("CreateOffer")
+            offer_id = _required_text(offer, "offerId")
+            offer_version = _required_int(offer, "offerVersion")
+
+            order = self.client.post(
+                "journey-order",
+                "/api/v1/journey-orders",
+                {
+                    "accountId": account_id,
+                    "offerId": offer_id,
+                    "offerVersion": offer_version,
+                    "travelerRefs": [traveler_ref],
+                    "segmentRefs": [segment_ref],
+                },
+                _headers(ctx, "order"),
+            )
+            commands.append("CreateJourneyOrder")
+            order_id = _required_text(order, "orderId")
+
+            saga_id = self._resolve_saga(order_id, account_id, offer_id, [traveler_ref], [segment_ref], ctx, commands)
+            segment_booking_id = deterministic_prefixed_uuid("sb", f"{order_id}:{segment_ref}:{traveler_ref}")
+            self.client.post(
+                "booking-orchestration",
+                f"/api/v1/internal/booking-sagas/{quote(saga_id)}/request-reservation",
+                {"segmentRef": segment_ref, "travelerRef": traveler_ref, "segmentBookingId": segment_booking_id},
+                _headers(ctx, "reservation"),
+            )
+            commands.append("RequestSegmentReservation")
+
+            result_refs = {
+                "orderId": order_id,
+                "offerId": offer_id,
+                "total": offer.get("total") or _nested(fare_quote, "breakdown", "total"),
+            }
+            return self._finish(LegacyOperation.PRESERVE, Outcome.SUCCEEDED, ctx, commands, result_refs, None)
+        except Exception as exc:
+            return self._failure(LegacyOperation.PRESERVE, ctx, commands, exc)
+
+    def inside_payment(self, payload: Mapping[str, Any], ctx: LegacyContext) -> LegacyResult:
+        commands: list[str] = []
+        try:
+            order_id = _required_text(payload, "orderId")
+            order = self._get_order(order_id)
+            intent = self.client.post(
+                "payment",
+                "/api/v1/payment-intents",
+                {
+                    "businessRef": order_id,
+                    "purpose": "purchase",
+                    "amount": _required_mapping(payload, "price"),
+                    "payerRef": _required_text(order, "accountId"),
+                },
+                _headers(ctx, "payment-intent"),
+            )
+            commands.append("CreatePaymentIntent")
+            payment_intent_id = _required_text(intent, "paymentIntentId")
+            self.client.post(
+                "payment",
+                f"/api/v1/payment-intents/{quote(payment_intent_id)}/capture",
+                {},
+                _headers(ctx, "capture"),
+            )
+            commands.append("CapturePayment")
+            return self._finish(
+                LegacyOperation.INSIDE_PAYMENT,
+                Outcome.SUCCEEDED,
+                ctx,
+                commands,
+                {"paymentIntentId": payment_intent_id},
+                None,
+            )
+        except Exception as exc:
+            return self._failure(LegacyOperation.INSIDE_PAYMENT, ctx, commands, exc)
+
+    def ticket_issue(self, payload: Mapping[str, Any], ctx: LegacyContext) -> LegacyResult:
+        commands: list[str] = []
+        try:
+            order_id = _required_text(payload, "orderId")
+            order = self._get_order(order_id)
+            segment_ref, traveler_ref = self._single_order_refs(order)
+            segment_booking_id = self._segment_booking_id(order_id, segment_ref, traveler_ref, ctx)
+            entitlement = self.client.post(
+                "entitlement-ticketing",
+                "/api/v1/entitlements",
+                {
+                    "segmentBookingId": segment_booking_id,
+                    "journeyOrderId": order_id,
+                    "travelerRef": traveler_ref,
+                    "segmentRef": segment_ref,
+                    "issuePurpose": "INITIAL",
+                },
+                _headers(ctx, "issue"),
+            )
+            commands.append("IssueEntitlement")
+            entitlement_id = _required_text(entitlement, "entitlementId")
+            saga_id = self._find_saga(order_id, ctx)
+            if saga_id:
+                self.client.post(
+                    "booking-orchestration",
+                    f"/api/v1/internal/booking-sagas/{quote(saga_id)}/mark-ticketed",
+                    {"segmentBookingId": segment_booking_id, "entitlementId": entitlement_id},
+                    _headers(ctx, "mark-ticketed"),
+                )
+                commands.append("MarkSegmentTicketed")
+            return self._finish(
+                LegacyOperation.TICKET_ISSUE,
+                Outcome.SUCCEEDED,
+                ctx,
+                commands,
+                {"entitlementId": entitlement_id, "segmentBookingId": segment_booking_id},
+                None,
+            )
+        except Exception as exc:
+            return self._failure(LegacyOperation.TICKET_ISSUE, ctx, commands, exc)
+
+    def execute(self, payload: Mapping[str, Any], ctx: LegacyContext) -> LegacyResult:
+        commands: list[str] = []
+        try:
+            order_id = _required_text(payload, "orderId")
+            self._get_order(order_id)
+            entitlement = self._first_entitlement(order_id)
+            body = {
+                "entitlementId": _required_text(entitlement, "entitlementId"),
+                "segmentBookingId": _required_text(entitlement, "segmentBookingId"),
+                "journeyOrderId": order_id,
+                "travelerId": _required_text(entitlement, "travelerRef"),
+                "segmentRef": _required_text(entitlement, "segmentRef"),
+                "source": "GATE",
+                "sourceEventId": ctx.source_ref,
+                "occurredAt": rfc3339_utc(datetime.now(UTC)),
+            }
+            boarding = self.client.post("fulfillment", "/api/v1/fulfillment-records/boarding", body, _headers(ctx, "boarding"))
+            commands.append("VerifyBoarding")
+            return self._finish(
+                LegacyOperation.EXECUTE,
+                Outcome.SUCCEEDED,
+                ctx,
+                commands,
+                {"fulfillmentRecordId": _required_text(boarding, "fulfillmentRecordId")},
+                None,
+            )
+        except Exception as exc:
+            return self._failure(LegacyOperation.EXECUTE, ctx, commands, exc)
+
+    def cancel(self, payload: Mapping[str, Any], ctx: LegacyContext) -> LegacyResult:
+        return self._post_sales(payload, ctx, LegacyOperation.CANCEL, "REFUND", "CUSTOMER_REQUEST", "refundAmount")
+
+    def rebook(self, payload: Mapping[str, Any], ctx: LegacyContext) -> LegacyResult:
+        return self._post_sales(payload, ctx, LegacyOperation.REBOOK, "CHANGE", "CUSTOMER_CHANGE", "amountDue")
+
+    def _post_sales(
+        self,
+        payload: Mapping[str, Any],
+        ctx: LegacyContext,
+        operation: LegacyOperation,
+        case_type: str,
+        reason_code: str,
+        result_amount_field: str,
+    ) -> LegacyResult:
+        commands: list[str] = []
+        try:
+            order_id = _required_text(payload, "orderId")
+            order = self._get_order(order_id)
+            entitlement = self._first_entitlement(order_id)
+            scope = {
+                "orderItemRefs": [_required_text(entitlement, "segmentBookingId")],
+                "segmentRefs": [_required_text(entitlement, "segmentRef")],
+                "travelerRefs": [_required_text(entitlement, "travelerRef")],
+                "entitlementRefs": [_required_text(entitlement, "entitlementId")],
+            }
+            opened = self.client.post(
+                "post-sales",
+                "/api/v1/post-sales-cases",
+                {
+                    "journeyOrderId": order_id,
+                    "caseType": case_type,
+                    "scope": scope,
+                    "reasonCode": reason_code,
+                    "actorRef": _required_text(order, "accountId"),
+                },
+                _headers(ctx, "case"),
+            )
+            commands.append("OpenPostSalesCase")
+            case_id = _required_text(opened, "caseId")
+            evaluated = self.client.post("post-sales", f"/api/v1/post-sales-cases/{quote(case_id)}/evaluate", {}, _headers(ctx, "evaluate"))
+            commands.append("EvaluatePostSalesEligibility")
+            self.client.post("post-sales", f"/api/v1/post-sales-cases/{quote(case_id)}/approve", {}, _headers(ctx, "approve"))
+            commands.append("ApprovePostSalesCase")
+            return self._finish(
+                operation,
+                Outcome.SUCCEEDED,
+                ctx,
+                commands,
+                {"caseId": case_id, result_amount_field: evaluated.get(result_amount_field) or {"currency": "CNY", "minorUnits": 0}},
+                None,
+            )
+        except Exception as exc:
+            return self._failure(operation, ctx, commands, exc)
+
+    def _finish(
+        self,
+        operation: LegacyOperation,
+        outcome: Outcome,
+        ctx: LegacyContext,
+        commands: list[str],
+        result_refs: Mapping[str, Any],
+        failure_message: str | None,
+    ) -> LegacyResult:
+        self._publish(operation, outcome, ctx, commands, result_refs, failure_message)
+        return LegacyResult(1, "success", result_refs)
+
+    def _failure(self, operation: LegacyOperation, ctx: LegacyContext, commands: list[str], exc: Exception) -> LegacyResult:
+        message = str(exc) or exc.__class__.__name__
+        self._publish(operation, Outcome.FAILED, ctx, commands, {}, message)
+        return LegacyResult(0, message, {})
+
+    def _publish(
+        self,
+        operation: LegacyOperation,
+        outcome: Outcome,
+        ctx: LegacyContext,
+        commands: list[str],
+        result_refs: Mapping[str, Any],
+        failure_message: str | None,
+    ) -> None:
+        event_id = deterministic_event_id(ctx.source_ref, operation.value)
+        causation_id = f"cmd-{ctx.source_ref}"
+        metadata = {
+            "eventId": event_id,
+            "occurredAt": rfc3339_utc(datetime.now(UTC)),
+            "sourceCommandId": ctx.source_ref,
+            "causationId": causation_id,
+            "correlationId": ctx.correlation_id,
+            "schemaVersion": 1,
+            "attributes": {},
+        }
+        payload: dict[str, Any] = {
+            "legacyOperation": operation.value,
+            "outcome": outcome.value,
+            "operatorRef": ctx.operator_ref,
+            "mappedCommands": list(commands),
+            "resultRefs": dict(result_refs),
+            "sourceRef": ctx.source_ref,
+            "metadata": metadata,
+        }
+        if ctx.reason:
+            payload["reason"] = ctx.reason
+        if failure_message:
+            payload["failureMessage"] = failure_message
+        self.publisher.publish(
+            EventEnvelope(
+                eventId=event_id,
+                eventType="LegacyCommandMapped",
+                occurredAt=metadata["occurredAt"],
+                correlationId=ctx.correlation_id,
+                causationId=causation_id,
+                producer="legacy-acl",
+                schemaVersion=1,
+                payload=payload,
+            )
+        )
+
+    def _traveler_ref(self, account_id: str, contacts_id: Any, ctx: LegacyContext, commands: list[str]) -> str:
+        if isinstance(contacts_id, str) and contacts_id.strip():
+            return contacts_id.strip()
+        if not isinstance(contacts_id, Mapping):
+            raise ValueError("contactsId is required")
+        traveler = self.client.post(
+            "traveler-profile",
+            "/api/v1/travelers",
+            {
+                "accountId": account_id,
+                "travelerType": "ADULT",
+                "givenName": _required_text(contacts_id, "name"),
+                "familyName": _required_text(contacts_id, "name"),
+                "documentType": contacts_id.get("documentType", "OTHER"),
+                "documentNumber": contacts_id.get("documentNumber"),
+            },
+            _headers(ctx, "traveler"),
+        )
+        commands.append("CreateTravelerProfile")
+        return _required_text(traveler, "travelerId")
+
+    def _resolve_saga(
+        self,
+        order_id: str,
+        account_id: str,
+        offer_id: str,
+        traveler_refs: list[str],
+        segment_refs: list[str],
+        ctx: LegacyContext,
+        commands: list[str],
+    ) -> str:
+        found = self._find_saga(order_id, ctx)
+        if found:
+            return found
+        saga = self.client.post(
+            "booking-orchestration",
+            "/api/v1/internal/booking-sagas",
+            {
+                "journeyOrderId": order_id,
+                "accountId": account_id,
+                "offerId": offer_id,
+                "travelerRefs": traveler_refs,
+                "segmentRefs": segment_refs,
+            },
+            _headers(ctx, "saga"),
+        )
+        commands.append("StartBookingSaga")
+        return _required_text(saga, "sagaId")
+
+    def _find_saga(self, order_id: str, ctx: LegacyContext) -> str | None:
+        # No list-by-order contract exists. In phase 1, the ACL starts a saga when
+        # it cannot query one directly, and reconstructs refs from owner APIs for later steps.
+        return None
+
+    def _segment_booking_id(self, order_id: str, segment_ref: str, traveler_ref: str, ctx: LegacyContext) -> str:
+        existing = self.client.get(
+            "entitlement-ticketing",
+            f"/api/v1/entitlements?journeyOrderId={quote(order_id)}&limit=20&offset=0",
+            _headers(ctx, "list-entitlements"),
+        )
+        items = existing.get("items")
+        if isinstance(items, list):
+            for item in items:
+                if isinstance(item, Mapping) and item.get("segmentRef") == segment_ref and item.get("travelerRef") == traveler_ref:
+                    return _required_text(item, "segmentBookingId")
+        return deterministic_prefixed_uuid("sb", f"{order_id}:{segment_ref}:{traveler_ref}")
+
+    def _get_order(self, order_id: str) -> Mapping[str, Any]:
+        return self.client.get("journey-order", f"/api/v1/journey-orders/{quote(order_id)}")
+
+    def _single_order_refs(self, order: Mapping[str, Any]) -> tuple[str, str]:
+        segment_refs = _required_string_list(order, "segmentRefs")
+        traveler_refs = _required_string_list(order, "travelerRefs")
+        return segment_refs[0], traveler_refs[0]
+
+    def _first_entitlement(self, order_id: str) -> Mapping[str, Any]:
+        page = self.client.get("entitlement-ticketing", f"/api/v1/entitlements?journeyOrderId={quote(order_id)}&limit=20&offset=0")
+        item = _first_mapping(page, "items", "no entitlement found for order")
+        return item
+
+
+def _headers(ctx: LegacyContext, suffix: str) -> dict[str, str]:
+    return {"Idempotency-Key": ctx.source_ref, "X-Correlation-Id": ctx.correlation_id, "X-Request-Id": f"{ctx.source_ref}-{suffix}"}
+
+
+def _required_text(payload: Mapping[str, Any], field: str) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} is required")
+    return value.strip()
+
+
+def _required_int(payload: Mapping[str, Any], field: str) -> int:
+    value = payload.get(field)
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    raise ValueError(f"{field} is required")
+
+
+def _required_mapping(payload: Mapping[str, Any], field: str) -> Mapping[str, Any]:
+    value = payload.get(field)
+    if isinstance(value, Mapping):
+        return value
+    raise ValueError(f"{field} is required")
+
+
+def _required_string_list(payload: Mapping[str, Any], field: str) -> list[str]:
+    value = payload.get(field)
+    if isinstance(value, list):
+        result = [item.strip() for item in value if isinstance(item, str) and item.strip()]
+        if result:
+            return result
+    raise ValueError(f"{field} is required")
+
+
+def _first_mapping(payload: Mapping[str, Any], field: str, message: str) -> Mapping[str, Any]:
+    value = payload.get(field)
+    if isinstance(value, list) and value and isinstance(value[0], Mapping):
+        return value[0]
+    raise DownstreamError(message)
+
+
+def _nested(payload: Mapping[str, Any], outer: str, inner: str) -> Any:
+    value = payload.get(outer)
+    return value.get(inner) if isinstance(value, Mapping) else None

--- a/services/legacy-acl/src/legacy_acl/downstream.py
+++ b/services/legacy-acl/src/legacy_acl/downstream.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from json import JSONDecodeError
+import os
+from typing import Any, Mapping
+from urllib import parse, request, error
+
+
+class DownstreamError(RuntimeError):
+    pass
+
+
+def _env_name(service: str) -> str:
+    return service.upper().replace("-", "_") + "_URL"
+
+
+@dataclass(frozen=True)
+class ServiceUrls:
+    trip_planning: str
+    fare_pricing: str
+    offer_management: str
+    journey_order: str
+    booking_orchestration: str
+    payment: str
+    entitlement_ticketing: str
+    fulfillment: str
+    post_sales: str
+    traveler_profile: str
+
+    @classmethod
+    def from_env(cls) -> "ServiceUrls":
+        def base(service: str) -> str:
+            return os.getenv(_env_name(service), f"http://{service}:8080").rstrip("/")
+
+        return cls(
+            trip_planning=base("trip-planning"),
+            fare_pricing=base("fare-pricing"),
+            offer_management=base("offer-management"),
+            journey_order=base("journey-order"),
+            booking_orchestration=base("booking-orchestration"),
+            payment=base("payment"),
+            entitlement_ticketing=base("entitlement-ticketing"),
+            fulfillment=base("fulfillment"),
+            post_sales=base("post-sales"),
+            traveler_profile=base("traveler-profile"),
+        )
+
+
+class DownstreamClient:
+    def __init__(self, urls: ServiceUrls | None = None, timeout: float | None = None) -> None:
+        self.urls = urls or ServiceUrls.from_env()
+        self.timeout = timeout or float(os.getenv("DOWNSTREAM_TIMEOUT_SECONDS", "10"))
+
+    def get(self, service: str, path: str, headers: Mapping[str, str] | None = None) -> dict[str, Any]:
+        return self._request(service, "GET", path, None, headers)
+
+    def post(self, service: str, path: str, body: Mapping[str, Any], headers: Mapping[str, str] | None = None) -> dict[str, Any]:
+        return self._request(service, "POST", path, body, headers)
+
+    def _request(
+        self,
+        service: str,
+        method: str,
+        path: str,
+        body: Mapping[str, Any] | None,
+        headers: Mapping[str, str] | None,
+    ) -> dict[str, Any]:
+        import json
+
+        base = getattr(self.urls, service.replace("-", "_"))
+        data = None if body is None else json.dumps(body, separators=(",", ":")).encode("utf-8")
+        req = request.Request(
+            base + path,
+            data=data,
+            method=method,
+            headers={"Accept": "application/json", "Content-Type": "application/json", **dict(headers or {})},
+        )
+        try:
+            with request.urlopen(req, timeout=self.timeout) as response:  # noqa: S310 - URLs are configured service bases
+                raw = response.read().decode("utf-8")
+                if not raw:
+                    return {}
+                parsed_body = json.loads(raw)
+                if not isinstance(parsed_body, dict):
+                    raise DownstreamError(f"{service} returned a non-object response")
+                return parsed_body
+        except error.HTTPError as exc:
+            raw = exc.read().decode("utf-8", errors="replace")
+            raise DownstreamError(_downstream_message(service, raw, exc.reason)) from exc
+        except error.URLError as exc:
+            raise DownstreamError(f"{service} unavailable: {exc.reason}") from exc
+        except JSONDecodeError as exc:
+            raise DownstreamError(f"{service} returned invalid JSON") from exc
+
+
+def _downstream_message(service: str, raw: str, fallback: str) -> str:
+    import json
+
+    try:
+        parsed = json.loads(raw)
+    except JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, dict):
+        message = parsed.get("message") or parsed.get("msg") or parsed.get("error")
+        if isinstance(message, str) and message.strip():
+            return message.strip()
+    return f"{service} request failed: {fallback}"
+
+
+def quote(value: str) -> str:
+    return parse.quote(value, safe="")

--- a/services/legacy-acl/src/legacy_acl/ids.py
+++ b/services/legacy-acl/src/legacy_acl/ids.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from hashlib import sha256
+from uuid import UUID
+
+from train_ticket_platform.ids import new_uuid7
+
+
+def prefixed_uuid7(prefix: str) -> str:
+    return f"{prefix}-{new_uuid7()}"
+
+
+def deterministic_event_id(source_ref: str, operation: str) -> str:
+    digest = bytearray(sha256(f"legacy-acl:{operation}:{source_ref}".encode("utf-8")).digest()[:16])
+    digest[6] = (digest[6] & 0x0F) | 0x70
+    digest[8] = (digest[8] & 0x3F) | 0x80
+    return f"evt-{UUID(bytes=bytes(digest))}"
+
+
+def deterministic_prefixed_uuid(prefix: str, material: str) -> str:
+    digest = bytearray(sha256(f"legacy-acl:{prefix}:{material}".encode("utf-8")).digest()[:16])
+    digest[6] = (digest[6] & 0x0F) | 0x70
+    digest[8] = (digest[8] & 0x3F) | 0x80
+    return f"{prefix}-{UUID(bytes=bytes(digest))}"

--- a/services/legacy-acl/src/legacy_acl/ids.py
+++ b/services/legacy-acl/src/legacy_acl/ids.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from hashlib import sha256
-from uuid import UUID
+from uuid import NAMESPACE_URL, UUID, uuid5
 
 from train_ticket_platform.ids import new_uuid7
 
@@ -22,3 +22,11 @@ def deterministic_prefixed_uuid(prefix: str, material: str) -> str:
     digest[6] = (digest[6] & 0x0F) | 0x70
     digest[8] = (digest[8] & 0x3F) | 0x80
     return f"{prefix}-{UUID(bytes=bytes(digest))}"
+
+
+def deterministic_uuid7(source_ref: str, suffix: str) -> str:
+    seeded = uuid5(NAMESPACE_URL, f"train-ticket:legacy-acl:idempotency:{source_ref}:{suffix}")
+    digest = bytearray(seeded.bytes)
+    digest[6] = (digest[6] & 0x0F) | 0x70
+    digest[8] = (digest[8] & 0x3F) | 0x80
+    return str(UUID(bytes=bytes(digest)))

--- a/services/legacy-acl/src/legacy_acl/main.py
+++ b/services/legacy-acl/src/legacy_acl/main.py
@@ -1,0 +1,3 @@
+from .api import create_app
+
+app = create_app()

--- a/services/legacy-acl/src/legacy_acl/runtime.py
+++ b/services/legacy-acl/src/legacy_acl/runtime.py
@@ -1,0 +1,30 @@
+from typing import List, NotRequired, TypedDict
+
+
+class ServiceProfile(TypedDict):
+    service_id: str
+    domain: str
+    language: str
+    phase: str
+    work_packages: List[str]
+    owns: List[str]
+    boundary: NotRequired[str]
+
+
+SERVICE_PROFILE: ServiceProfile = {
+    "service_id": "legacy-acl",
+    "domain": "Legacy ACL",
+    "language": "python",
+    "phase": "phase-1-core",
+    "work_packages": ["REQ-071", "WP-23"],
+    "owns": [],
+    "boundary": "Strangler facade; owns no domain state",
+}
+
+
+def health() -> str:
+    return "ok"
+
+
+def profile() -> ServiceProfile:
+    return dict(SERVICE_PROFILE)  # type: ignore[return-value]

--- a/services/legacy-acl/tests/test_api.py
+++ b/services/legacy-acl/tests/test_api.py
@@ -8,6 +8,7 @@ from train_ticket_platform.messaging import InMemoryEventPublisher
 from legacy_acl.api import create_app
 from legacy_acl.downstream import DownstreamError
 from legacy_acl.ids import deterministic_event_id
+from train_ticket_platform.ids import is_uuid7
 
 
 KEY = "0194f2e0-7b3e-7610-8000-000000000111"
@@ -16,11 +17,11 @@ HEADERS = {"Idempotency-Key": KEY, "X-Legacy-Operator": "op-1", "X-Correlation-I
 
 class FakeDownstream:
     def __init__(self) -> None:
-        self.calls: list[tuple[str, str, str, Mapping[str, Any]]] = []
+        self.calls: list[tuple[str, str, str, Mapping[str, Any], Mapping[str, str]]] = []
         self.fail_on: tuple[str, str] | None = None
 
     def post(self, service: str, path: str, body: Mapping[str, Any], headers: Mapping[str, str] | None = None) -> dict[str, Any]:
-        self.calls.append(("POST", service, path, dict(body)))
+        self.calls.append(("POST", service, path, dict(body), dict(headers or {})))
         if self.fail_on == (service, path):
             raise DownstreamError("downstream rejected")
         if service == "trip-planning":
@@ -52,7 +53,7 @@ class FakeDownstream:
         raise AssertionError((service, path, body))
 
     def get(self, service: str, path: str, headers: Mapping[str, str] | None = None) -> dict[str, Any]:
-        self.calls.append(("GET", service, path, {}))
+        self.calls.append(("GET", service, path, {}, dict(headers or {})))
         if service == "journey-order":
             return {"orderId": "ord-1", "accountId": "acc-1", "travelerRefs": ["tvl-1"], "segmentRefs": ["seg-1"]}
         if service == "entitlement-ticketing":
@@ -127,8 +128,29 @@ def test_inside_payment_ticket_issue_execute_cancel_and_rebook_mapping() -> None
         body = response.json()
         assert body["status"] == 1
         assert result_field in body["data"]
+        if operation == "CANCEL":
+            assert body["data"]["refundAmount"] == {"currency": "CNY", "minorUnits": 8750}
         assert publisher.envelopes[-1].payload["legacyOperation"] == operation
         assert publisher.envelopes[-1].payload["outcome"] == "SUCCEEDED"
+
+
+def test_downstream_post_idempotency_keys_are_distinct_uuid7_and_stable_on_replay() -> None:
+    payload = {"accountId": "acc-1", "contactsId": "tvl-1", "tripId": "G1", "seatType": "SECOND", "date": "2026-08-01", "from": "p-bj", "to": "p-sh"}
+
+    fake_first = FakeDownstream()
+    first_response = client(fake_first, InMemoryEventPublisher()).post("/api/v1/legacy/preserve", headers=HEADERS, json=payload)
+    assert first_response.status_code == 200
+    first_post_keys = [call[4]["Idempotency-Key"] for call in fake_first.calls if call[0] == "POST"]
+
+    fake_replay = FakeDownstream()
+    replay_response = client(fake_replay, InMemoryEventPublisher()).post("/api/v1/legacy/preserve", headers=HEADERS, json=payload)
+    assert replay_response.status_code == 200
+    replay_post_keys = [call[4]["Idempotency-Key"] for call in fake_replay.calls if call[0] == "POST"]
+
+    assert first_post_keys == replay_post_keys
+    assert len(first_post_keys) == len(set(first_post_keys))
+    assert all(is_uuid7(key) for key in first_post_keys)
+    assert HEADERS["Idempotency-Key"] not in first_post_keys
 
 
 def test_operator_header_is_required() -> None:

--- a/services/legacy-acl/tests/test_api.py
+++ b/services/legacy-acl/tests/test_api.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from fastapi.testclient import TestClient
+from train_ticket_platform.messaging import InMemoryEventPublisher
+
+from legacy_acl.api import create_app
+from legacy_acl.downstream import DownstreamError
+from legacy_acl.ids import deterministic_event_id
+
+
+KEY = "0194f2e0-7b3e-7610-8000-000000000111"
+HEADERS = {"Idempotency-Key": KEY, "X-Legacy-Operator": "op-1", "X-Correlation-Id": "corr-0194f2e0-7b3e-7610-8000-000000000999"}
+
+
+class FakeDownstream:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str, Mapping[str, Any]]] = []
+        self.fail_on: tuple[str, str] | None = None
+
+    def post(self, service: str, path: str, body: Mapping[str, Any], headers: Mapping[str, str] | None = None) -> dict[str, Any]:
+        self.calls.append(("POST", service, path, dict(body)))
+        if self.fail_on == (service, path):
+            raise DownstreamError("downstream rejected")
+        if service == "trip-planning":
+            return {"itineraries": [{"itineraryRef": "itin_1", "legs": [{"serviceSegmentRef": "seg-1"}]}]}
+        if service == "fare-pricing" and path == "/api/v1/fare-quotes":
+            return {"quoteId": "fq-1", "breakdown": {"total": {"currency": "CNY", "minorUnits": 10750}}}
+        if service == "offer-management":
+            return {"offerId": "off-1", "offerVersion": 1, "total": {"currency": "CNY", "minorUnits": 10750}}
+        if service == "journey-order" and path == "/api/v1/journey-orders":
+            return {"orderId": "ord-1", "accountId": "acc-1", "travelerRefs": ["tvl-1"], "segmentRefs": ["seg-1"]}
+        if service == "booking-orchestration" and path == "/api/v1/internal/booking-sagas":
+            return {"sagaId": "saga-1"}
+        if service == "booking-orchestration" and path.endswith("/request-reservation"):
+            return {"segmentBookingId": body["segmentBookingId"], "status": "REQUESTED"}
+        if service == "payment" and path == "/api/v1/payment-intents":
+            return {"paymentIntentId": "pi-1"}
+        if service == "payment" and path.endswith("/capture"):
+            return {"paymentIntentId": "pi-1", "status": "CAPTURED"}
+        if service == "entitlement-ticketing" and path == "/api/v1/entitlements":
+            return {"entitlementId": "ent-1", "segmentBookingId": body["segmentBookingId"]}
+        if service == "fulfillment":
+            return {"fulfillmentRecordId": "fr-1"}
+        if service == "post-sales" and path == "/api/v1/post-sales-cases":
+            return {"caseId": "psc-1"}
+        if service == "post-sales" and path.endswith("/evaluate"):
+            return {"caseId": "psc-1", "refundableAmount": {"currency": "CNY", "minorUnits": 8750}, "amountDue": {"currency": "CNY", "minorUnits": 0}}
+        if service == "post-sales" and path.endswith("/approve"):
+            return {"caseId": "psc-1", "status": "APPROVED"}
+        raise AssertionError((service, path, body))
+
+    def get(self, service: str, path: str, headers: Mapping[str, str] | None = None) -> dict[str, Any]:
+        self.calls.append(("GET", service, path, {}))
+        if service == "journey-order":
+            return {"orderId": "ord-1", "accountId": "acc-1", "travelerRefs": ["tvl-1"], "segmentRefs": ["seg-1"]}
+        if service == "entitlement-ticketing":
+            return {"items": [{"entitlementId": "ent-1", "segmentBookingId": "sb-1", "journeyOrderId": "ord-1", "travelerRef": "tvl-1", "segmentRef": "seg-1"}], "total": 1, "limit": 20, "offset": 0}
+        raise AssertionError((service, path))
+
+
+def client(fake: FakeDownstream, publisher: InMemoryEventPublisher) -> TestClient:
+    return TestClient(create_app(client=fake, event_publisher=publisher))
+
+
+def test_preserve_maps_full_chain_and_publishes_contract_event() -> None:
+    fake = FakeDownstream()
+    publisher = InMemoryEventPublisher()
+    response = client(fake, publisher).post(
+        "/api/v1/legacy/preserve",
+        headers=HEADERS,
+        json={"accountId": "acc-1", "contactsId": "tvl-1", "tripId": "G1", "seatType": "SECOND", "date": "2026-08-01", "from": "p-bj", "to": "p-sh"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == 1
+    assert body["msg"] == "success"
+    assert body["data"]["orderId"] == "ord-1"
+    assert [call[1] for call in fake.calls[:6]] == ["trip-planning", "fare-pricing", "offer-management", "journey-order", "booking-orchestration", "booking-orchestration"]
+    envelope = publisher.envelopes[-1]
+    assert envelope.eventId == deterministic_event_id(KEY, "PRESERVE")
+    assert envelope.producer == "legacy-acl"
+    assert envelope.eventType == "LegacyCommandMapped"
+    assert envelope.payload["legacyOperation"] == "PRESERVE"
+    assert envelope.payload["outcome"] == "SUCCEEDED"
+    assert envelope.payload["operatorRef"] == "op-1"
+    assert envelope.payload["sourceRef"] == KEY
+    assert envelope.payload["resultRefs"]["offerId"] == "off-1"
+    assert envelope.payload["metadata"]["sourceCommandId"] == KEY
+
+
+def test_failure_returns_legacy_shape_and_publishes_failed_event() -> None:
+    fake = FakeDownstream()
+    fake.fail_on = ("trip-planning", "/api/v1/itineraries/search")
+    publisher = InMemoryEventPublisher()
+    response = client(fake, publisher).post(
+        "/api/v1/legacy/preserve",
+        headers=HEADERS,
+        json={"accountId": "acc-1", "contactsId": "tvl-1", "date": "2026-08-01", "from": "p-bj", "to": "p-sh"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": 0, "msg": "downstream rejected", "data": {}}
+    envelope = publisher.envelopes[-1]
+    assert envelope.eventId == deterministic_event_id(KEY, "PRESERVE")
+    assert envelope.payload["outcome"] == "FAILED"
+    assert envelope.payload["failureMessage"] == "downstream rejected"
+    assert envelope.payload["resultRefs"] == {}
+
+
+def test_inside_payment_ticket_issue_execute_cancel_and_rebook_mapping() -> None:
+    endpoints = [
+        ("/api/v1/legacy/inside_payment", {"orderId": "ord-1", "price": {"currency": "CNY", "minorUnits": 10750}}, "INSIDE_PAYMENT", "paymentIntentId"),
+        ("/api/v1/legacy/ticket_issue", {"orderId": "ord-1"}, "TICKET_ISSUE", "entitlementId"),
+        ("/api/v1/legacy/execute", {"orderId": "ord-1"}, "EXECUTE", "fulfillmentRecordId"),
+        ("/api/v1/legacy/cancel", {"orderId": "ord-1"}, "CANCEL", "refundAmount"),
+        ("/api/v1/legacy/rebook", {"orderId": "ord-1", "date": "2026-08-02", "seatType": "FIRST"}, "REBOOK", "amountDue"),
+    ]
+    for index, (path, payload, operation, result_field) in enumerate(endpoints):
+        fake = FakeDownstream()
+        publisher = InMemoryEventPublisher()
+        headers = {**HEADERS, "Idempotency-Key": f"0194f2e0-7b3e-7610-8000-0000000002{index:02d}"}
+        response = client(fake, publisher).post(path, headers=headers, json=payload)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == 1
+        assert result_field in body["data"]
+        assert publisher.envelopes[-1].payload["legacyOperation"] == operation
+        assert publisher.envelopes[-1].payload["outcome"] == "SUCCEEDED"
+
+
+def test_operator_header_is_required() -> None:
+    fake = FakeDownstream()
+    publisher = InMemoryEventPublisher()
+    response = client(fake, publisher).post("/api/v1/legacy/execute", headers={"Idempotency-Key": KEY}, json={"orderId": "ord-1"})
+
+    assert response.status_code == 400
+    assert response.json()["status"] == 0
+    assert publisher.envelopes == []

--- a/services/legacy-acl/tests/test_skeleton.py
+++ b/services/legacy-acl/tests/test_skeleton.py
@@ -1,0 +1,13 @@
+import unittest
+
+from legacy_acl.runtime import health, profile
+
+
+class LegacyAclSkeletonTest(unittest.TestCase):
+    def test_service_profile(self) -> None:
+        self.assertEqual("ok", health())
+        self.assertEqual("legacy-acl", profile()["service_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/legacy-acl/uv.lock
+++ b/services/legacy-acl/uv.lock
@@ -1,0 +1,396 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
+]
+
+[[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.138.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/c9/5e8defe249899c0dc900643695fc07829a67fc88b4ff2cdb03fcbdbf5a4b/fastapi-0.138.1.tar.gz", hash = "sha256:96e3702dce09ee0dce48856135620d3d865ca684a79fe7513fd7b13a12f82862", size = 419646, upload-time = "2026-06-25T15:40:42.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/a9/69a6924f645eb4dd8cd625bf255b3625990eb3e14e073438a53c405dcd3e/fastapi-0.138.1-py3-none-any.whl", hash = "sha256:b994cae7ba8b82c976a728b544244de31333fa5f7d261f9a1dffe526444cae23", size = 129182, upload-time = "2026-06-25T15:40:40.771Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/5c12df521b5322fb1114a83d46911b2fbcb8855ddb3a635f11c01a214af5/httpcore2-2.5.0.tar.gz", hash = "sha256:88aa170137c17328d5ac44234f9fd10706466d5fb347f3edac4d39b91137b09d", size = 64808, upload-time = "2026-06-25T14:16:56.472Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/a1/7564199d1a8728fe737b0a72e5b3f8d92dfe085a74ddf7cdd83bce5f206d/httpcore2-2.5.0-py3-none-any.whl", hash = "sha256:5ce35188de461d31e8d000bfb8ef8bf22c6c16587a211e5571deaa5e9bdf842a", size = 80330, upload-time = "2026-06-25T14:16:53.634Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/e2/b5dedc0cf35aa65de5f541ccd30d2bc1fd7f1d43c9ab09f8ed9a7342317b/httpx2-2.5.0.tar.gz", hash = "sha256:e2df9cb4611021527ff8a675b1c320b610a2ec397acc8d6fe6e91df2d9b33c29", size = 83121, upload-time = "2026-06-25T14:16:57.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/22/859d8252dad9bc9adee34b52e62cde621ece07b042ccb2ab4da1be46695f/httpx2-2.5.0-py3-none-any.whl", hash = "sha256:3d2d4d9cf4b61f1a1f46a95947cfdb47e80cb56a2f91c6256ac8f58e4891df41", size = 76652, upload-time = "2026-06-25T14:16:55.23Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "legacy-acl"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "train-ticket-platform" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "httpx2" },
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "train-ticket-platform", editable = "../../platform/python-kit" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx2", specifier = ">=2.5.0" },
+    { name = "pytest", specifier = "==9.1.1" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "redis"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c3/928b290c2c0ca99ab96eea5b4ff8f30be8112b075301a7d3ba214a3c8c12/redis-8.0.1.tar.gz", hash = "sha256:afc5a7a2f5a084f5b1880dec548dd45be17db7e43c82a30d84f952aefb05cfb0", size = 5114170, upload-time = "2026-06-23T14:52:37.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/0a/c2345ebf1ebe70840ce3f6c6ee612f8fa749cfbd1b03069c53bf0c62aaad/redis-8.0.1-py3-none-any.whl", hash = "sha256:47daa35a058c23468d6437f17a8c76882cb316b838ef763036af99b96cedd743", size = 502406, upload-time = "2026-06-23T14:52:36.137Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "train-ticket-platform"
+version = "0.1.1"
+source = { editable = "../../platform/python-kit" }
+dependencies = [
+    { name = "fastapi" },
+    { name = "httpx2" },
+    { name = "redis" },
+    { name = "uuid6" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = "==0.138.1" },
+    { name = "httpx2", specifier = ">=2.5.0" },
+    { name = "redis", specifier = ">=5.0.0" },
+    { name = "uuid6", specifier = ">=2024.7.10" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx2", specifier = ">=2.5.0" },
+    { name = "pytest", specifier = "==9.1.1" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uuid6"
+version = "2025.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/b7/4c0f736ca824b3a25b15e8213d1bcfc15f8ac2ae48d1b445b310892dc4da/uuid6-2025.0.1.tar.gz", hash = "sha256:cd0af94fa428675a44e32c5319ec5a3485225ba2179eefcf4c3f205ae30a81bd", size = 13932, upload-time = "2025-07-04T18:30:35.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/b2/93faaab7962e2aa8d6e174afb6f76be2ca0ce89fde14d3af835acebcaa59/uuid6-2025.0.1-py3-none-any.whl", hash = "sha256:80530ce4d02a93cdf82e7122ca0da3ebbbc269790ec1cb902481fa3e9cc9ff99", size = 6979, upload-time = "2025-07-04T18:30:34.001Z" },
+]


### PR DESCRIPTION
## Summary
- Add Python/FastAPI legacy-acl service implementing preserve, inside_payment, ticket_issue, execute, cancel, and rebook legacy endpoints with downstream command mapping and LegacyCommandMapped publication.
- Subscribe admin-audit to events:legacy-acl and record LegacyCommandMapped as audit entries without poisoning unknown-event handling.
- Add legacy-acl Docker/K8s/build wiring plus e2e legacy lifecycle script.

## Validation
- services/legacy-acl/.venv/bin/pytest services/legacy-acl -q
- mvn test -q -f services/admin-audit/pom.xml
- bash -n deploy/e2e/11-legacy-acl.sh
- kubectl kustomize deploy/k8s | grep -c 'kind: Deployment' # 24
- make check