### PR TITLE
Phase-2 persistence & outbox ruling; status docs refresh

### DIFF
--- a/deploy/e2e/01-seed.sh
+++ b/deploy/e2e/01-seed.sh
@@ -55,5 +55,8 @@ N_SH=$N_SH
 SS=$SS
 SEG=$SEG
 EOF
-cp /tmp/e2e-refs.env "$(dirname "$0")/.refs.env" 2>/dev/null || true
+# script already cd'd to its own dir at the top; a second dirname "$0"
+# here resolves wrong when invoked from the repo root and the copy was
+# silently skipped, breaking every later script's `. ./.refs.env`.
+cp /tmp/e2e-refs.env ./.refs.env
 summary

--- a/docs/00-current-status.md
+++ b/docs/00-current-status.md
@@ -1,100 +1,73 @@
 # Current Project Status
 
-Last updated: 2026-07-05
+Last updated: 2026-07-07
 
-## Status
+## Status: Phase 1 functionally complete; Phase 2 (engineering hardening) in progress
 
-This repository is being prepared for a full rewrite / greenfield rebuild of the
-Train Ticket system.
+The greenfield DDD rewrite has delivered a working, end-to-end-verified
+system. All Phase-1 work packages (WP-01..WP-23 of the accepted roadmap)
+are implemented, merged to `refactor/greenfield-ddd`, and certified on the
+live kind cluster.
 
-The current tree is a greenfield skeleton: DDD reference documents, a service
-catalog, per-bounded-context service skeletons, and a devcontainer. It is not a
-partially completed implementation of the old Train Ticket services.
+## What runs today
 
-## Authoritative Current Framing
+23 deployed business services + redis (event bus), all under
+`deploy/k8s/`, images built by `deploy/build-images.sh`:
 
-- Build new code from the accepted DDD design and current rewrite decisions.
-- Treat the old `WP-01` / `WP-xx` work-package plan as legacy planning material.
-  It must not be used as the current execution backlog unless it is explicitly
-  regenerated and re-approved for the rewrite.
-- Treat `project-index.yaml` entries `REQ-101` through `REQ-123` as legacy
-  references, not active implementation requirements.
-- Treat `REQ-003` as the first regenerated active slice: a minimal Shared
-  Kernel contract baseline in `platform/shared-kernel-rust`.
-- Treat `REQ-004` as the regenerated Place & Network slice: validated
-  master-data primitives in `services/place-network`.
-- Treat `REQ-005` as the regenerated Service Plan slice: a tested Go domain
-  foundation in `services/service-plan` covering ServicePlan, ServicePattern,
-  ServiceStop, Calendar, Timetable, ScheduledService, ServiceSegment, and
-  PlanVersion invariants.
-- Treat `REQ-006` as the regenerated Capacity & Availability slice: a tested
-  Rust domain foundation in `services/capacity-availability` covering
-  InventoryPool identity, StationInterval overlap, CapacityHold lifecycle and
-  conflict rules, and non-locking AvailabilitySnapshot calculation.
-- Treat `REQ-007` as a regenerated active slice: the first tested Fare & Pricing
-  domain foundation in `services/fare-pricing`, covering rule-set publication,
-  quote calculation, immutable rule snapshots, and basic refund/change fee
-  assessment.
-- Treat `REQ-008` as the regenerated Trip Planning search foundation in
-  `services/trip-planning`, covering validated trip intent, deterministic
-  itinerary candidate ranking, and non-authoritative price/availability hints.
-- Treat `REQ-009` as the regenerated Offer Management domain foundation in
-  `services/offer-management`, covering immutable offer snapshots, TTL/lifecycle
-  behavior, passenger mix, risk disclosures, and non-mutation boundary proof.
-- Treat `REQ-010` as the regenerated Journey Order domain foundation in
-  `services/journey-order`, covering the JourneyOrder aggregate lifecycle, order
-  creation from valid Offer, OrderItems with TravelerRefs and SegmentOrderSnapshots,
-  MonetarySummary invariants, ConfirmationConditions guards, and the order state
-  machine (Created, PendingPayment, Confirmed, with Cancelled as terminal).
-- Treat `REQ-016` as the current OpenTelemetry collection baseline: a local
-  OTLP collector configuration and service-side telemetry environment contract.
-- Treat `REQ-011` through `REQ-015` as status-reconciliation-needed where local
-  service metadata or code references those IDs. They must not be promoted to
-  authoritative active slices until this status file is updated with their
-  accepted scope.
-- Treat legacy `WP-01` / `WP-xx` identifiers in service runtime profiles as
-  traceability-only metadata. Runtime health/profile payloads that still expose
-  them do not make those WP IDs an active backlog or completion signal.
-- Treat `docs/04-implementation-plan/status.md` as a superseded historical
-  AgentM loop record, not as the current blocker list.
-- Legacy service behavior may be consulted only as reference material or through
-  a future Legacy ACL / strangler strategy; it must not be copied forward as the
-  implementation source of truth.
+| Language | Services |
+|---|---|
+| Java (Boot 4) | admin-audit, booking-orchestration, finance-settlement, journey-order, payment, post-sales, traveler-profile |
+| Python (FastAPI) | fare-pricing, legacy-acl, reporting, risk-compliance, trip-planning |
+| Node (TS) | account, customer-service, notification, offer-management |
+| Go | fulfillment, place-network, provider-integration, service-plan, supplier-catalog |
+| Rust | capacity-availability, entitlement-ticketing |
 
