### PR TITLE
REQ-072 PostgreSQL persistence infrastructure wiring

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,7 +1,7 @@
 # Local kind integration environment
 
-This directory contains the Docker and Kubernetes assets for running the 22
-integration-ready Train Ticket services plus one Redis Streams broker in a local
+This directory contains the Docker and Kubernetes assets for running the 23
+integration-ready Train Ticket services plus Redis Streams and PostgreSQL in a local
 kind cluster for 联调.
 
 ## Prerequisites
@@ -27,7 +27,8 @@ LOAD_INTO_KIND=0 deploy/build-images.sh local
 ```
 
 The script builds images as `train-ticket/<service>:<tag>` using the per-service
-Dockerfiles under `deploy/docker/`.
+Dockerfiles under `deploy/docker/`. PostgreSQL uses the stock `postgres:16-alpine`
+image and is not built or loaded by `build-images.sh`.
 
 ## Deploy
 
@@ -35,9 +36,20 @@ Dockerfiles under `deploy/docker/`.
 kubectl apply -k deploy/k8s
 ```
 
-The kustomization creates namespace `train-ticket`, a single non-persistent
-`redis:7-alpine` Deployment/Service, and one Deployment/Service per integration-ready
-service. Service pods receive `REDIS_URL=redis://redis.train-ticket.svc.cluster.local:6379`.
+The kustomization creates namespace `train-ticket`, a Redis `redis:7-alpine`
+Deployment/Service with append-only persistence enabled, a stock `postgres:16-alpine`
+Deployment/Service/PVC, and one Deployment/Service per integration-ready service.
+Service pods receive `REDIS_URL=redis://redis.train-ticket.svc.cluster.local:6379`
+and a service-specific `DATABASE_URL=postgresql://trainticket:trainticket-dev@postgres:5432/<db>`.
+
+PostgreSQL is sourced directly from the public `postgres:16-alpine` image and is
+not included in `build-images.sh`. In kind environments, either allow the node to
+pull the public image or preload it into the cluster before deploying:
+
+```bash
+docker pull postgres:16-alpine
+kind load docker-image postgres:16-alpine --name arl-test
+```
 
 ## Smoke check
 
@@ -50,7 +62,7 @@ kubectl -n train-ticket get pods \
   -o custom-columns='NAME:.metadata.name,READY:.status.containerStatuses[*].ready,PHASE:.status.phase'
 ```
 
-A rendered-manifest sanity check should report 23 Deployments (22 services + Redis):
+A rendered-manifest sanity check should report 25 Deployments (23 services + Redis + PostgreSQL):
 
 ```bash
 kubectl kustomize deploy/k8s > /tmp/k8s-out.yaml

--- a/deploy/e2e/lib.sh
+++ b/deploy/e2e/lib.sh
@@ -10,9 +10,17 @@ REDIS_POD=""
 k() { kubectl --context "$KCTX" -n "$NS" "$@"; }
 
 ensure_curl_pod() {
-  k get pod e2e-curl >/dev/null 2>&1 || {
-    k run e2e-curl --image=curlimages/curl:8.10.1 --restart=Never --command -- sleep 86400 >/dev/null
-  }
+  # A finite sleep or an eviction leaves the pod in Completed/Failed, where
+  # `k wait` can only time out — recreate unless it is actually alive.
+  local phase
+  phase=$(k get pod e2e-curl -o jsonpath='{.status.phase}' 2>/dev/null || true)
+  case "$phase" in
+    Running|Pending) ;;
+    *)
+      k delete pod e2e-curl --ignore-not-found --wait=true >/dev/null 2>&1
+      k run e2e-curl --image=curlimages/curl:8.10.1 --restart=Never --command -- sleep infinity >/dev/null
+      ;;
+  esac
   k wait --for=condition=Ready pod/e2e-curl --timeout=60s >/dev/null
 }
 

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - postgres.yaml
   - redis.yaml
   - services.yaml

