### PR TITLE
REQ-107 Implement waitlist service

### DIFF
--- a/deploy/build-images.sh
+++ b/deploy/build-images.sh
@@ -30,6 +30,7 @@ services=(
   reporting
   supplier-catalog
   legacy-acl
+  waitlist
 )
 
 for service in "${services[@]}"; do

--- a/deploy/docker/waitlist/Dockerfile
+++ b/deploy/docker/waitlist/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1.7
+FROM rust:1.91-bookworm AS builder
+WORKDIR /src
+COPY platform/shared-kernel-rust ./platform/shared-kernel-rust
+COPY platform/rust-kit ./platform/rust-kit
+COPY services/waitlist/Cargo.toml services/waitlist/Cargo.lock ./services/waitlist/
+COPY services/waitlist/src ./services/waitlist/src
+COPY services/waitlist/migrations ./services/waitlist/migrations
+RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/services/waitlist/target \
+    cargo build --release --manifest-path services/waitlist/Cargo.toml && \
+    cp services/waitlist/target/release/waitlist /usr/local/bin/waitlist
+
+FROM debian:bookworm-slim
+RUN useradd --system --create-home --home-dir /home/app app && \
+    apt-get update && apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/bin/waitlist /usr/local/bin/waitlist
+COPY --from=builder /src/services/waitlist/migrations /app/migrations
+USER app
+ENV PORT=8080 REDIS_URL=redis://localhost:6379 MIGRATIONS_DIR=/app/migrations
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/waitlist"]

--- a/deploy/k8s/postgres.yaml
+++ b/deploy/k8s/postgres.yaml
@@ -67,6 +67,8 @@ data:
     WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'traveler_profile')\gexec
     SELECT 'CREATE DATABASE trip_planning'
     WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'trip_planning')\gexec
+    SELECT 'CREATE DATABASE waitlist'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'waitlist')\gexec
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/deploy/k8s/services.yaml
+++ b/deploy/k8s/services.yaml
@@ -2044,3 +2044,93 @@ spec:
       targetPort: http
   selector:
     app.kubernetes.io/name: legacy-acl
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: waitlist
+  namespace: train-ticket
+  labels:
+    app.kubernetes.io/name: waitlist
+    app.kubernetes.io/part-of: train-ticket
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: waitlist
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: waitlist
+        app.kubernetes.io/part-of: train-ticket
+    spec:
+      containers:
+        - name: waitlist
+          image: train-ticket/waitlist:local
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://otel-collector:4317
+            - name: OTEL_SERVICE_NAME
+              value: waitlist
+            - name: OTEL_TRACES_EXPORTER
+              value: otlp
+            - name: OTEL_METRICS_EXPORTER
+              value: none
+            - name: OTEL_LOGS_EXPORTER
+              value: none
+            - name: PORT
+              value: "8080"
+            - name: SERVER_PORT
+              value: "8080"
+            - name: REDIS_URL
+              value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/waitlist
+            - name: JOURNEY_ORDER_BASE_URL
+              value: http://journey-order:8080
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: waitlist
+  namespace: train-ticket
+  labels:
+    app.kubernetes.io/name: waitlist
+    app.kubernetes.io/part-of: train-ticket
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+  selector:
+    app.kubernetes.io/name: waitlist

--- a/services/waitlist/Cargo.lock
+++ b/services/waitlist/Cargo.lock
@@ -3,10 +3,66 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
@@ -61,10 +117,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -73,10 +165,270 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
+name = "cc"
+version = "1.2.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -88,12 +440,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -101,6 +469,45 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -120,10 +527,148 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -181,6 +726,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -189,6 +735,36 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -197,13 +773,173 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -224,10 +960,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.9.0",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -236,10 +1024,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -261,7 +1065,52 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -269,6 +1118,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
@@ -285,16 +1140,192 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest 0.13.4",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.13.4",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tonic-types",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -306,12 +1337,417 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.4",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.4",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "redis"
+version = "0.25.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e46922bd01fefcfdcf58d9cd626da082bb2cde27211920dacfde6b2ecf9a35b"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "combine",
+ "futures",
+ "futures-util",
+ "itoa",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-retry",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rust-kit"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "chrono",
+ "log",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "redis",
+ "serde",
+ "serde_json",
+ "sha2",
+ "shared-kernel",
+ "sqlx",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -325,6 +1761,44 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -393,6 +1867,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "shared-kernel"
 version = "0.1.0"
 dependencies = [
@@ -400,6 +1902,32 @@ dependencies = [
  "opentelemetry",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -413,6 +1941,19 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -421,8 +1962,244 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -440,6 +2217,20 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "thiserror"
@@ -462,17 +2253,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "signal-hook-registry",
+ "socket2 0.6.4",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -487,6 +2305,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-retry"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
+dependencies = [
+ "pin-project-lite",
+ "rand 0.10.2",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "rustls-native-certs",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,12 +2407,33 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -522,7 +2456,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -535,21 +2481,121 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "rand 0.10.2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "waitlist"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
+ "chrono",
+ "log",
  "opentelemetry",
+ "opentelemetry_sdk",
+ "reqwest 0.12.28",
+ "rust-kit",
  "serde",
+ "serde_json",
+ "sha2",
  "shared-kernel",
+ "sqlx",
  "tokio",
  "tower",
+ "uuid",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -557,6 +2603,21 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -569,6 +2630,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -604,10 +2675,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -616,6 +2806,242 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/services/waitlist/Cargo.toml
+++ b/services/waitlist/Cargo.toml
@@ -7,12 +7,26 @@ edition = "2024"
 name = "waitlist"
 path = "src/lib.rs"
 
+[[bin]]
+name = "waitlist"
+path = "src/main.rs"
+
 [dependencies]
 opentelemetry = "0.32.0"
+opentelemetry_sdk = "0.32.0"
 axum = "0.8.9"
+async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
+log = "0.4"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sha2 = "0.10"
 shared-kernel = { path = "../../platform/shared-kernel-rust" }
+rust-kit = { path = "../../platform/rust-kit", features = ["redis-impl"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "chrono", "json"] }
+tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "net", "signal", "sync", "time"] }
+uuid = { version = "1.0", features = ["v7", "fast-rng"] }
 
 [dev-dependencies]
-tokio = { version = "1.48", features = ["macros", "rt"] }
 tower = { version = "0.5.3", features = ["util"] }

--- a/services/waitlist/migrations/001_waitlist.sql
+++ b/services/waitlist/migrations/001_waitlist.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS waitlist_requests (
+    waitlist_request_id text PRIMARY KEY,
+    traveler_ref text NOT NULL,
+    intent_fingerprint text NOT NULL,
+    segment_ref text NOT NULL,
+    status text NOT NULL,
+    deadline timestamptz NOT NULL,
+    queued_at timestamptz,
+    order_ref text,
+    version bigint NOT NULL,
+    data jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS active_waitlist_request
+    ON waitlist_requests (traveler_ref, intent_fingerprint)
+    WHERE status IN ('DRAFT', 'QUEUED', 'MATCHING', 'SUSPENDED');
+
+CREATE INDEX IF NOT EXISTS waitlist_queue_head_idx
+    ON waitlist_requests (segment_ref, queued_at, created_at, waitlist_request_id)
+    WHERE status = 'QUEUED';
+CREATE INDEX IF NOT EXISTS waitlist_order_ref_idx ON waitlist_requests (order_ref) WHERE order_ref IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS idempotency_records (key text PRIMARY KEY, request_hash text NOT NULL, status_code int NOT NULL, response_body jsonb, created_at timestamptz NOT NULL DEFAULT now());
+CREATE TABLE IF NOT EXISTS outbox (seq bigserial PRIMARY KEY, event_id text NOT NULL UNIQUE, stream text NOT NULL, envelope jsonb NOT NULL, created_at timestamptz NOT NULL DEFAULT now(), published_at timestamptz);
+CREATE TABLE IF NOT EXISTS processed_events (event_id text NOT NULL, stream text NOT NULL, processed_at timestamptz NOT NULL DEFAULT now(), PRIMARY KEY (event_id, stream));

--- a/services/waitlist/src/lib.rs
+++ b/services/waitlist/src/lib.rs
@@ -1,6 +1,28 @@
-use axum::Router;
-use serde::Serialize;
-use shared_kernel::{OpenTelemetryObserver, RuntimeConfig, apply_runtime, router_with_config};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use axum::{
+    Json, Router,
+    extract::{Extension, Path, RawQuery, State, rejection::JsonRejection},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::{get, post},
+};
+use chrono::{DateTime, SecondsFormat, Utc};
+use opentelemetry::Context as OtelContext;
+use opentelemetry::propagation::{Injector, TextMapPropagator};
+use rust_kit::messaging::AsyncEventSubscriber;
+use rust_kit::{http as kit_http, idempotency as kit_idempotency};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use shared_kernel::{
+    OpenTelemetryObserver, RequestContext, RuntimeConfig, apply_runtime, router_with_config,
+};
+use tokio::task::JoinHandle;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ServiceProfile {
@@ -11,63 +33,1978 @@ pub struct ServiceProfile {
     pub work_packages: &'static [&'static str],
     pub owns: &'static [&'static str],
 }
-
 pub fn profile() -> ServiceProfile {
     ServiceProfile {
         service_id: "waitlist",
         domain: "Waitlist",
         language: "rust",
-        phase: "future-scope",
-        work_packages: &[],
-        owns: &["WaitlistRequest", "QueuePolicy", "FulfillmentWindow"],
+        phase: "phase-1-activation",
+        work_packages: &["REQ-107"],
+        owns: &["WaitlistRequest", "WaitlistQueue", "FulfillmentWindow"],
     }
 }
-
 pub fn health() -> &'static str {
     "ok"
 }
-
 pub fn metadata() -> ServiceProfile {
     profile()
 }
-
 pub fn runtime_config() -> RuntimeConfig {
     RuntimeConfig::from_metadata(metadata())
         .with_observer(OpenTelemetryObserver::from_env(profile().service_id))
 }
