### PR TITLE
REQ-079 DLQ attribution and failure classification

### DIFF
--- a/platform/go-kit/go.mod
+++ b/platform/go-kit/go.mod
@@ -10,6 +10,7 @@ require (
 )
 
 require (
+	github.com/alicebob/miniredis/v2 v2.35.0 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
@@ -38,6 +39,7 @@ require (
 	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel v1.38.0 // indirect

--- a/platform/go-kit/go.sum
+++ b/platform/go-kit/go.sum
@@ -1,3 +1,5 @@
+github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
+github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -88,6 +90,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
 github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 go.mongodb.org/mongo-driver/v2 v2.5.0 h1:yXUhImUjjAInNcpTcAlPHiT7bIXhshCTL3jVBkF3xaE=

--- a/platform/go-kit/messaging/envelope_test.go
+++ b/platform/go-kit/messaging/envelope_test.go
@@ -2,6 +2,7 @@ package messaging
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -54,5 +55,21 @@ func TestNewEventEnvelopeOmitsOptionalCausationID(t *testing.T) {
 	}
 	if len(fields) != 7 {
 		t.Fatalf("envelope without causationId must have 7 fields, got %d: %s", len(fields), body)
+	}
+}
+
+func TestDeadLetterFieldsIncludeAttributionMetadata(t *testing.T) {
+	fields := dlqFields(`{"eventId":"evt-1"}`, "go-kit", "consumer-a", truncateFailureReason(FatalHandlerError(errors.New("poison"))), 5)
+	if fields[EnvelopeField] != `{"eventId":"evt-1"}` {
+		t.Fatalf("missing envelope field: %#v", fields)
+	}
+	if fields["consumerGroup"] != "go-kit" || fields["consumerName"] != "consumer-a" {
+		t.Fatalf("missing attribution fields: %#v", fields)
+	}
+	if fields["failureReason"] != "messaging.HandlerError: poison" || fields["attempts"] != "5" {
+		t.Fatalf("missing failure details: %#v", fields)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, fields["deadLetteredAt"].(string)); err != nil {
+		t.Fatalf("deadLetteredAt must be RFC3339 UTC: %v", err)
 	}
 }

--- a/platform/go-kit/messaging/envelope_test.go
+++ b/platform/go-kit/messaging/envelope_test.go
@@ -1,11 +1,17 @@
 package messaging
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
+	"log"
 	"strings"
 	"testing"
 	"time"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+	redis "github.com/redis/go-redis/v9"
 )
 
 func TestNewEventEnvelopeCanonicalShape(t *testing.T) {
@@ -71,5 +77,68 @@ func TestDeadLetterFieldsIncludeAttributionMetadata(t *testing.T) {
 	}
 	if _, err := time.Parse(time.RFC3339Nano, fields["deadLetteredAt"].(string)); err != nil {
 		t.Fatalf("deadLetteredAt must be RFC3339 UTC: %v", err)
+	}
+}
+
+func TestRedisSubscriptionFatalHandlerMovesMessageToDLQWithMetadataAndWarnLog(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	bus := NewRedisEventBusWithClient(client, RedisConfig{ReadBlock: 10 * time.Millisecond, RecoveryEvery: time.Hour})
+	defer bus.Close()
+
+	envelope, err := NewEventEnvelope("PoisonEvent", "payment", "0194f2e0-7b3e-7610-0284-5c26e8b0c123", map[string]string{"id": "1"}, EnvelopeOptions{Now: time.Date(2026, 7, 5, 10, 30, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var logBuffer bytes.Buffer
+	originalWriter := log.Writer()
+	log.SetOutput(&logBuffer)
+	defer log.SetOutput(originalWriter)
+
+	stream := StreamName("payment")
+	if err := bus.Subscribe(ctx, Subscription{Streams: []string{"payment"}, Group: "journey-order", ConsumerName: "consumer-1"}, func(context.Context, EventEnvelope) error {
+		return FatalHandlerError(errors.New("poison root cause"))
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := bus.client.XAdd(ctx, &redis.XAddArgs{Stream: stream, Values: map[string]any{EnvelopeField: string(body)}}).Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	var dlq []redis.XMessage
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		messages, err := bus.client.XRange(ctx, stream+DeadLetterSuffix, "-", "+").Result()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(messages) > 0 {
+			dlq = messages
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(dlq) != 1 {
+		t.Fatalf("expected one DLQ message, got %d", len(dlq))
+	}
+	fields := dlq[0].Values
+	if fields["consumerGroup"] != "journey-order" || fields["consumerName"] != "consumer-1" {
+		t.Fatalf("missing attribution metadata: %#v", fields)
+	}
+	if !strings.Contains(fields["failureReason"].(string), "poison root cause") || fields["attempts"] != "1" {
+		t.Fatalf("missing failure metadata: %#v", fields)
+	}
+	if _, err := time.Parse(time.RFC3339Nano, fields["deadLetteredAt"].(string)); err != nil {
+		t.Fatalf("bad deadLetteredAt: %v", err)
+	}
+	if logText := logBuffer.String(); !strings.Contains(logText, "WARN service=journey-order") || !strings.Contains(logText, envelope.EventID) || !strings.Contains(logText, "poison root cause") {
+		t.Fatalf("missing WARN DLQ log: %s", logText)
 	}
 }

--- a/platform/go-kit/messaging/redis.go
+++ b/platform/go-kit/messaging/redis.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/url"
 	"strings"
 	"sync"
@@ -202,7 +203,7 @@ func (b *RedisEventBus) consumeLoop(ctx context.Context, streams []string, group
 		}
 		for _, stream := range result {
 			for _, msg := range stream.Messages {
-				b.processMessage(ctx, stream.Stream, group, msg, handler)
+				b.processMessage(ctx, stream.Stream, group, consumer, msg, handler)
 			}
 		}
 	}
@@ -215,7 +216,7 @@ func (b *RedisEventBus) recoverPending(ctx context.Context, stream, group, consu
 			return
 		}
 		for _, m := range messages {
-			b.processMessage(ctx, stream, group, m, handler)
+			b.processMessage(ctx, stream, group, consumer, m, handler)
 		}
 		if next == "0-0" || next == start {
 			return
@@ -223,16 +224,16 @@ func (b *RedisEventBus) recoverPending(ctx context.Context, stream, group, consu
 		start = next
 	}
 }
-func (b *RedisEventBus) processMessage(ctx context.Context, stream, group string, message redis.XMessage, handler Handler) {
+func (b *RedisEventBus) processMessage(ctx context.Context, stream, group, consumer string, message redis.XMessage, handler Handler) {
 	raw, ok := message.Values[EnvelopeField].(string)
 	if !ok || strings.TrimSpace(raw) == "" {
-		b.moveToDLQAndAck(ctx, stream, group, message.ID, raw)
+		b.moveToDLQAndAck(ctx, stream, group, consumer, message.ID, raw, "MissingEnvelope", 1)
 		return
 	}
 	attempts := b.deliveryAttempts(ctx, stream, group, message.ID)
 	var envelope EventEnvelope
 	if err := json.Unmarshal([]byte(raw), &envelope); err != nil || envelope.Validate() != nil {
-		b.moveToDLQAndAck(ctx, stream, group, message.ID, raw)
+		b.moveToDLQAndAck(ctx, stream, group, consumer, message.ID, raw, "InvalidEnvelope", attempts)
 		return
 	}
 	if b.dedup != nil && b.dedup.Seen(envelope.EventID) {
@@ -241,7 +242,7 @@ func (b *RedisEventBus) processMessage(ctx context.Context, stream, group string
 	}
 	if err := handler(ctx, envelope); err != nil {
 		if IsFatalHandlerError(err) || attempts >= MaxDeliveryAttempts {
-			b.moveToDLQAndAck(ctx, stream, group, message.ID, raw)
+			b.moveToDLQAndAck(ctx, stream, group, consumer, message.ID, raw, err, attempts)
 		}
 		return
 	}
@@ -257,7 +258,54 @@ func (b *RedisEventBus) deliveryAttempts(ctx context.Context, stream, group, id 
 	}
 	return entries[0].RetryCount
 }
-func (b *RedisEventBus) moveToDLQAndAck(ctx context.Context, stream, group, id, raw string) {
-	_ = b.client.XAdd(ctx, &redis.XAddArgs{Stream: stream + DeadLetterSuffix, MaxLen: MaxLen, Approx: true, Values: map[string]any{EnvelopeField: raw}}).Err()
+func (b *RedisEventBus) moveToDLQAndAck(ctx context.Context, stream, group, consumer, id, raw string, reason any, attempts int64) {
+	failureReason := truncateFailureReason(reason)
+	log.Printf("WARN service=%s stream=%s eventId=%s failureReason=%s moving message to DLQ", group, stream, eventIDForLog(raw), failureReason)
+	_ = b.client.XAdd(ctx, &redis.XAddArgs{
+		Stream: stream + DeadLetterSuffix,
+		MaxLen: MaxLen,
+		Approx: true,
+		Values: dlqFields(raw, group, consumer, failureReason, attempts),
+	}).Err()
 	_ = b.client.XAck(ctx, stream, group, id).Err()
+}
+
+func dlqFields(raw, group, consumer, failureReason string, attempts int64) map[string]any {
+	return map[string]any{
+		EnvelopeField:    raw,
+		"consumerGroup":  group,
+		"consumerName":   consumer,
+		"failureReason":  failureReason,
+		"attempts":       fmt.Sprintf("%d", maxInt64(1, attempts)),
+		"deadLetteredAt": time.Now().UTC().Format(time.RFC3339Nano),
+	}
+}
+
+func truncateFailureReason(reason any) string {
+	text := fmt.Sprint(reason)
+	if err, ok := reason.(error); ok {
+		text = fmt.Sprintf("%T: %s", err, err.Error())
+	}
+	if len(text) > 500 {
+		return text[:500]
+	}
+	if strings.TrimSpace(text) == "" {
+		return "unknown"
+	}
+	return text
+}
+
+func eventIDForLog(raw string) string {
+	var envelope EventEnvelope
+	if err := json.Unmarshal([]byte(raw), &envelope); err != nil || envelope.EventID == "" {
+		return "unknown"
+	}
+	return envelope.EventID
+}
+
+func maxInt64(left, right int64) int64 {
+	if left > right {
+		return left
+	}
+	return right
 }

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/DlqMetadata.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/DlqMetadata.java
@@ -1,0 +1,10 @@
+package com.trainticket.platformkit.messaging;
+
+public record DlqMetadata(
+    String consumerGroup,
+    String consumerName,
+    String failureReason,
+    int attempts,
+    String deadLetteredAt
+) {
+}

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/LettuceRedisStreamOperations.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/LettuceRedisStreamOperations.java
@@ -75,8 +75,19 @@ public final class LettuceRedisStreamOperations implements RedisStreamOperations
     }
 
     @Override
-    public void moveToDlq(String stream, String envelopeJson) {
-        connection.sync().xadd(RedisStreamNames.dlqFor(stream), XAddArgs.Builder.maxlen(100_000).approximateTrimming(), Map.of("envelope", envelopeJson));
+    public void moveToDlq(String stream, String envelopeJson, DlqMetadata metadata) {
+        connection.sync().xadd(
+            RedisStreamNames.dlqFor(stream),
+            XAddArgs.Builder.maxlen(100_000).approximateTrimming(),
+            Map.of(
+                "envelope", envelopeJson,
+                "consumerGroup", metadata.consumerGroup(),
+                "consumerName", metadata.consumerName(),
+                "failureReason", metadata.failureReason(),
+                "attempts", String.valueOf(metadata.attempts()),
+                "deadLetteredAt", metadata.deadLetteredAt()
+            )
+        );
     }
 
     private static StreamEntry toEntry(StreamMessage<String, String> message) {

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
@@ -4,8 +4,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.api.StatefulRedisConnection;
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -13,6 +16,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class RedisEventSubscriber implements EventSubscriber {
     public static final int MAX_DELIVERY_ATTEMPTS = 5;
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedisEventSubscriber.class);
     private static final long POLL_FAILURE_BACKOFF_MILLIS = 1_000;
 
     private final RedisStreamOperations streams;
@@ -79,7 +83,7 @@ public class RedisEventSubscriber implements EventSubscriber {
                 try {
                     recover(stream, group, consumerName, handler);
                     for (RedisStreamOperations.StreamEntry message : streams.readGroup(stream, group, consumerName)) {
-                        handle(stream, group, message, handler, streams.deliveryCount(stream, group, message.id()));
+                        handle(stream, group, consumerName, message, handler, streams.deliveryCount(stream, group, message.id()));
                     }
                 } catch (RuntimeException exception) {
                     // Keep the subscriber alive; messages read but not acked remain in the Redis PEL for recovery/DLQ policy.
@@ -101,19 +105,19 @@ public class RedisEventSubscriber implements EventSubscriber {
 
     private void recover(String stream, String group, String consumerName, EventHandler handler) {
         for (RedisStreamOperations.StreamEntry message : streams.autoClaim(stream, group, consumerName)) {
-            handle(stream, group, message, handler, streams.deliveryCount(stream, group, message.id()));
+            handle(stream, group, consumerName, message, handler, streams.deliveryCount(stream, group, message.id()));
         }
     }
 
-    private void handle(String stream, String group, RedisStreamOperations.StreamEntry message, EventHandler handler, int deliveryAttempts) {
+    private void handle(String stream, String group, String consumerName, RedisStreamOperations.StreamEntry message, EventHandler handler, int deliveryAttempts) {
         String json = message.envelopeJson();
         if (json == null) {
-            streams.moveToDlq(stream, "{}");
+            moveToDlq(stream, group, consumerName, message.id(), "{}", "MissingEnvelope", deliveryAttempts);
             streams.ack(stream, group, message.id());
             return;
         }
         if (deliveryAttempts >= MAX_DELIVERY_ATTEMPTS) {
-            streams.moveToDlq(stream, json);
+            moveToDlq(stream, group, consumerName, message.id(), json, "MaxDeliveryAttempts", deliveryAttempts);
             streams.ack(stream, group, message.id());
             return;
         }
@@ -121,7 +125,7 @@ public class RedisEventSubscriber implements EventSubscriber {
         try {
             envelope = deserialize(json);
         } catch (SubscribeFailedException exception) {
-            streams.moveToDlq(stream, json);
+            moveToDlq(stream, group, consumerName, message.id(), json, exception, deliveryAttempts);
             streams.ack(stream, group, message.id());
             return;
         }
@@ -139,9 +143,42 @@ public class RedisEventSubscriber implements EventSubscriber {
             consumedEvents.recordConsumed(group, envelope.eventId());
             streams.ack(stream, group, message.id());
         } else if (result == HandlerResult.FATAL_FAILURE) {
-            streams.moveToDlq(stream, json);
+            moveToDlq(stream, group, consumerName, message.id(), json, "HandlerResult.FATAL_FAILURE", deliveryAttempts);
             streams.ack(stream, group, message.id());
         }
+    }
+
+
+    private void moveToDlq(String stream, String group, String consumerName, String messageId, String envelopeJson, Throwable reason, int attempts) {
+        String reasonText = reason.getClass().getSimpleName() + ": " + Objects.toString(reason.getMessage(), "");
+        moveToDlq(stream, group, consumerName, messageId, envelopeJson, reasonText, attempts);
+    }
+
+    private void moveToDlq(String stream, String group, String consumerName, String messageId, String envelopeJson, String reason, int attempts) {
+        EventEnvelope envelope = tryDeserialize(envelopeJson);
+        String eventId = envelope == null ? "unknown" : envelope.eventId();
+        String truncatedReason = truncate(reason);
+        LOGGER.warn(
+            "service={} stream={} eventId={} failureReason={} moving message to DLQ",
+            group,
+            stream,
+            eventId,
+            truncatedReason
+        );
+        streams.moveToDlq(stream, envelopeJson, new DlqMetadata(group, consumerName, truncatedReason, Math.max(1, attempts), Instant.now().toString()));
+    }
+
+    private EventEnvelope tryDeserialize(String json) {
+        try {
+            return deserialize(json);
+        } catch (RuntimeException exception) {
+            return null;
+        }
+    }
+
+    private static String truncate(String reason) {
+        String value = Objects.toString(reason, "unknown");
+        return value.length() <= 500 ? value : value.substring(0, 500);
     }
 
     private static boolean isNoGroup(RuntimeException exception) {

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.api.StatefulRedisConnection;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,6 +20,7 @@ public class RedisEventSubscriber implements EventSubscriber {
     public static final int MAX_DELIVERY_ATTEMPTS = 5;
     private static final Logger LOGGER = LoggerFactory.getLogger(RedisEventSubscriber.class);
     private static final long POLL_FAILURE_BACKOFF_MILLIS = 1_000;
+    private static final int LAST_FAILURE_CACHE_SIZE = 1_024;
 
     private final RedisStreamOperations streams;
     private final ObjectMapper objectMapper;
@@ -25,6 +28,12 @@ public class RedisEventSubscriber implements EventSubscriber {
     private final AtomicBoolean running = new AtomicBoolean();
     private final AutoCloseable closeable;
     private final ConsumedEventStore consumedEvents;
+    private final Map<String, RuntimeException> lastFailures = new LinkedHashMap<>(16, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<String, RuntimeException> eldest) {
+            return size() > LAST_FAILURE_CACHE_SIZE;
+        }
+    };
 
     public RedisEventSubscriber(StatefulRedisConnection<String, String> connection, ObjectMapper objectMapper) {
         this(new LettuceRedisStreamOperations(connection), objectMapper, connection::close);
@@ -125,12 +134,7 @@ public class RedisEventSubscriber implements EventSubscriber {
             return;
         }
         if (deliveryAttempts >= MAX_DELIVERY_ATTEMPTS) {
-            RuntimeException lastException = null;
-            try {
-                handler.handle(envelope);
-            } catch (RuntimeException exception) {
-                lastException = exception;
-            }
+            RuntimeException lastException = removeLastFailure(message.id());
             if (lastException != null) {
                 moveToDlq(stream, group, consumerName, message.id(), json, lastException, deliveryAttempts);
             } else {
@@ -147,17 +151,31 @@ public class RedisEventSubscriber implements EventSubscriber {
         try {
             result = handler.handle(envelope);
         } catch (RuntimeException exception) {
+            rememberLastFailure(message.id(), exception);
             return;
         }
         if (result == HandlerResult.SUCCESS) {
             consumedEvents.recordConsumed(group, envelope.eventId());
             streams.ack(stream, group, message.id());
+            removeLastFailure(message.id());
         } else if (result == HandlerResult.FATAL_FAILURE) {
+            removeLastFailure(message.id());
             moveToDlq(stream, group, consumerName, message.id(), json, "HandlerResult.FATAL_FAILURE", deliveryAttempts);
             streams.ack(stream, group, message.id());
         }
     }
 
+    private void rememberLastFailure(String messageId, RuntimeException exception) {
+        synchronized (lastFailures) {
+            lastFailures.put(messageId, exception);
+        }
+    }
+
+    private RuntimeException removeLastFailure(String messageId) {
+        synchronized (lastFailures) {
+            return lastFailures.remove(messageId);
+        }
+    }
 
     private void moveToDlq(String stream, String group, String consumerName, String messageId, String envelopeJson, Throwable reason, int attempts) {
         String reasonText = reason.getClass().getSimpleName() + ": " + Objects.toString(reason.getMessage(), "");

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
@@ -116,16 +116,26 @@ public class RedisEventSubscriber implements EventSubscriber {
             streams.ack(stream, group, message.id());
             return;
         }
-        if (deliveryAttempts >= MAX_DELIVERY_ATTEMPTS) {
-            moveToDlq(stream, group, consumerName, message.id(), json, "MaxDeliveryAttempts", deliveryAttempts);
-            streams.ack(stream, group, message.id());
-            return;
-        }
         EventEnvelope envelope;
         try {
             envelope = deserialize(json);
         } catch (SubscribeFailedException exception) {
             moveToDlq(stream, group, consumerName, message.id(), json, exception, deliveryAttempts);
+            streams.ack(stream, group, message.id());
+            return;
+        }
+        if (deliveryAttempts >= MAX_DELIVERY_ATTEMPTS) {
+            RuntimeException lastException = null;
+            try {
+                handler.handle(envelope);
+            } catch (RuntimeException exception) {
+                lastException = exception;
+            }
+            if (lastException != null) {
+                moveToDlq(stream, group, consumerName, message.id(), json, lastException, deliveryAttempts);
+            } else {
+                moveToDlq(stream, group, consumerName, message.id(), json, "MaxDeliveryAttempts", deliveryAttempts);
+            }
             streams.ack(stream, group, message.id());
             return;
         }

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisEventSubscriber.java
@@ -28,9 +28,9 @@ public class RedisEventSubscriber implements EventSubscriber {
     private final AtomicBoolean running = new AtomicBoolean();
     private final AutoCloseable closeable;
     private final ConsumedEventStore consumedEvents;
-    private final Map<String, RuntimeException> lastFailures = new LinkedHashMap<>(16, 0.75f, true) {
+    private final Map<FailureKey, RuntimeException> lastFailures = new LinkedHashMap<>(16, 0.75f, true) {
         @Override
-        protected boolean removeEldestEntry(Map.Entry<String, RuntimeException> eldest) {
+        protected boolean removeEldestEntry(Map.Entry<FailureKey, RuntimeException> eldest) {
             return size() > LAST_FAILURE_CACHE_SIZE;
         }
     };
@@ -134,7 +134,7 @@ public class RedisEventSubscriber implements EventSubscriber {
             return;
         }
         if (deliveryAttempts >= MAX_DELIVERY_ATTEMPTS) {
-            RuntimeException lastException = removeLastFailure(message.id());
+            RuntimeException lastException = removeLastFailure(stream, message.id());
             if (lastException != null) {
                 moveToDlq(stream, group, consumerName, message.id(), json, lastException, deliveryAttempts);
             } else {
@@ -151,31 +151,33 @@ public class RedisEventSubscriber implements EventSubscriber {
         try {
             result = handler.handle(envelope);
         } catch (RuntimeException exception) {
-            rememberLastFailure(message.id(), exception);
+            rememberLastFailure(stream, message.id(), exception);
             return;
         }
         if (result == HandlerResult.SUCCESS) {
             consumedEvents.recordConsumed(group, envelope.eventId());
             streams.ack(stream, group, message.id());
-            removeLastFailure(message.id());
+            removeLastFailure(stream, message.id());
         } else if (result == HandlerResult.FATAL_FAILURE) {
-            removeLastFailure(message.id());
+            removeLastFailure(stream, message.id());
             moveToDlq(stream, group, consumerName, message.id(), json, "HandlerResult.FATAL_FAILURE", deliveryAttempts);
             streams.ack(stream, group, message.id());
         }
     }
 
-    private void rememberLastFailure(String messageId, RuntimeException exception) {
+    private void rememberLastFailure(String stream, String messageId, RuntimeException exception) {
         synchronized (lastFailures) {
-            lastFailures.put(messageId, exception);
+            lastFailures.put(new FailureKey(stream, messageId), exception);
         }
     }
 
-    private RuntimeException removeLastFailure(String messageId) {
+    private RuntimeException removeLastFailure(String stream, String messageId) {
         synchronized (lastFailures) {
-            return lastFailures.remove(messageId);
+            return lastFailures.remove(new FailureKey(stream, messageId));
         }
     }
+
+    private record FailureKey(String stream, String messageId) {}
 
     private void moveToDlq(String stream, String group, String consumerName, String messageId, String envelopeJson, Throwable reason, int attempts) {
         String reasonText = reason.getClass().getSimpleName() + ": " + Objects.toString(reason.getMessage(), "");

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisStreamOperations.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisStreamOperations.java
@@ -15,7 +15,7 @@ public interface RedisStreamOperations {
 
     void ack(String stream, String group, String messageId);
 
-    void moveToDlq(String stream, String envelopeJson);
+    void moveToDlq(String stream, String envelopeJson, DlqMetadata metadata);
 
     record StreamEntry(String id, String envelopeJson) {
     }

--- a/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/RedisEventSubscriberTest.java
+++ b/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/RedisEventSubscriberTest.java
@@ -68,33 +68,35 @@ class RedisEventSubscriberTest {
 
 
     @Test
-    void maxDeliveryAttemptsUsesLastRuntimeExceptionAsFailureReason() throws Exception {
+    void maxDeliveryAttemptsUsesLastRuntimeExceptionAsFailureReasonWithoutRedispatching() throws Exception {
         ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
         EventEnvelope event = new EventEnvelopeFactory("payment").create("PaymentCaptured", Map.of("id", "1"));
         FakeRedisStreams streams = new FakeRedisStreams(List.of(
             new RedisStreamOperations.StreamEntry("1-0", objectMapper.writeValueAsString(event))
         ));
-        streams.deliveryCount = RedisEventSubscriber.MAX_DELIVERY_ATTEMPTS;
+        streams.autoClaimEnabled = true;
         RedisEventSubscriber subscriber = new RedisEventSubscriber(streams, objectMapper, null);
 
-        subscriber.subscribe(List.of("events:payment"), "journey-order", "consumer-1", envelope -> {
+        subscriber.recoverOnce("events:payment", "journey-order", "consumer-1", envelope -> {
             throw new IllegalStateException("payment parse failed");
         });
-
-        for (int i = 0; i < 20 && streams.dlqMetadata.get() == null; i++) {
-            Thread.sleep(50);
-        }
-        subscriber.close();
+        streams.deliveryCount = RedisEventSubscriber.MAX_DELIVERY_ATTEMPTS;
+        subscriber.recoverOnce("events:payment", "journey-order", "consumer-1", envelope -> {
+            throw new AssertionError("handler must not be called at max delivery attempts");
+        });
 
         assertThat(streams.dlqMetadata.get()).isNotNull();
         assertThat(streams.dlqMetadata.get().failureReason()).isEqualTo("IllegalStateException: payment parse failed");
         assertThat(streams.dlqMetadata.get().attempts()).isEqualTo(RedisEventSubscriber.MAX_DELIVERY_ATTEMPTS);
+        assertThat(streams.acked).contains("1-0");
     }
 
     private static final class FakeRedisStreams implements RedisStreamOperations {
         private final List<StreamEntry> firstBatch;
         private final List<String> acked = new ArrayList<>();
         private boolean delivered;
+        private boolean autoClaimEnabled;
+        private int autoClaimCalls;
         private int deliveryCount = 1;
         private volatile String dlqStream;
         private final AtomicReference<DlqMetadata> dlqMetadata = new AtomicReference<>();
@@ -123,7 +125,11 @@ class RedisEventSubscriberTest {
 
         @Override
         public List<StreamEntry> autoClaim(String stream, String group, String consumerName) {
-            return List.of();
+            if (!autoClaimEnabled) {
+                return List.of();
+            }
+            autoClaimCalls++;
+            return autoClaimCalls <= 2 ? firstBatch : List.of();
         }
 
         @Override

--- a/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/RedisEventSubscriberTest.java
+++ b/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/RedisEventSubscriberTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
@@ -38,10 +39,39 @@ class RedisEventSubscriberTest {
         assertThat(streams.acked).doesNotContain("1-0");
     }
 
+
+    @Test
+    void fatalHandlerResultMovesMessageToDlqWithAttributionMetadata() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        EventEnvelope event = new EventEnvelopeFactory("payment").create("PaymentCaptured", Map.of("id", "1"));
+        FakeRedisStreams streams = new FakeRedisStreams(List.of(
+            new RedisStreamOperations.StreamEntry("1-0", objectMapper.writeValueAsString(event))
+        ));
+        RedisEventSubscriber subscriber = new RedisEventSubscriber(streams, objectMapper, null);
+        AtomicReference<DlqMetadata> metadata = streams.dlqMetadata;
+
+        subscriber.subscribe(List.of("events:payment"), "journey-order", "consumer-1", envelope -> HandlerResult.FATAL_FAILURE);
+
+        for (int i = 0; i < 20 && metadata.get() == null; i++) {
+            Thread.sleep(50);
+        }
+        subscriber.close();
+        assertThat(metadata.get()).isNotNull();
+        assertThat(streams.acked).contains("1-0");
+        assertThat(streams.dlqStream).isEqualTo("events:payment");
+        assertThat(metadata.get().consumerGroup()).isEqualTo("journey-order");
+        assertThat(metadata.get().consumerName()).isEqualTo("consumer-1");
+        assertThat(metadata.get().failureReason()).isEqualTo("HandlerResult.FATAL_FAILURE");
+        assertThat(metadata.get().attempts()).isEqualTo(1);
+        assertThat(metadata.get().deadLetteredAt()).isNotBlank();
+    }
+
     private static final class FakeRedisStreams implements RedisStreamOperations {
         private final List<StreamEntry> firstBatch;
         private final List<String> acked = new ArrayList<>();
         private boolean delivered;
+        private volatile String dlqStream;
+        private final AtomicReference<DlqMetadata> dlqMetadata = new AtomicReference<>();
 
         private FakeRedisStreams(List<StreamEntry> firstBatch) {
             this.firstBatch = firstBatch;
@@ -81,7 +111,9 @@ class RedisEventSubscriberTest {
         }
 
         @Override
-        public void moveToDlq(String stream, String envelopeJson) {
+        public void moveToDlq(String stream, String envelopeJson, DlqMetadata metadata) {
+            this.dlqStream = stream;
+            this.dlqMetadata.set(metadata);
         }
     }
 }

--- a/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/RedisEventSubscriberTest.java
+++ b/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/RedisEventSubscriberTest.java
@@ -66,10 +66,36 @@ class RedisEventSubscriberTest {
         assertThat(metadata.get().deadLetteredAt()).isNotBlank();
     }
 
+
+    @Test
+    void maxDeliveryAttemptsUsesLastRuntimeExceptionAsFailureReason() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        EventEnvelope event = new EventEnvelopeFactory("payment").create("PaymentCaptured", Map.of("id", "1"));
+        FakeRedisStreams streams = new FakeRedisStreams(List.of(
+            new RedisStreamOperations.StreamEntry("1-0", objectMapper.writeValueAsString(event))
+        ));
+        streams.deliveryCount = RedisEventSubscriber.MAX_DELIVERY_ATTEMPTS;
+        RedisEventSubscriber subscriber = new RedisEventSubscriber(streams, objectMapper, null);
+
+        subscriber.subscribe(List.of("events:payment"), "journey-order", "consumer-1", envelope -> {
+            throw new IllegalStateException("payment parse failed");
+        });
+
+        for (int i = 0; i < 20 && streams.dlqMetadata.get() == null; i++) {
+            Thread.sleep(50);
+        }
+        subscriber.close();
+
+        assertThat(streams.dlqMetadata.get()).isNotNull();
+        assertThat(streams.dlqMetadata.get().failureReason()).isEqualTo("IllegalStateException: payment parse failed");
+        assertThat(streams.dlqMetadata.get().attempts()).isEqualTo(RedisEventSubscriber.MAX_DELIVERY_ATTEMPTS);
+    }
+
     private static final class FakeRedisStreams implements RedisStreamOperations {
         private final List<StreamEntry> firstBatch;
         private final List<String> acked = new ArrayList<>();
         private boolean delivered;
+        private int deliveryCount = 1;
         private volatile String dlqStream;
         private final AtomicReference<DlqMetadata> dlqMetadata = new AtomicReference<>();
 
@@ -102,7 +128,7 @@ class RedisEventSubscriberTest {
 
         @Override
         public int deliveryCount(String stream, String group, String messageId) {
-            return 1;
+            return deliveryCount;
         }
 
         @Override

--- a/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/RedisEventSubscriberTest.java
+++ b/platform/java-kit/src/test/java/com/trainticket/platformkit/messaging/RedisEventSubscriberTest.java
@@ -2,6 +2,10 @@ package com.trainticket.platformkit.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.ArrayList;
@@ -11,6 +15,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 class RedisEventSubscriberTest {
     @Test
@@ -49,13 +54,20 @@ class RedisEventSubscriberTest {
         ));
         RedisEventSubscriber subscriber = new RedisEventSubscriber(streams, objectMapper, null);
         AtomicReference<DlqMetadata> metadata = streams.dlqMetadata;
+        Logger logger = (Logger) LoggerFactory.getLogger(RedisEventSubscriber.class);
+        ListAppender<ILoggingEvent> logs = new ListAppender<>();
+        logs.start();
+        logger.addAppender(logs);
+        try {
+            subscriber.subscribe(List.of("events:payment"), "journey-order", "consumer-1", envelope -> HandlerResult.FATAL_FAILURE);
 
-        subscriber.subscribe(List.of("events:payment"), "journey-order", "consumer-1", envelope -> HandlerResult.FATAL_FAILURE);
-
-        for (int i = 0; i < 20 && metadata.get() == null; i++) {
-            Thread.sleep(50);
+            for (int i = 0; i < 20 && metadata.get() == null; i++) {
+                Thread.sleep(50);
+            }
+        } finally {
+            subscriber.close();
+            logger.detachAppender(logs);
         }
-        subscriber.close();
         assertThat(metadata.get()).isNotNull();
         assertThat(streams.acked).contains("1-0");
         assertThat(streams.dlqStream).isEqualTo("events:payment");
@@ -64,6 +76,12 @@ class RedisEventSubscriberTest {
         assertThat(metadata.get().failureReason()).isEqualTo("HandlerResult.FATAL_FAILURE");
         assertThat(metadata.get().attempts()).isEqualTo(1);
         assertThat(metadata.get().deadLetteredAt()).isNotBlank();
+        assertThat(logs.list)
+            .anySatisfy(eventLog -> {
+                assertThat(eventLog.getLoggerName()).isEqualTo(RedisEventSubscriber.class.getName());
+                assertThat(eventLog.getLevel()).isEqualTo(Level.WARN);
+                assertThat(eventLog.getFormattedMessage()).contains("events:payment", event.eventId(), "HandlerResult.FATAL_FAILURE");
+            });
     }
 
 

--- a/platform/python-kit/src/train_ticket_platform/messaging.py
+++ b/platform/python-kit/src/train_ticket_platform/messaging.py
@@ -356,13 +356,14 @@ class RedisEventSubscriber(EventSubscriber):
         fields: Mapping[Any, Any],
         handler: Callable[[EventEnvelope], Any],
         delivery_count: int = 0,
+        consumer_name: str = "unknown",
     ) -> None:
         if delivery_count >= MAX_DELIVERY_ATTEMPTS:
             envelope_json = self._extract_envelope_json(fields)
-            self._move_to_dlq(stream, group, "unknown", envelope_json or "{}", "MaxDeliveryAttempts", delivery_count)
+            self._move_to_dlq(stream, group, consumer_name, envelope_json or "{}", "MaxDeliveryAttempts", delivery_count)
             self._xack(stream, group, entry_id)
             return
-        self._process_message(stream, group, "unknown", entry_id, fields, handler)
+        self._process_message(stream, group, consumer_name, entry_id, fields, handler)
 
 
 class InMemoryEventPublisher(EventPublisher):

--- a/platform/python-kit/src/train_ticket_platform/messaging.py
+++ b/platform/python-kit/src/train_ticket_platform/messaging.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
+from datetime import UTC, datetime
 import json
+import logging
 import os
 import socket
 import threading
@@ -20,6 +22,7 @@ CLAIM_MIN_IDLE_MS = 60000
 CLAIM_COUNT = 100
 POLL_BLOCK_MS = 2000
 POLL_COUNT = 10
+LOGGER = logging.getLogger(__name__)
 
 
 class PublishFailed(RuntimeError):
@@ -161,7 +164,7 @@ class RedisEventSubscriber(EventSubscriber):
                     count=POLL_COUNT,
                     block=POLL_BLOCK_MS,
                 )
-                self._process_results(results, group, handler)
+                self._process_results(results, group, consumer_name, handler)
             except Exception as exc:
                 if self._stop_requested.is_set():
                     break
@@ -220,48 +223,48 @@ class RedisEventSubscriber(EventSubscriber):
             claimed = self._client.xautoclaim(stream, group, consumer_name, CLAIM_MIN_IDLE_MS, "0", count=CLAIM_COUNT)
             messages = claimed[1] if claimed and len(claimed) > 1 else []
             for msg_id, msg_data in messages:
-                self._process_message(stream, group, msg_id, msg_data, handler)
+                self._process_message(stream, group, consumer_name, msg_id, msg_data, handler)
 
-    def _process_results(self, results: Any, group: str, handler: Callable[[EventEnvelope], Any]) -> None:
+    def _process_results(self, results: Any, group: str, consumer_name: str, handler: Callable[[EventEnvelope], Any]) -> None:
         for stream_name, messages in results or []:
             stream = stream_name.decode("utf-8") if isinstance(stream_name, bytes) else str(stream_name)
             for msg_id, msg_data in messages:
-                self._process_message(stream, group, msg_id, msg_data, handler)
+                self._process_message(stream, group, consumer_name, msg_id, msg_data, handler)
 
-    def _process_message(self, stream: str, group: str, msg_id: bytes | str, msg_data: Mapping[Any, Any], handler: Callable[[EventEnvelope], Any]) -> None:
+    def _process_message(self, stream: str, group: str, consumer_name: str, msg_id: bytes | str, msg_data: Mapping[Any, Any], handler: Callable[[EventEnvelope], Any]) -> None:
         msg_id_str = msg_id.decode("utf-8") if isinstance(msg_id, bytes) else str(msg_id)
         envelope_json = self._extract_envelope_json(msg_data)
         try:
             envelope = self._deserialize_envelope(json.loads(envelope_json))
         except Exception:
-            self._move_to_dlq(stream, envelope_json or "{}")
+            self._move_to_dlq(stream, group, consumer_name, envelope_json or "{}", "DeserializeError", self._delivery_count(stream, group, msg_id_str) or 1)
             self._xack(stream, group, msg_id_str)
             return
         if self._already_seen(envelope.eventId):
             self._xack(stream, group, msg_id_str)
             return
         if self._delivery_count(stream, group, msg_id_str) >= MAX_DELIVERY_ATTEMPTS:
-            self._move_to_dlq(stream, envelope_json)
+            self._move_to_dlq(stream, group, consumer_name, envelope_json, "MaxDeliveryAttempts", self._delivery_count(stream, group, msg_id_str))
             self._xack(stream, group, msg_id_str)
             return
         try:
             result = handler(envelope)
         except TransientHandlerError:
             return
-        except FatalHandlerError:
-            self._move_to_dlq(stream, envelope_json)
+        except FatalHandlerError as exc:
+            self._move_to_dlq(stream, group, consumer_name, envelope_json, exc, self._delivery_count(stream, group, msg_id_str))
             self._xack(stream, group, msg_id_str)
             return
-        except Exception:
+        except Exception as exc:
             if self._delivery_count(stream, group, msg_id_str) >= MAX_DELIVERY_ATTEMPTS:
-                self._move_to_dlq(stream, envelope_json)
+                self._move_to_dlq(stream, group, consumer_name, envelope_json, exc, self._delivery_count(stream, group, msg_id_str))
                 self._xack(stream, group, msg_id_str)
             return
         if isinstance(result, HandlerResult):
             if result.status is HandlerStatus.TRANSIENT_ERROR:
                 return
             if result.status is HandlerStatus.FATAL_ERROR:
-                self._move_to_dlq(stream, envelope_json)
+                self._move_to_dlq(stream, group, consumer_name, envelope_json, result.message or "HandlerResult.FATAL_ERROR", self._delivery_count(stream, group, msg_id_str))
                 self._xack(stream, group, msg_id_str)
                 return
         self._record_seen(envelope.eventId)
@@ -314,8 +317,29 @@ class RedisEventSubscriber(EventSubscriber):
         with lock:
             seen.add(event_id)
 
-    def _move_to_dlq(self, stream: str, envelope_json: str) -> None:
-        self._client.xadd(dlq_for_stream(stream), {"envelope": envelope_json}, maxlen=MAXLEN, approximate=True)
+    def _move_to_dlq(self, stream: str, group: str, consumer_name: str, envelope_json: str, reason: object, attempts: int) -> None:
+        failure_reason = _truncate_failure_reason(reason)
+        event_id = _event_id_for_log(envelope_json)
+        LOGGER.warning(
+            "service=%s stream=%s eventId=%s failureReason=%s moving message to DLQ",
+            group,
+            stream,
+            event_id,
+            failure_reason,
+        )
+        self._client.xadd(
+            dlq_for_stream(stream),
+            {
+                "envelope": envelope_json,
+                "consumerGroup": group,
+                "consumerName": consumer_name,
+                "failureReason": failure_reason,
+                "attempts": str(max(1, attempts)),
+                "deadLetteredAt": datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+            },
+            maxlen=MAXLEN,
+            approximate=True,
+        )
 
     def _xack(self, stream: str, group: str, msg_id: str) -> None:
         self._client.xack(stream, group, msg_id)
@@ -335,10 +359,10 @@ class RedisEventSubscriber(EventSubscriber):
     ) -> None:
         if delivery_count >= MAX_DELIVERY_ATTEMPTS:
             envelope_json = self._extract_envelope_json(fields)
-            self._move_to_dlq(stream, envelope_json or "{}")
+            self._move_to_dlq(stream, group, "unknown", envelope_json or "{}", "MaxDeliveryAttempts", delivery_count)
             self._xack(stream, group, entry_id)
             return
-        self._process_message(stream, group, entry_id, fields, handler)
+        self._process_message(stream, group, "unknown", entry_id, fields, handler)
 
 
 class InMemoryEventPublisher(EventPublisher):
@@ -372,3 +396,23 @@ class InMemoryEventSubscriber(EventSubscriber):
 
     def stop(self) -> None:
         return None
+
+
+def _truncate_failure_reason(reason: object) -> str:
+    if isinstance(reason, BaseException):
+        text = f"{reason.__class__.__name__}: {reason}"
+    else:
+        text = str(reason or "unknown")
+    return text[:500]
+
+
+def _event_id_for_log(envelope_json: str) -> str:
+    try:
+        raw = json.loads(envelope_json)
+    except Exception:
+        return "unknown"
+    if isinstance(raw, dict):
+        event_id = raw.get("eventId")
+        if event_id is not None:
+            return str(event_id)
+    return "unknown"

--- a/platform/python-kit/src/train_ticket_platform/messaging.py
+++ b/platform/python-kit/src/train_ticket_platform/messaging.py
@@ -223,13 +223,31 @@ class RedisEventSubscriber(EventSubscriber):
             claimed = self._client.xautoclaim(stream, group, consumer_name, CLAIM_MIN_IDLE_MS, "0", count=CLAIM_COUNT)
             messages = claimed[1] if claimed and len(claimed) > 1 else []
             for msg_id, msg_data in messages:
-                self._process_message(stream, group, consumer_name, msg_id, msg_data, handler)
+                msg_id_str = msg_id.decode("utf-8") if isinstance(msg_id, bytes) else str(msg_id)
+                self._process_entry(
+                    stream,
+                    group,
+                    msg_id_str,
+                    msg_data,
+                    handler,
+                    self._delivery_count(stream, group, msg_id_str),
+                    consumer_name,
+                )
 
     def _process_results(self, results: Any, group: str, consumer_name: str, handler: Callable[[EventEnvelope], Any]) -> None:
         for stream_name, messages in results or []:
             stream = stream_name.decode("utf-8") if isinstance(stream_name, bytes) else str(stream_name)
             for msg_id, msg_data in messages:
-                self._process_message(stream, group, consumer_name, msg_id, msg_data, handler)
+                msg_id_str = msg_id.decode("utf-8") if isinstance(msg_id, bytes) else str(msg_id)
+                self._process_entry(
+                    stream,
+                    group,
+                    msg_id_str,
+                    msg_data,
+                    handler,
+                    self._delivery_count(stream, group, msg_id_str),
+                    consumer_name,
+                )
 
     def _process_message(self, stream: str, group: str, consumer_name: str, msg_id: bytes | str, msg_data: Mapping[Any, Any], handler: Callable[[EventEnvelope], Any]) -> None:
         msg_id_str = msg_id.decode("utf-8") if isinstance(msg_id, bytes) else str(msg_id)
@@ -355,15 +373,16 @@ class RedisEventSubscriber(EventSubscriber):
         entry_id: str,
         fields: Mapping[Any, Any],
         handler: Callable[[EventEnvelope], Any],
-        delivery_count: int = 0,
-        consumer_name: str = "unknown",
+        delivery_count: int,
+        consumer_name: str | None = None,
     ) -> None:
+        actual_consumer_name = consumer_name or default_consumer_name(group)
         if delivery_count >= MAX_DELIVERY_ATTEMPTS:
             envelope_json = self._extract_envelope_json(fields)
-            self._move_to_dlq(stream, group, consumer_name, envelope_json or "{}", "MaxDeliveryAttempts", delivery_count)
+            self._move_to_dlq(stream, group, actual_consumer_name, envelope_json or "{}", "MaxDeliveryAttempts", delivery_count)
             self._xack(stream, group, entry_id)
             return
-        self._process_message(stream, group, consumer_name, entry_id, fields, handler)
+        self._process_message(stream, group, actual_consumer_name, entry_id, fields, handler)
 
 
 class InMemoryEventPublisher(EventPublisher):

--- a/platform/python-kit/tests/test_messaging.py
+++ b/platform/python-kit/tests/test_messaging.py
@@ -44,3 +44,25 @@ def test_unexpected_handler_exception_uses_dlq_policy_without_escaping(caplog) -
     assert fields["attempts"] == "1"
     assert fields["deadLetteredAt"].endswith("Z")
     assert "moving message to DLQ" in caplog.text
+
+
+def test_process_entry_uses_supplied_consumer_name_for_max_delivery_dlq() -> None:
+    subscriber = object.__new__(RedisEventSubscriber)
+    subscriber._client = FakeRedis()
+    subscriber._dedup = set()
+    subscriber._dedup_lock = None
+    envelope = EventEnvelope(eventType="SomethingHappened", producer="tester", payload={"x": 1})
+    fields = {"envelope": json.dumps(envelope.to_json_dict())}
+
+    subscriber._process_entry(
+        "events:tester",
+        "tester",
+        "1-0",
+        fields,
+        lambda _: None,
+        5,
+        consumer_name="tester-consumer",
+    )
+
+    dlq_fields = subscriber._client.dlq_entries[0][1]
+    assert dlq_fields["consumerName"] == "tester-consumer"

--- a/platform/python-kit/tests/test_messaging.py
+++ b/platform/python-kit/tests/test_messaging.py
@@ -1,14 +1,15 @@
 import json
+import logging
 
 from train_ticket_platform.events import EventEnvelope
-from train_ticket_platform.messaging import MAX_DELIVERY_ATTEMPTS, RedisEventSubscriber, dlq_for_stream
+from train_ticket_platform.messaging import FatalHandlerError, RedisEventSubscriber, dlq_for_stream
 
 
 class FakeRedis:
     def __init__(self) -> None:
         self.acks: list[tuple[str, str, str]] = []
         self.dlq_entries: list[tuple[str, dict[str, str]]] = []
-        self.delivery_count = MAX_DELIVERY_ATTEMPTS
+        self.delivery_count = 1
 
     def xpending_range(self, stream: str, group: str, min: str, max: str, count: int) -> list[dict[str, int]]:
         return [{"times_delivered": self.delivery_count}]
@@ -20,7 +21,8 @@ class FakeRedis:
         self.acks.append((stream, group, msg_id))
 
 
-def test_unexpected_handler_exception_uses_dlq_policy_without_escaping() -> None:
+def test_unexpected_handler_exception_uses_dlq_policy_without_escaping(caplog) -> None:
+    caplog.set_level(logging.WARNING)
     subscriber = object.__new__(RedisEventSubscriber)
     subscriber._client = FakeRedis()
     subscriber._dedup = set()
@@ -29,9 +31,16 @@ def test_unexpected_handler_exception_uses_dlq_policy_without_escaping() -> None
     fields = {"envelope": json.dumps(envelope.to_json_dict())}
 
     def handler(_: EventEnvelope) -> None:
-        raise ValueError("poison message")
+        raise FatalHandlerError("poison message")
 
-    subscriber._process_message("events:tester", "tester", "1-0", fields, handler)
+    subscriber._process_message("events:tester", "tester", "tester-consumer", "1-0", fields, handler)
 
     assert subscriber._client.acks == [("events:tester", "tester", "1-0")]
     assert subscriber._client.dlq_entries[0][0] == dlq_for_stream("events:tester")
+    fields = subscriber._client.dlq_entries[0][1]
+    assert fields["consumerGroup"] == "tester"
+    assert fields["consumerName"] == "tester-consumer"
+    assert fields["failureReason"] == "FatalHandlerError: poison message"
+    assert fields["attempts"] == "1"
+    assert fields["deadLetteredAt"].endswith("Z")
+    assert "moving message to DLQ" in caplog.text

--- a/platform/rust-kit/Cargo.lock
+++ b/platform/rust-kit/Cargo.lock
@@ -895,6 +895,19 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+dependencies = [
+ "value-bag",
+]
+
+[[package]]
+name = "logtest"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3e43a8657c1d64516dcc9db8ca03826a4aceaf89d5ce1b37b59f6ff0e43026"
+dependencies = [
+ "lazy_static",
+ "log",
+]
 
 [[package]]
 name = "matchit"
@@ -1257,6 +1270,7 @@ dependencies = [
  "axum",
  "chrono",
  "log",
+ "logtest",
  "redis",
  "serde",
  "serde_json",
@@ -1973,6 +1987,12 @@ dependencies = [
  "rand 0.10.2",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"

--- a/platform/rust-kit/Cargo.toml
+++ b/platform/rust-kit/Cargo.toml
@@ -28,3 +28,4 @@ redis-impl = ["redis"]
 [dev-dependencies]
 tokio = { version = "1.48", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
 tower = { version = "0.5.3", features = ["util"] }
+logtest = "2.0"

--- a/platform/rust-kit/src/messaging.rs
+++ b/platform/rust-kit/src/messaging.rs
@@ -635,6 +635,145 @@ pub mod redis_runtime {
         })))
     }
 
+    #[async_trait]
+    trait StreamOps: Send {
+        async fn create_group(&mut self, stream: &str, group: &str) -> Result<(), SubscribeFailed>;
+        async fn recover_pending(
+            &mut self,
+            stream: &str,
+            group: &str,
+            consumer_name: &str,
+        ) -> Result<Vec<StreamMessage>, SubscribeFailed>;
+        async fn read_group(
+            &mut self,
+            streams: &[String],
+            group: &str,
+            consumer_name: &str,
+        ) -> Result<Vec<StreamMessage>, SubscribeFailed>;
+        async fn delivery_count(
+            &mut self,
+            stream: &str,
+            group: &str,
+            id: &str,
+        ) -> Result<u64, SubscribeFailed>;
+        async fn xadd_dlq(
+            &mut self,
+            dlq: &str,
+            raw_envelope: &str,
+            fields: Vec<(&'static str, String)>,
+        ) -> Result<(), SubscribeFailed>;
+        async fn ack(&mut self, stream: &str, group: &str, id: &str)
+        -> Result<(), SubscribeFailed>;
+    }
+
+    struct RedisStreamOps {
+        connection: redis::aio::MultiplexedConnection,
+    }
+
+    #[async_trait]
+    impl StreamOps for RedisStreamOps {
+        async fn create_group(&mut self, stream: &str, group: &str) -> Result<(), SubscribeFailed> {
+            let result: RedisResult<String> = redis::cmd("XGROUP")
+                .arg("CREATE")
+                .arg(stream)
+                .arg(group)
+                .arg("$")
+                .arg("MKSTREAM")
+                .query_async(&mut self.connection)
+                .await;
+            if let Err(error) = result {
+                if !error.to_string().contains("BUSYGROUP") {
+                    return Err(SubscribeFailed(format!(
+                        "failed to create consumer group for {stream}: {error}"
+                    )));
+                }
+            }
+            Ok(())
+        }
+
+        async fn recover_pending(
+            &mut self,
+            stream: &str,
+            group: &str,
+            consumer_name: &str,
+        ) -> Result<Vec<StreamMessage>, SubscribeFailed> {
+            let response: redis::Value = redis::cmd("XAUTOCLAIM")
+                .arg(stream)
+                .arg(group)
+                .arg(consumer_name)
+                .arg(60_000)
+                .arg("0-0")
+                .arg("COUNT")
+                .arg(100)
+                .query_async(&mut self.connection)
+                .await
+                .map_err(|error| SubscribeFailed(error.to_string()))?;
+            Ok(parse_autoclaim_messages(stream, response))
+        }
+
+        async fn read_group(
+            &mut self,
+            streams: &[String],
+            group: &str,
+            consumer_name: &str,
+        ) -> Result<Vec<StreamMessage>, SubscribeFailed> {
+            let response: redis::Value = redis::cmd("XREADGROUP")
+                .arg("GROUP")
+                .arg(group)
+                .arg(consumer_name)
+                .arg("BLOCK")
+                .arg(2_000)
+                .arg("COUNT")
+                .arg(10)
+                .arg("STREAMS")
+                .arg(streams)
+                .arg(vec![">"; streams.len()])
+                .query_async(&mut self.connection)
+                .await
+                .map_err(|error| SubscribeFailed(error.to_string()))?;
+            Ok(parse_stream_messages(response))
+        }
+
+        async fn delivery_count(
+            &mut self,
+            stream: &str,
+            group: &str,
+            id: &str,
+        ) -> Result<u64, SubscribeFailed> {
+            pending_delivery_count(&mut self.connection, stream, group, id).await
+        }
+
+        async fn xadd_dlq(
+            &mut self,
+            dlq: &str,
+            raw_envelope: &str,
+            fields: Vec<(&'static str, String)>,
+        ) -> Result<(), SubscribeFailed> {
+            let _: String = redis::cmd("XADD")
+                .arg(dlq)
+                .arg("MAXLEN")
+                .arg("~")
+                .arg(RETENTION_MAXLEN)
+                .arg("*")
+                .arg("envelope")
+                .arg(raw_envelope)
+                .arg(fields)
+                .query_async(&mut self.connection)
+                .await
+                .map_err(|error| SubscribeFailed(error.to_string()))?;
+            Ok(())
+        }
+
+        async fn ack(
+            &mut self,
+            stream: &str,
+            group: &str,
+            id: &str,
+        ) -> Result<(), SubscribeFailed> {
+            ack(&mut self.connection, stream, group, id).await
+        }
+    }
+
     #[derive(Clone)]
     pub struct RedisEventSubscriber {
         client: redis::Client,
@@ -658,72 +797,48 @@ pub mod redis_runtime {
         pub fn shutdown(&self) {
             self.stop.store(true, std::sync::atomic::Ordering::SeqCst);
         }
-        async fn create_groups(
-            connection: &mut redis::aio::MultiplexedConnection,
+        async fn create_groups_with_ops(
+            ops: &mut dyn StreamOps,
             streams: &[String],
             group: &str,
         ) -> Result<(), SubscribeFailed> {
             for stream in streams {
-                let result: RedisResult<String> = redis::cmd("XGROUP")
-                    .arg("CREATE")
-                    .arg(stream)
-                    .arg(group)
-                    .arg("$")
-                    .arg("MKSTREAM")
-                    .query_async(&mut *connection)
-                    .await;
-                if let Err(error) = result {
-                    if !error.to_string().contains("BUSYGROUP") {
-                        return Err(SubscribeFailed(format!(
-                            "failed to create consumer group for {stream}: {error}"
-                        )));
-                    }
-                }
+                ops.create_group(stream, group).await?;
             }
             Ok(())
         }
         // A non-persistent Redis loses consumer groups on restart: a NOGROUP
         // error means recreate the groups and carry on. Every consume error
         // backs off so a dead connection never hot-spins the subscribe loop.
-        async fn handle_consume_error(
-            connection: &mut redis::aio::MultiplexedConnection,
+        async fn handle_consume_error_with_ops(
+            ops: &mut dyn StreamOps,
             streams: &[String],
             group: &str,
             error: &str,
         ) {
             if error.to_uppercase().contains("NOGROUP") {
-                let _ = Self::create_groups(connection, streams, group).await;
+                let _ = Self::create_groups_with_ops(ops, streams, group).await;
             }
             sleep(Duration::from_secs(1)).await;
         }
-        async fn recover_pending(
+        async fn recover_pending_with_ops(
             &self,
-            connection: &mut redis::aio::MultiplexedConnection,
+            ops: &mut dyn StreamOps,
             streams: &[String],
             group: &str,
             consumer_name: &str,
             handler: &(dyn Fn(EventEnvelope) -> HandlerFuture + Send + Sync),
         ) -> Result<(), SubscribeFailed> {
             for stream in streams {
-                let response: redis::Value = redis::cmd("XAUTOCLAIM")
-                    .arg(stream)
-                    .arg(group)
-                    .arg(consumer_name)
-                    .arg(60_000)
-                    .arg("0-0")
-                    .arg("COUNT")
-                    .arg(100)
-                    .query_async(&mut *connection)
-                    .await
-                    .map_err(|error| SubscribeFailed(error.to_string()))?;
-                for mut message in parse_autoclaim_messages(stream, response) {
-                    message.delivery_count =
-                        pending_delivery_count(connection, stream, group, &message.id)
-                            .await
-                            .unwrap_or(message.delivery_count);
+                let mut messages = ops.recover_pending(stream, group, consumer_name).await?;
+                for message in &mut messages {
+                    message.delivery_count = ops
+                        .delivery_count(&message.stream, group, &message.id)
+                        .await
+                        .unwrap_or(message.delivery_count);
                     if message.delivery_count >= MAX_DELIVERY_ATTEMPTS {
                         move_to_dlq(
-                            connection,
+                            ops,
                             &message.stream,
                             group,
                             consumer_name,
@@ -734,17 +849,16 @@ pub mod redis_runtime {
                         )
                         .await?;
                     } else {
-                        self.process_message(connection, group, consumer_name, message, handler)
+                        self.process_message(ops, group, consumer_name, message.clone(), handler)
                             .await?;
                     }
                 }
             }
             Ok(())
         }
-        #[cfg_attr(test, allow(dead_code))]
         async fn process_message(
             &self,
-            connection: &mut redis::aio::MultiplexedConnection,
+            ops: &mut dyn StreamOps,
             group: &str,
             consumer_name: &str,
             message: StreamMessage,
@@ -754,7 +868,7 @@ pub mod redis_runtime {
                 Ok(envelope) => envelope,
                 Err(error) => {
                     return move_to_dlq(
-                        connection,
+                        ops,
                         &message.stream,
                         group,
                         consumer_name,
@@ -767,18 +881,18 @@ pub mod redis_runtime {
                 }
             };
             if self.state.has_seen(&envelope.event_id) {
-                return ack(connection, &message.stream, group, &message.id).await;
+                return ops.ack(&message.stream, group, &message.id).await;
             }
             match handler(envelope.clone()).await {
                 Ok(()) => {
                     self.state.mark_consumed(&envelope.event_id);
-                    ack(connection, &message.stream, group, &message.id).await
+                    ops.ack(&message.stream, group, &message.id).await
                 }
                 Err(HandlerError::Transient(_)) => Ok(()),
                 Err(HandlerError::Fatal(reason)) => {
                     self.state.mark_consumed(&envelope.event_id);
                     move_to_dlq(
-                        connection,
+                        ops,
                         &message.stream,
                         group,
                         consumer_name,
@@ -792,42 +906,52 @@ pub mod redis_runtime {
             }
         }
 
-        #[cfg(test)]
-        async fn process_message_with_dlq_writer<F, Fut>(
+        async fn subscribe_with_ops(
             &self,
-            group: &str,
-            consumer_name: &str,
-            message: StreamMessage,
-            handler: &(dyn Fn(EventEnvelope) -> HandlerFuture + Send + Sync),
-            mut write_dlq: F,
-        ) -> Result<bool, SubscribeFailed>
-        where
-            F: FnMut(String, String, String, u64) -> Fut,
-            Fut: Future<Output = Result<(), SubscribeFailed>>,
-        {
-            let envelope: EventEnvelope = serde_json::from_str(&message.raw_envelope)
-                .map_err(|error| SubscribeFailed(error.to_string()))?;
-            match handler(envelope.clone()).await {
-                Ok(()) => Ok(false),
-                Err(HandlerError::Transient(_)) => Ok(false),
-                Err(HandlerError::Fatal(reason)) => {
-                    self.state.mark_consumed(&envelope.event_id);
-                    let failure_reason = truncate_failure_reason(&reason);
-                    log::warn!(
-                        "service={} stream={} eventId={} failureReason={} moving message to DLQ",
-                        group,
-                        message.stream,
-                        event_id_for_log(&message.raw_envelope),
-                        failure_reason
-                    );
-                    write_dlq(
-                        message.raw_envelope.clone(),
-                        consumer_name.to_string(),
-                        failure_reason,
-                        message.delivery_count,
+            ops: &mut dyn StreamOps,
+            streams: Vec<String>,
+            group: String,
+            consumer_name: String,
+            handler: Box<dyn Fn(EventEnvelope) -> HandlerFuture + Send + Sync>,
+            run_once: bool,
+        ) -> Result<(), SubscribeFailed> {
+            Self::create_groups_with_ops(ops, &streams, &group).await?;
+            loop {
+                if self.stop.load(std::sync::atomic::Ordering::SeqCst) {
+                    return Ok(());
+                }
+                if let Err(error) = self
+                    .recover_pending_with_ops(
+                        ops,
+                        &streams,
+                        &group,
+                        &consumer_name,
+                        handler.as_ref(),
                     )
-                    .await?;
-                    Ok(true)
+                    .await
+                {
+                    Self::handle_consume_error_with_ops(ops, &streams, &group, &error.0).await;
+                    if run_once {
+                        return Err(error);
+                    }
+                    continue;
+                }
+                let messages = match ops.read_group(&streams, &group, &consumer_name).await {
+                    Ok(messages) => messages,
+                    Err(error) => {
+                        Self::handle_consume_error_with_ops(ops, &streams, &group, &error.0).await;
+                        if run_once {
+                            return Err(error);
+                        }
+                        continue;
+                    }
+                };
+                for message in messages {
+                    self.process_message(ops, &group, &consumer_name, message, handler.as_ref())
+                        .await?;
+                }
+                if run_once {
+                    return Ok(());
                 }
             }
         }
@@ -841,64 +965,14 @@ pub mod redis_runtime {
             consumer_name: String,
             handler: Box<dyn Fn(EventEnvelope) -> HandlerFuture + Send + Sync>,
         ) -> Result<(), SubscribeFailed> {
-            let mut connection = self
+            let connection = self
                 .client
                 .get_multiplexed_async_connection()
                 .await
                 .map_err(|error| SubscribeFailed(error.to_string()))?;
-            Self::create_groups(&mut connection, &streams, &group).await?;
-            while !self.stop.load(std::sync::atomic::Ordering::SeqCst) {
-                if let Err(error) = self
-                    .recover_pending(
-                        &mut connection,
-                        &streams,
-                        &group,
-                        &consumer_name,
-                        handler.as_ref(),
-                    )
-                    .await
-                {
-                    Self::handle_consume_error(&mut connection, &streams, &group, &error.0).await;
-                    continue;
-                }
-                let response: RedisResult<redis::Value> = redis::cmd("XREADGROUP")
-                    .arg("GROUP")
-                    .arg(&group)
-                    .arg(&consumer_name)
-                    .arg("BLOCK")
-                    .arg(2_000)
-                    .arg("COUNT")
-                    .arg(10)
-                    .arg("STREAMS")
-                    .arg(&streams)
-                    .arg(vec![">"; streams.len()])
-                    .query_async(&mut connection)
-                    .await;
-                let response = match response {
-                    Ok(value) => value,
-                    Err(error) => {
-                        Self::handle_consume_error(
-                            &mut connection,
-                            &streams,
-                            &group,
-                            &error.to_string(),
-                        )
-                        .await;
-                        continue;
-                    }
-                };
-                for message in parse_stream_messages(response) {
-                    self.process_message(
-                        &mut connection,
-                        &group,
-                        &consumer_name,
-                        message,
-                        handler.as_ref(),
-                    )
-                    .await?;
-                }
-            }
-            Ok(())
+            let mut ops = RedisStreamOps { connection };
+            self.subscribe_with_ops(&mut ops, streams, group, consumer_name, handler, false)
+                .await
         }
     }
 
@@ -1018,7 +1092,7 @@ pub mod redis_runtime {
         }
     }
     async fn move_to_dlq(
-        connection: &mut redis::aio::MultiplexedConnection,
+        ops: &mut dyn StreamOps,
         stream: &str,
         group: &str,
         consumer_name: &str,
@@ -1036,25 +1110,19 @@ pub mod redis_runtime {
             event_id_for_log(raw_envelope),
             failure_reason
         );
-        let _: String = redis::cmd("XADD")
-            .arg(dlq)
-            .arg("MAXLEN")
-            .arg("~")
-            .arg(RETENTION_MAXLEN)
-            .arg("*")
-            .arg("envelope")
-            .arg(raw_envelope)
-            .arg(dlq_metadata_fields(
+        ops.xadd_dlq(
+            &dlq,
+            raw_envelope,
+            dlq_metadata_fields(
                 group,
                 consumer_name,
                 &failure_reason,
                 attempts,
                 &crate::messaging::now_rfc3339_utc(),
-            ))
-            .query_async(&mut *connection)
-            .await
-            .map_err(|error| SubscribeFailed(error.to_string()))?;
-        ack(connection, stream, group, id).await
+            ),
+        )
+        .await?;
+        ops.ack(stream, group, id).await
     }
 
     fn truncate_failure_reason(reason: &str) -> String {
@@ -1126,8 +1194,79 @@ pub mod redis_runtime {
             );
         }
 
+        #[derive(Default)]
+        struct FakeStreamOps {
+            read_messages: Vec<StreamMessage>,
+            dlq_entries: Vec<(String, String, Vec<(&'static str, String)>)>,
+            acked: Vec<(String, String, String)>,
+            created_groups: Vec<(String, String)>,
+        }
+
+        #[async_trait]
+        impl StreamOps for FakeStreamOps {
+            async fn create_group(
+                &mut self,
+                stream: &str,
+                group: &str,
+            ) -> Result<(), SubscribeFailed> {
+                self.created_groups
+                    .push((stream.to_string(), group.to_string()));
+                Ok(())
+            }
+
+            async fn recover_pending(
+                &mut self,
+                _stream: &str,
+                _group: &str,
+                _consumer_name: &str,
+            ) -> Result<Vec<StreamMessage>, SubscribeFailed> {
+                Ok(Vec::new())
+            }
+
+            async fn read_group(
+                &mut self,
+                _streams: &[String],
+                _group: &str,
+                _consumer_name: &str,
+            ) -> Result<Vec<StreamMessage>, SubscribeFailed> {
+                Ok(std::mem::take(&mut self.read_messages))
+            }
+
+            async fn delivery_count(
+                &mut self,
+                _stream: &str,
+                _group: &str,
+                _id: &str,
+            ) -> Result<u64, SubscribeFailed> {
+                Ok(1)
+            }
+
+            async fn xadd_dlq(
+                &mut self,
+                dlq: &str,
+                raw_envelope: &str,
+                fields: Vec<(&'static str, String)>,
+            ) -> Result<(), SubscribeFailed> {
+                self.dlq_entries
+                    .push((dlq.to_string(), raw_envelope.to_string(), fields));
+                Ok(())
+            }
+
+            async fn ack(
+                &mut self,
+                stream: &str,
+                group: &str,
+                id: &str,
+            ) -> Result<(), SubscribeFailed> {
+                self.acked
+                    .push((stream.to_string(), group.to_string(), id.to_string()));
+                Ok(())
+            }
+        }
+
         #[tokio::test]
-        async fn subscription_processing_fatal_handler_writes_dlq_metadata() {
+        async fn subscription_processing_fatal_handler_writes_dlq_metadata_warn_log_and_acks() {
+            let mut logger = logtest::Logger::start();
             let subscriber = RedisEventSubscriber {
                 client: redis::Client::open("redis://127.0.0.1:0").unwrap(),
                 state: Arc::new(SubscriberState::new()),
@@ -1141,41 +1280,67 @@ pub mod redis_runtime {
                 serde_json::json!({"id":"1"}),
             );
             let raw = serde_json::to_string(&envelope).unwrap();
-            let captured = Arc::new(Mutex::new(Vec::<(String, String, String, u64)>::new()));
-            let captured_for_writer = Arc::clone(&captured);
-            let wrote = subscriber
-                .process_message_with_dlq_writer(
-                    "journey-order",
-                    "consumer-1",
-                    StreamMessage {
-                        stream: "events:payment".to_string(),
-                        id: "1-0".to_string(),
-                        raw_envelope: raw.clone(),
-                        delivery_count: 3,
-                    },
-                    &|_| Box::pin(async { Err(HandlerError::Fatal("poison root cause".into())) }),
-                    move |raw, consumer, reason, attempts| {
-                        let captured = Arc::clone(&captured_for_writer);
-                        async move {
-                            captured
-                                .lock()
-                                .expect("capture lock poisoned")
-                                .push((raw, consumer, reason, attempts));
-                            Ok(())
-                        }
-                    },
+            let mut ops = FakeStreamOps {
+                read_messages: vec![StreamMessage {
+                    stream: "events:payment".to_string(),
+                    id: "1-0".to_string(),
+                    raw_envelope: raw.clone(),
+                    delivery_count: 3,
+                }],
+                ..Default::default()
+            };
+
+            subscriber
+                .subscribe_with_ops(
+                    &mut ops,
+                    vec!["events:payment".to_string()],
+                    "journey-order".to_string(),
+                    "consumer-1".to_string(),
+                    Box::new(|_| {
+                        Box::pin(async { Err(HandlerError::Fatal("poison root cause".into())) })
+                    }),
+                    true,
                 )
                 .await
                 .unwrap();
 
-            assert!(wrote);
-            let captured = captured.lock().expect("capture lock poisoned");
-            assert_eq!(captured.len(), 1);
-            assert_eq!(captured[0].0, raw);
-            assert_eq!(captured[0].1, "consumer-1");
-            assert_eq!(captured[0].2, "poison root cause");
-            assert_eq!(captured[0].3, 3);
+            assert_eq!(
+                ops.created_groups,
+                vec![("events:payment".to_string(), "journey-order".to_string())]
+            );
+            assert_eq!(ops.dlq_entries.len(), 1);
+            assert_eq!(ops.dlq_entries[0].0, "events:payment:dlq");
+            assert_eq!(ops.dlq_entries[0].1, raw);
+            let metadata: std::collections::HashMap<_, _> =
+                ops.dlq_entries[0].2.iter().cloned().collect();
+            assert_eq!(
+                metadata.get("consumerGroup"),
+                Some(&"journey-order".to_string())
+            );
+            assert_eq!(
+                metadata.get("consumerName"),
+                Some(&"consumer-1".to_string())
+            );
+            assert_eq!(
+                metadata.get("failureReason"),
+                Some(&"poison root cause".to_string())
+            );
+            assert_eq!(metadata.get("attempts"), Some(&"3".to_string()));
+            assert!(metadata.get("deadLetteredAt").is_some());
+            assert_eq!(
+                ops.acked,
+                vec![(
+                    "events:payment".to_string(),
+                    "journey-order".to_string(),
+                    "1-0".to_string()
+                )]
+            );
             assert!(subscriber.state.has_seen(&envelope.event_id));
+            let log = logger.pop().expect("expected WARN DLQ log");
+            assert_eq!(log.level(), log::Level::Warn);
+            assert!(log.args().contains("events:payment"));
+            assert!(log.args().contains(&envelope.event_id));
+            assert!(log.args().contains("poison root cause"));
         }
 
         #[tokio::test]

--- a/platform/rust-kit/src/messaging.rs
+++ b/platform/rust-kit/src/messaging.rs
@@ -741,6 +741,7 @@ pub mod redis_runtime {
             }
             Ok(())
         }
+        #[cfg_attr(test, allow(dead_code))]
         async fn process_message(
             &self,
             connection: &mut redis::aio::MultiplexedConnection,
@@ -787,6 +788,46 @@ pub mod redis_runtime {
                         message.delivery_count,
                     )
                     .await
+                }
+            }
+        }
+
+        #[cfg(test)]
+        async fn process_message_with_dlq_writer<F, Fut>(
+            &self,
+            group: &str,
+            consumer_name: &str,
+            message: StreamMessage,
+            handler: &(dyn Fn(EventEnvelope) -> HandlerFuture + Send + Sync),
+            mut write_dlq: F,
+        ) -> Result<bool, SubscribeFailed>
+        where
+            F: FnMut(String, String, String, u64) -> Fut,
+            Fut: Future<Output = Result<(), SubscribeFailed>>,
+        {
+            let envelope: EventEnvelope = serde_json::from_str(&message.raw_envelope)
+                .map_err(|error| SubscribeFailed(error.to_string()))?;
+            match handler(envelope.clone()).await {
+                Ok(()) => Ok(false),
+                Err(HandlerError::Transient(_)) => Ok(false),
+                Err(HandlerError::Fatal(reason)) => {
+                    self.state.mark_consumed(&envelope.event_id);
+                    let failure_reason = truncate_failure_reason(&reason);
+                    log::warn!(
+                        "service={} stream={} eventId={} failureReason={} moving message to DLQ",
+                        group,
+                        message.stream,
+                        event_id_for_log(&message.raw_envelope),
+                        failure_reason
+                    );
+                    write_dlq(
+                        message.raw_envelope.clone(),
+                        consumer_name.to_string(),
+                        failure_reason,
+                        message.delivery_count,
+                    )
+                    .await?;
+                    Ok(true)
                 }
             }
         }
@@ -1083,6 +1124,58 @@ pub mod redis_runtime {
                     ("deadLetteredAt", "2026-07-07T12:00:00.000Z".to_string()),
                 ]
             );
+        }
+
+        #[tokio::test]
+        async fn subscription_processing_fatal_handler_writes_dlq_metadata() {
+            let subscriber = RedisEventSubscriber {
+                client: redis::Client::open("redis://127.0.0.1:0").unwrap(),
+                state: Arc::new(SubscriberState::new()),
+                stop: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            };
+            let envelope = EventEnvelope::canonical(
+                "PoisonEvent",
+                correlation_id(),
+                Some(command_id()),
+                "payment",
+                serde_json::json!({"id":"1"}),
+            );
+            let raw = serde_json::to_string(&envelope).unwrap();
+            let captured = Arc::new(Mutex::new(Vec::<(String, String, String, u64)>::new()));
+            let captured_for_writer = Arc::clone(&captured);
+            let wrote = subscriber
+                .process_message_with_dlq_writer(
+                    "journey-order",
+                    "consumer-1",
+                    StreamMessage {
+                        stream: "events:payment".to_string(),
+                        id: "1-0".to_string(),
+                        raw_envelope: raw.clone(),
+                        delivery_count: 3,
+                    },
+                    &|_| Box::pin(async { Err(HandlerError::Fatal("poison root cause".into())) }),
+                    move |raw, consumer, reason, attempts| {
+                        let captured = Arc::clone(&captured_for_writer);
+                        async move {
+                            captured
+                                .lock()
+                                .expect("capture lock poisoned")
+                                .push((raw, consumer, reason, attempts));
+                            Ok(())
+                        }
+                    },
+                )
+                .await
+                .unwrap();
+
+            assert!(wrote);
+            let captured = captured.lock().expect("capture lock poisoned");
+            assert_eq!(captured.len(), 1);
+            assert_eq!(captured[0].0, raw);
+            assert_eq!(captured[0].1, "consumer-1");
+            assert_eq!(captured[0].2, "poison root cause");
+            assert_eq!(captured[0].3, 3);
+            assert!(subscriber.state.has_seen(&envelope.event_id));
         }
 
         #[tokio::test]

--- a/platform/rust-kit/src/messaging.rs
+++ b/platform/rust-kit/src/messaging.rs
@@ -726,12 +726,15 @@ pub mod redis_runtime {
                             connection,
                             &message.stream,
                             group,
+                            consumer_name,
                             &message.id,
                             &message.raw_envelope,
+                            "MaxDeliveryAttempts",
+                            message.delivery_count,
                         )
                         .await?;
                     } else {
-                        self.process_message(connection, group, message, handler)
+                        self.process_message(connection, group, consumer_name, message, handler)
                             .await?;
                     }
                 }
@@ -742,11 +745,26 @@ pub mod redis_runtime {
             &self,
             connection: &mut redis::aio::MultiplexedConnection,
             group: &str,
+            consumer_name: &str,
             message: StreamMessage,
             handler: &(dyn Fn(EventEnvelope) -> HandlerFuture + Send + Sync),
         ) -> Result<(), SubscribeFailed> {
-            let envelope: EventEnvelope = serde_json::from_str(&message.raw_envelope)
-                .map_err(|error| SubscribeFailed(error.to_string()))?;
+            let envelope: EventEnvelope = match serde_json::from_str(&message.raw_envelope) {
+                Ok(envelope) => envelope,
+                Err(error) => {
+                    return move_to_dlq(
+                        connection,
+                        &message.stream,
+                        group,
+                        consumer_name,
+                        &message.id,
+                        &message.raw_envelope,
+                        &error.to_string(),
+                        message.delivery_count,
+                    )
+                    .await;
+                }
+            };
             if self.state.has_seen(&envelope.event_id) {
                 return ack(connection, &message.stream, group, &message.id).await;
             }
@@ -756,14 +774,17 @@ pub mod redis_runtime {
                     ack(connection, &message.stream, group, &message.id).await
                 }
                 Err(HandlerError::Transient(_)) => Ok(()),
-                Err(HandlerError::Fatal(_)) => {
+                Err(HandlerError::Fatal(reason)) => {
                     self.state.mark_consumed(&envelope.event_id);
                     move_to_dlq(
                         connection,
                         &message.stream,
                         group,
+                        consumer_name,
                         &message.id,
                         &message.raw_envelope,
+                        &reason,
+                        message.delivery_count,
                     )
                     .await
                 }
@@ -826,8 +847,14 @@ pub mod redis_runtime {
                     }
                 };
                 for message in parse_stream_messages(response) {
-                    self.process_message(&mut connection, &group, message, handler.as_ref())
-                        .await?;
+                    self.process_message(
+                        &mut connection,
+                        &group,
+                        &consumer_name,
+                        message,
+                        handler.as_ref(),
+                    )
+                    .await?;
                 }
             }
             Ok(())
@@ -953,10 +980,21 @@ pub mod redis_runtime {
         connection: &mut redis::aio::MultiplexedConnection,
         stream: &str,
         group: &str,
+        consumer_name: &str,
         id: &str,
         raw_envelope: &str,
+        reason: &str,
+        attempts: u64,
     ) -> Result<(), SubscribeFailed> {
         let dlq = format!("{stream}:dlq");
+        let failure_reason = truncate_failure_reason(reason);
+        log::warn!(
+            "service={} stream={} eventId={} failureReason={} moving message to DLQ",
+            group,
+            stream,
+            event_id_for_log(raw_envelope),
+            failure_reason
+        );
         let _: String = redis::cmd("XADD")
             .arg(dlq)
             .arg("MAXLEN")
@@ -965,10 +1003,43 @@ pub mod redis_runtime {
             .arg("*")
             .arg("envelope")
             .arg(raw_envelope)
+            .arg(dlq_metadata_fields(
+                group,
+                consumer_name,
+                &failure_reason,
+                attempts,
+                &crate::messaging::now_rfc3339_utc(),
+            ))
             .query_async(&mut *connection)
             .await
             .map_err(|error| SubscribeFailed(error.to_string()))?;
         ack(connection, stream, group, id).await
+    }
+
+    fn truncate_failure_reason(reason: &str) -> String {
+        reason.chars().take(500).collect()
+    }
+
+    fn event_id_for_log(raw_envelope: &str) -> String {
+        serde_json::from_str::<EventEnvelope>(raw_envelope)
+            .map(|envelope| envelope.event_id)
+            .unwrap_or_else(|_| "unknown".to_string())
+    }
+
+    fn dlq_metadata_fields(
+        group: &str,
+        consumer_name: &str,
+        failure_reason: &str,
+        attempts: u64,
+        dead_lettered_at: &str,
+    ) -> Vec<(&'static str, String)> {
+        vec![
+            ("consumerGroup", group.to_string()),
+            ("consumerName", consumer_name.to_string()),
+            ("failureReason", failure_reason.to_string()),
+            ("attempts", attempts.max(1).to_string()),
+            ("deadLetteredAt", dead_lettered_at.to_string()),
+        ]
     }
     fn redis_value_to_string(value: &redis::Value) -> Option<String> {
         match value {
@@ -991,6 +1062,27 @@ pub mod redis_runtime {
                 redis::Value::Int(5),
             ])]);
             assert_eq!(parse_xpending_delivery_count(value), Some(5));
+        }
+
+        #[test]
+        fn dlq_metadata_fields_are_camel_case_and_attributed() {
+            let fields = dlq_metadata_fields(
+                "capacity-availability",
+                "capacity-availability-1",
+                "Fatal: missing segmentRef",
+                0,
+                "2026-07-07T12:00:00.000Z",
+            );
+            assert_eq!(
+                fields,
+                vec![
+                    ("consumerGroup", "capacity-availability".to_string()),
+                    ("consumerName", "capacity-availability-1".to_string()),
+                    ("failureReason", "Fatal: missing segmentRef".to_string()),
+                    ("attempts", "1".to_string()),
+                    ("deadLetteredAt", "2026-07-07T12:00:00.000Z".to_string()),
+                ]
+            );
         }
 
         #[tokio::test]

--- a/platform/ts-kit/src/messaging.test.ts
+++ b/platform/ts-kit/src/messaging.test.ts
@@ -65,10 +65,36 @@ describe("EventEnvelope factory", () => {
       /cmd- or evt-|cmd-/,
     );
   });
+
+
 });
 
 
 describe("RedisEventSubscriber DLQ observability", () => {
+
+  it("uses pending delivery count as DLQ attempts for claimed poison entries", async () => {
+    const xadds: unknown[][] = [];
+    const redis = {
+      xadd: async (...args: unknown[]) => { xadds.push(args); return "2-1"; },
+      xack: async () => 1,
+      xautoclaim: async () => ["0-0", [["2-0", ["envelope", JSON.stringify(createEventEnvelope({ eventType: "Poisoned", producer: "ts-kit-test", payload: {} }))]]]],
+      xpending: async () => [["2-0", "consumer-old", 10_000, 3]],
+    };
+    const subscriber = new RedisEventSubscriber(redis as never);
+    const originalWarn = console.warn;
+    console.warn = () => undefined;
+    try {
+      await (subscriber as unknown as { claimAndProcess: (stream: string, group: string, consumerName: string, handler: () => unknown) => Promise<void> })
+        .claimAndProcess("events:ts-kit-test", "ts-kit", "consumer-a", () => { throw new HandlerError("fatal", "bad payload"); });
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    const args = xadds[0];
+    assert.equal(args[13], "attempts");
+    assert.equal(args[14], "3");
+  });
+
   it("adds attribution metadata and warns when dead-lettering fatal handler errors", async () => {
     const xadds: unknown[][] = [];
     const xacks: unknown[][] = [];

--- a/platform/ts-kit/src/messaging.test.ts
+++ b/platform/ts-kit/src/messaging.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { createEventEnvelope } from "./messaging.js";
+import { createEventEnvelope, HandlerError, RedisEventSubscriber } from "./messaging.js";
 import { isPrefixedUuidV7, newCommandId, newCorrelationId, newEventId } from "./ids.js";
 
 describe("EventEnvelope factory", () => {
@@ -64,5 +64,51 @@ describe("EventEnvelope factory", () => {
       }),
       /cmd- or evt-|cmd-/,
     );
+  });
+});
+
+
+describe("RedisEventSubscriber DLQ observability", () => {
+  it("adds attribution metadata and warns when dead-lettering fatal handler errors", async () => {
+    const xadds: unknown[][] = [];
+    const xacks: unknown[][] = [];
+    const redis = {
+      xadd: async (...args: unknown[]) => { xadds.push(args); return "1-1"; },
+      xack: async (...args: unknown[]) => { xacks.push(args); return 1; },
+    };
+    const subscriber = new RedisEventSubscriber(redis as never);
+    const envelope = createEventEnvelope({ eventType: "Poisoned", producer: "ts-kit-test", payload: {} });
+    const entry: [string, string[]] = ["1-0", ["envelope", JSON.stringify(envelope)]];
+    const warnings: unknown[] = [];
+    const originalWarn = console.warn;
+    console.warn = (value?: unknown) => { warnings.push(value); };
+    try {
+      await (subscriber as unknown as { processEntry: (stream: string, group: string, consumerName: string, entry: [string, string[]], handler: () => unknown) => Promise<void> })
+        .processEntry("events:ts-kit-test", "ts-kit", "consumer-a", entry, () => { throw new HandlerError("fatal", "bad payload"); });
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    const args = xadds[0];
+    assert.equal(args[0], "events:ts-kit-test:dlq");
+    assert.equal(args[5], "envelope");
+    assert.equal(args[7], "consumerGroup");
+    assert.equal(args[8], "ts-kit");
+    assert.equal(args[9], "consumerName");
+    assert.equal(args[10], "consumer-a");
+    assert.equal(args[11], "failureReason");
+    assert.equal(args[12], "HandlerError: bad payload");
+    assert.equal(args[13], "attempts");
+    assert.equal(args[14], "1");
+    assert.equal(args[15], "deadLetteredAt");
+    assert.equal(typeof args[16], "string");
+    assert.equal(xacks.length, 1);
+    assert.deepEqual(warnings[0], {
+      service: "ts-kit",
+      stream: "events:ts-kit-test",
+      eventId: envelope.eventId,
+      failureReason: "HandlerError: bad payload",
+      message: "moving message to DLQ",
+    });
   });
 });

--- a/platform/ts-kit/src/messaging.ts
+++ b/platform/ts-kit/src/messaging.ts
@@ -355,7 +355,7 @@ export class RedisEventSubscriber implements EventSubscriber {
           ...streams,
           ...streams.map(() => ">"),
         ) as StreamMessages[] | null;
-        await this.processMessages(messages, group, handler);
+        await this.processMessages(messages, group, consumerName, handler);
       } catch (error) {
         // Non-persistent redis loses consumer groups on restart; recreate then back off so a dead connection never hot-spins.
         if (String(error).includes("NOGROUP")) {
@@ -383,27 +383,27 @@ export class RedisEventSubscriber implements EventSubscriber {
     }
   }
 
-  private async processMessages(messages: StreamMessages[] | null, group: string, handler: EventHandler): Promise<void> {
+  private async processMessages(messages: StreamMessages[] | null, group: string, consumerName: string, handler: EventHandler): Promise<void> {
     for (const [stream, entries] of messages ?? []) {
       for (const entry of entries) {
-        await this.processEntry(stream, group, entry, handler);
+        await this.processEntry(stream, group, consumerName, entry, handler);
       }
     }
   }
 
-  private async processEntry(stream: string, group: string, entry: StreamEntry, handler: EventHandler): Promise<void> {
+  private async processEntry(stream: string, group: string, consumerName: string, entry: StreamEntry, handler: EventHandler): Promise<void> {
     const [entryId, fields] = entry;
     const envelopeJson = fieldValue(fields, "envelope");
     if (!envelopeJson) {
-      await this.deadLetterAndAck(stream, group, entry);
+      await this.deadLetterAndAck(stream, group, consumerName, entry, "MissingEnvelope", 1);
       return;
     }
 
     let envelope: EventEnvelope;
     try {
       envelope = JSON.parse(envelopeJson) as EventEnvelope;
-    } catch {
-      await this.deadLetterAndAck(stream, group, entry);
+    } catch (error) {
+      await this.deadLetterAndAck(stream, group, consumerName, entry, error, 1);
       return;
     }
 
@@ -413,14 +413,17 @@ export class RedisEventSubscriber implements EventSubscriber {
     }
 
     let result: "ack" | "retry" | "dlq";
+    let failureReason: unknown = "HandlerResult.dlq";
     try {
       const rawResult = await handler(envelope);
       result = rawResult === undefined ? "ack" : normalizeHandlerResult(rawResult);
+      failureReason = failureReasonFromHandlerResult(rawResult);
     } catch (error) {
       console.error(sanitizedErrorForLog(error));
       result = error instanceof HandlerError
         ? (error.kind === "fatal" ? "dlq" : "retry")
         : (this.options.thrownHandlerErrors === "retry" ? "retry" : "dlq");
+      failureReason = error;
     }
 
     if (result === "ack") {
@@ -429,7 +432,7 @@ export class RedisEventSubscriber implements EventSubscriber {
       return;
     }
     if (result === "dlq") {
-      await this.deadLetterAndAck(stream, group, entry);
+      await this.deadLetterAndAck(stream, group, consumerName, entry, failureReason, 1);
     }
   }
 
@@ -439,9 +442,9 @@ export class RedisEventSubscriber implements EventSubscriber {
     const deliveryCounts = await this.deliveryCounts(stream, group, entries.map(([entryId]) => entryId));
     for (const entry of entries) {
       if ((deliveryCounts.get(entry[0]) ?? 1) >= MAX_DELIVERIES) {
-        await this.deadLetterAndAck(stream, group, entry);
+        await this.deadLetterAndAck(stream, group, consumerName, entry, "MaxDeliveries", deliveryCounts.get(entry[0]) ?? MAX_DELIVERIES);
       } else {
-        await this.processEntry(stream, group, entry, handler);
+        await this.processEntry(stream, group, consumerName, entry, handler);
       }
     }
   }
@@ -459,9 +462,35 @@ export class RedisEventSubscriber implements EventSubscriber {
     return counts;
   }
 
-  private async deadLetterAndAck(stream: string, group: string, entry: StreamEntry): Promise<void> {
+  private async deadLetterAndAck(stream: string, group: string, consumerName: string, entry: StreamEntry, reason: unknown, attempts: number): Promise<void> {
     const envelopeJson = fieldValue(entry[1], "envelope") ?? JSON.stringify({});
-    await this.redis.xadd(dlqForStream(stream), "MAXLEN", "~", STREAM_MAXLEN, "*", "envelope", envelopeJson);
+    const failureReason = truncateFailureReason(reason);
+    console.warn({
+      service: group,
+      stream,
+      eventId: eventIdForLog(envelopeJson),
+      failureReason,
+      message: "moving message to DLQ",
+    });
+    await this.redis.xadd(
+      dlqForStream(stream),
+      "MAXLEN",
+      "~",
+      STREAM_MAXLEN,
+      "*",
+      "envelope",
+      envelopeJson,
+      "consumerGroup",
+      group,
+      "consumerName",
+      consumerName,
+      "failureReason",
+      failureReason,
+      "attempts",
+      String(Math.max(1, attempts)),
+      "deadLetteredAt",
+      new Date().toISOString(),
+    );
     await this.redis.xack(stream, group, entry[0]);
   }
 
@@ -522,6 +551,22 @@ export function redisUrl(): string {
   return process.env.REDIS_URL ?? "redis://localhost:6379";
 }
 
+function truncateFailureReason(reason: unknown): string {
+  const text = reason instanceof Error
+    ? `${reason.name || "Error"}: ${reason.message || "Handler failed"}`
+    : String(reason || "unknown");
+  return text.length > 500 ? text.slice(0, 500) : text;
+}
+
+function eventIdForLog(envelopeJson: string): string {
+  try {
+    const envelope = JSON.parse(envelopeJson) as { eventId?: unknown };
+    return typeof envelope.eventId === "string" ? envelope.eventId : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
 function isRecoverableRedisReadError(error: unknown): boolean {
   const message = String(error);
   return message.includes("NOGROUP") || message.includes("Connection is closed") || message.includes("Connection is not established") || message.includes("ECONNREFUSED") || message.includes("ETIMEDOUT") || message.includes("READONLY") || message.includes("LOADING");
@@ -547,6 +592,19 @@ function normalizeHandlerResult(result: EventHandlerResult | StringHandlerResult
 
 function handlerSucceeded(result: EventHandlerResult | StringHandlerResult): boolean {
   return normalizeHandlerResult(result) === "ack";
+}
+
+function failureReasonFromHandlerResult(result: EventHandlerResult | StringHandlerResult | undefined): unknown {
+  if (result === undefined || result === "ack" || result === "retry") {
+    return "HandlerResult.dlq";
+  }
+  if (result === "dlq") {
+    return "HandlerResult.dlq";
+  }
+  if (!result.ok) {
+    return result.error ?? `HandlerResult.${result.kind ?? result.errorType ?? "transient"}`;
+  }
+  return "HandlerResult.dlq";
 }
 
 function occurredAt(value: Date | string | undefined): string {

--- a/platform/ts-kit/src/messaging.ts
+++ b/platform/ts-kit/src/messaging.ts
@@ -391,11 +391,12 @@ export class RedisEventSubscriber implements EventSubscriber {
     }
   }
 
-  private async processEntry(stream: string, group: string, consumerName: string, entry: StreamEntry, handler: EventHandler): Promise<void> {
+  private async processEntry(stream: string, group: string, consumerName: string, entry: StreamEntry, handler: EventHandler, deliveryAttempts = 1): Promise<void> {
     const [entryId, fields] = entry;
+    const attempts = Math.max(1, deliveryAttempts);
     const envelopeJson = fieldValue(fields, "envelope");
     if (!envelopeJson) {
-      await this.deadLetterAndAck(stream, group, consumerName, entry, "MissingEnvelope", 1);
+      await this.deadLetterAndAck(stream, group, consumerName, entry, "MissingEnvelope", attempts);
       return;
     }
 
@@ -403,7 +404,7 @@ export class RedisEventSubscriber implements EventSubscriber {
     try {
       envelope = JSON.parse(envelopeJson) as EventEnvelope;
     } catch (error) {
-      await this.deadLetterAndAck(stream, group, consumerName, entry, error, 1);
+      await this.deadLetterAndAck(stream, group, consumerName, entry, error, attempts);
       return;
     }
 
@@ -419,7 +420,6 @@ export class RedisEventSubscriber implements EventSubscriber {
       result = rawResult === undefined ? "ack" : normalizeHandlerResult(rawResult);
       failureReason = failureReasonFromHandlerResult(rawResult);
     } catch (error) {
-      console.error(sanitizedErrorForLog(error));
       result = error instanceof HandlerError
         ? (error.kind === "fatal" ? "dlq" : "retry")
         : (this.options.thrownHandlerErrors === "retry" ? "retry" : "dlq");
@@ -432,7 +432,7 @@ export class RedisEventSubscriber implements EventSubscriber {
       return;
     }
     if (result === "dlq") {
-      await this.deadLetterAndAck(stream, group, consumerName, entry, failureReason, 1);
+      await this.deadLetterAndAck(stream, group, consumerName, entry, failureReason, attempts);
     }
   }
 
@@ -444,7 +444,7 @@ export class RedisEventSubscriber implements EventSubscriber {
       if ((deliveryCounts.get(entry[0]) ?? 1) >= MAX_DELIVERIES) {
         await this.deadLetterAndAck(stream, group, consumerName, entry, "MaxDeliveries", deliveryCounts.get(entry[0]) ?? MAX_DELIVERIES);
       } else {
-        await this.processEntry(stream, group, consumerName, entry, handler);
+        await this.processEntry(stream, group, consumerName, entry, handler, deliveryCounts.get(entry[0]) ?? 1);
       }
     }
   }

--- a/services/capacity-availability/src/adapters/storage/mod.rs
+++ b/services/capacity-availability/src/adapters/storage/mod.rs
@@ -605,9 +605,8 @@ impl PostgresCapacityService {
             "SegmentReservationConfirmed" => {
                 self.handle_segment_reservation_confirmed(envelope).await
             }
-            "SegmentBookingCancelled" | "PostSalesApplied" => {
-                self.handle_release_requested(envelope).await
-            }
+            "SegmentBookingCancelled" => self.handle_release_requested(envelope).await,
+            "PostSalesApplied" => self.handle_post_sales_applied(envelope).await,
             "EntitlementVoided" => self.handle_entitlement_voided(envelope).await,
             _ => Ok(()),
         };
@@ -631,8 +630,9 @@ impl PostgresCapacityService {
         let Some(traveler_ref) = string_field(&envelope.payload, "travelerRef") else {
             return Err(InboundEventError::Fatal("missing travelerRef".into()));
         };
-        let idempotency_key = string_field(&envelope.payload, "idempotencyKey")
-            .unwrap_or_else(|| format!("{}:{}:hold", envelope.event_id, segment_booking_id));
+        let Some(idempotency_key) = string_field(&envelope.payload, "idempotencyKey") else {
+            return Err(InboundEventError::Fatal("missing idempotencyKey".into()));
+        };
         let request = HoldCapacityRequest {
             segment_ref,
             traveler_ref,
@@ -845,6 +845,29 @@ impl PostgresCapacityService {
                 hold_id: hold_id.clone(),
                 status: "RELEASED".to_string(),
             },
+        )
+        .await
+    }
+
+    async fn handle_post_sales_applied(
+        &self,
+        envelope: WireEnvelope,
+    ) -> Result<(), InboundEventError> {
+        let Some(segment_booking_ref) = post_sales_release_ref(&envelope.payload) else {
+            return Ok(());
+        };
+        let idempotency_key = format!(
+            "{}:{}:post-sales-applied-release",
+            envelope.event_id, segment_booking_ref
+        );
+        let fingerprint =
+            format!("release-by-segment-booking:{segment_booking_ref}:post-sales-applied");
+        self.handle_inbound_segment_booking_release(
+            envelope,
+            &segment_booking_ref,
+            &idempotency_key,
+            &fingerprint,
+            "post-sales-applied",
         )
         .await
     }
@@ -1545,6 +1568,29 @@ fn segment_booking_ref_from_entitlement_voided(value: &Value) -> Option<String> 
         .get("references")
         .and_then(|references| string_field(references, "segmentBookingRef"))
         .or_else(|| string_field(value, "segmentBookingId"))
+}
+
+fn post_sales_release_ref(value: &Value) -> Option<String> {
+    value
+        .get("references")
+        .and_then(|references| {
+            string_field(references, "segmentBookingRef")
+                .or_else(|| string_field(references, "segmentBookingId"))
+                .or_else(|| string_field(references, "capacityHoldId"))
+                .or_else(|| string_field(references, "holdId"))
+        })
+        .or_else(|| {
+            value.get("scope").and_then(|scope| {
+                string_field(scope, "segmentBookingRef")
+                    .or_else(|| string_field(scope, "segmentBookingId"))
+                    .or_else(|| string_field(scope, "capacityHoldId"))
+                    .or_else(|| string_field(scope, "holdId"))
+            })
+        })
+        .or_else(|| string_field(value, "segmentBookingRef"))
+        .or_else(|| string_field(value, "segmentBookingId"))
+        .or_else(|| string_field(value, "capacityHoldId"))
+        .or_else(|| string_field(value, "holdId"))
 }
 
 fn now_millis() -> u64 {

--- a/services/capacity-availability/src/adapters/storage/mod.rs
+++ b/services/capacity-availability/src/adapters/storage/mod.rs
@@ -824,9 +824,6 @@ impl PostgresCapacityService {
         let Some(segment_booking_ref) = string_field(&envelope.payload, "segmentBookingId") else {
             return Err(InboundEventError::Fatal("missing segmentBookingId".into()));
         };
-        let Some(_) = string_field(&envelope.payload, "providerReference") else {
-            return Err(InboundEventError::Fatal("missing providerReference".into()));
-        };
         let Some(_) = string_field(&envelope.payload, "evidence") else {
             return Err(InboundEventError::Fatal("missing evidence".into()));
         };

--- a/services/capacity-availability/src/adapters/storage/mod.rs
+++ b/services/capacity-availability/src/adapters/storage/mod.rs
@@ -597,6 +597,28 @@ impl PostgresCapacityService {
         .transpose()
     }
 
+    async fn find_confirmable_hold_by_segment_booking(
+        &self,
+        tx: &mut PgTransaction<'_>,
+        segment_booking_ref: &str,
+    ) -> Result<Option<Snapshot<CapacityHoldSnapshot>>, StorageError> {
+        let sql = format!(
+            "SELECT id, version, data FROM {HOLD_TABLE} WHERE data #>> '{{references,segmentBookingRef}}' = $1 AND data ->> 'state' = 'Held' ORDER BY updated_at DESC LIMIT 1"
+        );
+        let row: Option<(String, i64, Value)> = sqlx::query_as(&sql)
+            .bind(segment_booking_ref)
+            .fetch_optional(&mut **tx)
+            .await?;
+        row.map(|(id, version, data)| {
+            Ok(Snapshot {
+                id,
+                version,
+                data: serde_json::from_value(data)?,
+            })
+        })
+        .transpose()
+    }
+
     pub async fn handle_inbound_event(&self, envelope: WireEnvelope) -> HandlerResult {
         let result = match envelope.event_type.as_str() {
             "SegmentReservationRequested" => {
@@ -795,26 +817,149 @@ impl PostgresCapacityService {
         &self,
         envelope: WireEnvelope,
     ) -> Result<(), InboundEventError> {
-        let Some(hold_id) = string_field(&envelope.payload, "capacityHoldId") else {
-            return Err(InboundEventError::Fatal("missing capacityHoldId".into()));
+        let Some(segment_booking_ref) = string_field(&envelope.payload, "segmentBookingId") else {
+            return Err(InboundEventError::Fatal("missing segmentBookingId".into()));
         };
-        let idempotency_key = format!("{}:{}:confirm", envelope.event_id, hold_id);
-        self.handle_inbound_hold_mutation(
+        let idempotency_key = format!("{}:{}:confirm", envelope.event_id, segment_booking_ref);
+        let fingerprint = format!("confirm-by-segment-booking:{segment_booking_ref}");
+        self.handle_inbound_segment_booking_confirm(
             envelope,
-            &hold_id,
+            &segment_booking_ref,
             &idempotency_key,
-            &format!("confirm:{hold_id}"),
-            200,
-            |pool, now| {
-                pool.confirm_hold(&HoldId::new(&hold_id).map_err(to_internal)?, now)
-                    .map_err(map_hold_mutation_error)
-            },
-            |_| ConfirmHoldResponse {
-                hold_id: hold_id.clone(),
-                status: "CONFIRMED".to_string(),
-            },
+            &fingerprint,
         )
         .await
+    }
+
+    async fn handle_inbound_segment_booking_confirm(
+        &self,
+        envelope: WireEnvelope,
+        segment_booking_ref: &str,
+        idempotency_key: &str,
+        fingerprint: &str,
+    ) -> Result<(), InboundEventError> {
+        let stream = stream_for_producer(&envelope.producer);
+        for attempt in 0..MAX_RETRIES {
+            let result = self
+                .try_handle_inbound_segment_booking_confirm(
+                    &envelope,
+                    &stream,
+                    segment_booking_ref,
+                    idempotency_key,
+                    fingerprint,
+                )
+                .await;
+            match result {
+                Err(InboundEventError::Transient(message))
+                    if message.contains("optimistic concurrency conflict")
+                        && attempt + 1 < MAX_RETRIES =>
+                {
+                    continue;
+                }
+                result => return result,
+            }
+        }
+        Err(InboundEventError::Transient(
+            "capacity hold write conflict".into(),
+        ))
+    }
+
+    async fn try_handle_inbound_segment_booking_confirm(
+        &self,
+        envelope: &WireEnvelope,
+        stream: &str,
+        segment_booking_ref: &str,
+        idempotency_key: &str,
+        fingerprint: &str,
+    ) -> Result<(), InboundEventError> {
+        let mut tx = self.pool().begin().await.map_err(inbound_transient)?;
+        if !mark_event_processing(&mut tx, &envelope.event_id, stream)
+            .await
+            .map_err(inbound_transient)?
+        {
+            tx.rollback().await.map_err(inbound_transient)?;
+            return Ok(());
+        }
+        let Some(hold_snapshot) = self
+            .find_confirmable_hold_by_segment_booking(&mut tx, segment_booking_ref)
+            .await
+            .map_err(inbound_transient)?
+        else {
+            tx.commit().await.map_err(inbound_transient)?;
+            return Ok(());
+        };
+        if self
+            .claim_idempotency::<ConfirmHoldResponse>(&mut tx, idempotency_key, fingerprint)
+            .await
+            .map_err(inbound_from_app_error)?
+            .is_some()
+        {
+            tx.commit().await.map_err(inbound_transient)?;
+            return Ok(());
+        }
+        let hold_id = hold_snapshot.id.clone();
+        let pool_id = hold_snapshot.data.inventory_pool_id.clone();
+        let Some(loaded_pool) = self
+            .inventory_repo
+            .get::<InventoryPoolSnapshot>(&mut *tx, &pool_id)
+            .await
+            .map_err(inbound_transient)?
+        else {
+            tx.commit().await.map_err(inbound_transient)?;
+            return Ok(());
+        };
+        let mut pool = loaded_pool
+            .data
+            .try_into_domain()
+            .map_err(inbound_from_app_error)?;
+        let hold_id_value = HoldId::new(&hold_id).map_err(inbound_fatal)?;
+        let Some(current_hold) = pool.hold(&hold_id_value) else {
+            tx.commit().await.map_err(inbound_transient)?;
+            return Ok(());
+        };
+        if !matches!(current_hold.state, CapacityHoldState::Held) {
+            tx.commit().await.map_err(inbound_transient)?;
+            return Ok(());
+        }
+        let event = pool
+            .confirm_hold(&hold_id_value, now_millis())
+            .map_err(map_hold_mutation_error)
+            .map_err(inbound_from_app_error)?;
+        let outbound = domain_event_to_wire(&event, &envelope.correlation_id)
+            .map_err(inbound_from_app_error)?;
+        self.inventory_repo
+            .save(
+                &mut tx,
+                &pool_id,
+                Some(loaded_pool.version),
+                &InventoryPoolSnapshot::from_domain(&pool),
+            )
+            .await
+            .map_err(inbound_transient)?;
+        let hold = pool
+            .hold(&hold_id_value)
+            .ok_or_else(|| InboundEventError::Fatal("hold not found".into()))?;
+        self.upsert_hold_snapshot(&mut tx, &hold_id, hold)
+            .await
+            .map_err(inbound_from_app_error)?;
+        OutboxAppender::append(&mut tx, &stream_for_producer(PRODUCER), &outbound)
+            .await
+            .map_err(inbound_transient)?;
+        let resp = ConfirmHoldResponse {
+            hold_id,
+            status: "CONFIRMED".to_string(),
+        };
+        self.finish_idempotency(
+            &mut tx,
+            idempotency_key,
+            fingerprint,
+            200,
+            serde_json::to_value(&resp).map_err(inbound_transient)?,
+        )
+        .await
+        .map_err(inbound_from_app_error)?;
+        tx.commit().await.map_err(inbound_transient)?;
+        Ok(())
     }
 
     async fn handle_release_requested(

--- a/services/capacity-availability/src/adapters/storage/mod.rs
+++ b/services/capacity-availability/src/adapters/storage/mod.rs
@@ -623,7 +623,7 @@ impl PostgresCapacityService {
         envelope: WireEnvelope,
     ) -> Result<(), InboundEventError> {
         let Some(segment_booking_id) = string_field(&envelope.payload, "segmentBookingId") else {
-            return Ok(());
+            return Err(InboundEventError::Fatal("missing segmentBookingId".into()));
         };
         let Some(segment_ref) = string_field(&envelope.payload, "segmentRef") else {
             return Err(InboundEventError::Fatal("missing segmentRef".into()));
@@ -796,7 +796,7 @@ impl PostgresCapacityService {
         envelope: WireEnvelope,
     ) -> Result<(), InboundEventError> {
         let Some(hold_id) = string_field(&envelope.payload, "capacityHoldId") else {
-            return Ok(());
+            return Err(InboundEventError::Fatal("missing capacityHoldId".into()));
         };
         let idempotency_key = format!("{}:{}:confirm", envelope.event_id, hold_id);
         self.handle_inbound_hold_mutation(
@@ -824,7 +824,7 @@ impl PostgresCapacityService {
         let Some(hold_id) = string_field(&envelope.payload, "capacityHoldId")
             .or_else(|| string_field(&envelope.payload, "holdId"))
         else {
-            return Ok(());
+            return Err(InboundEventError::Fatal("missing capacityHoldId".into()));
         };
         let idempotency_key = format!("{}:{}:release", envelope.event_id, hold_id);
         self.handle_inbound_hold_mutation(
@@ -856,7 +856,7 @@ impl PostgresCapacityService {
         let Some(segment_booking_ref) =
             segment_booking_ref_from_entitlement_voided(&envelope.payload)
         else {
-            return Ok(());
+            return Err(InboundEventError::Fatal("missing segmentBookingRef".into()));
         };
         let idempotency_key = format!(
             "{}:{}:entitlement-voided-release",
@@ -1170,9 +1170,12 @@ fn inbound_fatal(error: impl std::fmt::Display) -> InboundEventError {
 
 fn inbound_from_app_error(error: AppError) -> InboundEventError {
     match error {
-        AppError::Unavailable(message)
-        | AppError::Internal(message)
-        | AppError::Conflict(message) => InboundEventError::Transient(message),
+        AppError::Unavailable(message) | AppError::Internal(message) => {
+            InboundEventError::Transient(message)
+        }
+        AppError::Conflict(message) if message.contains("optimistic concurrency conflict") => {
+            InboundEventError::Transient(message)
+        }
         error => InboundEventError::Fatal(error.message().to_string()),
     }
 }
@@ -1511,7 +1514,7 @@ fn to_app_storage(error: impl std::fmt::Display) -> AppError {
     let message = error.to_string();
     if message.contains("optimistic concurrency conflict") {
         AppError::Conflict(message)
-    } else if message == "IDEMPOTENCY_KEY_REUSED" {
+    } else if message == "IDEMPOTENCY_KEY_REUSED" || message.contains("IDEMPOTENCY_KEY_REUSED") {
         AppError::IdempotencyKeyReused(
             "Idempotency-Key was reused with a different request body".into(),
         )

--- a/services/capacity-availability/src/adapters/storage/mod.rs
+++ b/services/capacity-availability/src/adapters/storage/mod.rs
@@ -627,7 +627,8 @@ impl PostgresCapacityService {
             "SegmentReservationConfirmed" => {
                 self.handle_segment_reservation_confirmed(envelope).await
             }
-            "SegmentBookingCancelled" => self.handle_release_requested(envelope).await,
+            "SegmentBookingCancelled" => self.handle_segment_booking_cancelled(envelope).await,
+            "SegmentTicketed" => self.handle_segment_ticketed(envelope).await,
             "PostSalesApplied" => self.handle_post_sales_applied(envelope).await,
             "EntitlementVoided" => self.handle_entitlement_voided(envelope).await,
             _ => Ok(()),
@@ -651,6 +652,9 @@ impl PostgresCapacityService {
         };
         let Some(traveler_ref) = string_field(&envelope.payload, "travelerRef") else {
             return Err(InboundEventError::Fatal("missing travelerRef".into()));
+        };
+        let Some(_) = string_field(&envelope.payload, "journeyOrderId") else {
+            return Err(InboundEventError::Fatal("missing journeyOrderId".into()));
         };
         let Some(idempotency_key) = string_field(&envelope.payload, "idempotencyKey") else {
             return Err(InboundEventError::Fatal("missing idempotencyKey".into()));
@@ -820,6 +824,12 @@ impl PostgresCapacityService {
         let Some(segment_booking_ref) = string_field(&envelope.payload, "segmentBookingId") else {
             return Err(InboundEventError::Fatal("missing segmentBookingId".into()));
         };
+        let Some(_) = string_field(&envelope.payload, "providerReference") else {
+            return Err(InboundEventError::Fatal("missing providerReference".into()));
+        };
+        let Some(_) = string_field(&envelope.payload, "evidence") else {
+            return Err(InboundEventError::Fatal("missing evidence".into()));
+        };
         let idempotency_key = format!("{}:{}:confirm", envelope.event_id, segment_booking_ref);
         let fingerprint = format!("confirm-by-segment-booking:{segment_booking_ref}");
         self.handle_inbound_segment_booking_confirm(
@@ -962,42 +972,60 @@ impl PostgresCapacityService {
         Ok(())
     }
 
-    async fn handle_release_requested(
+    async fn handle_segment_booking_cancelled(
         &self,
         envelope: WireEnvelope,
     ) -> Result<(), InboundEventError> {
-        let Some(hold_id) = string_field(&envelope.payload, "capacityHoldId")
-            .or_else(|| string_field(&envelope.payload, "holdId"))
-        else {
-            return Err(InboundEventError::Fatal("missing capacityHoldId".into()));
+        let Some(segment_booking_ref) = string_field(&envelope.payload, "segmentBookingId") else {
+            return Err(InboundEventError::Fatal("missing segmentBookingId".into()));
         };
-        let idempotency_key = format!("{}:{}:release", envelope.event_id, hold_id);
-        self.handle_inbound_hold_mutation(
+        let Some(_) = string_field(&envelope.payload, "reason") else {
+            return Err(InboundEventError::Fatal("missing reason".into()));
+        };
+        let idempotency_key = format!(
+            "{}:{}:segment-booking-cancelled-release",
+            envelope.event_id, segment_booking_ref
+        );
+        let fingerprint =
+            format!("release-by-segment-booking:{segment_booking_ref}:segment-booking-cancelled");
+        self.handle_inbound_segment_booking_release(
             envelope,
-            &hold_id,
+            &segment_booking_ref,
             &idempotency_key,
-            &format!("release:{hold_id}"),
-            200,
-            |pool, now| {
-                pool.release_hold(
-                    &HoldId::new(&hold_id).map_err(to_internal)?,
-                    now,
-                    "client-requested-release",
-                )
-                .map_err(map_hold_mutation_error)
-            },
-            |_| ReleaseHoldResponse {
-                hold_id: hold_id.clone(),
-                status: "RELEASED".to_string(),
-            },
+            &fingerprint,
+            "segment-booking-cancelled",
         )
         .await
+    }
+
+    async fn handle_segment_ticketed(
+        &self,
+        envelope: WireEnvelope,
+    ) -> Result<(), InboundEventError> {
+        for field in ["segmentBookingId", "entitlementId"] {
+            if string_field(&envelope.payload, field).is_none() {
+                return Err(InboundEventError::Fatal(format!("missing {field}")));
+            }
+        }
+        Ok(())
     }
 
     async fn handle_post_sales_applied(
         &self,
         envelope: WireEnvelope,
     ) -> Result<(), InboundEventError> {
+        for field in ["caseId", "orderId"] {
+            if string_field(&envelope.payload, field).is_none() {
+                return Err(InboundEventError::Fatal(format!("missing {field}")));
+            }
+        }
+        if envelope
+            .payload
+            .get("resultSummary")
+            .is_none_or(Value::is_null)
+        {
+            return Err(InboundEventError::Fatal("missing resultSummary".into()));
+        }
         let Some(segment_booking_ref) = post_sales_release_ref(&envelope.payload) else {
             return Ok(());
         };
@@ -1026,6 +1054,11 @@ impl PostgresCapacityService {
         else {
             return Err(InboundEventError::Fatal("missing segmentBookingRef".into()));
         };
+        for field in ["entitlementId", "voidedAt", "reason", "policy"] {
+            if string_field(&envelope.payload, field).is_none() {
+                return Err(InboundEventError::Fatal(format!("missing {field}")));
+            }
+        }
         let idempotency_key = format!(
             "{}:{}:entitlement-voided-release",
             envelope.event_id, segment_booking_ref
@@ -1179,6 +1212,7 @@ impl PostgresCapacityService {
         Ok(())
     }
 
+    #[allow(dead_code)]
     async fn handle_inbound_hold_mutation<T, M, R>(
         &self,
         envelope: WireEnvelope,
@@ -1223,6 +1257,7 @@ impl PostgresCapacityService {
         ))
     }
 
+    #[allow(dead_code)]
     async fn try_handle_inbound_hold_mutation<T, M, R>(
         &self,
         envelope: &WireEnvelope,

--- a/services/capacity-availability/src/application.rs
+++ b/services/capacity-availability/src/application.rs
@@ -35,7 +35,8 @@ impl CapacityService {
         match envelope.event_type.as_str() {
             "SegmentReservationRequested" => self.handle_segment_reservation_requested(&envelope),
             "SegmentReservationConfirmed" => self.handle_segment_reservation_confirmed(&envelope),
-            "SegmentBookingCancelled" => self.handle_release_trigger(&envelope),
+            "SegmentBookingCancelled" => self.handle_segment_booking_cancelled(&envelope),
+            "SegmentTicketed" => self.handle_segment_ticketed(&envelope),
             "PostSalesApplied" => self.handle_post_sales_applied(&envelope),
             "EntitlementVoided" => self.handle_entitlement_voided(&envelope),
             _ => HandlerResult::Success,
@@ -51,6 +52,9 @@ impl CapacityService {
         };
         let Some(traveler_ref) = string_field(&envelope.payload, "travelerRef") else {
             return HandlerResult::FatalError("missing travelerRef".into());
+        };
+        let Some(_) = string_field(&envelope.payload, "journeyOrderId") else {
+            return HandlerResult::FatalError("missing journeyOrderId".into());
         };
         let Some(idempotency_key) = string_field(&envelope.payload, "idempotencyKey") else {
             return HandlerResult::FatalError("missing idempotencyKey".into());
@@ -78,6 +82,12 @@ impl CapacityService {
         let Some(segment_booking_ref) = string_field(&envelope.payload, "segmentBookingId") else {
             return HandlerResult::FatalError("missing segmentBookingId".into());
         };
+        let Some(_) = string_field(&envelope.payload, "providerReference") else {
+            return HandlerResult::FatalError("missing providerReference".into());
+        };
+        let Some(_) = string_field(&envelope.payload, "evidence") else {
+            return HandlerResult::FatalError("missing evidence".into());
+        };
         let idempotency_key = format!("{}:{}:confirm", envelope.event_id, segment_booking_ref);
         match self.confirm_hold_by_segment_booking(
             &segment_booking_ref,
@@ -94,15 +104,26 @@ impl CapacityService {
         }
     }
 
-    fn handle_release_trigger(&self, envelope: &WireEnvelope) -> HandlerResult {
-        let Some(hold_id) = string_field(&envelope.payload, "capacityHoldId")
-            .or_else(|| string_field(&envelope.payload, "holdId"))
-        else {
-            return HandlerResult::FatalError("missing capacityHoldId".into());
+    fn handle_segment_booking_cancelled(&self, envelope: &WireEnvelope) -> HandlerResult {
+        let Some(segment_booking_ref) = string_field(&envelope.payload, "segmentBookingId") else {
+            return HandlerResult::FatalError("missing segmentBookingId".into());
         };
-        let idempotency_key = format!("{}:{}:release", envelope.event_id, hold_id);
-        match self.release_hold(&hold_id, &idempotency_key, &envelope.correlation_id) {
-            Ok(_) | Err(AppError::NotFound(_)) => HandlerResult::Success,
+        let Some(_) = string_field(&envelope.payload, "reason") else {
+            return HandlerResult::FatalError("missing reason".into());
+        };
+        let idempotency_key = format!(
+            "{}:{}:segment-booking-cancelled-release",
+            envelope.event_id, segment_booking_ref
+        );
+        match self.release_hold_by_segment_booking(
+            &segment_booking_ref,
+            &idempotency_key,
+            &envelope.correlation_id,
+            "segment-booking-cancelled",
+        ) {
+            Ok(_) | Err(AppError::NotFound(_)) | Err(AppError::PreconditionFailed(_)) => {
+                HandlerResult::Success
+            }
             Err(AppError::Unavailable(message)) | Err(AppError::Internal(message)) => {
                 HandlerResult::TransientError(message)
             }
@@ -110,7 +131,28 @@ impl CapacityService {
         }
     }
 
+    fn handle_segment_ticketed(&self, envelope: &WireEnvelope) -> HandlerResult {
+        for field in ["segmentBookingId", "entitlementId"] {
+            if string_field(&envelope.payload, field).is_none() {
+                return HandlerResult::FatalError(format!("missing {field}"));
+            }
+        }
+        HandlerResult::Success
+    }
+
     fn handle_post_sales_applied(&self, envelope: &WireEnvelope) -> HandlerResult {
+        for field in ["caseId", "orderId"] {
+            if string_field(&envelope.payload, field).is_none() {
+                return HandlerResult::FatalError(format!("missing {field}"));
+            }
+        }
+        if envelope
+            .payload
+            .get("resultSummary")
+            .is_none_or(Value::is_null)
+        {
+            return HandlerResult::FatalError("missing resultSummary".into());
+        }
         let Some(segment_booking_ref) = post_sales_release_ref(&envelope.payload) else {
             return HandlerResult::Success;
         };
@@ -140,6 +182,11 @@ impl CapacityService {
         else {
             return HandlerResult::FatalError("missing segmentBookingRef".into());
         };
+        for field in ["entitlementId", "voidedAt", "reason", "policy"] {
+            if string_field(&envelope.payload, field).is_none() {
+                return HandlerResult::FatalError(format!("missing {field}"));
+            }
+        }
         let idempotency_key = format!(
             "{}:{}:entitlement-voided-release",
             envelope.event_id, segment_booking_ref

--- a/services/capacity-availability/src/application.rs
+++ b/services/capacity-availability/src/application.rs
@@ -82,9 +82,6 @@ impl CapacityService {
         let Some(segment_booking_ref) = string_field(&envelope.payload, "segmentBookingId") else {
             return HandlerResult::FatalError("missing segmentBookingId".into());
         };
-        let Some(_) = string_field(&envelope.payload, "providerReference") else {
-            return HandlerResult::FatalError("missing providerReference".into());
-        };
         let Some(_) = string_field(&envelope.payload, "evidence") else {
             return HandlerResult::FatalError("missing evidence".into());
         };

--- a/services/capacity-availability/src/application.rs
+++ b/services/capacity-availability/src/application.rs
@@ -45,7 +45,7 @@ impl CapacityService {
 
     fn handle_segment_reservation_requested(&self, envelope: &WireEnvelope) -> HandlerResult {
         let Some(segment_booking_id) = string_field(&envelope.payload, "segmentBookingId") else {
-            return HandlerResult::Success;
+            return HandlerResult::FatalError("missing segmentBookingId".into());
         };
         let Some(segment_ref) = string_field(&envelope.payload, "segmentRef") else {
             return HandlerResult::FatalError("missing segmentRef".into());
@@ -76,7 +76,7 @@ impl CapacityService {
 
     fn handle_segment_reservation_confirmed(&self, envelope: &WireEnvelope) -> HandlerResult {
         let Some(hold_id) = string_field(&envelope.payload, "capacityHoldId") else {
-            return HandlerResult::Success;
+            return HandlerResult::FatalError("missing capacityHoldId".into());
         };
         let idempotency_key = format!("{}:{}:confirm", envelope.event_id, hold_id);
         match self.confirm_hold(&hold_id, &idempotency_key, &envelope.correlation_id) {
@@ -94,7 +94,7 @@ impl CapacityService {
         let Some(hold_id) = string_field(&envelope.payload, "capacityHoldId")
             .or_else(|| string_field(&envelope.payload, "holdId"))
         else {
-            return HandlerResult::Success;
+            return HandlerResult::FatalError("missing capacityHoldId".into());
         };
         let idempotency_key = format!("{}:{}:release", envelope.event_id, hold_id);
         match self.release_hold(&hold_id, &idempotency_key, &envelope.correlation_id) {
@@ -110,7 +110,7 @@ impl CapacityService {
         let Some(segment_booking_ref) =
             segment_booking_ref_from_entitlement_voided(&envelope.payload)
         else {
-            return HandlerResult::Success;
+            return HandlerResult::FatalError("missing segmentBookingRef".into());
         };
         let idempotency_key = format!(
             "{}:{}:entitlement-voided-release",

--- a/services/capacity-availability/src/application.rs
+++ b/services/capacity-availability/src/application.rs
@@ -75,11 +75,15 @@ impl CapacityService {
     }
 
     fn handle_segment_reservation_confirmed(&self, envelope: &WireEnvelope) -> HandlerResult {
-        let Some(hold_id) = string_field(&envelope.payload, "capacityHoldId") else {
-            return HandlerResult::FatalError("missing capacityHoldId".into());
+        let Some(segment_booking_ref) = string_field(&envelope.payload, "segmentBookingId") else {
+            return HandlerResult::FatalError("missing segmentBookingId".into());
         };
-        let idempotency_key = format!("{}:{}:confirm", envelope.event_id, hold_id);
-        match self.confirm_hold(&hold_id, &idempotency_key, &envelope.correlation_id) {
+        let idempotency_key = format!("{}:{}:confirm", envelope.event_id, segment_booking_ref);
+        match self.confirm_hold_by_segment_booking(
+            &segment_booking_ref,
+            &idempotency_key,
+            &envelope.correlation_id,
+        ) {
             Ok(_) | Err(AppError::PreconditionFailed(_)) | Err(AppError::NotFound(_)) => {
                 HandlerResult::Success
             }
@@ -404,6 +408,33 @@ impl CapacityService {
             }
         }
         Err(AppError::NotFound("hold not found".into()))
+    }
+
+    fn confirm_hold_by_segment_booking(
+        &self,
+        segment_booking_ref: &str,
+        idempotency_key: &str,
+        correlation_id: &str,
+    ) -> Result<ConfirmHoldResponse, AppError> {
+        let hold_id = {
+            let pools = self
+                .pools
+                .lock()
+                .map_err(|e| AppError::Internal(format!("lock error: {}", e)))?;
+            pools
+                .values()
+                .flat_map(|pool| pool.holds())
+                .find(|hold| {
+                    hold.scope.references.segment_booking_ref.as_deref()
+                        == Some(segment_booking_ref)
+                        && matches!(hold.state, CapacityHoldState::Held)
+                })
+                .map(|hold| hold.hold_id.to_string())
+        };
+        let Some(hold_id) = hold_id else {
+            return Err(AppError::NotFound("hold not found".into()));
+        };
+        self.confirm_hold(&hold_id, idempotency_key, correlation_id)
     }
 
     /// Release a hold.

--- a/services/capacity-availability/src/application.rs
+++ b/services/capacity-availability/src/application.rs
@@ -35,9 +35,8 @@ impl CapacityService {
         match envelope.event_type.as_str() {
             "SegmentReservationRequested" => self.handle_segment_reservation_requested(&envelope),
             "SegmentReservationConfirmed" => self.handle_segment_reservation_confirmed(&envelope),
-            "SegmentBookingCancelled" | "PostSalesApplied" => {
-                self.handle_release_trigger(&envelope)
-            }
+            "SegmentBookingCancelled" => self.handle_release_trigger(&envelope),
+            "PostSalesApplied" => self.handle_post_sales_applied(&envelope),
             "EntitlementVoided" => self.handle_entitlement_voided(&envelope),
             _ => HandlerResult::Success,
         }
@@ -53,8 +52,9 @@ impl CapacityService {
         let Some(traveler_ref) = string_field(&envelope.payload, "travelerRef") else {
             return HandlerResult::FatalError("missing travelerRef".into());
         };
-        let idempotency_key = string_field(&envelope.payload, "idempotencyKey")
-            .unwrap_or_else(|| format!("{}:{}:hold", envelope.event_id, segment_booking_id));
+        let Some(idempotency_key) = string_field(&envelope.payload, "idempotencyKey") else {
+            return HandlerResult::FatalError("missing idempotencyKey".into());
+        };
         let request = HoldCapacityRequest {
             segment_ref,
             traveler_ref,
@@ -99,6 +99,30 @@ impl CapacityService {
         let idempotency_key = format!("{}:{}:release", envelope.event_id, hold_id);
         match self.release_hold(&hold_id, &idempotency_key, &envelope.correlation_id) {
             Ok(_) | Err(AppError::NotFound(_)) => HandlerResult::Success,
+            Err(AppError::Unavailable(message)) | Err(AppError::Internal(message)) => {
+                HandlerResult::TransientError(message)
+            }
+            Err(error) => HandlerResult::FatalError(error.message().to_string()),
+        }
+    }
+
+    fn handle_post_sales_applied(&self, envelope: &WireEnvelope) -> HandlerResult {
+        let Some(segment_booking_ref) = post_sales_release_ref(&envelope.payload) else {
+            return HandlerResult::Success;
+        };
+        let idempotency_key = format!(
+            "{}:{}:post-sales-applied-release",
+            envelope.event_id, segment_booking_ref
+        );
+        match self.release_hold_by_segment_booking(
+            &segment_booking_ref,
+            &idempotency_key,
+            &envelope.correlation_id,
+            "post-sales-applied",
+        ) {
+            Ok(_) | Err(AppError::NotFound(_)) | Err(AppError::PreconditionFailed(_)) => {
+                HandlerResult::Success
+            }
             Err(AppError::Unavailable(message)) | Err(AppError::Internal(message)) => {
                 HandlerResult::TransientError(message)
             }
@@ -811,6 +835,29 @@ fn segment_booking_ref_from_entitlement_voided(value: &Value) -> Option<String> 
         .get("references")
         .and_then(|references| string_field(references, "segmentBookingRef"))
         .or_else(|| string_field(value, "segmentBookingId"))
+}
+
+fn post_sales_release_ref(value: &Value) -> Option<String> {
+    value
+        .get("references")
+        .and_then(|references| {
+            string_field(references, "segmentBookingRef")
+                .or_else(|| string_field(references, "segmentBookingId"))
+                .or_else(|| string_field(references, "capacityHoldId"))
+                .or_else(|| string_field(references, "holdId"))
+        })
+        .or_else(|| {
+            value.get("scope").and_then(|scope| {
+                string_field(scope, "segmentBookingRef")
+                    .or_else(|| string_field(scope, "segmentBookingId"))
+                    .or_else(|| string_field(scope, "capacityHoldId"))
+                    .or_else(|| string_field(scope, "holdId"))
+            })
+        })
+        .or_else(|| string_field(value, "segmentBookingRef"))
+        .or_else(|| string_field(value, "segmentBookingId"))
+        .or_else(|| string_field(value, "capacityHoldId"))
+        .or_else(|| string_field(value, "holdId"))
 }
 
 fn now_millis() -> u64 {

--- a/services/capacity-availability/tests/skeleton.rs
+++ b/services/capacity-availability/tests/skeleton.rs
@@ -543,6 +543,7 @@ fn in_memory_segment_reservation_requested_missing_idempotency_key_is_fatal() {
         occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
         payload: json!({
             "segmentBookingId": "sb-1",
+            "journeyOrderId": "ord-1",
             "segmentRef": "seg-1",
             "travelerRef": "traveler-1"
         }),
@@ -603,7 +604,7 @@ async fn postgres_inbound_classifies_known_event_schema_errors_as_fatal() {
             causation_id: None,
             correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fa02".to_string(),
             occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
-            payload: json!({"segmentBookingId": "sb-1", "segmentRef": "seg-1", "travelerRef": "traveler-1"}),
+            payload: json!({"segmentBookingId": "sb-1", "journeyOrderId": "ord-1", "segmentRef": "seg-1", "travelerRef": "traveler-1"}),
         })
         .await;
 
@@ -665,6 +666,7 @@ fn in_memory_segment_reservation_confirmed_without_capacity_hold_id_is_acked() {
         occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
         payload: json!({
             "segmentBookingId": "sb-1",
+            "providerReference": "prov-1",
             "evidence": "confirmed"
         }),
     });
@@ -727,6 +729,201 @@ async fn postgres_segment_reservation_confirmed_missing_segment_booking_id_is_fa
     assert!(
         matches!(result, HandlerResult::FatalError(message) if message.contains("segmentBookingId"))
     );
+}
+
+#[test]
+fn in_memory_capacity_inbound_event_contract_classification_matrix() {
+    use capacity_availability::adapters::messaging::InMemoryEventPublisher;
+    use capacity_availability::application::CapacityService;
+    use capacity_availability::ports::{HandlerResult, WireEnvelope};
+    use serde_json::{Value, json};
+    use std::sync::Arc;
+
+    fn envelope(event_type: &str, producer: &str, payload: Value) -> WireEnvelope {
+        WireEnvelope {
+            event_id: format!("evt-0194f2e0-7b3e-7610-0284-5c26e8{:04}", event_type.len()),
+            event_type: event_type.to_string(),
+            schema_version: 1,
+            producer: producer.to_string(),
+            causation_id: None,
+            correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fb01".to_string(),
+            occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+            payload,
+        }
+    }
+
+    let service = CapacityService::new(Arc::new(InMemoryEventPublisher::new()));
+    let cases = [
+        (
+            envelope(
+                "SegmentReservationRequested",
+                "booking-orchestration",
+                json!({"segmentBookingId":"sb-1","journeyOrderId":"ord-1","segmentRef":"seg-1","travelerRef":"traveler-1"}),
+            ),
+            "fatal",
+            "idempotencyKey",
+        ),
+        (
+            envelope(
+                "SegmentReservationConfirmed",
+                "booking-orchestration",
+                json!({"segmentBookingId":"sb-1","providerReference":"prov-1","evidence":"confirmed"}),
+            ),
+            "success",
+            "",
+        ),
+        (
+            envelope(
+                "SegmentReservationConfirmed",
+                "booking-orchestration",
+                json!({"evidence":"confirmed"}),
+            ),
+            "fatal",
+            "segmentBookingId",
+        ),
+        (
+            envelope(
+                "SegmentBookingCancelled",
+                "booking-orchestration",
+                json!({"segmentBookingId":"sb-1","reason":"customer"}),
+            ),
+            "success",
+            "",
+        ),
+        (
+            envelope(
+                "SegmentBookingCancelled",
+                "booking-orchestration",
+                json!({"reason":"customer"}),
+            ),
+            "fatal",
+            "segmentBookingId",
+        ),
+        (
+            envelope(
+                "SegmentTicketed",
+                "booking-orchestration",
+                json!({"segmentBookingId":"sb-1","entitlementId":"ent-1"}),
+            ),
+            "success",
+            "",
+        ),
+        (
+            envelope(
+                "PostSalesApplied",
+                "post-sales",
+                json!({"caseId":"psc-1","orderId":"ord-1","resultSummary":{}}),
+            ),
+            "success",
+            "",
+        ),
+        (
+            envelope(
+                "EntitlementVoided",
+                "entitlement-ticketing",
+                json!({"entitlementId":"ent-1","voidedAt":"2026-07-03T10:30:00.000Z","reason":"REFUND","policy":"NORMAL"}),
+            ),
+            "fatal",
+            "segmentBookingRef",
+        ),
+    ];
+
+    for (event, expected, detail) in cases {
+        let result = service.handle_inbound_event(event);
+        match expected {
+            "success" => assert_eq!(result, HandlerResult::Success),
+            "fatal" => assert!(
+                matches!(result, HandlerResult::FatalError(message) if message.contains(detail))
+            ),
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[tokio::test]
+async fn postgres_capacity_inbound_event_contract_classification_pre_db_matrix() {
+    use capacity_availability::adapters::storage::PostgresCapacityService;
+    use capacity_availability::ports::{HandlerResult, WireEnvelope};
+    use rust_kit::storage::Storage;
+    use serde_json::{Value, json};
+    use sqlx::postgres::PgPoolOptions;
+
+    fn envelope(event_type: &str, producer: &str, payload: Value) -> WireEnvelope {
+        WireEnvelope {
+            event_id: format!("evt-0194f2e0-7b3e-7610-0284-5c26e8{:04}", event_type.len()),
+            event_type: event_type.to_string(),
+            schema_version: 1,
+            producer: producer.to_string(),
+            causation_id: None,
+            correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fb02".to_string(),
+            occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+            payload,
+        }
+    }
+
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect_lazy("postgres://capacity:capacity@127.0.0.1:1/capacity")
+        .unwrap();
+    let service = PostgresCapacityService::from_storage(Storage::new(pool)).unwrap();
+
+    let fatal_cases = [
+        (
+            envelope(
+                "SegmentReservationRequested",
+                "booking-orchestration",
+                json!({"segmentBookingId":"sb-1","journeyOrderId":"ord-1","segmentRef":"seg-1","travelerRef":"traveler-1"}),
+            ),
+            "idempotencyKey",
+        ),
+        (
+            envelope(
+                "SegmentReservationConfirmed",
+                "booking-orchestration",
+                json!({"evidence":"confirmed"}),
+            ),
+            "segmentBookingId",
+        ),
+        (
+            envelope(
+                "SegmentBookingCancelled",
+                "booking-orchestration",
+                json!({"reason":"customer"}),
+            ),
+            "segmentBookingId",
+        ),
+        (
+            envelope(
+                "EntitlementVoided",
+                "entitlement-ticketing",
+                json!({"entitlementId":"ent-1","voidedAt":"2026-07-03T10:30:00.000Z","reason":"REFUND","policy":"NORMAL"}),
+            ),
+            "segmentBookingRef",
+        ),
+    ];
+    for (event, detail) in fatal_cases {
+        let result = service.handle_inbound_event(event).await;
+        assert!(matches!(result, HandlerResult::FatalError(message) if message.contains(detail)));
+    }
+
+    let success_cases = [
+        envelope(
+            "SegmentTicketed",
+            "booking-orchestration",
+            json!({"segmentBookingId":"sb-1","entitlementId":"ent-1"}),
+        ),
+        envelope(
+            "PostSalesApplied",
+            "post-sales",
+            json!({"caseId":"psc-1","orderId":"ord-1","resultSummary":{}}),
+        ),
+    ];
+    for event in success_cases {
+        assert_eq!(
+            service.handle_inbound_event(event).await,
+            HandlerResult::Success
+        );
+    }
 }
 
 #[tokio::test]

--- a/services/capacity-availability/tests/skeleton.rs
+++ b/services/capacity-availability/tests/skeleton.rs
@@ -524,6 +524,62 @@ fn subscriber_decision_logic_retries_dlqs_and_dedups() {
     assert_eq!(*calls.lock().unwrap(), 1);
 }
 
+#[test]
+fn in_memory_segment_reservation_requested_missing_idempotency_key_is_fatal() {
+    use capacity_availability::adapters::messaging::InMemoryEventPublisher;
+    use capacity_availability::application::CapacityService;
+    use capacity_availability::ports::{HandlerResult, WireEnvelope};
+    use serde_json::json;
+    use std::sync::Arc;
+
+    let service = CapacityService::new(Arc::new(InMemoryEventPublisher::new()));
+    let result = service.handle_inbound_event(WireEnvelope {
+        event_id: "evt-0194f2e0-7b3e-7610-0284-5c26e8b0fa11".to_string(),
+        event_type: "SegmentReservationRequested".to_string(),
+        schema_version: 1,
+        producer: "booking-orchestration".to_string(),
+        causation_id: None,
+        correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fa12".to_string(),
+        occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+        payload: json!({
+            "segmentBookingId": "sb-1",
+            "segmentRef": "seg-1",
+            "travelerRef": "traveler-1"
+        }),
+    });
+
+    assert!(
+        matches!(result, HandlerResult::FatalError(message) if message.contains("idempotencyKey"))
+    );
+}
+
+#[test]
+fn in_memory_post_sales_applied_without_hold_pointer_is_acked() {
+    use capacity_availability::adapters::messaging::InMemoryEventPublisher;
+    use capacity_availability::application::CapacityService;
+    use capacity_availability::ports::{HandlerResult, WireEnvelope};
+    use serde_json::json;
+    use std::sync::Arc;
+
+    let service = CapacityService::new(Arc::new(InMemoryEventPublisher::new()));
+    let result = service.handle_inbound_event(WireEnvelope {
+        event_id: "evt-0194f2e0-7b3e-7610-0284-5c26e8b0fa21".to_string(),
+        event_type: "PostSalesApplied".to_string(),
+        schema_version: 1,
+        producer: "post-sales".to_string(),
+        causation_id: None,
+        correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fa22".to_string(),
+        occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+        payload: json!({
+            "caseId": "psc-1",
+            "orderId": "ord-1",
+            "resultSummary": {}
+        }),
+    });
+
+    assert_eq!(result, HandlerResult::Success);
+}
+
 #[tokio::test]
 async fn postgres_inbound_classifies_known_event_schema_errors_as_fatal() {
     use capacity_availability::adapters::storage::PostgresCapacityService;
@@ -547,13 +603,47 @@ async fn postgres_inbound_classifies_known_event_schema_errors_as_fatal() {
             causation_id: None,
             correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fa02".to_string(),
             occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
-            payload: json!({"segmentRef": "seg-1", "travelerRef": "traveler-1"}),
+            payload: json!({"segmentBookingId": "sb-1", "segmentRef": "seg-1", "travelerRef": "traveler-1"}),
         })
         .await;
 
     assert!(
-        matches!(result, HandlerResult::FatalError(message) if message.contains("segmentBookingId"))
+        matches!(result, HandlerResult::FatalError(message) if message.contains("idempotencyKey"))
     );
+}
+
+#[tokio::test]
+async fn postgres_post_sales_applied_without_hold_pointer_is_acked() {
+    use capacity_availability::adapters::storage::PostgresCapacityService;
+    use capacity_availability::ports::{HandlerResult, WireEnvelope};
+    use rust_kit::storage::Storage;
+    use serde_json::json;
+    use sqlx::postgres::PgPoolOptions;
+
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect_lazy("postgres://capacity:capacity@127.0.0.1:1/capacity")
+        .unwrap();
+    let service = PostgresCapacityService::from_storage(Storage::new(pool)).unwrap();
+
+    let result = service
+        .handle_inbound_event(WireEnvelope {
+            event_id: "evt-0194f2e0-7b3e-7610-0284-5c26e8b0fa31".to_string(),
+            event_type: "PostSalesApplied".to_string(),
+            schema_version: 1,
+            producer: "post-sales".to_string(),
+            causation_id: None,
+            correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fa32".to_string(),
+            occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+            payload: json!({
+                "caseId": "psc-1",
+                "orderId": "ord-1",
+                "resultSummary": {}
+            }),
+        })
+        .await;
+
+    assert_eq!(result, HandlerResult::Success);
 }
 
 #[tokio::test]

--- a/services/capacity-availability/tests/skeleton.rs
+++ b/services/capacity-availability/tests/skeleton.rs
@@ -646,6 +646,89 @@ async fn postgres_post_sales_applied_without_hold_pointer_is_acked() {
     assert_eq!(result, HandlerResult::Success);
 }
 
+#[test]
+fn in_memory_segment_reservation_confirmed_without_capacity_hold_id_is_acked() {
+    use capacity_availability::adapters::messaging::InMemoryEventPublisher;
+    use capacity_availability::application::CapacityService;
+    use capacity_availability::ports::{HandlerResult, WireEnvelope};
+    use serde_json::json;
+    use std::sync::Arc;
+
+    let service = CapacityService::new(Arc::new(InMemoryEventPublisher::new()));
+    let result = service.handle_inbound_event(WireEnvelope {
+        event_id: "evt-0194f2e0-7b3e-7610-0284-5c26e8b0fa41".to_string(),
+        event_type: "SegmentReservationConfirmed".to_string(),
+        schema_version: 1,
+        producer: "booking-orchestration".to_string(),
+        causation_id: None,
+        correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fa42".to_string(),
+        occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+        payload: json!({
+            "segmentBookingId": "sb-1",
+            "evidence": "confirmed"
+        }),
+    });
+
+    assert_eq!(result, HandlerResult::Success);
+}
+
+#[test]
+fn in_memory_segment_reservation_confirmed_missing_segment_booking_id_is_fatal() {
+    use capacity_availability::adapters::messaging::InMemoryEventPublisher;
+    use capacity_availability::application::CapacityService;
+    use capacity_availability::ports::{HandlerResult, WireEnvelope};
+    use serde_json::json;
+    use std::sync::Arc;
+
+    let service = CapacityService::new(Arc::new(InMemoryEventPublisher::new()));
+    let result = service.handle_inbound_event(WireEnvelope {
+        event_id: "evt-0194f2e0-7b3e-7610-0284-5c26e8b0fa43".to_string(),
+        event_type: "SegmentReservationConfirmed".to_string(),
+        schema_version: 1,
+        producer: "booking-orchestration".to_string(),
+        causation_id: None,
+        correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fa44".to_string(),
+        occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+        payload: json!({"evidence": "confirmed"}),
+    });
+
+    assert!(
+        matches!(result, HandlerResult::FatalError(message) if message.contains("segmentBookingId"))
+    );
+}
+
+#[tokio::test]
+async fn postgres_segment_reservation_confirmed_missing_segment_booking_id_is_fatal() {
+    use capacity_availability::adapters::storage::PostgresCapacityService;
+    use capacity_availability::ports::{HandlerResult, WireEnvelope};
+    use rust_kit::storage::Storage;
+    use serde_json::json;
+    use sqlx::postgres::PgPoolOptions;
+
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect_lazy("postgres://capacity:capacity@127.0.0.1:1/capacity")
+        .unwrap();
+    let service = PostgresCapacityService::from_storage(Storage::new(pool)).unwrap();
+
+    let result = service
+        .handle_inbound_event(WireEnvelope {
+            event_id: "evt-0194f2e0-7b3e-7610-0284-5c26e8b0fa47".to_string(),
+            event_type: "SegmentReservationConfirmed".to_string(),
+            schema_version: 1,
+            producer: "booking-orchestration".to_string(),
+            causation_id: None,
+            correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fa48".to_string(),
+            occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+            payload: json!({"evidence": "confirmed"}),
+        })
+        .await;
+
+    assert!(
+        matches!(result, HandlerResult::FatalError(message) if message.contains("segmentBookingId"))
+    );
+}
+
 #[tokio::test]
 async fn api_responses_include_runtime_correlation_and_request_headers() {
     let app = test_router();

--- a/services/capacity-availability/tests/skeleton.rs
+++ b/services/capacity-availability/tests/skeleton.rs
@@ -525,6 +525,38 @@ fn subscriber_decision_logic_retries_dlqs_and_dedups() {
 }
 
 #[tokio::test]
+async fn postgres_inbound_classifies_known_event_schema_errors_as_fatal() {
+    use capacity_availability::adapters::storage::PostgresCapacityService;
+    use capacity_availability::ports::{HandlerResult, WireEnvelope};
+    use rust_kit::storage::Storage;
+    use serde_json::json;
+    use sqlx::postgres::PgPoolOptions;
+
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect_lazy("postgres://capacity:capacity@127.0.0.1:1/capacity")
+        .unwrap();
+    let service = PostgresCapacityService::from_storage(Storage::new(pool)).unwrap();
+
+    let result = service
+        .handle_inbound_event(WireEnvelope {
+            event_id: "evt-0194f2e0-7b3e-7610-0284-5c26e8b0fa01".to_string(),
+            event_type: "SegmentReservationRequested".to_string(),
+            schema_version: 1,
+            producer: "booking-orchestration".to_string(),
+            causation_id: None,
+            correlation_id: "corr-0194f2e0-7b3e-7610-0284-5c26e8b0fa02".to_string(),
+            occurred_at: "2026-07-03T10:30:00.000Z".to_string(),
+            payload: json!({"segmentRef": "seg-1", "travelerRef": "traveler-1"}),
+        })
+        .await;
+
+    assert!(
+        matches!(result, HandlerResult::FatalError(message) if message.contains("segmentBookingId"))
+    );
+}
+
+#[tokio::test]
 async fn api_responses_include_runtime_correlation_and_request_headers() {
     let app = test_router();
     let response = app

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/application/service/OrderManagementService.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/application/service/OrderManagementService.java
@@ -341,7 +341,7 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
                 case "OfferExpired", "OfferQuoted",
                     "TravelerProfileUpdated", "TravelerSnapshotUpdated", "TravelerDocumentVerified", "TravelerEligibilityChanged",
                     "SessionOpened", "SessionRevoked", "PreferenceUpdated" -> new EventSubscriber.Success();
-                default -> new EventSubscriber.FatalError("unsupported event type for journey-order: " + envelope.eventType());
+                default -> new EventSubscriber.Success();
             };
         } catch (RuntimeException ex) {
             consumedEventIds.remove(envelope.eventId());

--- a/services/journey-order/src/test/java/com/trainticket/journeyorder/application/OrderManagementServiceTest.java
+++ b/services/journey-order/src/test/java/com/trainticket/journeyorder/application/OrderManagementServiceTest.java
@@ -285,13 +285,13 @@ class OrderManagementServiceTest {
     }
 
     @Test
-    void unknownEventTypeRemainsFatal() {
+    void unknownEventTypeIsAckedAndSkipped() {
         EventSubscriber.HandlerResult result = service.handle(accountEvent(
             "evt-0194f2e0-7b3e-7610-8284-5c26e8b0cb01",
             "UnknownAccountEvent",
             "acct-gated"));
 
-        assertTrue(result instanceof EventSubscriber.FatalError);
+        assertEquals(new EventSubscriber.Success(), result);
     }
 
     private static void assertNotNull(Object obj) {

--- a/services/reporting/src/reporting/application/service.py
+++ b/services/reporting/src/reporting/application/service.py
@@ -175,7 +175,7 @@ class ReportingApplicationService:
             if self.repository.record_consumed_event(envelope):
                 self._rebuild_stale_dashboards(envelope)
         except Exception as exc:  # pragma: no cover - defensive boundary for broker callback
-            return HandlerResult.fatal_error(str(exc))
+            return HandlerResult.transient_error(str(exc))
         return HandlerResult.success()
 
     def _rebuild_stale_dashboards(self, envelope: EventEnvelope) -> None:

--- a/services/reporting/tests/test_api_and_messaging.py
+++ b/services/reporting/tests/test_api_and_messaging.py
@@ -214,6 +214,29 @@ class MessagingTest(unittest.TestCase):
         self.assertIsNone(subscriber._deserialize_envelope(minimal).causationId)
         self.assertEqual(subscriber._deserialize_envelope(with_causation).causationId, with_causation["causationId"])
 
+
+    def test_reporting_projection_exception_is_transient_not_fatal(self) -> None:
+        class FailingRepository:
+            def record_consumed_event(self, _: EventEnvelope) -> bool:
+                raise RuntimeError("projection store unavailable")
+
+        service = ReportingApplicationService(repository=FailingRepository())  # type: ignore[arg-type]
+        envelope = EventEnvelope(
+            eventId="evt-reporting-transient",
+            eventType="PaymentCaptured",
+            occurredAt="2026-07-05T10:30:00.000Z",
+            correlationId="corr-1",
+            producer="payment",
+            schemaVersion=1,
+            payload={},
+            causationId="evt-1",
+        )
+
+        result = service.handle_event(envelope)
+
+        self.assertEqual(result.status.value, "TRANSIENT_ERROR")
+        self.assertIn("projection store unavailable", result.message)
+
     def test_subscriber_dedups_duplicate_event_id(self) -> None:
         service = ReportingApplicationService()
         subscriber = FakeSubscriber()


### PR DESCRIPTION
## Summary
- add DLQ attribution metadata and WARN logging in Java/Python/TypeScript/Go/Rust kits
- preserve handler fatal reasons in rust-kit DLQ metadata
- classify capacity inbound deterministic schema/idempotency failures as fatal while keeping transient storage conflicts retryable
- ack unknown journey-order events instead of poisoning DLQ

## Validation
- make check
- go test ./platform/go-kit/messaging
- platform/java-kit: mvn test
- platform/python-kit: PYTHONPATH=src python3 -m pytest tests/test_messaging.py
- platform/ts-kit: npm test
- cargo test --manifest-path platform/rust-kit/Cargo.toml --features redis-impl dlq_metadata_fields_are_camel_case_and_attributed
- cargo test --manifest-path services/capacity-availability/Cargo.toml --quiet