-## Current Source Of Truth
+`services/` also contains six future-scope skeletons that are NOT
+deployed and NOT part of Phase 1: ancillary-service, dispatch,
+disruption-recovery, transfer-management, waitlist, wallet-promotion.
+Treat them as placeholders until a roadmap decision activates them.
 
-Use these documents to understand the intended domain model and skeleton layout:
+## Verification baseline
 
-1. `docs/03-ddd-final/` — accepted DDD baseline and decision records.
-2. `docs/02-domains/` — bounded-context details.
-3. `docs/05-service-architecture/` — service skeleton and language assignment.
-4. `service-catalog.json` — machine-readable service/domain/language map.
-5. `docs/07-observability/` — OpenTelemetry collection and runtime telemetry
-   contract.
-6. This file — current project-status framing for the rewrite.
+`deploy/e2e/01..11` — 11 self-contained, rerunnable scripts, 159
+asserts, all green at certification (2026-07-07):
 
-When a new implementation plan is needed, create it from the current DDD baseline
-and the actual rewrite priorities instead of resuming the legacy WP sequence.
+seed(6) purchase(15) refund(15) change(8) fulfillment(11) risk(7)
+fare-rules(29) notify-support(9) manual-action(7) account-gate(19)
+legacy-acl(33).
 
-## Development Environment
+The legacy-acl script walks a complete order lifecycle exclusively
+through the strangler facade's legacy-shaped endpoints.
 
-The standard development environment is the configured devcontainer. It contains
-the Java, Go, Python, Rust, TypeScript, and operational tools needed for full
-skeleton validation.
+## Governance
 
-Use host checks only as a quick adaptive smoke test:
+- Cross-service contracts live in `docs/08-contracts/` (api/, events/,
+  messaging.md, shared-primitives.md, persistence.md). Rulings in those
+  files are binding; PRs are reviewed field-by-field against them.
+- Established invariants: deterministic event ids derived from consumed
+  eventId/sourceRef; consumer-side eventId dedup; HTTP Idempotency-Key
+  on every mutating endpoint; camelCase payload fields,
+  SCREAMING_SNAKE enums, RFC3339 UTC timestamps.
 
-```bash
-make check
-```
+## Phase 2 — engineering hardening (current backlog)
 
-Use the devcontainer or CI for authoritative validation:
+Ruling: `docs/08-contracts/persistence.md`. In flight:
 
-```bash
-.devcontainer/scripts/check.sh
-make check-strict
-```
+1. PostgreSQL persistence (aggregate snapshots + optimistic concurrency)
+   replacing all in-memory state, service by service.
+2. Transactional outbox + durable consumer dedup (replaces the
+   rollback+503 publish pattern).
+3. Redis AOF for bus durability.
+4. Notification real channel adapters (SMTP via in-cluster mailpit).
+5. Repo tidy: stale docs refreshed, future-scope skeletons marked.
 