--- a/deploy/k8s/postgres.yaml
+++ b/deploy/k8s/postgres.yaml
@@ -1,0 +1,179 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+  namespace: train-ticket
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: train-ticket
+type: Opaque
+stringData:
+  POSTGRES_USER: trainticket
+  POSTGRES_PASSWORD: trainticket-dev
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-initdb
+  namespace: train-ticket
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: train-ticket
+data:
+  01-create-service-databases.sql: |
+    SELECT 'CREATE DATABASE account'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'account')\gexec
+    SELECT 'CREATE DATABASE admin_audit'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'admin_audit')\gexec
+    SELECT 'CREATE DATABASE booking_orchestration'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'booking_orchestration')\gexec
+    SELECT 'CREATE DATABASE capacity_availability'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'capacity_availability')\gexec
+    SELECT 'CREATE DATABASE customer_service'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'customer_service')\gexec
+    SELECT 'CREATE DATABASE entitlement_ticketing'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'entitlement_ticketing')\gexec
+    SELECT 'CREATE DATABASE fare_pricing'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'fare_pricing')\gexec
+    SELECT 'CREATE DATABASE finance_settlement'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'finance_settlement')\gexec
+    SELECT 'CREATE DATABASE fulfillment'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'fulfillment')\gexec
+    SELECT 'CREATE DATABASE journey_order'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'journey_order')\gexec
+    SELECT 'CREATE DATABASE legacy_acl'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'legacy_acl')\gexec
+    SELECT 'CREATE DATABASE notification'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'notification')\gexec
+    SELECT 'CREATE DATABASE offer_management'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'offer_management')\gexec
+    SELECT 'CREATE DATABASE payment'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'payment')\gexec
+    SELECT 'CREATE DATABASE place_network'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'place_network')\gexec
+    SELECT 'CREATE DATABASE post_sales'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'post_sales')\gexec
+    SELECT 'CREATE DATABASE provider_integration'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'provider_integration')\gexec
+    SELECT 'CREATE DATABASE reporting'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'reporting')\gexec
+    SELECT 'CREATE DATABASE risk_compliance'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'risk_compliance')\gexec
+    SELECT 'CREATE DATABASE service_plan'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'service_plan')\gexec
+    SELECT 'CREATE DATABASE supplier_catalog'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'supplier_catalog')\gexec
+    SELECT 'CREATE DATABASE traveler_profile'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'traveler_profile')\gexec
+    SELECT 'CREATE DATABASE trip_planning'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'trip_planning')\gexec
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  namespace: train-ticket
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: train-ticket
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: standard
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: train-ticket
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: train-ticket
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+        app.kubernetes.io/part-of: train-ticket
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgres
+              containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+            - name: postgres-initdb
+              mountPath: /docker-entrypoint-initdb.d
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - trainticket
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            tcpSocket:
+              port: postgres
+            initialDelaySeconds: 30
+            periodSeconds: 10
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: postgres-data
+        - name: postgres-initdb
+          configMap:
+            name: postgres-initdb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: train-ticket
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/part-of: train-ticket
+spec:
+  type: ClusterIP
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+  selector:
+    app.kubernetes.io/name: postgres

--- a/deploy/k8s/redis.yaml
+++ b/deploy/k8s/redis.yaml
@@ -21,6 +21,9 @@ spec:
         - name: redis
           image: redis:7-alpine
           imagePullPolicy: IfNotPresent
+          args:
+            - --appendonly
+            - "yes"
           ports:
             - name: redis
               containerPort: 6379

--- a/deploy/k8s/services.yaml
+++ b/deploy/k8s/services.yaml
@@ -34,6 +34,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/place_network
           resources:
             requests:
               cpu: 50m
@@ -111,6 +113,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/service_plan
           resources:
             requests:
               cpu: 50m
@@ -188,6 +192,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/capacity_availability
           resources:
             requests:
               cpu: 50m
@@ -265,6 +271,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/fare_pricing
           resources:
             requests:
               cpu: 50m
@@ -342,6 +350,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/trip_planning
           resources:
             requests:
               cpu: 50m
@@ -419,6 +429,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/offer_management
           resources:
             requests:
               cpu: 50m
@@ -496,6 +508,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/journey_order
           resources:
             requests:
               cpu: 50m
@@ -573,6 +587,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/booking_orchestration
           resources:
             requests:
               cpu: 50m
@@ -650,6 +666,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/payment
           resources:
             requests:
               cpu: 50m
@@ -727,6 +745,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/provider_integration
           resources:
             requests:
               cpu: 50m
@@ -804,6 +824,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/entitlement_ticketing
           resources:
             requests:
               cpu: 50m
@@ -881,6 +903,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/fulfillment
           resources:
             requests:
               cpu: 50m
@@ -958,6 +982,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/post_sales
           resources:
             requests:
               cpu: 50m
@@ -1035,6 +1061,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/notification
           resources:
             requests:
               cpu: 50m
@@ -1112,6 +1140,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/traveler_profile
           resources:
             requests:
               cpu: 50m
@@ -1189,6 +1219,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/risk_compliance
           resources:
             requests:
               cpu: 50m
@@ -1266,6 +1298,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/account
           resources:
             requests:
               cpu: 50m
@@ -1343,6 +1377,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/admin_audit
           resources:
             requests:
               cpu: 50m
@@ -1420,6 +1456,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/customer_service
           resources:
             requests:
               cpu: 50m
@@ -1497,6 +1535,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/finance_settlement
           resources:
             requests:
               cpu: 50m
@@ -1574,6 +1614,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/reporting
           resources:
             requests:
               cpu: 50m
@@ -1651,6 +1693,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/supplier_catalog
           resources:
             requests:
               cpu: 50m
@@ -1726,6 +1770,8 @@ spec:
               value: "8080"
             - name: REDIS_URL
               value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/legacy_acl
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
## Summary
- Add stock postgres:16-alpine Deployment/Service/PVC/Secret/initdb databases to deploy/k8s
- Wire DATABASE_URL into all 23 deployed services
- Enable Redis AOF and document kind image loading for Postgres

## Validation
- kubectl kustomize deploy/k8s
- rendered Deployment count = 25; DATABASE_URL count = 23; per-service database URL self-check passed
- mvn -q -f platform/java-kit/pom.xml install -DskipTests (precondition for local make check)
- make check

E2E sandbox: not run (requires live cluster orchestration).