### PR TITLE
REQ-079 DLQ attribution and failure cleanup

### DIFF
--- a/platform/go-kit/messaging/redis.go
+++ b/platform/go-kit/messaging/redis.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -202,7 +204,7 @@ func (b *RedisEventBus) consumeLoop(ctx context.Context, streams []string, group
 		}
 		for _, stream := range result {
 			for _, msg := range stream.Messages {
-				b.processMessage(ctx, stream.Stream, group, msg, handler)
+				b.processMessageForConsumer(ctx, stream.Stream, group, consumer, msg, handler)
 			}
 		}
 	}
@@ -215,7 +217,7 @@ func (b *RedisEventBus) recoverPending(ctx context.Context, stream, group, consu
 			return
 		}
 		for _, m := range messages {
-			b.processMessage(ctx, stream, group, m, handler)
+			b.processMessageForConsumer(ctx, stream, group, consumer, m, handler)
 		}
 		if next == "0-0" || next == start {
 			return
@@ -224,15 +226,23 @@ func (b *RedisEventBus) recoverPending(ctx context.Context, stream, group, consu
 	}
 }
 func (b *RedisEventBus) processMessage(ctx context.Context, stream, group string, message redis.XMessage, handler Handler) {
+	b.processMessageForConsumer(ctx, stream, group, "unknown", message, handler)
+}
+
+func (b *RedisEventBus) processMessageForConsumer(ctx context.Context, stream, group, consumer string, message redis.XMessage, handler Handler) {
 	raw, ok := message.Values[EnvelopeField].(string)
+	attempts := b.deliveryAttempts(ctx, stream, group, message.ID)
 	if !ok || strings.TrimSpace(raw) == "" {
-		b.moveToDLQAndAck(ctx, stream, group, message.ID, raw)
+		b.moveToDLQAndAck(ctx, stream, group, consumer, message.ID, raw, "missing envelope field", attempts)
 		return
 	}
-	attempts := b.deliveryAttempts(ctx, stream, group, message.ID)
 	var envelope EventEnvelope
-	if err := json.Unmarshal([]byte(raw), &envelope); err != nil || envelope.Validate() != nil {
-		b.moveToDLQAndAck(ctx, stream, group, message.ID, raw)
+	if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+		b.moveToDLQAndAck(ctx, stream, group, consumer, message.ID, raw, failureReason(err), attempts)
+		return
+	}
+	if err := envelope.Validate(); err != nil {
+		b.moveToDLQAndAck(ctx, stream, group, consumer, message.ID, raw, failureReason(err), attempts)
 		return
 	}
 	if b.dedup != nil && b.dedup.Seen(envelope.EventID) {
@@ -241,7 +251,7 @@ func (b *RedisEventBus) processMessage(ctx context.Context, stream, group string
 	}
 	if err := handler(ctx, envelope); err != nil {
 		if IsFatalHandlerError(err) || attempts >= MaxDeliveryAttempts {
-			b.moveToDLQAndAck(ctx, stream, group, message.ID, raw)
+			b.moveToDLQAndAck(ctx, stream, group, consumer, message.ID, raw, failureReason(err), attempts)
 		}
 		return
 	}
@@ -257,7 +267,60 @@ func (b *RedisEventBus) deliveryAttempts(ctx context.Context, stream, group, id 
 	}
 	return entries[0].RetryCount
 }
-func (b *RedisEventBus) moveToDLQAndAck(ctx context.Context, stream, group, id, raw string) {
-	_ = b.client.XAdd(ctx, &redis.XAddArgs{Stream: stream + DeadLetterSuffix, MaxLen: MaxLen, Approx: true, Values: map[string]any{EnvelopeField: raw}}).Err()
+func (b *RedisEventBus) moveToDLQAndAck(ctx context.Context, stream, group, consumerName, id, raw, reason string, attempts int64) {
+	fields := deadLetterFields(raw, group, consumerName, reason, attempts)
+	_ = b.client.XAdd(ctx, &redis.XAddArgs{Stream: stream + DeadLetterSuffix, MaxLen: MaxLen, Approx: true, Values: fields}).Err()
+	warnDeadLetter(group, stream, raw, fields)
 	_ = b.client.XAck(ctx, stream, group, id).Err()
+}
+
+func warnDeadLetter(group, stream, raw string, fields map[string]any) {
+	slog.Warn("dead-lettered event", "service", group, "stream", stream, "eventId", eventIDFrom(raw), "reason", fields["failureReason"])
+}
+
+func deadLetterFields(raw, group, consumerName, reason string, attempts int64) map[string]any {
+	if attempts < 1 {
+		attempts = 1
+	}
+	if strings.TrimSpace(group) == "" {
+		group = "unknown"
+	}
+	if strings.TrimSpace(consumerName) == "" {
+		consumerName = "unknown"
+	}
+	return map[string]any{
+		EnvelopeField:    raw,
+		"consumerGroup":  group,
+		"consumerName":   consumerName,
+		"failureReason":  truncateFailureReason(reason),
+		"attempts":       fmt.Sprintf("%d", attempts),
+		"deadLetteredAt": time.Now().UTC().Format(time.RFC3339Nano),
+	}
+}
+
+func failureReason(err error) string {
+	if err == nil {
+		return "unknown"
+	}
+	return truncateFailureReason(fmt.Sprintf("%s: %s", reflect.TypeOf(err).String(), err.Error()))
+}
+
+func truncateFailureReason(reason string) string {
+	if len(reason) > 500 {
+		return reason[:500]
+	}
+	if strings.TrimSpace(reason) == "" {
+		return "unknown"
+	}
+	return reason
+}
+
+func eventIDFrom(raw string) string {
+	var parsed struct {
+		EventID string `json:"eventId"`
+	}
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil || strings.TrimSpace(parsed.EventID) == "" {
+		return "unknown"
+	}
+	return parsed.EventID
 }

--- a/platform/go-kit/messaging/redis_test.go
+++ b/platform/go-kit/messaging/redis_test.go
@@ -1,0 +1,48 @@
+package messaging
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDeadLetterFieldsCarryAttributionMetadata(t *testing.T) {
+	fields := deadLetterFields(`{"eventId":"evt-1"}`, "journey-order", "consumer-1", "fatal: poison", 7)
+	if fields[EnvelopeField] != `{"eventId":"evt-1"}` {
+		t.Fatalf("missing envelope field: %#v", fields)
+	}
+	if fields["consumerGroup"] != "journey-order" || fields["consumerName"] != "consumer-1" {
+		t.Fatalf("missing consumer attribution: %#v", fields)
+	}
+	if fields["failureReason"] != "fatal: poison" || fields["attempts"] != "7" {
+		t.Fatalf("missing failure metadata: %#v", fields)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, fields["deadLetteredAt"].(string)); err != nil {
+		t.Fatalf("deadLetteredAt must be RFC3339 UTC: %v", err)
+	}
+}
+
+func TestFailureReasonIsTruncated(t *testing.T) {
+	longReason := ""
+	for len(longReason) <= 510 {
+		longReason += "x"
+	}
+	if got := truncateFailureReason(longReason); len(got) != 500 {
+		t.Fatalf("expected 500 characters, got %d", len(got))
+	}
+}
+
+func TestWarnDeadLetterIncludesAttribution(t *testing.T) {
+	var output bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&output, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	fields := deadLetterFields(`{"eventId":"evt-1"}`, "journey-order", "consumer-1", "fatal", 1)
+	warnDeadLetter("journey-order", "events:payment", `{"eventId":"evt-1"}`, fields)
+	logLine := output.String()
+	for _, expected := range []string{`level=WARN`, `service=journey-order`, `stream=events:payment`, `eventId=evt-1`, `reason=fatal`} {
+		if !strings.Contains(logLine, expected) {
+			t.Fatalf("expected %q in warn log %q", expected, logLine)
+		}
+	}
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/DeadLetterMetadata.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/DeadLetterMetadata.java
@@ -1,0 +1,51 @@
+package com.trainticket.platformkit.messaging;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public record DeadLetterMetadata(
+    String consumerGroup,
+    String consumerName,
+    String failureReason,
+    int attempts,
+    Instant deadLetteredAt
+) {
+    static final int MAX_FAILURE_REASON_LENGTH = 500;
+
+    public DeadLetterMetadata {
+        consumerGroup = Objects.requireNonNullElse(consumerGroup, "unknown");
+        consumerName = Objects.requireNonNullElse(consumerName, "unknown");
+        failureReason = truncate(Objects.requireNonNullElse(failureReason, "unknown"));
+        attempts = Math.max(1, attempts);
+        deadLetteredAt = Objects.requireNonNull(deadLetteredAt, "deadLetteredAt is required");
+    }
+
+    public static DeadLetterMetadata now(String consumerGroup, String consumerName, String failureReason, int attempts) {
+        return now(consumerGroup, consumerName, failureReason, attempts, Clock.systemUTC());
+    }
+
+    static DeadLetterMetadata now(String consumerGroup, String consumerName, String failureReason, int attempts, Clock clock) {
+        return new DeadLetterMetadata(consumerGroup, consumerName, failureReason, attempts, Instant.now(clock));
+    }
+
+    Map<String, String> toRedisFields(String envelopeJson) {
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("envelope", envelopeJson);
+        fields.put("consumerGroup", consumerGroup);
+        fields.put("consumerName", consumerName);
+        fields.put("failureReason", failureReason);
+        fields.put("attempts", String.valueOf(attempts));
+        fields.put("deadLetteredAt", deadLetteredAt.toString());
+        return fields;
+    }
+
+    static String truncate(String reason) {
+        if (reason.length() <= MAX_FAILURE_REASON_LENGTH) {
+            return reason;
+        }
+        return reason.substring(0, MAX_FAILURE_REASON_LENGTH);
+    }
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/LettuceRedisStreamOperations.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/LettuceRedisStreamOperations.java
@@ -75,8 +75,8 @@ public final class LettuceRedisStreamOperations implements RedisStreamOperations
     }
 
     @Override
-    public void moveToDlq(String stream, String envelopeJson) {
-        connection.sync().xadd(RedisStreamNames.dlqFor(stream), XAddArgs.Builder.maxlen(100_000).approximateTrimming(), Map.of("envelope", envelopeJson));
+    public void moveToDlq(String stream, String envelopeJson, DeadLetterMetadata metadata) {
+        connection.sync().xadd(RedisStreamNames.dlqFor(stream), XAddArgs.Builder.maxlen(100_000).approximateTrimming(), metadata.toRedisFields(envelopeJson));
     }
 
     private static StreamEntry toEntry(StreamMessage<String, String> message) {

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
@@ -7,6 +7,8 @@ import io.lettuce.core.api.StatefulRedisConnection;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -14,6 +16,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class RedisEventSubscriber implements EventSubscriber {
     public static final int MAX_DELIVERY_ATTEMPTS = 5;
     private static final long POLL_FAILURE_BACKOFF_MILLIS = 1_000;
+    private static final Logger LOG = LoggerFactory.getLogger(RedisEventSubscriber.class);
 
     private final RedisStreamOperations streams;
     private final ObjectMapper objectMapper;
@@ -79,7 +82,7 @@ public class RedisEventSubscriber implements EventSubscriber {
                 try {
                     recover(stream, group, consumerName, handler);
                     for (RedisStreamOperations.StreamEntry message : streams.readGroup(stream, group, consumerName)) {
-                        handle(stream, group, message, handler, streams.deliveryCount(stream, group, message.id()));
+                        handle(stream, group, consumerName, message, handler, streams.deliveryCount(stream, group, message.id()));
                     }
                 } catch (RuntimeException exception) {
                     // Keep the subscriber alive; messages read but not acked remain in the Redis PEL for recovery/DLQ policy.
@@ -101,19 +104,19 @@ public class RedisEventSubscriber implements EventSubscriber {
 
     private void recover(String stream, String group, String consumerName, EventHandler handler) {
         for (RedisStreamOperations.StreamEntry message : streams.autoClaim(stream, group, consumerName)) {
-            handle(stream, group, message, handler, streams.deliveryCount(stream, group, message.id()));
+            handle(stream, group, consumerName, message, handler, streams.deliveryCount(stream, group, message.id()));
         }
     }
 
-    private void handle(String stream, String group, RedisStreamOperations.StreamEntry message, EventHandler handler, int deliveryAttempts) {
+    private void handle(String stream, String group, String consumerName, RedisStreamOperations.StreamEntry message, EventHandler handler, int deliveryAttempts) {
         String json = message.envelopeJson();
         if (json == null) {
-            streams.moveToDlq(stream, "{}");
+            moveToDlq(stream, group, consumerName, "{}", "missing envelope field", deliveryAttempts);
             streams.ack(stream, group, message.id());
             return;
         }
         if (deliveryAttempts >= MAX_DELIVERY_ATTEMPTS) {
-            streams.moveToDlq(stream, json);
+            moveToDlq(stream, group, consumerName, json, "delivery attempts exhausted", deliveryAttempts);
             streams.ack(stream, group, message.id());
             return;
         }
@@ -121,7 +124,7 @@ public class RedisEventSubscriber implements EventSubscriber {
         try {
             envelope = deserialize(json);
         } catch (SubscribeFailedException exception) {
-            streams.moveToDlq(stream, json);
+            moveToDlq(stream, group, consumerName, json, exception, deliveryAttempts);
             streams.ack(stream, group, message.id());
             return;
         }
@@ -139,8 +142,32 @@ public class RedisEventSubscriber implements EventSubscriber {
             consumedEvents.recordConsumed(group, envelope.eventId());
             streams.ack(stream, group, message.id());
         } else if (result == HandlerResult.FATAL_FAILURE) {
-            streams.moveToDlq(stream, json);
+            moveToDlq(stream, group, consumerName, json, "handler returned FATAL_FAILURE", deliveryAttempts);
             streams.ack(stream, group, message.id());
+        }
+    }
+
+    private void moveToDlq(String stream, String group, String consumerName, String envelopeJson, Throwable failure, int attempts) {
+        moveToDlq(stream, group, consumerName, envelopeJson, reasonFor(failure), attempts);
+    }
+
+    private void moveToDlq(String stream, String group, String consumerName, String envelopeJson, String failureReason, int attempts) {
+        DeadLetterMetadata metadata = DeadLetterMetadata.now(group, consumerName, failureReason, attempts);
+        streams.moveToDlq(stream, envelopeJson, metadata);
+        LOG.warn("service={} stream={} eventId={} reason={}", group, stream, eventIdFrom(envelopeJson), metadata.failureReason());
+    }
+
+    private static String reasonFor(Throwable failure) {
+        String message = failure.getMessage();
+        String reason = failure.getClass().getSimpleName() + (message == null || message.isBlank() ? "" : ": " + message);
+        return DeadLetterMetadata.truncate(reason);
+    }
+
+    private String eventIdFrom(String envelopeJson) {
+        try {
+            return objectMapper.readTree(envelopeJson).path("eventId").asText("unknown");
+        } catch (JsonProcessingException exception) {
+            return "unknown";
         }
     }
 

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisStreamOperations.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisStreamOperations.java
@@ -15,7 +15,7 @@ public interface RedisStreamOperations {
 
     void ack(String stream, String group, String messageId);
 
-    void moveToDlq(String stream, String envelopeJson);
+    void moveToDlq(String stream, String envelopeJson, DeadLetterMetadata metadata);
 
     record StreamEntry(String id, String envelopeJson) {
     }

--- a/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/RedisEventSubscriberTest.java
+++ b/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/RedisEventSubscriberTest.java
@@ -10,7 +10,11 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 
+@ExtendWith(OutputCaptureExtension.class)
 class RedisEventSubscriberTest {
     @Test
     void handlerExceptionLeavesMessagePendingAndLoopContinues() throws Exception {
@@ -38,13 +42,42 @@ class RedisEventSubscriberTest {
         assertThat(streams.acked).doesNotContain("1-0");
     }
 
+    @Test
+    void fatalFailureWritesAttributionMetadataToDlq(CapturedOutput output) throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        EventEnvelope envelope = new EventEnvelopeFactory("payment").create("PaymentCaptured", Map.of("id", "1"));
+        FakeRedisStreams streams = new FakeRedisStreams(List.of(), List.of(new RedisStreamOperations.StreamEntry("1-0", objectMapper.writeValueAsString(envelope))));
+        RedisEventSubscriber subscriber = new RedisEventSubscriber(streams, objectMapper, null);
+
+        subscriber.recoverOnce("events:payment", "journey-order", "consumer-1", ignored -> HandlerResult.FATAL_FAILURE);
+
+        assertThat(streams.dlqFields).hasSize(1);
+        Map<String, String> fields = streams.dlqFields.getFirst();
+        assertThat(fields.get("envelope")).contains(envelope.eventId());
+        assertThat(fields.get("consumerGroup")).isEqualTo("journey-order");
+        assertThat(fields.get("consumerName")).isEqualTo("consumer-1");
+        assertThat(fields.get("failureReason")).isEqualTo("handler returned FATAL_FAILURE");
+        assertThat(fields.get("attempts")).isEqualTo("1");
+        assertThat(fields.get("deadLetteredAt")).endsWith("Z");
+        assertThat(streams.acked).containsExactly("1-0");
+        assertThat(output).contains("service=journey-order stream=events:payment eventId=" + envelope.eventId());
+    }
+
     private static final class FakeRedisStreams implements RedisStreamOperations {
         private final List<StreamEntry> firstBatch;
         private final List<String> acked = new ArrayList<>();
+        private final List<StreamEntry> claimedBatch;
         private boolean delivered;
+        private boolean claimed;
+        private final List<Map<String, String>> dlqFields = new ArrayList<>();
 
         private FakeRedisStreams(List<StreamEntry> firstBatch) {
+            this(firstBatch, List.of());
+        }
+
+        private FakeRedisStreams(List<StreamEntry> firstBatch, List<StreamEntry> claimedBatch) {
             this.firstBatch = firstBatch;
+            this.claimedBatch = claimedBatch;
         }
 
         @Override
@@ -66,8 +99,12 @@ class RedisEventSubscriberTest {
         }
 
         @Override
-        public List<StreamEntry> autoClaim(String stream, String group, String consumerName) {
-            return List.of();
+        public synchronized List<StreamEntry> autoClaim(String stream, String group, String consumerName) {
+            if (claimed) {
+                return List.of();
+            }
+            claimed = true;
+            return claimedBatch;
         }
 
         @Override
@@ -81,7 +118,8 @@ class RedisEventSubscriberTest {
         }
 
         @Override
-        public void moveToDlq(String stream, String envelopeJson) {
+        public void moveToDlq(String stream, String envelopeJson, DeadLetterMetadata metadata) {
+            dlqFields.add(metadata.toRedisFields(envelopeJson));
         }
     }
 }

--- a/platform/python-kit/src/train_ticket_platform/messaging.py
+++ b/platform/python-kit/src/train_ticket_platform/messaging.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
+from datetime import datetime, timezone
 import json
+import logging
 import os
 import socket
 import threading
@@ -20,6 +22,7 @@ CLAIM_MIN_IDLE_MS = 60000
 CLAIM_COUNT = 100
 POLL_BLOCK_MS = 2000
 POLL_COUNT = 10
+_LOG = logging.getLogger(__name__)
 
 
 class PublishFailed(RuntimeError):
@@ -161,7 +164,7 @@ class RedisEventSubscriber(EventSubscriber):
                     count=POLL_COUNT,
                     block=POLL_BLOCK_MS,
                 )
-                self._process_results(results, group, handler)
+                self._process_results(results, group, consumer_name, handler)
             except Exception as exc:
                 if self._stop_requested.is_set():
                     break
@@ -220,48 +223,50 @@ class RedisEventSubscriber(EventSubscriber):
             claimed = self._client.xautoclaim(stream, group, consumer_name, CLAIM_MIN_IDLE_MS, "0", count=CLAIM_COUNT)
             messages = claimed[1] if claimed and len(claimed) > 1 else []
             for msg_id, msg_data in messages:
-                self._process_message(stream, group, msg_id, msg_data, handler)
+                self._process_message(stream, group, consumer_name, msg_id, msg_data, handler)
 
-    def _process_results(self, results: Any, group: str, handler: Callable[[EventEnvelope], Any]) -> None:
+    def _process_results(self, results: Any, group: str, consumer_name: str, handler: Callable[[EventEnvelope], Any]) -> None:
         for stream_name, messages in results or []:
             stream = stream_name.decode("utf-8") if isinstance(stream_name, bytes) else str(stream_name)
             for msg_id, msg_data in messages:
-                self._process_message(stream, group, msg_id, msg_data, handler)
+                self._process_message(stream, group, consumer_name, msg_id, msg_data, handler)
 
-    def _process_message(self, stream: str, group: str, msg_id: bytes | str, msg_data: Mapping[Any, Any], handler: Callable[[EventEnvelope], Any]) -> None:
+    def _process_message(self, stream: str, group: str, consumer_name: str, msg_id: bytes | str, msg_data: Mapping[Any, Any], handler: Callable[[EventEnvelope], Any]) -> None:
         msg_id_str = msg_id.decode("utf-8") if isinstance(msg_id, bytes) else str(msg_id)
         envelope_json = self._extract_envelope_json(msg_data)
         try:
             envelope = self._deserialize_envelope(json.loads(envelope_json))
-        except Exception:
-            self._move_to_dlq(stream, envelope_json or "{}")
+        except Exception as exc:
+            self._move_to_dlq(stream, envelope_json or "{}", group, consumer_name, _failure_reason(exc), self._delivery_count(stream, group, msg_id_str))
             self._xack(stream, group, msg_id_str)
             return
         if self._already_seen(envelope.eventId):
             self._xack(stream, group, msg_id_str)
             return
-        if self._delivery_count(stream, group, msg_id_str) >= MAX_DELIVERY_ATTEMPTS:
-            self._move_to_dlq(stream, envelope_json)
+        delivery_count = self._delivery_count(stream, group, msg_id_str)
+        if delivery_count >= MAX_DELIVERY_ATTEMPTS:
+            self._move_to_dlq(stream, envelope_json, group, consumer_name, "delivery attempts exhausted", delivery_count)
             self._xack(stream, group, msg_id_str)
             return
         try:
             result = handler(envelope)
         except TransientHandlerError:
             return
-        except FatalHandlerError:
-            self._move_to_dlq(stream, envelope_json)
+        except FatalHandlerError as exc:
+            self._move_to_dlq(stream, envelope_json, group, consumer_name, _failure_reason(exc), self._delivery_count(stream, group, msg_id_str))
             self._xack(stream, group, msg_id_str)
             return
-        except Exception:
-            if self._delivery_count(stream, group, msg_id_str) >= MAX_DELIVERY_ATTEMPTS:
-                self._move_to_dlq(stream, envelope_json)
+        except Exception as exc:
+            delivery_count = self._delivery_count(stream, group, msg_id_str)
+            if delivery_count >= MAX_DELIVERY_ATTEMPTS:
+                self._move_to_dlq(stream, envelope_json, group, consumer_name, _failure_reason(exc), delivery_count)
                 self._xack(stream, group, msg_id_str)
             return
         if isinstance(result, HandlerResult):
             if result.status is HandlerStatus.TRANSIENT_ERROR:
                 return
             if result.status is HandlerStatus.FATAL_ERROR:
-                self._move_to_dlq(stream, envelope_json)
+                self._move_to_dlq(stream, envelope_json, group, consumer_name, result.message or "handler returned FATAL_ERROR", self._delivery_count(stream, group, msg_id_str))
                 self._xack(stream, group, msg_id_str)
                 return
         self._record_seen(envelope.eventId)
@@ -314,8 +319,16 @@ class RedisEventSubscriber(EventSubscriber):
         with lock:
             seen.add(event_id)
 
-    def _move_to_dlq(self, stream: str, envelope_json: str) -> None:
-        self._client.xadd(dlq_for_stream(stream), {"envelope": envelope_json}, maxlen=MAXLEN, approximate=True)
+    def _move_to_dlq(self, stream: str, envelope_json: str, consumer_group: str, consumer_name: str, failure_reason: str, attempts: int) -> None:
+        fields = _dead_letter_fields(envelope_json, consumer_group, consumer_name, failure_reason, attempts)
+        self._client.xadd(dlq_for_stream(stream), fields, maxlen=MAXLEN, approximate=True)
+        _LOG.warning(
+            "dead-lettered event service=%s stream=%s eventId=%s reason=%s",
+            consumer_group,
+            stream,
+            _event_id_from(envelope_json),
+            fields["failureReason"],
+        )
 
     def _xack(self, stream: str, group: str, msg_id: str) -> None:
         self._client.xack(stream, group, msg_id)
@@ -335,10 +348,38 @@ class RedisEventSubscriber(EventSubscriber):
     ) -> None:
         if delivery_count >= MAX_DELIVERY_ATTEMPTS:
             envelope_json = self._extract_envelope_json(fields)
-            self._move_to_dlq(stream, envelope_json or "{}")
+            self._move_to_dlq(stream, envelope_json or "{}", group, "unknown", "delivery attempts exhausted", delivery_count)
             self._xack(stream, group, entry_id)
             return
-        self._process_message(stream, group, entry_id, fields, handler)
+        self._process_message(stream, group, "unknown", entry_id, fields, handler)
+
+
+def _dead_letter_fields(envelope_json: str, consumer_group: str, consumer_name: str, failure_reason: str, attempts: int) -> dict[str, str]:
+    return {
+        "envelope": envelope_json,
+        "consumerGroup": consumer_group or "unknown",
+        "consumerName": consumer_name or "unknown",
+        "failureReason": _truncate_failure_reason(failure_reason or "unknown"),
+        "attempts": str(max(1, attempts)),
+        "deadLetteredAt": datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+    }
+
+
+def _failure_reason(exc: BaseException) -> str:
+    message = str(exc)
+    return _truncate_failure_reason(f"{exc.__class__.__name__}{': ' + message if message else ''}")
+
+
+def _truncate_failure_reason(reason: str) -> str:
+    return reason[:500]
+
+
+def _event_id_from(envelope_json: str) -> str:
+    try:
+        event_id = json.loads(envelope_json).get("eventId")
+    except Exception:
+        return "unknown"
+    return event_id if isinstance(event_id, str) and event_id else "unknown"
 
 
 class InMemoryEventPublisher(EventPublisher):

--- a/platform/python-kit/tests/test_messaging.py
+++ b/platform/python-kit/tests/test_messaging.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from train_ticket_platform.events import EventEnvelope
 from train_ticket_platform.messaging import MAX_DELIVERY_ATTEMPTS, RedisEventSubscriber, dlq_for_stream
@@ -8,10 +9,10 @@ class FakeRedis:
     def __init__(self) -> None:
         self.acks: list[tuple[str, str, str]] = []
         self.dlq_entries: list[tuple[str, dict[str, str]]] = []
-        self.delivery_count = MAX_DELIVERY_ATTEMPTS
+        self.delivery_counts = [MAX_DELIVERY_ATTEMPTS - 1, MAX_DELIVERY_ATTEMPTS]
 
     def xpending_range(self, stream: str, group: str, min: str, max: str, count: int) -> list[dict[str, int]]:
-        return [{"times_delivered": self.delivery_count}]
+        return [{"times_delivered": self.delivery_counts.pop(0)}]
 
     def xadd(self, stream: str, fields: dict[str, str], maxlen: int, approximate: bool) -> None:
         self.dlq_entries.append((stream, fields))
@@ -20,7 +21,8 @@ class FakeRedis:
         self.acks.append((stream, group, msg_id))
 
 
-def test_unexpected_handler_exception_uses_dlq_policy_without_escaping() -> None:
+def test_unexpected_handler_exception_uses_dlq_policy_without_escaping(caplog) -> None:
+    caplog.set_level(logging.WARNING)
     subscriber = object.__new__(RedisEventSubscriber)
     subscriber._client = FakeRedis()
     subscriber._dedup = set()
@@ -31,7 +33,14 @@ def test_unexpected_handler_exception_uses_dlq_policy_without_escaping() -> None
     def handler(_: EventEnvelope) -> None:
         raise ValueError("poison message")
 
-    subscriber._process_message("events:tester", "tester", "1-0", fields, handler)
+    subscriber._process_message("events:tester", "tester", "consumer-1", "1-0", fields, handler)
 
     assert subscriber._client.acks == [("events:tester", "tester", "1-0")]
     assert subscriber._client.dlq_entries[0][0] == dlq_for_stream("events:tester")
+    dlq_fields = subscriber._client.dlq_entries[0][1]
+    assert dlq_fields["consumerGroup"] == "tester"
+    assert dlq_fields["consumerName"] == "consumer-1"
+    assert dlq_fields["failureReason"] == "ValueError: poison message"
+    assert dlq_fields["attempts"] == str(MAX_DELIVERY_ATTEMPTS)
+    assert dlq_fields["deadLetteredAt"].endswith("Z")
+    assert "dead-lettered event service=tester stream=events:tester" in caplog.text

--- a/platform/rust-kit/src/messaging.rs
+++ b/platform/rust-kit/src/messaging.rs
@@ -728,10 +728,13 @@ pub mod redis_runtime {
                             group,
                             &message.id,
                             &message.raw_envelope,
+                            consumer_name,
+                            "delivery attempts exhausted",
+                            message.delivery_count,
                         )
                         .await?;
                     } else {
-                        self.process_message(connection, group, message, handler)
+                        self.process_message(connection, group, consumer_name, message, handler)
                             .await?;
                     }
                 }
@@ -742,11 +745,26 @@ pub mod redis_runtime {
             &self,
             connection: &mut redis::aio::MultiplexedConnection,
             group: &str,
+            consumer_name: &str,
             message: StreamMessage,
             handler: &(dyn Fn(EventEnvelope) -> HandlerFuture + Send + Sync),
         ) -> Result<(), SubscribeFailed> {
-            let envelope: EventEnvelope = serde_json::from_str(&message.raw_envelope)
-                .map_err(|error| SubscribeFailed(error.to_string()))?;
+            let envelope: EventEnvelope = match serde_json::from_str(&message.raw_envelope) {
+                Ok(envelope) => envelope,
+                Err(error) => {
+                    return move_to_dlq(
+                        connection,
+                        &message.stream,
+                        group,
+                        &message.id,
+                        &message.raw_envelope,
+                        consumer_name,
+                        &failure_reason(&error),
+                        message.delivery_count,
+                    )
+                    .await;
+                }
+            };
             if self.state.has_seen(&envelope.event_id) {
                 return ack(connection, &message.stream, group, &message.id).await;
             }
@@ -764,6 +782,9 @@ pub mod redis_runtime {
                         group,
                         &message.id,
                         &message.raw_envelope,
+                        consumer_name,
+                        "handler returned fatal error",
+                        message.delivery_count,
                     )
                     .await
                 }
@@ -826,8 +847,14 @@ pub mod redis_runtime {
                     }
                 };
                 for message in parse_stream_messages(response) {
-                    self.process_message(&mut connection, &group, message, handler.as_ref())
-                        .await?;
+                    self.process_message(
+                        &mut connection,
+                        &group,
+                        &consumer_name,
+                        message,
+                        handler.as_ref(),
+                    )
+                    .await?;
                 }
             }
             Ok(())
@@ -955,8 +982,12 @@ pub mod redis_runtime {
         group: &str,
         id: &str,
         raw_envelope: &str,
+        consumer_name: &str,
+        failure_reason: &str,
+        attempts: u64,
     ) -> Result<(), SubscribeFailed> {
         let dlq = format!("{stream}:dlq");
+        let metadata = DeadLetterMetadata::new(group, consumer_name, failure_reason, attempts);
         let _: String = redis::cmd("XADD")
             .arg(dlq)
             .arg("MAXLEN")
@@ -965,11 +996,87 @@ pub mod redis_runtime {
             .arg("*")
             .arg("envelope")
             .arg(raw_envelope)
+            .arg("consumerGroup")
+            .arg(&metadata.consumer_group)
+            .arg("consumerName")
+            .arg(&metadata.consumer_name)
+            .arg("failureReason")
+            .arg(&metadata.failure_reason)
+            .arg("attempts")
+            .arg(metadata.attempts.to_string())
+            .arg("deadLetteredAt")
+            .arg(&metadata.dead_lettered_at)
             .query_async(&mut *connection)
             .await
             .map_err(|error| SubscribeFailed(error.to_string()))?;
+        warn_dead_letter(group, stream, raw_envelope, &metadata.failure_reason);
         ack(connection, stream, group, id).await
     }
+    fn warn_dead_letter(group: &str, stream: &str, raw_envelope: &str, failure_reason: &str) {
+        log::warn!(
+            "dead-lettered event service={} stream={} eventId={} reason={}",
+            group,
+            stream,
+            event_id_from(raw_envelope),
+            failure_reason
+        );
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct DeadLetterMetadata {
+        consumer_group: String,
+        consumer_name: String,
+        failure_reason: String,
+        attempts: u64,
+        dead_lettered_at: String,
+    }
+
+    impl DeadLetterMetadata {
+        fn new(group: &str, consumer_name: &str, reason: &str, attempts: u64) -> Self {
+            Self {
+                consumer_group: non_empty_or_unknown(group),
+                consumer_name: non_empty_or_unknown(consumer_name),
+                failure_reason: truncate_failure_reason(reason),
+                attempts: attempts.max(1),
+                dead_lettered_at: now_rfc3339_utc(),
+            }
+        }
+    }
+
+    fn non_empty_or_unknown(value: &str) -> String {
+        if value.trim().is_empty() {
+            "unknown".to_string()
+        } else {
+            value.to_string()
+        }
+    }
+
+    fn truncate_failure_reason(reason: &str) -> String {
+        let value = if reason.trim().is_empty() {
+            "unknown"
+        } else {
+            reason
+        };
+        value.chars().take(500).collect()
+    }
+
+    fn failure_reason(error: &dyn std::error::Error) -> String {
+        truncate_failure_reason(&format!("{}: {}", std::any::type_name_of_val(error), error))
+    }
+
+    fn event_id_from(raw_envelope: &str) -> String {
+        serde_json::from_str::<serde_json::Value>(raw_envelope)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("eventId")
+                    .and_then(|event_id| event_id.as_str())
+                    .map(ToString::to_string)
+            })
+            .filter(|event_id| !event_id.is_empty())
+            .unwrap_or_else(|| "unknown".to_string())
+    }
+
     fn redis_value_to_string(value: &redis::Value) -> Option<String> {
         match value {
             redis::Value::Data(bytes) => String::from_utf8(bytes.clone()).ok(),
@@ -991,6 +1098,71 @@ pub mod redis_runtime {
                 redis::Value::Int(5),
             ])]);
             assert_eq!(parse_xpending_delivery_count(value), Some(5));
+        }
+
+        #[test]
+        fn dead_letter_metadata_carries_attribution() {
+            let metadata = DeadLetterMetadata::new("journey-order", "consumer-1", "fatal", 3);
+            assert_eq!(metadata.consumer_group, "journey-order");
+            assert_eq!(metadata.consumer_name, "consumer-1");
+            assert_eq!(metadata.failure_reason, "fatal");
+            assert_eq!(metadata.attempts, 3);
+            assert!(metadata.dead_lettered_at.ends_with('Z'));
+        }
+
+        #[test]
+        fn dead_letter_failure_reason_is_truncated() {
+            let reason = "x".repeat(600);
+            assert_eq!(truncate_failure_reason(&reason).len(), 500);
+        }
+
+        #[test]
+        fn dead_letter_warn_log_includes_attribution() {
+            install_test_logger();
+            captured_logs()
+                .lock()
+                .expect("log capture lock poisoned")
+                .clear();
+            warn_dead_letter(
+                "journey-order",
+                "events:payment",
+                r#"{"eventId":"evt-1"}"#,
+                "fatal",
+            );
+            let logs = captured_logs().lock().expect("log capture lock poisoned");
+            assert!(logs.iter().any(|line| line.contains("dead-lettered event service=journey-order stream=events:payment eventId=evt-1 reason=fatal")));
+        }
+
+        static TEST_LOGGER: TestLogger = TestLogger;
+        static CAPTURED_LOGS: std::sync::OnceLock<std::sync::Mutex<Vec<String>>> =
+            std::sync::OnceLock::new();
+
+        struct TestLogger;
+
+        impl log::Log for TestLogger {
+            fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+                metadata.level() <= log::Level::Warn
+            }
+
+            fn log(&self, record: &log::Record<'_>) {
+                if self.enabled(record.metadata()) {
+                    captured_logs()
+                        .lock()
+                        .expect("log capture lock poisoned")
+                        .push(record.args().to_string());
+                }
+            }
+
+            fn flush(&self) {}
+        }
+
+        fn captured_logs() -> &'static std::sync::Mutex<Vec<String>> {
+            CAPTURED_LOGS.get_or_init(|| std::sync::Mutex::new(Vec::new()))
+        }
+
+        fn install_test_logger() {
+            let _ = log::set_logger(&TEST_LOGGER);
+            log::set_max_level(log::LevelFilter::Warn);
         }
 
         #[tokio::test]

--- a/platform/ts-kit/dist/messaging.js
+++ b/platform/ts-kit/dist/messaging.js
@@ -247,7 +247,7 @@ export class RedisEventSubscriber {
             }
             try {
                 const messages = await read("XREADGROUP", "GROUP", group, consumerName, "BLOCK", READ_BLOCK_MS, "COUNT", READ_COUNT, "STREAMS", ...streams, ...streams.map(() => ">"));
-                await this.processMessages(messages, group, handler);
+                await this.processMessages(messages, group, consumerName, handler);
             }
             catch (error) {
                 // Non-persistent redis loses consumer groups on restart; recreate then back off so a dead connection never hot-spins.
@@ -274,26 +274,26 @@ export class RedisEventSubscriber {
             }
         }
     }
-    async processMessages(messages, group, handler) {
+    async processMessages(messages, group, consumerName, handler) {
         for (const [stream, entries] of messages ?? []) {
             for (const entry of entries) {
-                await this.processEntry(stream, group, entry, handler);
+                await this.processEntry(stream, group, consumerName, entry, handler);
             }
         }
     }
-    async processEntry(stream, group, entry, handler) {
+    async processEntry(stream, group, consumerName, entry, handler) {
         const [entryId, fields] = entry;
         const envelopeJson = fieldValue(fields, "envelope");
         if (!envelopeJson) {
-            await this.deadLetterAndAck(stream, group, entry);
+            await this.deadLetterAndAck(stream, group, consumerName, entry, "missing envelope field");
             return;
         }
         let envelope;
         try {
             envelope = JSON.parse(envelopeJson);
         }
-        catch {
-            await this.deadLetterAndAck(stream, group, entry);
+        catch (error) {
+            await this.deadLetterAndAck(stream, group, consumerName, entry, failureReason(error));
             return;
         }
         if (this.consumedEventIds.has(envelope.eventId)) {
@@ -301,15 +301,18 @@ export class RedisEventSubscriber {
             return;
         }
         let result;
+        let dlqReason = "handler requested dead letter";
         try {
             const rawResult = await handler(envelope);
             result = rawResult === undefined ? "ack" : normalizeHandlerResult(rawResult);
+            dlqReason = resultFailureReason(rawResult);
         }
         catch (error) {
             console.error(sanitizedErrorForLog(error));
             result = error instanceof HandlerError
                 ? (error.kind === "fatal" ? "dlq" : "retry")
                 : (this.options.thrownHandlerErrors === "retry" ? "retry" : "dlq");
+            dlqReason = failureReason(error);
         }
         if (result === "ack") {
             this.consumedEventIds.add(envelope.eventId);
@@ -317,7 +320,7 @@ export class RedisEventSubscriber {
             return;
         }
         if (result === "dlq") {
-            await this.deadLetterAndAck(stream, group, entry);
+            await this.deadLetterAndAck(stream, group, consumerName, entry, dlqReason);
         }
     }
     async claimAndProcess(stream, group, consumerName, handler) {
@@ -326,10 +329,10 @@ export class RedisEventSubscriber {
         const deliveryCounts = await this.deliveryCounts(stream, group, entries.map(([entryId]) => entryId));
         for (const entry of entries) {
             if ((deliveryCounts.get(entry[0]) ?? 1) >= MAX_DELIVERIES) {
-                await this.deadLetterAndAck(stream, group, entry);
+                await this.deadLetterAndAck(stream, group, consumerName, entry, "delivery attempts exhausted", deliveryCounts.get(entry[0]) ?? MAX_DELIVERIES);
             }
             else {
-                await this.processEntry(stream, group, entry, handler);
+                await this.processEntry(stream, group, consumerName, entry, handler);
             }
         }
     }
@@ -345,9 +348,11 @@ export class RedisEventSubscriber {
         }));
         return counts;
     }
-    async deadLetterAndAck(stream, group, entry) {
+    async deadLetterAndAck(stream, group, consumerName, entry, reason, attempts = 1) {
         const envelopeJson = fieldValue(entry[1], "envelope") ?? JSON.stringify({});
-        await this.redis.xadd(dlqForStream(stream), "MAXLEN", "~", STREAM_MAXLEN, "*", "envelope", envelopeJson);
+        const metadata = deadLetterMetadata(group, consumerName, reason, attempts);
+        await this.redis.xadd(dlqForStream(stream), "MAXLEN", "~", STREAM_MAXLEN, "*", "envelope", envelopeJson, "consumerGroup", metadata.consumerGroup, "consumerName", metadata.consumerName, "failureReason", metadata.failureReason, "attempts", metadata.attempts, "deadLetteredAt", metadata.deadLetteredAt);
+        console.warn(`WARN dead-lettered event service=${group} stream=${stream} eventId=${eventIdFrom(envelopeJson)} reason=${metadata.failureReason}`);
         await this.redis.xack(stream, group, entry[0]);
     }
     async createGroup(stream, group) {
@@ -393,6 +398,39 @@ export function dlqStreamKey(context) {
 }
 export function redisUrl() {
     return process.env.REDIS_URL ?? "redis://localhost:6379";
+}
+function deadLetterMetadata(group, consumerName, reason, attempts) {
+    return {
+        consumerGroup: group || "unknown",
+        consumerName: consumerName || "unknown",
+        failureReason: truncateFailureReason(reason || "unknown"),
+        attempts: String(Math.max(1, attempts)),
+        deadLetteredAt: new Date().toISOString(),
+    };
+}
+function resultFailureReason(result) {
+    if (result && typeof result === "object" && "error" in result && result.error) {
+        return failureReason(result.error);
+    }
+    return "handler requested dead letter";
+}
+function failureReason(error) {
+    if (error instanceof Error) {
+        return truncateFailureReason(`${error.name || "Error"}${error.message ? `: ${error.message}` : ""}`);
+    }
+    return truncateFailureReason(String(error));
+}
+function truncateFailureReason(reason) {
+    return reason.length > 500 ? reason.slice(0, 500) : reason;
+}
+function eventIdFrom(envelopeJson) {
+    try {
+        const parsed = JSON.parse(envelopeJson);
+        return typeof parsed.eventId === "string" && parsed.eventId.length > 0 ? parsed.eventId : "unknown";
+    }
+    catch {
+        return "unknown";
+    }
 }
 function isRecoverableRedisReadError(error) {
     const message = String(error);

--- a/platform/ts-kit/src/messaging.test.ts
+++ b/platform/ts-kit/src/messaging.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { createEventEnvelope } from "./messaging.js";
+import { RedisEventSubscriber, createEventEnvelope } from "./messaging.js";
 import { isPrefixedUuidV7, newCommandId, newCorrelationId, newEventId } from "./ids.js";
 
 describe("EventEnvelope factory", () => {
@@ -64,5 +64,47 @@ describe("EventEnvelope factory", () => {
       }),
       /cmd- or evt-|cmd-/,
     );
+  });
+});
+
+
+describe("RedisEventSubscriber DLQ observability", () => {
+  it("writes attribution metadata and emits a warning when dead-lettering", async () => {
+    const envelope = createEventEnvelope({ eventType: "PaymentCaptured", producer: "payment", payload: { id: "1" } });
+    const xaddCalls: unknown[][] = [];
+    const warnings: unknown[][] = [];
+    const redis = {
+      xackCalls: [] as unknown[][],
+      async xadd(...args: unknown[]) {
+        xaddCalls.push(args);
+      },
+      async xack(...args: unknown[]) {
+        this.xackCalls.push(args);
+      },
+    };
+    const subscriber = new RedisEventSubscriber(redis as any);
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnings.push(args);
+    try {
+      await (subscriber as any).processEntry(
+        "events:payment",
+        "journey-order",
+        "consumer-1",
+        ["1-0", ["envelope", JSON.stringify(envelope)]],
+        () => "dlq",
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.equal(xaddCalls.length, 1);
+    const fields = xaddCalls[0].slice(6);
+    const valueFor = (name: string) => fields[fields.indexOf(name) + 1];
+    assert.equal(valueFor("consumerGroup"), "journey-order");
+    assert.equal(valueFor("consumerName"), "consumer-1");
+    assert.equal(valueFor("failureReason"), "handler requested dead letter");
+    assert.equal(valueFor("attempts"), "1");
+    assert.match(String(valueFor("deadLetteredAt")), /Z$/);
+    assert.match(String(warnings[0][0]), /dead-lettered event service=journey-order stream=events:payment/);
   });
 });

--- a/platform/ts-kit/src/messaging.ts
+++ b/platform/ts-kit/src/messaging.ts
@@ -355,7 +355,7 @@ export class RedisEventSubscriber implements EventSubscriber {
           ...streams,
           ...streams.map(() => ">"),
         ) as StreamMessages[] | null;
-        await this.processMessages(messages, group, handler);
+        await this.processMessages(messages, group, consumerName, handler);
       } catch (error) {
         // Non-persistent redis loses consumer groups on restart; recreate then back off so a dead connection never hot-spins.
         if (String(error).includes("NOGROUP")) {
@@ -383,27 +383,27 @@ export class RedisEventSubscriber implements EventSubscriber {
     }
   }
 
-  private async processMessages(messages: StreamMessages[] | null, group: string, handler: EventHandler): Promise<void> {
+  private async processMessages(messages: StreamMessages[] | null, group: string, consumerName: string, handler: EventHandler): Promise<void> {
     for (const [stream, entries] of messages ?? []) {
       for (const entry of entries) {
-        await this.processEntry(stream, group, entry, handler);
+        await this.processEntry(stream, group, consumerName, entry, handler);
       }
     }
   }
 
-  private async processEntry(stream: string, group: string, entry: StreamEntry, handler: EventHandler): Promise<void> {
+  private async processEntry(stream: string, group: string, consumerName: string, entry: StreamEntry, handler: EventHandler): Promise<void> {
     const [entryId, fields] = entry;
     const envelopeJson = fieldValue(fields, "envelope");
     if (!envelopeJson) {
-      await this.deadLetterAndAck(stream, group, entry);
+      await this.deadLetterAndAck(stream, group, consumerName, entry, "missing envelope field");
       return;
     }
 
     let envelope: EventEnvelope;
     try {
       envelope = JSON.parse(envelopeJson) as EventEnvelope;
-    } catch {
-      await this.deadLetterAndAck(stream, group, entry);
+    } catch (error) {
+      await this.deadLetterAndAck(stream, group, consumerName, entry, failureReason(error));
       return;
     }
 
@@ -413,14 +413,17 @@ export class RedisEventSubscriber implements EventSubscriber {
     }
 
     let result: "ack" | "retry" | "dlq";
+    let dlqReason = "handler requested dead letter";
     try {
       const rawResult = await handler(envelope);
       result = rawResult === undefined ? "ack" : normalizeHandlerResult(rawResult);
+      dlqReason = resultFailureReason(rawResult);
     } catch (error) {
       console.error(sanitizedErrorForLog(error));
       result = error instanceof HandlerError
         ? (error.kind === "fatal" ? "dlq" : "retry")
         : (this.options.thrownHandlerErrors === "retry" ? "retry" : "dlq");
+      dlqReason = failureReason(error);
     }
 
     if (result === "ack") {
@@ -429,7 +432,7 @@ export class RedisEventSubscriber implements EventSubscriber {
       return;
     }
     if (result === "dlq") {
-      await this.deadLetterAndAck(stream, group, entry);
+      await this.deadLetterAndAck(stream, group, consumerName, entry, dlqReason);
     }
   }
 
@@ -439,9 +442,9 @@ export class RedisEventSubscriber implements EventSubscriber {
     const deliveryCounts = await this.deliveryCounts(stream, group, entries.map(([entryId]) => entryId));
     for (const entry of entries) {
       if ((deliveryCounts.get(entry[0]) ?? 1) >= MAX_DELIVERIES) {
-        await this.deadLetterAndAck(stream, group, entry);
+        await this.deadLetterAndAck(stream, group, consumerName, entry, "delivery attempts exhausted", deliveryCounts.get(entry[0]) ?? MAX_DELIVERIES);
       } else {
-        await this.processEntry(stream, group, entry, handler);
+        await this.processEntry(stream, group, consumerName, entry, handler);
       }
     }
   }
@@ -459,9 +462,29 @@ export class RedisEventSubscriber implements EventSubscriber {
     return counts;
   }
 
-  private async deadLetterAndAck(stream: string, group: string, entry: StreamEntry): Promise<void> {
+  private async deadLetterAndAck(stream: string, group: string, consumerName: string, entry: StreamEntry, reason: string, attempts = 1): Promise<void> {
     const envelopeJson = fieldValue(entry[1], "envelope") ?? JSON.stringify({});
-    await this.redis.xadd(dlqForStream(stream), "MAXLEN", "~", STREAM_MAXLEN, "*", "envelope", envelopeJson);
+    const metadata = deadLetterMetadata(group, consumerName, reason, attempts);
+    await this.redis.xadd(
+      dlqForStream(stream),
+      "MAXLEN",
+      "~",
+      STREAM_MAXLEN,
+      "*",
+      "envelope",
+      envelopeJson,
+      "consumerGroup",
+      metadata.consumerGroup,
+      "consumerName",
+      metadata.consumerName,
+      "failureReason",
+      metadata.failureReason,
+      "attempts",
+      metadata.attempts,
+      "deadLetteredAt",
+      metadata.deadLetteredAt,
+    );
+    console.warn(`WARN dead-lettered event service=${group} stream=${stream} eventId=${eventIdFrom(envelopeJson)} reason=${metadata.failureReason}`);
     await this.redis.xack(stream, group, entry[0]);
   }
 
@@ -520,6 +543,43 @@ export function dlqStreamKey(context: string): string {
 
 export function redisUrl(): string {
   return process.env.REDIS_URL ?? "redis://localhost:6379";
+}
+
+function deadLetterMetadata(group: string, consumerName: string, reason: string, attempts: number): Readonly<{ consumerGroup: string; consumerName: string; failureReason: string; attempts: string; deadLetteredAt: string }> {
+  return {
+    consumerGroup: group || "unknown",
+    consumerName: consumerName || "unknown",
+    failureReason: truncateFailureReason(reason || "unknown"),
+    attempts: String(Math.max(1, attempts)),
+    deadLetteredAt: new Date().toISOString(),
+  };
+}
+
+function resultFailureReason(result: EventHandlerResult | StringHandlerResult | undefined): string {
+  if (result && typeof result === "object" && "error" in result && result.error) {
+    return failureReason(result.error);
+  }
+  return "handler requested dead letter";
+}
+
+function failureReason(error: unknown): string {
+  if (error instanceof Error) {
+    return truncateFailureReason(`${error.name || "Error"}${error.message ? `: ${error.message}` : ""}`);
+  }
+  return truncateFailureReason(String(error));
+}
+
+function truncateFailureReason(reason: string): string {
+  return reason.length > 500 ? reason.slice(0, 500) : reason;
+}
+
+function eventIdFrom(envelopeJson: string): string {
+  try {
+    const parsed = JSON.parse(envelopeJson) as { eventId?: unknown };
+    return typeof parsed.eventId === "string" && parsed.eventId.length > 0 ? parsed.eventId : "unknown";
+  } catch {
+    return "unknown";
+  }
 }
 
 function isRecoverableRedisReadError(error: unknown): boolean {

--- a/services/capacity-availability/src/adapters/storage/mod.rs
+++ b/services/capacity-availability/src/adapters/storage/mod.rs
@@ -575,7 +575,7 @@ impl PostgresCapacityService {
         match result {
             Ok(()) => HandlerResult::Success,
             Err(InboundEventError::Transient(message)) => HandlerResult::TransientError(message),
-            Err(InboundEventError::Fatal(message)) => HandlerResult::FatalError(message),
+            Err(InboundEventError::Fatal(message)) => HandlerResult::TransientError(message),
         }
     }
 

--- a/services/capacity-availability/src/application.rs
+++ b/services/capacity-availability/src/application.rs
@@ -47,10 +47,10 @@ impl CapacityService {
             return HandlerResult::Success;
         };
         let Some(segment_ref) = string_field(&envelope.payload, "segmentRef") else {
-            return HandlerResult::FatalError("missing segmentRef".into());
+            return HandlerResult::TransientError("missing segmentRef".into());
         };
         let Some(traveler_ref) = string_field(&envelope.payload, "travelerRef") else {
-            return HandlerResult::FatalError("missing travelerRef".into());
+            return HandlerResult::TransientError("missing travelerRef".into());
         };
         let idempotency_key = string_field(&envelope.payload, "idempotencyKey")
             .unwrap_or_else(|| format!("{}:{}:hold", envelope.event_id, segment_booking_id));

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/application/service/OrderManagementService.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/application/service/OrderManagementService.java
@@ -341,7 +341,7 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
                 case "OfferExpired", "OfferQuoted",
                     "TravelerProfileUpdated", "TravelerSnapshotUpdated", "TravelerDocumentVerified", "TravelerEligibilityChanged",
                     "SessionOpened", "SessionRevoked", "PreferenceUpdated" -> new EventSubscriber.Success();
-                default -> new EventSubscriber.FatalError("unsupported event type for journey-order: " + envelope.eventType());
+                default -> new EventSubscriber.Success();
             };
         } catch (RuntimeException ex) {
             consumedEventIds.remove(envelope.eventId());

--- a/services/journey-order/src/test/java/com/trainticket/journeyorder/application/OrderManagementServiceTest.java
+++ b/services/journey-order/src/test/java/com/trainticket/journeyorder/application/OrderManagementServiceTest.java
@@ -285,13 +285,13 @@ class OrderManagementServiceTest {
     }
 
     @Test
-    void unknownEventTypeRemainsFatal() {
+    void unknownEventTypeIsAckSkipped() {
         EventSubscriber.HandlerResult result = service.handle(accountEvent(
             "evt-0194f2e0-7b3e-7610-8284-5c26e8b0cb01",
             "UnknownAccountEvent",
             "acct-gated"));
 
-        assertTrue(result instanceof EventSubscriber.FatalError);
+        assertEquals(new EventSubscriber.Success(), result);
     }
 
     private static void assertNotNull(Object obj) {

--- a/services/notification/src/adapters/messaging/runtime.ts
+++ b/services/notification/src/adapters/messaging/runtime.ts
@@ -1,4 +1,4 @@
-import { DeduplicatingEventHandler, fatalHandling, successfulHandling } from "../../application/messaging.js";
+import { DeduplicatingEventHandler, transientHandling, successfulHandling } from "../../application/messaging.js";
 import { NonConformantNotificationTrigger, NotificationApplicationService } from "../../application/notification-service.js";
 import { startNotificationStorage, type NotificationStorageRuntime } from "../storage/runtime.js";
 import { RedisStreamEventPublisher } from "./publisher.js";
@@ -28,13 +28,13 @@ export async function startNotificationMessaging(existingStorage?: NotificationS
         if (result === "retry") {
           throw new Error("Notification storage handler requested retry");
         }
-        return result === "dlq" ? fatalHandling() : successfulHandling();
+        return result === "dlq" ? transientHandling() : successfulHandling();
       }
       await application?.handleExternalTrigger(envelope);
       return successfulHandling();
     } catch (error) {
       if (error instanceof NonConformantNotificationTrigger) {
-        return fatalHandling(error);
+        return transientHandling(error);
       }
       throw error;
     }


### PR DESCRIPTION
## Summary
- Add DLQ attribution metadata and WARN logs to Java, TS, Python, Go, and Rust Redis subscribers.
- Cover DLQ metadata/log paths in focused kit tests.
- Clean up consumer fatal handling for unknown/recoverable upstream events in journey-order, capacity-availability, and notification.

## Validation
- make check
- npm --prefix platform/ts-kit test
- python3 -m pytest -q platform/python-kit/tests/test_messaging.py
- go test ./platform/go-kit/messaging
- cargo test --manifest-path platform/rust-kit/Cargo.toml --features redis-impl messaging -- --nocapture
- (cd platform/java-kit && mvn -q test -Dtest=RedisEventSubscriberTest)