-`make check` may skip language checks when host tools are missing. `make
-check-strict` must not skip required toolchains and is the validation gate for
-container/CI work.
+Known accepted gaps after Phase 2: payment remains a simulated provider
+boundary; legacy-acl rebook books the first leg only (caller follows up)
+— both by explicit ruling.
+
+## Historical note
+
+Earlier revisions of this file (and `docs/04-implementation-plan/status.md`)
+described the repo as a skeleton with WP-01 "rejected" briefs. That
+reflected the pre-implementation planning phase and is obsolete; the
+authoritative history is the merged PR trail on `refactor/greenfield-ddd`.

--- a/docs/04-implementation-plan/status.md
+++ b/docs/04-implementation-plan/status.md
@@ -1,40 +1,46 @@
-# Superseded Historical Implementation Status
+# Implementation Plan Status
 
-> **Superseded:** This file records an earlier AgentM loop and an old WP-oriented
-> interpretation. The project is now being prepared for a full rewrite /
-> greenfield rebuild. Do not treat `WP-01`, the `WP-xx` sequence, or the blocker
-> list below as the current execution plan. Start from
-> `docs/00-current-status.md` and regenerate any implementation plan from the
-> current DDD baseline and rewrite priorities.
+Last updated: 2026-07-07. Authoritative snapshot: `docs/00-current-status.md`.
 
-## Accepted Work
-- Accepted DDD baseline remains the implementation target under `docs/03-ddd-final`.
-- Repository status accepted: current source is legacy train-ticket microservice code with no verified DDD work package completion and no `src/test` coverage for required invariants.
-- Phase 1 priority accepted: start with WP-01, WP-02, WP-03, and WP-05.
+## Phase 1 — DONE (certified 2026-07-07)
 
-## Rejected Work
-- WP-01 brief rejected after 2 attempts.
-  - Provider Integration coverage is ambiguous: listed provider/channel facts are external facts and must be mapped before becoming core events.
-  - `ts-common` contract example payloads risk becoming shared domain-event payload ownership.
-  - Future-scope domains were included as implementation inputs despite Phase 1-only acceptance.
-  - EventMetadata UUID representation and validation boundary are underspecified.
-- Completion claim rejected for WP-01..WP-23: no assessed work package is complete in current source.
+WP-01..WP-23 delivered via AgentM WorkGraph (REQ-003..REQ-071, all merged
+to `refactor/greenfield-ddd`). Certification: 11 e2e scripts / 159
+asserts green on the live kind cluster, 24/24 pods healthy. Six
+future-scope domains excluded by roadmap ruling: waitlist,
+wallet-promotion, dispatch, ancillary, transfer, disruption-recovery.
 
-## Blockers
-- No approved WP-01 implementation brief exists.
-- Provider Integration coverage decision is required: exclude it from the producer matrix and cover through ACL mapping examples, or add a Provider Integration-owned normalized/archived fact that is not consumed as Payment or Booking state until mapped.
-- WP-01 must constrain shared-kernel payload examples to test-only non-normative stubs.
-- WP-01 must limit acceptance evidence to final Phase 1 domains and keep future-scope domains out of implementation inputs.
-- WP-01 must specify UUID storage/validation and JSON behavior for EventMetadata.
-- Current source still has direct legacy writes that violate baseline redlines: order payment/cancel/delete/rebook/admin updates and order-derived seat allocation.
+## Phase 2 — engineering hardening (IN PROGRESS)
 
