### PR TITLE
REQ-078 release capacity on EntitlementVoided

### DIFF
--- a/deploy/e2e/03-refund.sh
+++ b/deploy/e2e/03-refund.sh
@@ -33,14 +33,13 @@ echo "  entitlement stream:"; last_events events:entitlement-ticketing 2
 
 echo "== 5. final states"
 CASE_STATUS=""
-# APPLIED waits on CapacityReleased; today that release is booking's lazy
-# fallback (~90s after hold) — poll long enough to cover it. REQ-078 will
-# make capacity release promptly on EntitlementVoided.
-for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+# APPLIED waits on CapacityReleased from the prompt EntitlementVoided-driven
+# release path; this should complete within 30s.
+for attempt in 1 2 3 4 5 6; do
   req GET post-sales "/api/v1/post-sales-cases/$CASE"
   CASE_STATUS=$(jget "['status']")
   [ "$CASE_STATUS" = "APPLIED" ] && break
-  sleep 8
+  sleep 5
 done
 echo "  case status: $CASE_STATUS [$LAST_CODE]"
 [ "$CASE_STATUS" = "APPLIED" ] && ok "case APPLIED" || bad "case not applied ($CASE_STATUS)"

--- a/services/capacity-availability/migrations/002_capacity_hold_segment_booking_lookup.sql
+++ b/services/capacity-availability/migrations/002_capacity_hold_segment_booking_lookup.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_capacity_hold_segment_booking_state
+  ON capacity_hold_snapshots ((data #>> '{references,segmentBookingRef}'), (data ->> 'state'));

--- a/services/capacity-availability/src/adapters/messaging/mod.rs
+++ b/services/capacity-availability/src/adapters/messaging/mod.rs
@@ -139,6 +139,7 @@ pub mod redis_subscriber {
             let selected_streams = if streams.is_empty() {
                 vec![
                     "events:booking-orchestration".to_string(),
+                    "events:entitlement-ticketing".to_string(),
                     "events:post-sales".to_string(),
                 ]
             } else {

--- a/services/capacity-availability/src/adapters/storage/mod.rs
+++ b/services/capacity-availability/src/adapters/storage/mod.rs
@@ -301,7 +301,23 @@ impl PostgresCapacityService {
         idempotency_key: &str,
         correlation_id: &str,
     ) -> Result<ReleaseHoldResponse, AppError> {
-        let fingerprint = format!("release:{hold_id}");
+        self.release_hold_with_reason(
+            hold_id,
+            idempotency_key,
+            correlation_id,
+            "client-requested-release",
+        )
+        .await
+    }
+
+    async fn release_hold_with_reason(
+        &self,
+        hold_id: &str,
+        idempotency_key: &str,
+        correlation_id: &str,
+        release_reason: &'static str,
+    ) -> Result<ReleaseHoldResponse, AppError> {
+        let fingerprint = format!("release:{hold_id}:{release_reason}");
         if let Some(resp) = self
             .idempotency_replay::<ReleaseHoldResponse>(idempotency_key, &fingerprint)
             .await?
@@ -317,7 +333,7 @@ impl PostgresCapacityService {
                 pool.release_hold(
                     &HoldId::new(hold_id).map_err(to_internal)?,
                     now,
-                    "client-requested-release",
+                    release_reason,
                 )
                 .map_err(map_hold_mutation_error)
             },
@@ -559,6 +575,28 @@ impl PostgresCapacityService {
             .collect()
     }
 
+    async fn find_releasable_hold_by_segment_booking(
+        &self,
+        tx: &mut PgTransaction<'_>,
+        segment_booking_ref: &str,
+    ) -> Result<Option<Snapshot<CapacityHoldSnapshot>>, StorageError> {
+        let sql = format!(
+            "SELECT id, version, data FROM {HOLD_TABLE} WHERE data #>> '{{references,segmentBookingRef}}' = $1 AND data ->> 'state' IN ('Held', 'Confirmed') ORDER BY updated_at DESC LIMIT 1"
+        );
+        let row: Option<(String, i64, Value)> = sqlx::query_as(&sql)
+            .bind(segment_booking_ref)
+            .fetch_optional(&mut **tx)
+            .await?;
+        row.map(|(id, version, data)| {
+            Ok(Snapshot {
+                id,
+                version,
+                data: serde_json::from_value(data)?,
+            })
+        })
+        .transpose()
+    }
+
     pub async fn handle_inbound_event(&self, envelope: WireEnvelope) -> HandlerResult {
         let result = match envelope.event_type.as_str() {
             "SegmentReservationRequested" => {
@@ -570,6 +608,7 @@ impl PostgresCapacityService {
             "SegmentBookingCancelled" | "PostSalesApplied" => {
                 self.handle_release_requested(envelope).await
             }
+            "EntitlementVoided" => self.handle_entitlement_voided(envelope).await,
             _ => Ok(()),
         };
         match result {
@@ -808,6 +847,168 @@ impl PostgresCapacityService {
             },
         )
         .await
+    }
+
+    async fn handle_entitlement_voided(
+        &self,
+        envelope: WireEnvelope,
+    ) -> Result<(), InboundEventError> {
+        let Some(segment_booking_ref) =
+            segment_booking_ref_from_entitlement_voided(&envelope.payload)
+        else {
+            return Ok(());
+        };
+        let idempotency_key = format!(
+            "{}:{}:entitlement-voided-release",
+            envelope.event_id, segment_booking_ref
+        );
+        let fingerprint =
+            format!("release-by-segment-booking:{segment_booking_ref}:entitlement-voided");
+        self.handle_inbound_segment_booking_release(
+            envelope,
+            &segment_booking_ref,
+            &idempotency_key,
+            &fingerprint,
+            "entitlement-voided",
+        )
+        .await
+    }
+
+    async fn handle_inbound_segment_booking_release(
+        &self,
+        envelope: WireEnvelope,
+        segment_booking_ref: &str,
+        idempotency_key: &str,
+        fingerprint: &str,
+        release_reason: &'static str,
+    ) -> Result<(), InboundEventError> {
+        let stream = stream_for_producer(&envelope.producer);
+        for attempt in 0..MAX_RETRIES {
+            let result = self
+                .try_handle_inbound_segment_booking_release(
+                    &envelope,
+                    &stream,
+                    segment_booking_ref,
+                    idempotency_key,
+                    fingerprint,
+                    release_reason,
+                )
+                .await;
+            match result {
+                Err(InboundEventError::Transient(message))
+                    if message.contains("optimistic concurrency conflict")
+                        && attempt + 1 < MAX_RETRIES =>
+                {
+                    continue;
+                }
+                result => return result,
+            }
+        }
+        Err(InboundEventError::Transient(
+            "capacity hold write conflict".into(),
+        ))
+    }
+
+    async fn try_handle_inbound_segment_booking_release(
+        &self,
+        envelope: &WireEnvelope,
+        stream: &str,
+        segment_booking_ref: &str,
+        idempotency_key: &str,
+        fingerprint: &str,
+        release_reason: &'static str,
+    ) -> Result<(), InboundEventError> {
+        let mut tx = self.pool().begin().await.map_err(inbound_transient)?;
+        if !mark_event_processing(&mut tx, &envelope.event_id, stream)
+            .await
+            .map_err(inbound_transient)?
+        {
+            tx.rollback().await.map_err(inbound_transient)?;
+            return Ok(());
+        }
+        let Some(hold_snapshot) = self
+            .find_releasable_hold_by_segment_booking(&mut tx, segment_booking_ref)
+            .await
+            .map_err(inbound_transient)?
+        else {
+            tx.commit().await.map_err(inbound_transient)?;
+            return Ok(());
+        };
+        if self
+            .claim_idempotency::<ReleaseHoldResponse>(&mut tx, idempotency_key, fingerprint)
+            .await
+            .map_err(inbound_from_app_error)?
+            .is_some()
+        {
+            tx.commit().await.map_err(inbound_transient)?;
+            return Ok(());
+        }
+        let hold_id = hold_snapshot.id.clone();
+        let pool_id = hold_snapshot.data.inventory_pool_id.clone();
+        let Some(loaded_pool) = self
+            .inventory_repo
+            .get::<InventoryPoolSnapshot>(&mut *tx, &pool_id)
+            .await
+            .map_err(inbound_transient)?
+        else {
+            tx.commit().await.map_err(inbound_transient)?;
+            return Ok(());
+        };
+        let mut pool = loaded_pool
+            .data
+            .try_into_domain()
+            .map_err(inbound_from_app_error)?;
+        let hold_id_value = HoldId::new(&hold_id).map_err(inbound_fatal)?;
+        let Some(current_hold) = pool.hold(&hold_id_value) else {
+            tx.commit().await.map_err(inbound_transient)?;
+            return Ok(());
+        };
+        if !matches!(
+            current_hold.state,
+            CapacityHoldState::Held | CapacityHoldState::Confirmed
+        ) {
+            tx.commit().await.map_err(inbound_transient)?;
+            return Ok(());
+        }
+        let event = pool
+            .release_hold(&hold_id_value, now_millis(), release_reason)
+            .map_err(map_hold_mutation_error)
+            .map_err(inbound_from_app_error)?;
+        let outbound = domain_event_to_wire(&event, &envelope.correlation_id)
+            .map_err(inbound_from_app_error)?;
+        self.inventory_repo
+            .save(
+                &mut tx,
+                &pool_id,
+                Some(loaded_pool.version),
+                &InventoryPoolSnapshot::from_domain(&pool),
+            )
+            .await
+            .map_err(inbound_transient)?;
+        let hold = pool
+            .hold(&hold_id_value)
+            .ok_or_else(|| InboundEventError::Fatal("hold not found".into()))?;
+        self.upsert_hold_snapshot(&mut tx, &hold_id, hold)
+            .await
+            .map_err(inbound_from_app_error)?;
+        OutboxAppender::append(&mut tx, &stream_for_producer(PRODUCER), &outbound)
+            .await
+            .map_err(inbound_transient)?;
+        let resp = ReleaseHoldResponse {
+            hold_id,
+            status: "RELEASED".to_string(),
+        };
+        self.finish_idempotency(
+            &mut tx,
+            idempotency_key,
+            fingerprint,
+            200,
+            serde_json::to_value(&resp).map_err(inbound_transient)?,
+        )
+        .await
+        .map_err(inbound_from_app_error)?;
+        tx.commit().await.map_err(inbound_transient)?;
+        Ok(())
     }
 
     async fn handle_inbound_hold_mutation<T, M, R>(
@@ -1336,6 +1537,13 @@ fn string_field(value: &Value, field: &str) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+fn segment_booking_ref_from_entitlement_voided(value: &Value) -> Option<String> {
+    value
+        .get("references")
+        .and_then(|references| string_field(references, "segmentBookingRef"))
+        .or_else(|| string_field(value, "segmentBookingId"))
+}
+
 fn now_millis() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -1399,6 +1607,35 @@ mod tests {
             "snapshot pool version 1 was not current".into(),
         ));
         assert!(matches!(err, AppError::Conflict(_)));
+    }
+
+    #[test]
+    fn entitlement_voided_segment_booking_ref_prefers_references_shape() {
+        let payload = json!({
+            "entitlementId": "ent-1",
+            "segmentBookingId": "legacy-sb",
+            "references": {
+                "segmentBookingRef": "sb-1"
+            }
+        });
+
+        assert_eq!(
+            segment_booking_ref_from_entitlement_voided(&payload),
+            Some("sb-1".to_string())
+        );
+    }
+
+    #[test]
+    fn entitlement_voided_segment_booking_ref_accepts_legacy_direct_field() {
+        let payload = json!({
+            "entitlementId": "ent-1",
+            "segmentBookingId": "sb-legacy"
+        });
+
+        assert_eq!(
+            segment_booking_ref_from_entitlement_voided(&payload),
+            Some("sb-legacy".to_string())
+        );
     }
 
     #[test]

--- a/services/capacity-availability/src/application.rs
+++ b/services/capacity-availability/src/application.rs
@@ -38,6 +38,7 @@ impl CapacityService {
             "SegmentBookingCancelled" | "PostSalesApplied" => {
                 self.handle_release_trigger(&envelope)
             }
+            "EntitlementVoided" => self.handle_entitlement_voided(&envelope),
             _ => HandlerResult::Success,
         }
     }
@@ -98,6 +99,32 @@ impl CapacityService {
         let idempotency_key = format!("{}:{}:release", envelope.event_id, hold_id);
         match self.release_hold(&hold_id, &idempotency_key, &envelope.correlation_id) {
             Ok(_) | Err(AppError::NotFound(_)) => HandlerResult::Success,
+            Err(AppError::Unavailable(message)) | Err(AppError::Internal(message)) => {
+                HandlerResult::TransientError(message)
+            }
+            Err(error) => HandlerResult::FatalError(error.message().to_string()),
+        }
+    }
+
+    fn handle_entitlement_voided(&self, envelope: &WireEnvelope) -> HandlerResult {
+        let Some(segment_booking_ref) =
+            segment_booking_ref_from_entitlement_voided(&envelope.payload)
+        else {
+            return HandlerResult::Success;
+        };
+        let idempotency_key = format!(
+            "{}:{}:entitlement-voided-release",
+            envelope.event_id, segment_booking_ref
+        );
+        match self.release_hold_by_segment_booking(
+            &segment_booking_ref,
+            &idempotency_key,
+            &envelope.correlation_id,
+            "entitlement-voided",
+        ) {
+            Ok(_) | Err(AppError::NotFound(_)) | Err(AppError::PreconditionFailed(_)) => {
+                HandlerResult::Success
+            }
             Err(AppError::Unavailable(message)) | Err(AppError::Internal(message)) => {
                 HandlerResult::TransientError(message)
             }
@@ -362,7 +389,22 @@ impl CapacityService {
         idempotency_key: &str,
         correlation_id: &str,
     ) -> Result<ReleaseHoldResponse, AppError> {
-        let fingerprint = format!("release:{}", hold_id);
+        self.release_hold_with_reason(
+            hold_id,
+            idempotency_key,
+            correlation_id,
+            "client-requested-release",
+        )
+    }
+
+    fn release_hold_with_reason(
+        &self,
+        hold_id: &str,
+        idempotency_key: &str,
+        correlation_id: &str,
+        release_reason: &'static str,
+    ) -> Result<ReleaseHoldResponse, AppError> {
+        let fingerprint = format!("release:{}:{}", hold_id, release_reason);
         if let Some(resp) =
             self.idempotency_replay::<ReleaseHoldResponse>(idempotency_key, &fingerprint)?
         {
@@ -387,7 +429,7 @@ impl CapacityService {
                     &HoldId::new(hold_id)
                         .map_err(|_| AppError::NotFound("hold not found".into()))?,
                     now,
-                    "client-requested-release",
+                    release_reason,
                 ) {
                     Ok(event) => {
                         self.publish_domain_event(&event, correlation_id)
@@ -404,6 +446,37 @@ impl CapacityService {
             }
         }
         Err(AppError::NotFound("hold not found".into()))
+    }
+
+    fn release_hold_by_segment_booking(
+        &self,
+        segment_booking_ref: &str,
+        idempotency_key: &str,
+        correlation_id: &str,
+        release_reason: &'static str,
+    ) -> Result<ReleaseHoldResponse, AppError> {
+        let hold_id = {
+            let pools = self
+                .pools
+                .lock()
+                .map_err(|e| AppError::Internal(format!("lock error: {}", e)))?;
+            pools
+                .values()
+                .flat_map(|pool| pool.holds())
+                .find(|hold| {
+                    hold.scope.references.segment_booking_ref.as_deref()
+                        == Some(segment_booking_ref)
+                        && matches!(
+                            hold.state,
+                            CapacityHoldState::Held | CapacityHoldState::Confirmed
+                        )
+                })
+                .map(|hold| hold.hold_id.to_string())
+        };
+        let Some(hold_id) = hold_id else {
+            return Err(AppError::NotFound("hold not found".into()));
+        };
+        self.release_hold_with_reason(&hold_id, idempotency_key, correlation_id, release_reason)
     }
 
     fn idempotency_replay<T: DeserializeOwned>(
@@ -733,6 +806,13 @@ fn string_field(value: &Value, field: &str) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+fn segment_booking_ref_from_entitlement_voided(value: &Value) -> Option<String> {
+    value
+        .get("references")
+        .and_then(|references| string_field(references, "segmentBookingRef"))
+        .or_else(|| string_field(value, "segmentBookingId"))
+}
+
 fn now_millis() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -744,6 +824,58 @@ fn now_millis() -> u64 {
 mod tests {
     use super::*;
     use crate::adapters::messaging::InMemoryEventPublisher;
+
+    #[test]
+    fn entitlement_voided_releases_matching_hold_by_segment_booking_ref() {
+        let publisher = Arc::new(InMemoryEventPublisher::new());
+        let service = CapacityService::new(publisher.clone());
+        let correlation_id = rust_kit::messaging::correlation_id();
+        let response = service
+            .hold_capacity(
+                HoldCapacityRequest {
+                    segment_ref: "service-segment:G123:sha-nkg".into(),
+                    traveler_ref: "traveler-1".into(),
+                    class_ref: "first".into(),
+                    quantity: 1,
+                    segment_booking_id: "sb-1".into(),
+                },
+                "idem-hold-1",
+                &correlation_id,
+            )
+            .unwrap();
+
+        let inbound = WireEnvelope::try_new(
+            "EntitlementVoided",
+            unix_millis_to_rfc3339(now_millis()),
+            correlation_id,
+            None::<String>,
+            "entitlement-ticketing",
+            json!({
+                "entitlementId": "ent-1",
+                "references": { "segmentBookingRef": "sb-1" },
+                "voidedAt": "2026-07-07T00:00:00.000Z",
+                "reason": "REFUND",
+                "policy": "NORMAL"
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(
+            service.handle_inbound_event(inbound),
+            HandlerResult::Success
+        );
+        assert_eq!(
+            service.get_hold(&response.hold_id).unwrap().status,
+            "RELEASED"
+        );
+        let released = publisher
+            .published()
+            .into_iter()
+            .find(|envelope| envelope.event_type == "CapacityReleased")
+            .expect("CapacityReleased is published");
+        assert_eq!(released.payload["releaseReason"], "entitlement-voided");
+        assert_eq!(released.payload["references"]["segmentBookingRef"], "sb-1");
+    }
 
     #[test]
     fn capacity_hold_failed_payload_matches_contract_fields() {


### PR DESCRIPTION
## Summary
- subscribe capacity-availability to entitlement-ticketing and handle EntitlementVoided by releasing the hold for references.segmentBookingRef
- keep release transaction idempotent via processed_events, snapshot updates, and outbox append; skip unknown/already released holds
- tighten 03-refund APPLIED polling to 6x5s

## Validation
- cargo test --manifest-path services/capacity-availability/Cargo.toml --quiet
- cargo test --manifest-path platform/rust-kit/Cargo.toml --quiet
- bash -n deploy/e2e/03-refund.sh
- make check

E2E live cluster 01->02->03/04/05: not run in sandbox (no cluster).