-
-pub fn router() -> Router {
-    router_with_config(runtime_config())
-}
-
 pub fn apply_service_runtime(router: Router) -> Router {
     apply_runtime(router, runtime_config())
+}
+
+pub async fn router() -> Router {
+    let service = Arc::new(
+        PostgresWaitlistService::from_env()
+            .await
+            .expect("failed to initialize Postgres waitlist storage"),
+    );
+    router_with_postgres_state(service)
+}
+
+pub async fn build_runtime() -> Result<(Router, JoinHandle<()>), SubscribeFailed> {
+    let _otel = rust_kit::otel::init_from_env(profile().service_id)
+        .map_err(|e| SubscribeFailed(e.to_string()))?;
+    let redis_url =
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+    let service = Arc::new(
+        PostgresWaitlistService::from_env()
+            .await
+            .map_err(|e| SubscribeFailed(e.to_string()))?,
+    );
+    rust_kit::storage::spawn_outbox_relay(service.pool().clone(), redis_url);
+    let expiry_service = service.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(30));
+        loop {
+            interval.tick().await;
+            let _ = expiry_service
+                .expire_due(current_rfc3339(), rust_kit::messaging::correlation_id())
+                .await;
+        }
+    });
+    let subscriber = rust_kit::messaging::redis_runtime::RedisEventSubscriber::from_env()?;
+    let streams = vec![
+        rust_kit::messaging::stream_for_producer("capacity-availability"),
+        rust_kit::messaging::stream_for_producer("journey-order"),
+    ];
+    let consumer_name = std::env::var("HOSTNAME")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| format!("waitlist-{}", uuid::Uuid::now_v7()));
+    let handler_service = service.clone();
+    let handle = tokio::spawn(async move {
+        subscriber
+            .subscribe(
+                streams,
+                "waitlist".to_string(),
+                consumer_name,
+                Box::new(move |envelope| {
+                    let service = handler_service.clone();
+                    Box::pin(async move { service.handle_subscribed_event(envelope).await })
+                }),
+            )
+            .await
+            .expect("waitlist Redis subscriber stopped");
+    });
+    Ok((router_with_postgres_state(service), handle))
+}
+
+pub fn router_with_state<S: WaitlistApi + 'static>(service: Arc<S>) -> Router {
+    apply_service_runtime(router_with_config(runtime_config()).merge(waitlist_routes(service)))
+}
+pub fn router_with_postgres_state(service: Arc<PostgresWaitlistService>) -> Router {
+    let metadata = serde_json::to_value(metadata()).unwrap_or_else(|_| json!({}));
+    let standard = Router::new()
+        .route("/health", get(health_handler))
+        .route("/healthz", get(health_handler))
+        .route("/live", get(live_handler))
+        .route("/livez", get(live_handler))
+        .route("/ready", get(postgres_ready_handler))
+        .route("/readyz", get(postgres_ready_handler))
+        .route(
+            "/metadata",
+            get(move || {
+                let metadata = metadata.clone();
+                async move { Json(metadata) }
+            }),
+        )
+        .layer(Extension(service.clone()));
+    apply_service_runtime(standard.merge(waitlist_routes(service)))
+}
+fn waitlist_routes<S: WaitlistApi + 'static>(service: Arc<S>) -> Router {
+    Router::new()
+        .route(
+            "/api/v1/waitlist-requests",
+            post(create_waitlist::<S>).get(list_waitlist::<S>),
+        )
+        .route(
+            "/api/v1/waitlist-requests/{waitlist_request_id}",
+            get(get_waitlist::<S>),
+        )
+        .route(
+            "/api/v1/waitlist-requests/{waitlist_request_id}/cancel",
+            post(cancel_waitlist::<S>),
+        )
+        .with_state(ApiState { service })
+}
+#[derive(Debug, Serialize)]
+struct ProbeResponse {
+    status: &'static str,
+}
+async fn health_handler() -> Json<ProbeResponse> {
+    Json(ProbeResponse { status: health() })
+}
+async fn live_handler() -> Json<ProbeResponse> {
+    Json(ProbeResponse { status: "alive" })
+}
+async fn postgres_ready_handler(
+    Extension(service): Extension<Arc<PostgresWaitlistService>>,
+) -> (StatusCode, Json<ProbeResponse>) {
+    if service.is_ready().await {
+        (StatusCode::OK, Json(ProbeResponse { status: "ready" }))
+    } else {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ProbeResponse {
+                status: "not_ready",
+            }),
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum WaitlistStatus {
+    Draft,
+    Queued,
+    Matching,
+    Fulfilled,
+    Expired,
+    Cancelled,
+    Suspended,
+    Closed,
+}
+impl WaitlistStatus {
+    pub fn as_contract(self) -> &'static str {
+        match self {
+            Self::Draft => "DRAFT",
+            Self::Queued => "QUEUED",
+            Self::Matching => "MATCHING",
+            Self::Fulfilled => "FULFILLED",
+            Self::Expired => "EXPIRED",
+            Self::Cancelled => "CANCELLED",
+            Self::Suspended => "SUSPENDED",
+            Self::Closed => "CLOSED",
+        }
+    }
+    fn is_active(self) -> bool {
+        matches!(
+            self,
+            Self::Draft | Self::Queued | Self::Matching | Self::Suspended
+        )
+    }
+    fn can_transition_to(self, next: Self) -> bool {
+        matches!(
+            (self, next),
+            (Self::Draft, Self::Queued)
+                | (Self::Draft, Self::Cancelled)
+                | (Self::Queued, Self::Matching)
+                | (Self::Queued, Self::Expired)
+                | (Self::Queued, Self::Cancelled)
+                | (Self::Queued, Self::Suspended)
+                | (Self::Matching, Self::Fulfilled)
+                | (Self::Matching, Self::Queued)
+                | (Self::Fulfilled, Self::Closed)
+                | (Self::Expired, Self::Closed)
+                | (Self::Cancelled, Self::Closed)
+                | (Self::Suspended, Self::Queued)
+                | (Self::Suspended, Self::Cancelled)
+        )
+    }
+}
+impl fmt::Display for WaitlistStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_contract())
+    }
+}
+impl std::str::FromStr for WaitlistStatus {
+    type Err = WaitlistError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DRAFT" => Ok(Self::Draft),
+            "QUEUED" => Ok(Self::Queued),
+            "MATCHING" => Ok(Self::Matching),
+            "FULFILLED" => Ok(Self::Fulfilled),
+            "EXPIRED" => Ok(Self::Expired),
+            "CANCELLED" => Ok(Self::Cancelled),
+            "SUSPENDED" => Ok(Self::Suspended),
+            "CLOSED" => Ok(Self::Closed),
+            _ => Err(WaitlistError::ValidationFailed(
+                "invalid waitlist status".into(),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WaitlistRequest {
+    pub waitlist_request_id: String,
+    pub traveler_ref: String,
+    pub segment_ref: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub travel_class: Option<String>,
+    pub deadline: String,
+    pub payment_guarantee_ref: String,
+    pub intent_fingerprint: String,
+    pub status: WaitlistStatus,
+    pub created_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub queued_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order_ref: Option<String>,
+    #[serde(default)]
+    pub version: i64,
+}
+impl WaitlistRequest {
+    pub fn create(
+        command: CreateWaitlistCommand,
+        now: String,
+    ) -> Result<(Self, Vec<WaitlistEvent>), WaitlistError> {
+        validate_prefixed_uuid(&command.traveler_ref, "travelerRef", "tvl-")?;
+        validate_non_empty(&command.segment_ref, "segmentRef")?;
+        validate_non_empty(&command.intent_fingerprint, "intentFingerprint")?;
+        validate_payment_guarantee(&command.payment_guarantee_ref)?;
+        if !deadline_after(&command.deadline, &now) {
+            return Err(WaitlistError::DomainRuleViolation(
+                "deadline must be in the future".into(),
+            ));
+        }
+        let mut r = Self {
+            waitlist_request_id: format!("wlr-{}", uuid::Uuid::now_v7()),
+            traveler_ref: command.traveler_ref,
+            segment_ref: command.segment_ref,
+            travel_class: command.travel_class,
+            deadline: command.deadline,
+            payment_guarantee_ref: command.payment_guarantee_ref,
+            intent_fingerprint: command.intent_fingerprint,
+            status: WaitlistStatus::Draft,
+            created_at: now.clone(),
+            queued_at: None,
+            order_ref: None,
+            version: 1,
+        };
+        let created = WaitlistEvent::created(&r, now.clone());
+        let payment = WaitlistEvent::payment(&r, now.clone());
+        r.transition(WaitlistStatus::Queued)?;
+        r.queued_at = Some(now.clone());
+        let queued = WaitlistEvent::queued(&r, now, None);
+        Ok((r, vec![created, payment, queued]))
+    }
+    pub fn transition(&mut self, next: WaitlistStatus) -> Result<(), WaitlistError> {
+        if self.status.can_transition_to(next) {
+            self.status = next;
+            self.version += 1;
+            Ok(())
+        } else {
+            Err(WaitlistError::DomainRuleViolation(format!(
+                "invalid waitlist transition {} -> {}",
+                self.status, next
+            )))
+        }
+    }
+    pub fn start_matching(
+        &mut self,
+        release: String,
+        now: String,
+    ) -> Result<WaitlistEvent, WaitlistError> {
+        self.transition(WaitlistStatus::Matching)?;
+        Ok(WaitlistEvent::match_started(
+            self,
+            release,
+            journey_order_idempotency_key(&self.waitlist_request_id),
+            now,
+        ))
+    }
+    pub fn record_order_ref(&mut self, order: String) {
+        self.order_ref = Some(order);
+    }
+    pub fn requeue_after_order_cancelled(
+        &mut self,
+        now: String,
+    ) -> Result<WaitlistEvent, WaitlistError> {
+        let order = self.order_ref.clone();
+        if self.status == WaitlistStatus::Matching {
+            self.transition(WaitlistStatus::Queued)?;
+        }
+        self.queued_at = Some(now.clone());
+        self.order_ref = None;
+        Ok(WaitlistEvent::queued(self, now, order))
+    }
+    pub fn fulfill_and_close(
+        &mut self,
+        order: String,
+        now: String,
+    ) -> Result<Vec<WaitlistEvent>, WaitlistError> {
+        self.order_ref = Some(order.clone());
+        self.transition(WaitlistStatus::Fulfilled)?;
+        let ev = WaitlistEvent::fulfilled(self, order, now);
+        self.transition(WaitlistStatus::Closed)?;
+        Ok(vec![ev])
+    }
+    pub fn cancel(&mut self, reason: String, now: String) -> Result<WaitlistEvent, WaitlistError> {
+        validate_non_empty(&reason, "reason")?;
+        if !matches!(
+            self.status,
+            WaitlistStatus::Draft | WaitlistStatus::Queued | WaitlistStatus::Suspended
+        ) {
+            return Err(WaitlistError::PreconditionFailed(
+                "terminal or matching waitlist request cannot be cancelled".into(),
+            ));
+        }
+        self.transition(WaitlistStatus::Cancelled)?;
+        Ok(WaitlistEvent::cancelled(self, reason, now))
+    }
+    pub fn expire_and_close(&mut self, now: String) -> Result<Vec<WaitlistEvent>, WaitlistError> {
+        match self.status {
+            WaitlistStatus::Queued => {}
+            WaitlistStatus::Suspended => self.transition(WaitlistStatus::Queued)?,
+            _ => {
+                return Err(WaitlistError::PreconditionFailed(
+                    "only queued or suspended requests can expire".into(),
+                ));
+            }
+        };
+        self.transition(WaitlistStatus::Expired)?;
+        let ev = WaitlistEvent::expired(self, now);
+        self.transition(WaitlistStatus::Closed)?;
+        Ok(vec![ev])
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct WaitlistQueue {
+    partitions: HashMap<String, VecDeque<String>>,
+}
+impl WaitlistQueue {
+    pub fn rebuild(requests: impl IntoIterator<Item = WaitlistRequest>) -> Self {
+        let mut grouped: HashMap<String, Vec<WaitlistRequest>> = HashMap::new();
+        for r in requests {
+            if r.status == WaitlistStatus::Queued {
+                grouped.entry(r.segment_ref.clone()).or_default().push(r);
+            }
+        }
+        let mut partitions = HashMap::new();
+        for (seg, mut rs) in grouped {
+            rs.sort_by(|a, b| {
+                a.queued_at
+                    .as_deref()
+                    .unwrap_or(&a.created_at)
+                    .cmp(b.queued_at.as_deref().unwrap_or(&b.created_at))
+                    .then(a.waitlist_request_id.cmp(&b.waitlist_request_id))
+            });
+            partitions.insert(seg, rs.into_iter().map(|r| r.waitlist_request_id).collect());
+        }
+        Self { partitions }
+    }
+    pub fn head_for_segment(&self, segment: &str) -> Option<&str> {
+        self.partitions.get(segment)?.front().map(String::as_str)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WaitlistEvent {
+    Created(Value),
+    Payment(Value),
+    Queued(Value),
+    MatchStarted(Value),
+    HoldAuthorized(Value),
+    Fulfilled(Value),
+    Cancelled(Value),
+    Expired(Value),
+}
+impl WaitlistEvent {
+    fn event_type(&self) -> &'static str {
+        match self {
+            Self::Created(_) => "WaitlistRequestCreated",
+            Self::Payment(_) => "WaitlistPaymentAuthorizationRequested",
+            Self::Queued(_) => "WaitlistQueued",
+            Self::MatchStarted(_) => "WaitlistMatchStarted",
+            Self::HoldAuthorized(_) => "WaitlistHoldAuthorized",
+            Self::Fulfilled(_) => "WaitlistFulfilled",
+            Self::Cancelled(_) => "WaitlistCancelled",
+            Self::Expired(_) => "WaitlistExpired",
+        }
+    }
+    fn payload(&self) -> &Value {
+        match self {
+            Self::Created(v)
+            | Self::Payment(v)
+            | Self::Queued(v)
+            | Self::MatchStarted(v)
+            | Self::HoldAuthorized(v)
+            | Self::Fulfilled(v)
+            | Self::Cancelled(v)
+            | Self::Expired(v) => v,
+        }
+    }
+    fn envelope(
+        self,
+        id: &str,
+        version: i64,
+        corr: String,
+        cause: Option<String>,
+    ) -> rust_kit::messaging::EventEnvelope {
+        let ty = self.event_type();
+        let mut e = rust_kit::messaging::EventEnvelope::canonical(
+            ty,
+            rust_kit::messaging::valid_or_generated_correlation_id(corr),
+            cause,
+            profile().service_id,
+            self.payload().clone(),
+        );
+        e.event_id = deterministic_event_id(ty, id, version);
+        e
+    }
+    fn created(r: &WaitlistRequest, t: String) -> Self {
+        Self::Created(
+            json!({"waitlistRequestId":r.waitlist_request_id,"travelerRef":r.traveler_ref,"segmentRef":r.segment_ref,"travelClass":r.travel_class,"deadline":r.deadline,"paymentGuaranteeRef":r.payment_guarantee_ref,"intentFingerprint":r.intent_fingerprint,"status":"DRAFT","createdAt":t}),
+        )
+    }
+    fn payment(r: &WaitlistRequest, t: String) -> Self {
+        Self::Payment(
+            json!({"waitlistRequestId":r.waitlist_request_id,"travelerRef":r.traveler_ref,"paymentGuaranteeRef":r.payment_guarantee_ref,"requestedAt":t,"status":r.status.as_contract()}),
+        )
+    }
+    fn queued(r: &WaitlistRequest, t: String, order: Option<String>) -> Self {
+        let mut v = json!({"waitlistRequestId":r.waitlist_request_id,"travelerRef":r.traveler_ref,"segmentRef":r.segment_ref,"travelClass":r.travel_class,"intentFingerprint":r.intent_fingerprint,"queuedAt":t,"status":"QUEUED"});
+        if let Some(o) = order {
+            v["journeyOrderRef"] = json!(o)
+        }
+        Self::Queued(v)
+    }
+    fn match_started(r: &WaitlistRequest, rel: String, key: String, t: String) -> Self {
+        Self::MatchStarted(
+            json!({"waitlistRequestId":r.waitlist_request_id,"travelerRef":r.traveler_ref,"segmentRef":r.segment_ref,"travelClass":r.travel_class,"matchedCapacityReleaseRef":rel,"journeyOrderIdempotencyKey":key,"startedAt":t,"status":"MATCHING"}),
+        )
+    }
+    fn fulfilled(r: &WaitlistRequest, order: String, t: String) -> Self {
+        Self::Fulfilled(
+            json!({"waitlistRequestId":r.waitlist_request_id,"travelerRef":r.traveler_ref,"segmentRef":r.segment_ref,"travelClass":r.travel_class,"journeyOrderRef":order,"fulfilledAt":t,"status":"FULFILLED"}),
+        )
+    }
+    fn cancelled(r: &WaitlistRequest, reason: String, t: String) -> Self {
+        Self::Cancelled(
+            json!({"waitlistRequestId":r.waitlist_request_id,"travelerRef":r.traveler_ref,"segmentRef":r.segment_ref,"travelClass":r.travel_class,"cancelledAt":t,"reason":reason,"status":"CANCELLED"}),
+        )
+    }
+    fn expired(r: &WaitlistRequest, t: String) -> Self {
+        Self::Expired(
+            json!({"waitlistRequestId":r.waitlist_request_id,"travelerRef":r.traveler_ref,"segmentRef":r.segment_ref,"travelClass":r.travel_class,"deadline":r.deadline,"expiredAt":t,"status":"EXPIRED"}),
+        )
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateWaitlistCommand {
+    pub traveler_ref: String,
+    pub segment_ref: String,
+    pub travel_class: Option<String>,
+    pub deadline: String,
+    pub payment_guarantee_ref: String,
+    pub intent_fingerprint: String,
+}
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CancelWaitlistCommand {
+    pub reason: String,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WaitlistResource {
+    pub waitlist_request_id: String,
+    pub traveler_ref: String,
+    pub segment_ref: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub travel_class: Option<String>,
+    pub deadline: String,
+    pub payment_guarantee_ref: String,
+    pub intent_fingerprint: String,
+    pub status: WaitlistStatus,
+}
+impl From<&WaitlistRequest> for WaitlistResource {
+    fn from(r: &WaitlistRequest) -> Self {
+        Self {
+            waitlist_request_id: r.waitlist_request_id.clone(),
+            traveler_ref: r.traveler_ref.clone(),
+            segment_ref: r.segment_ref.clone(),
+            travel_class: r.travel_class.clone(),
+            deadline: r.deadline.clone(),
+            payment_guarantee_ref: r.payment_guarantee_ref.clone(),
+            intent_fingerprint: r.intent_fingerprint.clone(),
+            status: r.status,
+        }
+    }
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CancelWaitlistResponse {
+    pub waitlist_request_id: String,
+    pub status: WaitlistStatus,
+    pub cancelled_at: String,
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PaginatedWaitlistRequests {
+    pub items: Vec<WaitlistResource>,
+    pub total: usize,
+    pub limit: usize,
+    pub offset: usize,
+}
+
+#[derive(Debug, Clone)]
+pub enum WaitlistError {
+    ValidationFailed(String),
+    NotFound(String),
+    Conflict(String),
+    IdempotencyKeyReused(String),
+    PreconditionFailed(String),
+    DomainRuleViolation(String),
+    Unavailable(String),
+    Internal(String),
+}
+impl WaitlistError {
+    fn status(&self) -> StatusCode {
+        match self {
+            Self::ValidationFailed(_) => StatusCode::BAD_REQUEST,
+            Self::NotFound(_) => StatusCode::NOT_FOUND,
+            Self::Conflict(_) => StatusCode::CONFLICT,
+            Self::IdempotencyKeyReused(_) => StatusCode::UNPROCESSABLE_ENTITY,
+            Self::PreconditionFailed(_) => StatusCode::PRECONDITION_FAILED,
+            Self::DomainRuleViolation(_) => StatusCode::UNPROCESSABLE_ENTITY,
+            Self::Unavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
+            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+    fn code(&self) -> &'static str {
+        match self {
+            Self::ValidationFailed(_) => "VALIDATION_FAILED",
+            Self::NotFound(_) => "NOT_FOUND",
+            Self::Conflict(_) => "CONFLICT",
+            Self::IdempotencyKeyReused(_) => "IDEMPOTENCY_KEY_REUSED",
+            Self::PreconditionFailed(_) => "PRECONDITION_FAILED",
+            Self::DomainRuleViolation(_) => "DOMAIN_RULE_VIOLATION",
+            Self::Unavailable(_) | Self::Internal(_) => "UNAVAILABLE",
+        }
+    }
+    fn message(&self) -> &str {
+        match self {
+            Self::ValidationFailed(m)
+            | Self::NotFound(m)
+            | Self::Conflict(m)
+            | Self::IdempotencyKeyReused(m)
+            | Self::PreconditionFailed(m)
+            | Self::DomainRuleViolation(m)
+            | Self::Unavailable(m)
+            | Self::Internal(m) => m,
+        }
+    }
+}
+impl fmt::Display for WaitlistError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.message())
+    }
+}
+impl std::error::Error for WaitlistError {}
+fn api_error_response(e: WaitlistError, corr: String) -> Response {
+    kit_http::error_response(
+        e.status(),
+        e.code(),
+        e.message().to_string(),
+        corr,
+        Some(json!({"domainCode":e.code()})),
+    )
+}
+
+pub struct ApiState<S: WaitlistApi + 'static> {
+    service: Arc<S>,
+}
+impl<S: WaitlistApi + 'static> Clone for ApiState<S> {
+    fn clone(&self) -> Self {
+        Self {
+            service: Arc::clone(&self.service),
+        }
+    }
+}
+#[async_trait]
+pub trait WaitlistApi: Send + Sync {
+    async fn create(
+        &self,
+        c: CreateWaitlistCommand,
+        key: String,
+        corr: String,
+    ) -> Result<WaitlistResource, WaitlistError>;
+    async fn get(&self, id: String) -> Result<WaitlistResource, WaitlistError>;
+    async fn cancel(
+        &self,
+        id: String,
+        c: CancelWaitlistCommand,
+        key: String,
+        corr: String,
+    ) -> Result<CancelWaitlistResponse, WaitlistError>;
+    async fn list(
+        &self,
+        traveler: String,
+        status: Option<WaitlistStatus>,
+        limit: usize,
+        offset: usize,
+    ) -> Result<PaginatedWaitlistRequests, WaitlistError>;
+}
+
+async fn create_waitlist<S: WaitlistApi + 'static>(
+    State(st): State<ApiState<S>>,
+    Extension(ctx): Extension<RequestContext>,
+    headers: HeaderMap,
+    body: Result<Json<CreateWaitlistCommand>, JsonRejection>,
+) -> Response {
+    let corr = ctx.correlation_id().to_string();
+    let key = match idempotency_key(&headers) {
+        Ok(k) => k,
+        Err(e) => return idempotency_error_response(e, corr),
+    };
+    let Json(cmd) = match body {
+        Ok(b) => b,
+        Err(e) => return validation_error(corr, e.body_text()),
+    };
+    match st.service.create(cmd, key, corr.clone()).await {
+        Ok(r) => (StatusCode::CREATED, Json(r)).into_response(),
+        Err(e) => api_error_response(e, corr),
+    }
+}
+async fn get_waitlist<S: WaitlistApi + 'static>(
+    State(st): State<ApiState<S>>,
+    Extension(ctx): Extension<RequestContext>,
+    Path(id): Path<String>,
+) -> Response {
+    let corr = ctx.correlation_id().to_string();
+    match st.service.get(id).await {
+        Ok(r) => (StatusCode::OK, Json(r)).into_response(),
+        Err(e) => api_error_response(e, corr),
+    }
+}
+async fn cancel_waitlist<S: WaitlistApi + 'static>(
+    State(st): State<ApiState<S>>,
+    Extension(ctx): Extension<RequestContext>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    body: Result<Json<CancelWaitlistCommand>, JsonRejection>,
+) -> Response {
+    let corr = ctx.correlation_id().to_string();
+    let key = match idempotency_key(&headers) {
+        Ok(k) => k,
+        Err(e) => return idempotency_error_response(e, corr),
+    };
+    let Json(cmd) = match body {
+        Ok(b) => b,
+        Err(e) => return validation_error(corr, e.body_text()),
+    };
+    match st.service.cancel(id, cmd, key, corr.clone()).await {
+        Ok(r) => (StatusCode::OK, Json(r)).into_response(),
+        Err(e) => api_error_response(e, corr),
+    }
+}
+async fn list_waitlist<S: WaitlistApi + 'static>(
+    State(st): State<ApiState<S>>,
+    Extension(ctx): Extension<RequestContext>,
+    RawQuery(raw): RawQuery,
+) -> Response {
+    let corr = ctx.correlation_id().to_string();
+    let q = match parse_list_query(raw.as_deref()) {
+        Ok(q) => q,
+        Err(m) => return validation_error(corr, m),
+    };
+    match st
+        .service
+        .list(
+            q.traveler_ref,
+            q.status,
+            q.limit.unwrap_or(20).min(100),
+            q.offset.unwrap_or(0),
+        )
+        .await
+    {
+        Ok(r) => (StatusCode::OK, Json(r)).into_response(),
+        Err(e) => api_error_response(e, corr),
+    }
+}
+fn validation_error(corr: String, msg: impl Into<String>) -> Response {
+    kit_http::error_response(
+        StatusCode::BAD_REQUEST,
+        "VALIDATION_FAILED",
+        msg.into(),
+        corr,
+        Some(json!({"domainCode":"VALIDATION_FAILED"})),
+    )
+}
+fn idempotency_error_response(e: kit_idempotency::IdempotencyError, corr: String) -> Response {
+    match e {
+        kit_idempotency::IdempotencyError::Reused => api_error_response(
+            WaitlistError::IdempotencyKeyReused(
+                "Idempotency-Key was reused with a different request body".into(),
+            ),
+            corr,
+        ),
+        _ => validation_error(
+            corr,
+            "Idempotency-Key header is required and must be a valid UUID v7",
+        ),
+    }
+}
+fn idempotency_key(headers: &HeaderMap) -> Result<String, kit_idempotency::IdempotencyError> {
+    kit_idempotency::require_idempotency_key(headers)
+}
+struct ListQuery {
+    traveler_ref: String,
+    status: Option<WaitlistStatus>,
+    limit: Option<usize>,
+    offset: Option<usize>,
+}
+fn parse_list_query(raw: Option<&str>) -> Result<ListQuery, String> {
+    let raw = raw.ok_or_else(|| "travelerRef query parameter is required".to_string())?;
+    let (mut traveler, mut status, mut limit, mut offset) = (None, None, None, None);
+    for pair in raw.split('&').filter(|p| !p.is_empty()) {
+        let (n, v) = pair.split_once('=').unwrap_or((pair, ""));
+        match n {
+            "travelerRef" => traveler = Some(v.to_string()),
+            "status" => {
+                status = Some(
+                    v.parse()
+                        .map_err(|_| "status query parameter is invalid".to_string())?,
+                )
+            }
+            "limit" => {
+                limit = Some(v.parse().map_err(|_| {
+                    "limit query parameter must be a non-negative integer".to_string()
+                })?)
+            }
+            "offset" => {
+                offset = Some(v.parse().map_err(|_| {
+                    "offset query parameter must be a non-negative integer".to_string()
+                })?)
+            }
+            _ => {}
+        }
+    }
+    Ok(ListQuery {
+        traveler_ref: traveler
+            .filter(|v| !v.trim().is_empty())
+            .ok_or_else(|| "travelerRef query parameter is required".to_string())?,
+        status,
+        limit,
+        offset,
+    })
+}
+
+pub struct InMemoryWaitlistService {
+    state: Mutex<InMemoryState>,
+    publisher: Arc<dyn EventPublisher>,
+    order_client: Arc<dyn JourneyOrderClient>,
+}
+
+impl Default for InMemoryWaitlistService {
+    fn default() -> Self {
+        Self::new(
+            Arc::new(InMemoryEventPublisher::default()),
+            Arc::new(NoopJourneyOrderClient),
+        )
+    }
+}
+impl InMemoryWaitlistService {
+    pub fn new(
+        publisher: Arc<dyn EventPublisher>,
+        order_client: Arc<dyn JourneyOrderClient>,
+    ) -> Self {
+        Self {
+            state: Mutex::new(InMemoryState::default()),
+            publisher,
+            order_client,
+        }
+    }
+
+    pub async fn handle_subscribed_event(
+        &self,
+        envelope: rust_kit::messaging::EventEnvelope,
+    ) -> Result<(), rust_kit::messaging::HandlerError> {
+        self.apply_subscribed_event(envelope)
+            .await
+            .map_err(handler_error)
+    }
+
+    pub async fn apply_subscribed_event(
+        &self,
+        envelope: rust_kit::messaging::EventEnvelope,
+    ) -> Result<(), WaitlistError> {
+        {
+            let mut state = self.state.lock().expect("waitlist state lock poisoned");
+            if !state.processed_events.insert(envelope.event_id.clone()) {
+                return Ok(());
+            }
+        }
+        match envelope.event_type.as_str() {
+            "CapacityReleased" => self.handle_capacity_released(envelope).await,
+            "JourneyOrderConfirmed" => self.handle_journey_order_confirmed(envelope).await,
+            "JourneyOrderCancelled" => self.handle_journey_order_cancelled(envelope).await,
+            _ => Ok(()),
+        }
+    }
+
+    async fn handle_capacity_released(
+        &self,
+        envelope: rust_kit::messaging::EventEnvelope,
+    ) -> Result<(), WaitlistError> {
+        let segment = segment_from_payload(&envelope.payload).ok_or_else(|| {
+            WaitlistError::ValidationFailed("CapacityReleased missing segmentRef".into())
+        })?;
+        let (request, event, key) = {
+            let mut state = self.state.lock().expect("waitlist state lock poisoned");
+            let queue = WaitlistQueue::rebuild(state.requests.values().cloned());
+            let Some(id) = queue.head_for_segment(&segment).map(str::to_string) else {
+                return Ok(());
+            };
+            let request = state.requests.get_mut(&id).expect("queue head exists");
+            let event =
+                request.start_matching(envelope.event_id.clone(), envelope.occurred_at.clone())?;
+            let key = journey_order_idempotency_key(&request.waitlist_request_id);
+            (request.clone(), event, key)
+        };
+        publish_events(
+            self.publisher.as_ref(),
+            vec![PendingEnvelope::new(
+                &request.waitlist_request_id,
+                request.version,
+                event,
+                envelope.correlation_id.clone(),
+                Some(envelope.event_id.clone()),
+            )],
+        )
+        .await?;
+        match self
+            .order_client
+            .create_order(&request, &key, &envelope.correlation_id)
+            .await
+        {
+            Ok(order) => {
+                if let Some(stored) = self
+                    .state
+                    .lock()
+                    .expect("waitlist state lock poisoned")
+                    .requests
+                    .get_mut(&request.waitlist_request_id)
+                {
+                    stored.record_order_ref(order);
+                }
+                Ok(())
+            }
+            Err(OrderClientError::Transient(message)) => Err(WaitlistError::Unavailable(message)),
+            Err(OrderClientError::Rejected(message)) => {
+                log::warn!(
+                    "journey-order rejected waitlist fulfillment requestId={}: {message}",
+                    request.waitlist_request_id
+                );
+                let queued = {
+                    let mut state = self.state.lock().expect("waitlist state lock poisoned");
+                    state
+                        .requests
+                        .get_mut(&request.waitlist_request_id)
+                        .expect("request exists")
+                        .requeue_after_order_cancelled(current_rfc3339())?
+                };
+                publish_events(
+                    self.publisher.as_ref(),
+                    vec![PendingEnvelope::new(
+                        &request.waitlist_request_id,
+                        request.version + 1,
+                        queued,
+                        envelope.correlation_id,
+                        Some(envelope.event_id),
+                    )],
+                )
+                .await
+            }
+        }
+    }
+
+    async fn handle_journey_order_confirmed(
+        &self,
+        envelope: rust_kit::messaging::EventEnvelope,
+    ) -> Result<(), WaitlistError> {
+        let Some(order) = order_ref_from_payload(&envelope.payload) else {
+            return Ok(());
+        };
+        let pending = {
+            let mut state = self.state.lock().expect("waitlist state lock poisoned");
+            let Some(request) = state
+                .requests
+                .values_mut()
+                .find(|request| request.order_ref.as_deref() == Some(order.as_str()))
+            else {
+                return Ok(());
+            };
+            let events = request.fulfill_and_close(order, envelope.occurred_at.clone())?;
+            events
+                .into_iter()
+                .map(|event| {
+                    PendingEnvelope::new(
+                        &request.waitlist_request_id,
+                        request.version,
+                        event,
+                        envelope.correlation_id.clone(),
+                        Some(envelope.event_id.clone()),
+                    )
+                })
+                .collect()
+        };
+        publish_events(self.publisher.as_ref(), pending).await
+    }
+
+    async fn handle_journey_order_cancelled(
+        &self,
+        envelope: rust_kit::messaging::EventEnvelope,
+    ) -> Result<(), WaitlistError> {
+        let Some(order) = order_ref_from_payload(&envelope.payload) else {
+            return Ok(());
+        };
+        let pending = {
+            let mut state = self.state.lock().expect("waitlist state lock poisoned");
+            let Some(request) = state
+                .requests
+                .values_mut()
+                .find(|request| request.order_ref.as_deref() == Some(order.as_str()))
+            else {
+                return Ok(());
+            };
+            let event = request.requeue_after_order_cancelled(envelope.occurred_at.clone())?;
+            vec![PendingEnvelope::new(
+                &request.waitlist_request_id,
+                request.version,
+                event,
+                envelope.correlation_id.clone(),
+                Some(envelope.event_id.clone()),
+            )]
+        };
+        publish_events(self.publisher.as_ref(), pending).await
+    }
+
+    pub async fn expire_due(
+        &self,
+        now: String,
+        correlation_id: String,
+    ) -> Result<usize, WaitlistError> {
+        let pending = {
+            let mut state = self.state.lock().expect("waitlist state lock poisoned");
+            let mut pending = Vec::new();
+            for request in state.requests.values_mut() {
+                if matches!(
+                    request.status,
+                    WaitlistStatus::Queued | WaitlistStatus::Suspended
+                ) && !deadline_after(&request.deadline, &now)
+                {
+                    let events = request.expire_and_close(now.clone())?;
+                    pending.extend(events.into_iter().map(|event| {
+                        PendingEnvelope::new(
+                            &request.waitlist_request_id,
+                            request.version,
+                            event,
+                            correlation_id.clone(),
+                            None,
+                        )
+                    }));
+                }
+            }
+            pending
+        };
+        let count = pending.len();
+        publish_events(self.publisher.as_ref(), pending).await?;
+        Ok(count)
+    }
+}
+
+#[derive(Default)]
+struct InMemoryState {
+    requests: HashMap<String, WaitlistRequest>,
+    active_index: HashMap<(String, String), String>,
+    idempotency: HashMap<String, IdempotentRecord>,
+    processed_events: HashSet<String>,
+}
+
+#[derive(Clone)]
+struct IdempotentRecord {
+    operation: &'static str,
+    fingerprint: String,
+    response: IdempotentResponse,
+}
+#[derive(Clone)]
+enum IdempotentResponse {
+    Create(WaitlistResource),
+    Cancel(CancelWaitlistResponse),
+}
+
+#[async_trait]
+impl WaitlistApi for InMemoryWaitlistService {
+    async fn create(
+        &self,
+        command: CreateWaitlistCommand,
+        key: String,
+        correlation_id: String,
+    ) -> Result<WaitlistResource, WaitlistError> {
+        let fingerprint = serde_json::to_string(&command).unwrap_or_default();
+        let (id, version, response, events) = {
+            let mut state = self.state.lock().expect("waitlist state lock poisoned");
+            if let Some(record) = state.idempotency.get(&key) {
+                if record.fingerprint != fingerprint || record.operation != "create" {
+                    return Err(WaitlistError::IdempotencyKeyReused(
+                        "Idempotency-Key was reused with a different request body".into(),
+                    ));
+                }
+                if let IdempotentResponse::Create(response) = &record.response {
+                    return Ok(response.clone());
+                }
+            }
+            let (request, events) = WaitlistRequest::create(command, current_rfc3339())?;
+            let active_key = (
+                request.traveler_ref.clone(),
+                request.intent_fingerprint.clone(),
+            );
+            if let Some(existing) = state.active_index.get(&active_key) {
+                if state
+                    .requests
+                    .get(existing)
+                    .is_some_and(|request| request.status.is_active())
+                {
+                    return Err(WaitlistError::Conflict(
+                        "traveler already has an active waitlist request for this intent".into(),
+                    ));
+                }
+            }
+            let response = WaitlistResource::from(&request);
+            let id = request.waitlist_request_id.clone();
+            let version = request.version;
+            state.active_index.insert(active_key, id.clone());
+            state.requests.insert(id.clone(), request);
+            state.idempotency.insert(
+                key,
+                IdempotentRecord {
+                    operation: "create",
+                    fingerprint,
+                    response: IdempotentResponse::Create(response.clone()),
+                },
+            );
+            (id, version, response, events)
+        };
+        publish_events(
+            self.publisher.as_ref(),
+            events
+                .into_iter()
+                .enumerate()
+                .map(|(index, event)| {
+                    PendingEnvelope::new(
+                        &id,
+                        version + index as i64,
+                        event,
+                        correlation_id.clone(),
+                        None,
+                    )
+                })
+                .collect(),
+        )
+        .await?;
+        Ok(response)
+    }
+
+    async fn get(&self, id: String) -> Result<WaitlistResource, WaitlistError> {
+        validate_prefixed_uuid(&id, "waitlistRequestId", "wlr-")?;
+        self.state
+            .lock()
+            .expect("waitlist state lock poisoned")
+            .requests
+            .get(&id)
+            .map(WaitlistResource::from)
+            .ok_or_else(|| WaitlistError::NotFound("waitlist request not found".into()))
+    }
+
+    async fn cancel(
+        &self,
+        id: String,
+        command: CancelWaitlistCommand,
+        key: String,
+        correlation_id: String,
+    ) -> Result<CancelWaitlistResponse, WaitlistError> {
+        validate_prefixed_uuid(&id, "waitlistRequestId", "wlr-")?;
+        let fingerprint = format!(
+            "{}:{}",
+            id,
+            serde_json::to_string(&command).unwrap_or_default()
+        );
+        let (version, response, event) = {
+            let mut state = self.state.lock().expect("waitlist state lock poisoned");
+            if let Some(record) = state.idempotency.get(&key) {
+                if record.fingerprint != fingerprint || record.operation != "cancel" {
+                    return Err(WaitlistError::IdempotencyKeyReused(
+                        "Idempotency-Key was reused with a different request body".into(),
+                    ));
+                }
+                if let IdempotentResponse::Cancel(response) = &record.response {
+                    return Ok(response.clone());
+                }
+            }
+            let request = state
+                .requests
+                .get_mut(&id)
+                .ok_or_else(|| WaitlistError::NotFound("waitlist request not found".into()))?;
+            let cancelled_at = current_rfc3339();
+            let event = request.cancel(command.reason, cancelled_at.clone())?;
+            let response = CancelWaitlistResponse {
+                waitlist_request_id: id.clone(),
+                status: WaitlistStatus::Cancelled,
+                cancelled_at,
+            };
+            let active_key = (
+                request.traveler_ref.clone(),
+                request.intent_fingerprint.clone(),
+            );
+            let version = request.version;
+            state.active_index.remove(&active_key);
+            state.idempotency.insert(
+                key,
+                IdempotentRecord {
+                    operation: "cancel",
+                    fingerprint,
+                    response: IdempotentResponse::Cancel(response.clone()),
+                },
+            );
+            (version, response, event)
+        };
+        publish_events(
+            self.publisher.as_ref(),
+            vec![PendingEnvelope::new(
+                &id,
+                version,
+                event,
+                correlation_id,
+                None,
+            )],
+        )
+        .await?;
+        Ok(response)
+    }
+
+    async fn list(
+        &self,
+        traveler: String,
+        status: Option<WaitlistStatus>,
+        limit: usize,
+        offset: usize,
+    ) -> Result<PaginatedWaitlistRequests, WaitlistError> {
+        validate_prefixed_uuid(&traveler, "travelerRef", "tvl-")?;
+        let mut items: Vec<_> = self
+            .state
+            .lock()
+            .expect("waitlist state lock poisoned")
+            .requests
+            .values()
+            .filter(|request| {
+                request.traveler_ref == traveler
+                    && status.is_none_or(|status| request.status == status)
+            })
+            .map(WaitlistResource::from)
+            .collect();
+        items.sort_by(|left, right| left.waitlist_request_id.cmp(&right.waitlist_request_id));
+        let total = items.len();
+        Ok(PaginatedWaitlistRequests {
+            items: items.into_iter().skip(offset).take(limit).collect(),
+            total,
+            limit,
+            offset,
+        })
+    }
+}
+
+#[async_trait]
+pub trait EventPublisher: Send + Sync {
+    async fn publish(
+        &self,
+        envelope: rust_kit::messaging::EventEnvelope,
+    ) -> Result<(), PublishFailed>;
+}
+#[derive(Debug, Clone)]
+pub struct PublishFailed(pub String);
+impl fmt::Display for PublishFailed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+impl std::error::Error for PublishFailed {}
+
+#[derive(Default)]
+pub struct InMemoryEventPublisher {
+    published: Mutex<Vec<rust_kit::messaging::EventEnvelope>>,
+    fail_next: Mutex<Option<String>>,
+}
+impl InMemoryEventPublisher {
+    pub fn published(&self) -> Vec<rust_kit::messaging::EventEnvelope> {
+        self.published
+            .lock()
+            .expect("publisher lock poisoned")
+            .clone()
+    }
+    pub fn fail_next(&self, message: impl Into<String>) {
+        *self.fail_next.lock().expect("publisher lock poisoned") = Some(message.into());
+    }
+}
+#[async_trait]
+impl EventPublisher for InMemoryEventPublisher {
+    async fn publish(
+        &self,
+        envelope: rust_kit::messaging::EventEnvelope,
+    ) -> Result<(), PublishFailed> {
+        if let Some(message) = self
+            .fail_next
+            .lock()
+            .expect("publisher lock poisoned")
+            .take()
+        {
+            return Err(PublishFailed(message));
+        }
+        self.published
+            .lock()
+            .expect("publisher lock poisoned")
+            .push(envelope);
+        Ok(())
+    }
+}
+#[async_trait]
+impl EventPublisher for rust_kit::messaging::redis_runtime::RedisEventPublisher {
+    async fn publish(
+        &self,
+        envelope: rust_kit::messaging::EventEnvelope,
+    ) -> Result<(), PublishFailed> {
+        rust_kit::messaging::AsyncEventPublisher::publish(self, envelope)
+            .await
+            .map_err(|error| PublishFailed(error.to_string()))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PendingEnvelope {
+    id: String,
+    version: i64,
+    event: WaitlistEvent,
+    correlation_id: String,
+    causation_id: Option<String>,
+}
+impl PendingEnvelope {
+    fn new(
+        id: &str,
+        version: i64,
+        event: WaitlistEvent,
+        correlation_id: String,
+        causation_id: Option<String>,
+    ) -> Self {
+        Self {
+            id: id.to_string(),
+            version,
+            event,
+            correlation_id,
+            causation_id,
+        }
+    }
+}
+async fn publish_events(
+    publisher: &dyn EventPublisher,
+    events: Vec<PendingEnvelope>,
+) -> Result<(), WaitlistError> {
+    for event in events {
+        publisher
+            .publish(event.event.envelope(
+                &event.id,
+                event.version,
+                event.correlation_id,
+                event.causation_id,
+            ))
+            .await
+            .map_err(|error| WaitlistError::Unavailable(error.to_string()))?;
+    }
+    Ok(())
+}
+
+#[async_trait]
+pub trait JourneyOrderClient: Send + Sync {
+    async fn create_order(
+        &self,
+        request: &WaitlistRequest,
+        idempotency_key: &str,
+        correlation_id: &str,
+    ) -> Result<String, OrderClientError>;
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OrderClientError {
+    Transient(String),
+    Rejected(String),
+}
+#[derive(Default)]
+pub struct NoopJourneyOrderClient;
+#[async_trait]
+impl JourneyOrderClient for NoopJourneyOrderClient {
+    async fn create_order(
+        &self,
+        _: &WaitlistRequest,
+        _: &str,
+        _: &str,
+    ) -> Result<String, OrderClientError> {
+        Ok(format!("ord-{}", uuid::Uuid::now_v7()))
+    }
+}
+
+pub struct ReqwestJourneyOrderClient {
+    base_url: String,
+    client: reqwest::Client,
+}
+impl ReqwestJourneyOrderClient {
+    pub fn from_env() -> Self {
+        Self {
+            base_url: std::env::var("JOURNEY_ORDER_BASE_URL")
+                .unwrap_or_else(|_| "http://journey-order:8080".into()),
+            client: reqwest::Client::new(),
+        }
+    }
+}
+#[async_trait]
+impl JourneyOrderClient for ReqwestJourneyOrderClient {
+    async fn create_order(
+        &self,
+        request: &WaitlistRequest,
+        key: &str,
+        _: &str,
+    ) -> Result<String, OrderClientError> {
+        let mut builder = self.client.post(format!("{}/api/v1/journey-orders", self.base_url.trim_end_matches('/'))).header("Idempotency-Key", key).json(&json!({ "accountId": request.traveler_ref, "offerId": format!("off-waitlist-{}", request.waitlist_request_id), "offerVersion": 1, "travelerRefs": [request.traveler_ref.clone()], "segmentRefs": [request.segment_ref.clone()] }));
+        for (key, value) in active_trace_headers() {
+            builder = builder.header(key, value);
+        }
+        let response = builder
+            .send()
+            .await
+            .map_err(|error| OrderClientError::Transient(error.to_string()))?;
+        let status = response.status();
+        if status.is_server_error() {
+            return Err(OrderClientError::Transient(format!(
+                "journey-order returned {status}"
+            )));
+        }
+        if status.is_client_error() {
+            return Err(OrderClientError::Rejected(format!(
+                "journey-order returned {status}"
+            )));
+        }
+        let body: Value = response
+            .json()
+            .await
+            .map_err(|error| OrderClientError::Transient(error.to_string()))?;
+        body.get("orderId")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .ok_or_else(|| {
+                OrderClientError::Transient("journey-order response missing orderId".into())
+            })
+    }
+}
+#[derive(Default)]
+struct HeaderInjector(HashMap<String, String>);
+impl Injector for HeaderInjector {
+    fn set(&mut self, key: &str, value: String) {
+        self.0.insert(key.to_string(), value);
+    }
+}
+fn active_trace_headers() -> HashMap<String, String> {
+    let mut injector = HeaderInjector::default();
+    opentelemetry_sdk::propagation::TraceContextPropagator::new()
+        .inject_context(&OtelContext::current(), &mut injector);
+    injector.0
+}
+
+pub struct PostgresWaitlistService {
+    storage: rust_kit::storage::Storage,
+    order_client: Arc<dyn JourneyOrderClient>,
+}
+impl PostgresWaitlistService {
+    pub async fn from_env() -> Result<Self, WaitlistError> {
+        let storage = rust_kit::storage::Storage::from_env()
+            .await
+            .map_err(storage_error)?;
+        storage
+            .migrate_dir("services/waitlist/migrations")
+            .await
+            .map_err(storage_error)?;
+        Ok(Self {
+            storage,
+            order_client: Arc::new(ReqwestJourneyOrderClient::from_env()),
+        })
+    }
+    pub fn pool(&self) -> &sqlx::PgPool {
+        self.storage.pool()
+    }
+    pub async fn is_ready(&self) -> bool {
+        self.storage.is_ready().await
+    }
+    async fn load_request_for_update(
+        tx: &mut rust_kit::storage::PgTransaction<'_>,
+        id: &str,
+    ) -> Result<Option<WaitlistRequest>, WaitlistError> {
+        let row: Option<(Value,)> = sqlx::query_as(
+            "SELECT data FROM waitlist_requests WHERE waitlist_request_id = $1 FOR UPDATE",
+        )
+        .bind(id)
+        .fetch_optional(&mut **tx)
+        .await
+        .map_err(db_error)?;
+        row.map(|(value,)| {
+            serde_json::from_value(value)
+                .map_err(|error| WaitlistError::Internal(error.to_string()))
+        })
+        .transpose()
+    }
+    async fn save_request(
+        tx: &mut rust_kit::storage::PgTransaction<'_>,
+        request: &WaitlistRequest,
+    ) -> Result<(), WaitlistError> {
+        let data = serde_json::to_value(request)
+            .map_err(|error| WaitlistError::Internal(error.to_string()))?;
+        sqlx::query("INSERT INTO waitlist_requests (waitlist_request_id, traveler_ref, intent_fingerprint, segment_ref, status, deadline, queued_at, order_ref, version, data) VALUES ($1,$2,$3,$4,$5,$6::timestamptz,$7::timestamptz,$8,$9,$10) ON CONFLICT (waitlist_request_id) DO UPDATE SET traveler_ref=EXCLUDED.traveler_ref,intent_fingerprint=EXCLUDED.intent_fingerprint,segment_ref=EXCLUDED.segment_ref,status=EXCLUDED.status,deadline=EXCLUDED.deadline,queued_at=EXCLUDED.queued_at,order_ref=EXCLUDED.order_ref,version=EXCLUDED.version,data=EXCLUDED.data,updated_at=now()")
+            .bind(&request.waitlist_request_id).bind(&request.traveler_ref).bind(&request.intent_fingerprint).bind(&request.segment_ref).bind(request.status.as_contract()).bind(&request.deadline).bind(&request.queued_at).bind(&request.order_ref).bind(request.version).bind(data).execute(&mut **tx).await.map_err(db_error)?;
+        Ok(())
+    }
+    async fn append_events(
+        tx: &mut rust_kit::storage::PgTransaction<'_>,
+        id: &str,
+        version: i64,
+        events: Vec<WaitlistEvent>,
+        correlation_id: String,
+        causation_id: Option<String>,
+    ) -> Result<(), WaitlistError> {
+        for (index, event) in events.into_iter().enumerate() {
+            let envelope = event.envelope(
+                id,
+                version + index as i64,
+                correlation_id.clone(),
+                causation_id.clone(),
+            );
+            rust_kit::storage::OutboxAppender::append(
+                tx,
+                &rust_kit::messaging::stream_for_producer(profile().service_id),
+                &envelope,
+            )
+            .await
+            .map_err(storage_error)?;
+        }
+        Ok(())
+    }
+    pub async fn handle_subscribed_event(
+        &self,
+        envelope: rust_kit::messaging::EventEnvelope,
+    ) -> Result<(), rust_kit::messaging::HandlerError> {
+        self.apply_subscribed_event(envelope)
+            .await
+            .map_err(handler_error)
+    }
+    pub async fn apply_subscribed_event(
+        &self,
+        envelope: rust_kit::messaging::EventEnvelope,
+    ) -> Result<(), WaitlistError> {
+        match envelope.event_type.as_str() {
+            "CapacityReleased" => self.handle_capacity_released(envelope).await,
+            "JourneyOrderConfirmed" => self.handle_order_terminal(envelope, true).await,
+            "JourneyOrderCancelled" => self.handle_order_terminal(envelope, false).await,
+            _ => Ok(()),
+        }
+    }
+    pub async fn expire_due(
+        &self,
+        now: String,
+        correlation_id: String,
+    ) -> Result<usize, WaitlistError> {
+        let mut tx = self.pool().begin().await.map_err(db_error)?;
+        let rows: Vec<(String,)> = sqlx::query_as("SELECT waitlist_request_id FROM waitlist_requests WHERE status IN ('QUEUED','SUSPENDED') AND deadline <= $1::timestamptz FOR UPDATE SKIP LOCKED").bind(&now).fetch_all(&mut *tx).await.map_err(db_error)?;
+        let mut count = 0;
+        for (id,) in rows {
+            if let Some(mut request) = Self::load_request_for_update(&mut tx, &id).await? {
+                let version = request.version;
+                let events = request.expire_and_close(now.clone())?;
+                Self::save_request(&mut tx, &request).await?;
+                Self::append_events(
+                    &mut tx,
+                    &request.waitlist_request_id,
+                    version + 1,
+                    events,
+                    correlation_id.clone(),
+                    None,
+                )
+                .await?;
+                count += 1;
+            }
+        }
+        tx.commit().await.map_err(db_error)?;
+        Ok(count)
+    }
+    async fn handle_capacity_released(
+        &self,
+        envelope: rust_kit::messaging::EventEnvelope,
+    ) -> Result<(), WaitlistError> {
+        let segment = segment_from_payload(&envelope.payload).ok_or_else(|| {
+            WaitlistError::ValidationFailed("CapacityReleased missing segmentRef".into())
+        })?;
+        let mut tx = self.pool().begin().await.map_err(db_error)?;
+        if !rust_kit::storage::mark_event_processing(
+            &mut tx,
+            &envelope.event_id,
+            "events:capacity-availability",
+        )
+        .await
+        .map_err(storage_error)?
+        {
+            tx.commit().await.map_err(db_error)?;
+            return Ok(());
+        }
+        let row: Option<(String,)> = sqlx::query_as("SELECT waitlist_request_id FROM waitlist_requests WHERE segment_ref=$1 AND status='QUEUED' ORDER BY queued_at ASC NULLS LAST, created_at ASC, waitlist_request_id ASC LIMIT 1 FOR UPDATE SKIP LOCKED").bind(&segment).fetch_optional(&mut *tx).await.map_err(db_error)?;
+        let Some((id,)) = row else {
+            tx.commit().await.map_err(db_error)?;
+            return Ok(());
+        };
+        let mut request = Self::load_request_for_update(&mut tx, &id)
+            .await?
+            .ok_or_else(|| WaitlistError::NotFound("waitlist request not found".into()))?;
+        let version = request.version;
+        let event =
+            request.start_matching(envelope.event_id.clone(), envelope.occurred_at.clone())?;
+        Self::save_request(&mut tx, &request).await?;
+        Self::append_events(
+            &mut tx,
+            &request.waitlist_request_id,
+            version + 1,
+            vec![event],
+            envelope.correlation_id.clone(),
+            Some(envelope.event_id.clone()),
+        )
+        .await?;
+        tx.commit().await.map_err(db_error)?;
+        let key = journey_order_idempotency_key(&request.waitlist_request_id);
+        match self
+            .order_client
+            .create_order(&request, &key, &envelope.correlation_id)
+            .await
+        {
+            Ok(order) => {
+                sqlx::query("UPDATE waitlist_requests SET order_ref=$2, data=jsonb_set(data,'{orderRef}',to_jsonb($2::text),true), updated_at=now() WHERE waitlist_request_id=$1").bind(&request.waitlist_request_id).bind(order).execute(self.pool()).await.map_err(db_error)?;
+                Ok(())
+            }
+            Err(OrderClientError::Transient(message)) => Err(WaitlistError::Unavailable(message)),
+            Err(OrderClientError::Rejected(message)) => {
+                log::warn!(
+                    "journey-order rejected waitlist fulfillment requestId={}: {message}",
+                    request.waitlist_request_id
+                );
+                Ok(())
+            }
+        }
+    }
+    async fn handle_order_terminal(
+        &self,
+        envelope: rust_kit::messaging::EventEnvelope,
+        confirmed: bool,
+    ) -> Result<(), WaitlistError> {
+        let Some(order) = order_ref_from_payload(&envelope.payload) else {
+            return Ok(());
+        };
+        let mut tx = self.pool().begin().await.map_err(db_error)?;
+        if !rust_kit::storage::mark_event_processing(
+            &mut tx,
+            &envelope.event_id,
+            "events:journey-order",
+        )
+        .await
+        .map_err(storage_error)?
+        {
+            tx.commit().await.map_err(db_error)?;
+            return Ok(());
+        }
+        let row: Option<(String,)> = sqlx::query_as("SELECT waitlist_request_id FROM waitlist_requests WHERE order_ref=$1 LIMIT 1 FOR UPDATE").bind(&order).fetch_optional(&mut *tx).await.map_err(db_error)?;
+        let Some((id,)) = row else {
+            tx.commit().await.map_err(db_error)?;
+            return Ok(());
+        };
+        let mut request = Self::load_request_for_update(&mut tx, &id)
+            .await?
+            .ok_or_else(|| WaitlistError::NotFound("waitlist request not found".into()))?;
+        let version = request.version;
+        let events = if confirmed {
+            request.fulfill_and_close(order, envelope.occurred_at.clone())?
+        } else {
+            vec![request.requeue_after_order_cancelled(envelope.occurred_at.clone())?]
+        };
+        Self::save_request(&mut tx, &request).await?;
+        Self::append_events(
+            &mut tx,
+            &request.waitlist_request_id,
+            version + 1,
+            events,
+            envelope.correlation_id,
+            Some(envelope.event_id),
+        )
+        .await?;
+        tx.commit().await.map_err(db_error)?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl WaitlistApi for PostgresWaitlistService {
+    async fn create(
+        &self,
+        command: CreateWaitlistCommand,
+        key: String,
+        correlation_id: String,
+    ) -> Result<WaitlistResource, WaitlistError> {
+        let fingerprint = serde_json::to_string(&command).unwrap_or_default();
+        let mut tx = self.pool().begin().await.map_err(db_error)?;
+        if let rust_kit::storage::IdempotencyTxDecision::Replay(record) =
+            rust_kit::storage::DbIdempotencyStore::claim_response(&mut tx, &key, &fingerprint)
+                .await
+                .map_err(storage_error)?
+        {
+            tx.commit().await.map_err(db_error)?;
+            return serde_json::from_value(record.body)
+                .map_err(|error| WaitlistError::Internal(error.to_string()));
+        }
+        let (request, events) = WaitlistRequest::create(command, current_rfc3339())?;
+        let response = WaitlistResource::from(&request);
+        Self::save_request(&mut tx, &request).await?;
+        Self::append_events(
+            &mut tx,
+            &request.waitlist_request_id,
+            1,
+            events,
+            correlation_id,
+            None,
+        )
+        .await?;
+        rust_kit::storage::DbIdempotencyStore::record_response(
+            &mut tx,
+            &key,
+            &fingerprint,
+            201,
+            serde_json::to_value(&response).unwrap(),
+        )
+        .await
+        .map_err(storage_error)?;
+        tx.commit().await.map_err(db_error)?;
+        Ok(response)
+    }
+    async fn get(&self, id: String) -> Result<WaitlistResource, WaitlistError> {
+        validate_prefixed_uuid(&id, "waitlistRequestId", "wlr-")?;
+        let row: Option<(Value,)> =
+            sqlx::query_as("SELECT data FROM waitlist_requests WHERE waitlist_request_id=$1")
+                .bind(&id)
+                .fetch_optional(self.pool())
+                .await
+                .map_err(db_error)?;
+        let request: WaitlistRequest = serde_json::from_value(
+            row.ok_or_else(|| WaitlistError::NotFound("waitlist request not found".into()))?
+                .0,
+        )
+        .map_err(|error| WaitlistError::Internal(error.to_string()))?;
+        Ok(WaitlistResource::from(&request))
+    }
+    async fn cancel(
+        &self,
+        id: String,
+        command: CancelWaitlistCommand,
+        key: String,
+        correlation_id: String,
+    ) -> Result<CancelWaitlistResponse, WaitlistError> {
+        validate_prefixed_uuid(&id, "waitlistRequestId", "wlr-")?;
+        let fingerprint = format!(
+            "{}:{}",
+            id,
+            serde_json::to_string(&command).unwrap_or_default()
+        );
+        let mut tx = self.pool().begin().await.map_err(db_error)?;
+        if let rust_kit::storage::IdempotencyTxDecision::Replay(record) =
+            rust_kit::storage::DbIdempotencyStore::claim_response(&mut tx, &key, &fingerprint)
+                .await
+                .map_err(storage_error)?
+        {
+            tx.commit().await.map_err(db_error)?;
+            return serde_json::from_value(record.body)
+                .map_err(|error| WaitlistError::Internal(error.to_string()));
+        }
+        let mut request = Self::load_request_for_update(&mut tx, &id)
+            .await?
+            .ok_or_else(|| WaitlistError::NotFound("waitlist request not found".into()))?;
+        let version = request.version;
+        let cancelled_at = current_rfc3339();
+        let event = request.cancel(command.reason, cancelled_at.clone())?;
+        let response = CancelWaitlistResponse {
+            waitlist_request_id: id.clone(),
+            status: WaitlistStatus::Cancelled,
+            cancelled_at,
+        };
+        Self::save_request(&mut tx, &request).await?;
+        Self::append_events(&mut tx, &id, version + 1, vec![event], correlation_id, None).await?;
+        rust_kit::storage::DbIdempotencyStore::record_response(
+            &mut tx,
+            &key,
+            &fingerprint,
+            200,
+            serde_json::to_value(&response).unwrap(),
+        )
+        .await
+        .map_err(storage_error)?;
+        tx.commit().await.map_err(db_error)?;
+        Ok(response)
+    }
+    async fn list(
+        &self,
+        traveler: String,
+        status: Option<WaitlistStatus>,
+        limit: usize,
+        offset: usize,
+    ) -> Result<PaginatedWaitlistRequests, WaitlistError> {
+        validate_prefixed_uuid(&traveler, "travelerRef", "tvl-")?;
+        let status_value = status.map(|status| status.as_contract().to_string());
+        let rows: Vec<(Value, i64)> = sqlx::query_as("SELECT data, count(*) OVER() AS total FROM waitlist_requests WHERE traveler_ref=$1 AND ($2::text IS NULL OR status=$2) ORDER BY created_at DESC, waitlist_request_id ASC LIMIT $3 OFFSET $4").bind(&traveler).bind(&status_value).bind(limit as i64).bind(offset as i64).fetch_all(self.pool()).await.map_err(db_error)?;
+        let total = rows.first().map(|(_, total)| *total as usize).unwrap_or(0);
+        let items = rows
+            .into_iter()
+            .map(|(value, _)| {
+                serde_json::from_value::<WaitlistRequest>(value)
+                    .map(|request| WaitlistResource::from(&request))
+                    .map_err(|error| WaitlistError::Internal(error.to_string()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(PaginatedWaitlistRequests {
+            items,
+            total,
+            limit,
+            offset,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SubscribeFailed(pub String);
+impl fmt::Display for SubscribeFailed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+impl std::error::Error for SubscribeFailed {}
+impl From<rust_kit::messaging::SubscribeFailed> for SubscribeFailed {
+    fn from(error: rust_kit::messaging::SubscribeFailed) -> Self {
+        Self(error.to_string())
+    }
+}
+fn handler_error(error: WaitlistError) -> rust_kit::messaging::HandlerError {
+    match error {
+        WaitlistError::Unavailable(message) | WaitlistError::Internal(message) => {
+            rust_kit::messaging::HandlerError::Transient(message)
+        }
+        other => rust_kit::messaging::HandlerError::Fatal(other.to_string()),
+    }
+}
+fn storage_error(error: rust_kit::storage::StorageError) -> WaitlistError {
+    match error {
+        rust_kit::storage::StorageError::IdempotencyKeyReused => {
+            WaitlistError::IdempotencyKeyReused(
+                "Idempotency-Key was reused with a different request body".into(),
+            )
+        }
+        other => WaitlistError::Internal(other.to_string()),
+    }
+}
+fn db_error(error: sqlx::Error) -> WaitlistError {
+    let message = error.to_string();
+    if message.contains("active_waitlist_request") {
+        WaitlistError::Conflict(
+            "traveler already has an active waitlist request for this intent".into(),
+        )
+    } else {
+        WaitlistError::Internal(message)
+    }
+}
+fn current_rfc3339() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+fn validate_non_empty(value: &str, field: &'static str) -> Result<(), WaitlistError> {
+    if value.trim().is_empty() {
+        Err(WaitlistError::ValidationFailed(format!(
+            "{field} must not be blank"
+        )))
+    } else {
+        Ok(())
+    }
+}
+fn validate_prefixed_uuid(
+    value: &str,
+    field: &'static str,
+    prefix: &'static str,
+) -> Result<(), WaitlistError> {
+    validate_non_empty(value, field)?;
+    let Some(uuid_part) = value.strip_prefix(prefix) else {
+        return Err(WaitlistError::ValidationFailed(format!(
+            "{field} must use {prefix}<uuid> format"
+        )));
+    };
+    uuid::Uuid::parse_str(uuid_part).map_err(|_| {
+        WaitlistError::ValidationFailed(format!("{field} must use {prefix}<uuid> format"))
+    })?;
+    Ok(())
+}
+fn validate_payment_guarantee(value: &str) -> Result<(), WaitlistError> {
+    validate_non_empty(value, "paymentGuaranteeRef")?;
+    if value.starts_with("pay-auth-") {
+        Ok(())
+    } else {
+        validate_prefixed_uuid(value, "paymentGuaranteeRef", "pi-")
+    }
+}
+fn deadline_after(deadline: &str, now: &str) -> bool {
+    let Ok(deadline) = DateTime::parse_from_rfc3339(deadline) else {
+        return false;
+    };
+    let Ok(now) = DateTime::parse_from_rfc3339(now) else {
+        return false;
+    };
+    deadline > now
+}
+fn deterministic_event_id(event_type: &str, id: &str, version: i64) -> String {
+    let seed = format!("waitlist:{event_type}:{id}:{version}");
+    format!("evt-wl-{:x}", Sha256::digest(seed.as_bytes()))
+}
+fn journey_order_idempotency_key(id: &str) -> String {
+    format!("wl-fulfill:{id}")
+}
+fn string_field(payload: &Value, field: &str) -> Option<String> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+}
+fn segment_from_payload(payload: &Value) -> Option<String> {
+    string_field(payload, "segmentRef")
+        .or_else(|| string_field(payload, "serviceSegmentRef"))
+        .or_else(|| string_field(payload, "capacityUnitRef"))
+}
+fn order_ref_from_payload(payload: &Value) -> Option<String> {
+    string_field(payload, "orderRef")
+        .or_else(|| string_field(payload, "orderId"))
+        .or_else(|| string_field(payload, "journeyOrderRef"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    fn tvl(suffix: &str) -> String {
+        format!("tvl-0194f2e0-7b3e-7610-8284-5c26e8b0{suffix}")
+    }
+    fn seg(suffix: &str) -> String {
+        format!("seg-0194f2e0-7b3e-7610-8284-5c26e8b0{suffix}")
+    }
+    fn key(suffix: &str) -> String {
+        format!("0194f2e0-7b3e-7610-8284-5c26e8b0{suffix}")
+    }
+    fn ord(suffix: &str) -> String {
+        format!("ord-0194f2e0-7b3e-7610-8284-5c26e8b0{suffix}")
+    }
+    fn command(traveler: String, segment: String) -> CreateWaitlistCommand {
+        CreateWaitlistCommand {
+            traveler_ref: traveler,
+            segment_ref: segment,
+            travel_class: Some("SECOND".into()),
+            deadline: "2099-01-01T00:00:00.000Z".into(),
+            payment_guarantee_ref: "pay-auth-test".into(),
+            intent_fingerprint: "intent-a".into(),
+        }
+    }
+    fn request() -> WaitlistRequest {
+        WaitlistRequest::create(
+            command(tvl("aa11"), seg("aa12")),
+            "2026-01-01T00:00:00.000Z".into(),
+        )
+        .unwrap()
+        .0
+    }
+    fn envelope(event_type: &str, payload: Value) -> rust_kit::messaging::EventEnvelope {
+        rust_kit::messaging::EventEnvelope::canonical(
+            event_type,
+            rust_kit::messaging::correlation_id(),
+            Some(rust_kit::messaging::command_id()),
+            "test",
+            payload,
+        )
+    }
 
     #[test]
-    fn skeleton_profile_matches_domain() {
-        let profile = profile();
-        assert_eq!(profile.service_id, "waitlist");
-        assert_eq!(profile.domain, "Waitlist");
+    fn profile_matches_domain() {
+        assert_eq!(profile().service_id, "waitlist");
         assert_eq!(health(), "ok");
     }
-
     #[test]
-    fn axum_router_can_be_constructed() {
-        let _router = router();
+    fn state_machine_full_transition_table() {
+        let statuses = [
+            WaitlistStatus::Draft,
+            WaitlistStatus::Queued,
+            WaitlistStatus::Matching,
+            WaitlistStatus::Fulfilled,
+            WaitlistStatus::Expired,
+            WaitlistStatus::Cancelled,
+            WaitlistStatus::Suspended,
+            WaitlistStatus::Closed,
+        ];
+        for from in statuses {
+            for to in statuses {
+                let allowed = matches!(
+                    (from, to),
+                    (WaitlistStatus::Draft, WaitlistStatus::Queued)
+                        | (WaitlistStatus::Draft, WaitlistStatus::Cancelled)
+                        | (WaitlistStatus::Queued, WaitlistStatus::Matching)
+                        | (WaitlistStatus::Queued, WaitlistStatus::Expired)
+                        | (WaitlistStatus::Queued, WaitlistStatus::Cancelled)
+                        | (WaitlistStatus::Queued, WaitlistStatus::Suspended)
+                        | (WaitlistStatus::Matching, WaitlistStatus::Fulfilled)
+                        | (WaitlistStatus::Matching, WaitlistStatus::Queued)
+                        | (WaitlistStatus::Fulfilled, WaitlistStatus::Closed)
+                        | (WaitlistStatus::Expired, WaitlistStatus::Closed)
+                        | (WaitlistStatus::Cancelled, WaitlistStatus::Closed)
+                        | (WaitlistStatus::Suspended, WaitlistStatus::Queued)
+                        | (WaitlistStatus::Suspended, WaitlistStatus::Cancelled)
+                );
+                assert_eq!(from.can_transition_to(to), allowed);
+            }
+        }
+        assert!(request().transition(WaitlistStatus::Fulfilled).is_err());
     }
-
     #[tokio::test]
-    async fn standard_runtime_endpoints_and_request_ids_are_available() {
+    async fn runtime_endpoints() {
         use axum::body::Body;
-        use axum::http::{Request, StatusCode};
+        use axum::http::Request;
         use shared_kernel::{CORRELATION_ID_HEADER, REQUEST_ID_HEADER};
         use tower::ServiceExt;
-
+        let router = router_with_state(Arc::new(InMemoryWaitlistService::default()));
         for path in [
             "/health",
             "/live",
@@ -76,13 +2013,242 @@ mod tests {
             "/readyz",
             "/metadata",
         ] {
-            let response = router()
+            let response = router
+                .clone()
                 .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
                 .await
                 .unwrap();
-            assert_eq!(response.status(), StatusCode::OK, "{path}");
+            assert_eq!(response.status(), StatusCode::OK);
             assert!(!response.headers()[REQUEST_ID_HEADER].is_empty());
             assert!(!response.headers()[CORRELATION_ID_HEADER].is_empty());
         }
+    }
+    #[tokio::test]
+    async fn mutual_exclusion() {
+        let service = InMemoryWaitlistService::default();
+        service
+            .create(
+                command(tvl("bb11"), seg("bb12")),
+                key("bb01"),
+                "corr".into(),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            service
+                .create(
+                    command(tvl("bb11"), seg("bb13")),
+                    key("bb02"),
+                    "corr".into()
+                )
+                .await
+                .unwrap_err(),
+            WaitlistError::Conflict(_)
+        ));
+    }
+    #[test]
+    fn queue_fifo_stable() {
+        let mut first = request();
+        first.waitlist_request_id = "wlr-0194f2e0-7b3e-7610-8284-5c26e8b0c001".into();
+        first.queued_at = Some("2026-01-01T00:00:00.000Z".into());
+        let mut second = request();
+        second.waitlist_request_id = "wlr-0194f2e0-7b3e-7610-8284-5c26e8b0c002".into();
+        second.queued_at = first.queued_at.clone();
+        let queue = WaitlistQueue::rebuild([second, first]);
+        assert_eq!(
+            queue.head_for_segment(&seg("aa12")),
+            Some("wlr-0194f2e0-7b3e-7610-8284-5c26e8b0c001")
+        );
+    }
+    #[derive(Default)]
+    struct FakeOrder {
+        result: Mutex<Option<Result<String, OrderClientError>>>,
+    }
+    #[async_trait]
+    impl JourneyOrderClient for FakeOrder {
+        async fn create_order(
+            &self,
+            _: &WaitlistRequest,
+            _: &str,
+            _: &str,
+        ) -> Result<String, OrderClientError> {
+            self.result
+                .lock()
+                .unwrap()
+                .take()
+                .unwrap_or_else(|| Ok(ord("cc01")))
+        }
+    }
+    #[tokio::test]
+    async fn capacity_released_match_and_skip() {
+        let publisher = Arc::new(InMemoryEventPublisher::default());
+        let service =
+            InMemoryWaitlistService::new(publisher.clone(), Arc::new(FakeOrder::default()));
+        let created = service
+            .create(
+                command(tvl("cc11"), seg("cc12")),
+                key("cc02"),
+                "corr".into(),
+            )
+            .await
+            .unwrap();
+        service
+            .apply_subscribed_event(envelope(
+                "CapacityReleased",
+                json!({"segmentRef": seg("cc12")}),
+            ))
+            .await
+            .unwrap();
+        let stored = service
+            .state
+            .lock()
+            .unwrap()
+            .requests
+            .get(&created.waitlist_request_id)
+            .unwrap()
+            .clone();
+        assert_eq!(stored.status, WaitlistStatus::Matching);
+        assert!(stored.order_ref.is_some());
+        let before = publisher.published().len();
+        service
+            .apply_subscribed_event(envelope(
+                "CapacityReleased",
+                json!({"segmentRef": seg("dd12")}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(publisher.published().len(), before);
+    }
+    #[tokio::test]
+    async fn order_confirm_cancel() {
+        let service = InMemoryWaitlistService::default();
+        let created = service
+            .create(
+                command(tvl("dd11"), seg("dd12")),
+                key("dd01"),
+                "corr".into(),
+            )
+            .await
+            .unwrap();
+        {
+            let mut state = service.state.lock().unwrap();
+            let request = state
+                .requests
+                .get_mut(&created.waitlist_request_id)
+                .unwrap();
+            request.transition(WaitlistStatus::Matching).unwrap();
+            request.record_order_ref(ord("dd02"));
+        }
+        service
+            .apply_subscribed_event(envelope(
+                "JourneyOrderCancelled",
+                json!({"orderId": ord("dd02")}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            service
+                .state
+                .lock()
+                .unwrap()
+                .requests
+                .get(&created.waitlist_request_id)
+                .unwrap()
+                .status,
+            WaitlistStatus::Queued
+        );
+        {
+            let mut state = service.state.lock().unwrap();
+            let request = state
+                .requests
+                .get_mut(&created.waitlist_request_id)
+                .unwrap();
+            request.transition(WaitlistStatus::Matching).unwrap();
+            request.record_order_ref(ord("dd03"));
+        }
+        service
+            .apply_subscribed_event(envelope(
+                "JourneyOrderConfirmed",
+                json!({"orderId": ord("dd03")}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            service
+                .state
+                .lock()
+                .unwrap()
+                .requests
+                .get(&created.waitlist_request_id)
+                .unwrap()
+                .status,
+            WaitlistStatus::Closed
+        );
+    }
+    #[tokio::test]
+    async fn expiry_scan() {
+        let service = InMemoryWaitlistService::default();
+        let mut cmd = command(tvl("ee11"), seg("ee12"));
+        cmd.deadline = "2026-01-01T00:00:01.000Z".into();
+        let (request, _) = WaitlistRequest::create(cmd, "2026-01-01T00:00:00.000Z".into()).unwrap();
+        let id = request.waitlist_request_id.clone();
+        service
+            .state
+            .lock()
+            .unwrap()
+            .requests
+            .insert(id.clone(), request);
+        assert_eq!(
+            service
+                .expire_due("2026-01-01T00:00:02.000Z".into(), "corr".into())
+                .await
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            service
+                .state
+                .lock()
+                .unwrap()
+                .requests
+                .get(&id)
+                .unwrap()
+                .status,
+            WaitlistStatus::Closed
+        );
+    }
+    #[tokio::test]
+    async fn idempotency_replay() {
+        let service = InMemoryWaitlistService::default();
+        let response = service
+            .create(
+                command(tvl("ff11"), seg("ff12")),
+                key("ff01"),
+                "corr".into(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response,
+            service
+                .create(
+                    command(tvl("ff11"), seg("ff12")),
+                    key("ff01"),
+                    "corr".into()
+                )
+                .await
+                .unwrap()
+        );
+        assert!(matches!(
+            service
+                .create(
+                    command(tvl("ff11"), seg("ff13")),
+                    key("ff01"),
+                    "corr".into()
+                )
+                .await
+                .unwrap_err(),
+            WaitlistError::IdempotencyKeyReused(_)
+        ));
     }
 }

--- a/services/waitlist/src/main.rs
+++ b/services/waitlist/src/main.rs
@@ -1,0 +1,16 @@
+#[tokio::main]
+async fn main() {
+    let (router, subscriber) = waitlist::build_runtime().await.expect("waitlist runtime");
+    let port = std::env::var("PORT")
+        .or_else(|_| std::env::var("SERVER_PORT"))
+        .unwrap_or_else(|_| "8080".to_string());
+    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{port}"))
+        .await
+        .expect("bind waitlist");
+    let server = axum::serve(listener, router);
+    tokio::select! {
+        result = server => result.expect("waitlist server"),
+        result = subscriber => result.expect("waitlist subscriber task"),
+        _ = tokio::signal::ctrl_c() => {},
+    }
+}


### PR DESCRIPTION
## Summary
- Implement Rust waitlist domain state machine, queueing, API, Postgres baseline, outbox/dedup, event consumers, expiry scanner, and journey-order fulfillment client
- Add waitlist Docker/Kubernetes deployment and Postgres database provisioning
- Cover state transitions, mutual exclusion, matching, order confirmation/cancellation, expiry, and idempotent replay tests

## Validation
- cargo test --manifest-path services/waitlist/Cargo.toml (passed)
- cargo test --manifest-path services/waitlist/Cargo.toml x3 (passed)
- make check (timed out after 120s; reached waitlist cargo tests and passed all executed suites before timeout)