-## Next Executable Steps
-1. Revise WP-01 brief only; do not implement yet.
-2. Define the exact Phase 1 envelope coverage matrix and Provider Integration handling.
-3. State that contract example payloads are test-only local stubs; real payloads stay in producer bounded contexts.
-4. Remove future-scope domains from WP-01 acceptance evidence or mark them non-acceptance references only.
-5. Choose EventMetadata UUID representation and validation boundary; require lowercase RFC-4122 JSON output and deserialization/rehydration validation.
-6. After WP-01 brief approval, implement the smallest shared-kernel slice with immutable value/reference objects, `DomainEventEnvelope`/`EventMetadata`, and unit tests.
-7. Prepare WP-02 brief for Place & Network.
-8. Prepare WP-03 brief for Service Plan after WP-02 dependency is explicit.
-9. Prepare WP-05 brief for Capacity & Availability after shared refs are available.
+Architecture ruling: `docs/08-contracts/persistence.md`.
+
+### Wave 10 — persistence foundation
+| Task | Scope |
+|---|---|
+| REQ-072 | PostgreSQL deployment (PVC, per-service DBs, secrets), DATABASE_URL wiring for all services, redis AOF |
+| REQ-073 | java-kit `persistence` module + pilot migration: payment |
+| REQ-074 | python-kit `storage.py` + pilot migration: fare-pricing (also retires the rollback+503 ruling section) |
+| REQ-075 | ts-kit `storage.ts` + pilot migration: notification |
+| REQ-076 | go-kit `storage/` + pilot migration: place-network |
+| REQ-077 | rust-kit `storage.rs` + pilot migration: capacity-availability |
+
+REQ-073..077 depend on REQ-072. Live gate per pilot: full e2e regression
+plus a restart-survival check (`kubectl delete pod` mid-flow, state
+intact afterwards).
+
+### Wave 11 — persistence rollout
+Remaining stateful services migrate in per-language batches using the
+proven kit modules (17 services; legacy-acl is stateless and exempt).
+A new `deploy/e2e/12-restart.sh` certifies cross-service restart
+survival once the rollout completes.
+
+### Wave 12 — channels & tidy
+- Notification: SMTP adapter + in-cluster mailpit; channel selection per
+  contract (IN_APP remains default).
+- Repo tidy: future-scope skeleton READMEs, docs sweep, dead-code pass.
+
+## Historical planning material
+
+Earlier revisions of this file tracked the pre-implementation WP-01
+brief cycle (rejections/blockers). That content is obsolete — the merged
+PR trail on `refactor/greenfield-ddd` is the historical record.

--- a/docs/08-contracts/persistence.md
+++ b/docs/08-contracts/persistence.md
@@ -1,0 +1,137 @@
+# Persistence & Durable Outbox — RULING (2026-07-07)
+
+Status: ACCEPTED. Applies to every deployed service. This is the phase-2
+storage baseline; PRs that touch state handling are checked against this
+document field by field.
+
+Supersedes: the "publish failure → rollback + 503" reliability ruling in
+`api/fare-pricing.md` §Reliability. Once a service adopts the transactional
+outbox below, command handlers commit state + outbox atomically and return
+success; there is no publish-failure HTTP path anymore. The fare-pricing
+migration task updates that contract section.
+
+Unchanged rulings that this document builds on:
+- Deterministic event ids (derive from consumed eventId / sourceRef).
+- Consumer-side eventId dedup (now durable, see §4).
+- Redis streams remain the event bus. Redis is NEVER a system of record.
+
+## 1. Infrastructure
+
+- One PostgreSQL instance: image `postgres:16-alpine`, Deployment name
+  `postgres`, strategy `Recreate`, single replica, PVC 5Gi
+  (storageclass `standard`), Service DNS `postgres:5432`, namespace
+  `train-ticket`.
+- Secret `postgres-credentials`: `POSTGRES_USER=trainticket`,
+  `POSTGRES_PASSWORD=trainticket-dev` (dev cluster only; never reuse
+  elsewhere).
+- One database per service. Database name = service directory name with
+  `-` → `_` (e.g. `services/fare-pricing` → `fare_pricing`). All databases
+  are created by an initdb ConfigMap script mounted at
+  `/docker-entrypoint-initdb.d/`.
+- Every service Deployment gets:
+  `DATABASE_URL=postgresql://trainticket:trainticket-dev@postgres:5432/<db>`
+  A service that has not migrated yet simply ignores it.
+- Java services receive the same `DATABASE_URL` (postgres URI form); the
+  java-kit adapter converts it to JDBC internally. There is exactly one
+  canonical env var; do not introduce `JDBC_URL`, `PGHOST`, etc.
+- Redis gains `--appendonly yes` so consumer-group offsets and unconsumed
+  stream entries survive a redis restart.
+
+## 2. Storage model
+
+- Aggregate state is persisted as snapshot rows, one table per aggregate
+  type, named `<aggregate>_snapshots`:
+
+  ```sql
+  CREATE TABLE <aggregate>_snapshots (
+    id         text PRIMARY KEY,
+    version    bigint NOT NULL,
+    data       jsonb NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT now()
+  );
+  ```
+
+- Optimistic concurrency is mandatory:
+  `UPDATE ... SET version = version + 1, data = $2, updated_at = now()
+   WHERE id = $1 AND version = $3` — zero rows updated means a concurrent
+  writer won; the handler retries the whole command or returns 409.
+- Read models / list endpoints may add dedicated tables or generated
+  columns; JSONB expression indexes are allowed. Full table scans on hot
+  list endpoints are not.
+- Schema migrations: per-service ordered SQL files in
+  `services/<svc>/migrations/NNN_description.sql`, applied at startup by
+  the language kit's migration runner, recorded in
+  `schema_migrations(version text PRIMARY KEY, applied_at timestamptz)`.
+  Readiness stays false until migrations are applied.
+- Domain layers stay persistence-ignorant: repository ports keep their
+  current interfaces; the Postgres implementation lives in the service's
+  infrastructure/adapter layer and uses only the kit's storage helpers.
+
+## 3. Transactional outbox (event publishing)
+
+- Every service that emits events gets one `outbox` table:
+
+  ```sql
+  CREATE TABLE outbox (
+    seq          bigserial PRIMARY KEY,
+    event_id     text NOT NULL UNIQUE,
+    stream       text NOT NULL,
+    envelope     jsonb NOT NULL,
+    created_at   timestamptz NOT NULL DEFAULT now(),
+    published_at timestamptz
+  );
+  ```
+
+  `envelope` is the exact JSON that will be XADDed (same shape that goes
+  into the stream field `d` today — no re-serialization drift).
+- Producers write the state change AND the outbox rows in ONE database
+  transaction. HTTP success means the transaction committed. The old
+  "rollback + 503 on publish failure" behavior is retired.
+- Relay: a kit-provided background loop per service instance polls
+  `SELECT ... WHERE published_at IS NULL ORDER BY seq LIMIT 100`,
+  XADDs each envelope to its stream, then sets `published_at`. Poll
+  interval ≤ 250 ms (e2e retry windows assume events land within a few
+  seconds). Ordering per service is preserved by `seq`.
+- Delivery is at-least-once (relay may crash between XADD and marking
+  published). That is safe because consumer dedup is durable (§4) and
+  event ids are deterministic.
+
+## 4. Durable consumer dedup & idempotency
+
+- `processed_events(event_id text PRIMARY KEY, stream text,
+  processed_at timestamptz NOT NULL DEFAULT now())` — the INSERT happens
+  in the SAME transaction as the handler's state mutation;
+  `ON CONFLICT DO NOTHING` + zero rows means duplicate → skip side
+  effects, ack the message.
+- HTTP idempotency records move from memory to
+  `idempotency_records(key text PRIMARY KEY, request_hash text NOT NULL,
+  status_code int NOT NULL, response_body jsonb, created_at timestamptz
+  NOT NULL DEFAULT now())`. Middleware semantics are unchanged: same key
+  + same hash replays the stored response; same key + different hash →
+  `IDEMPOTENCY_KEY_REUSED`.
+
+## 5. Kit obligations (one module per language, same port names)
+
+| Kit | Module | Driver |
+|---|---|---|
+| java-kit | `persistence` | plain JDBC (no JPA/Hibernate/Flyway) |
+| python-kit | `storage.py` | psycopg 3 |
+| ts-kit | `storage.ts` | `pg` |
+| go-kit | `storage/` | `pgx` |
+| rust-kit | `storage.rs` | `sqlx` (runtime-checked queries) |
+
+Each kit provides: DATABASE_URL parsing + pool, migration runner,
+snapshot repository helper (get/save with optimistic version), outbox
+appender + relay loop, processed-events guard, DB-backed idempotency
+store — and KEEPS the existing in-memory implementations behind the same
+ports for unit tests. `make check` must not require a running Postgres.
+
+## 6. Failure semantics
+
+- DB unreachable → readiness fails → traffic stops (single replica +
+  Recreate: brief dev-cluster outage is accepted).
+- Relay restart resumes from unpublished rows; duplicates are absorbed by
+  §4.
+- Pod restart must lose NOTHING: the live-gate check for every migrated
+  service is `kubectl delete pod` mid-flow, then the flow completes and
+  prior state is still queryable.


### PR DESCRIPTION
Contract-first ruling for phase-2 engineering hardening: PostgreSQL aggregate-snapshot persistence, transactional outbox (supersedes rollback+503 publish pattern), durable consumer dedup and idempotency stores, per-language kit obligations. Also refreshes the two stale status docs to phase-1-complete reality and fixes the 01-seed.sh .refs.env copy bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)