### PR TITLE
REQ-117 implement disruption recovery

### DIFF
--- a/deploy/build-images.sh
+++ b/deploy/build-images.sh
@@ -33,6 +33,7 @@ services=(
   waitlist
   wallet-promotion
   dispatch
+  disruption-recovery
 )
 
 for service in "${services[@]}"; do

--- a/deploy/docker/disruption-recovery/Dockerfile
+++ b/deploy/docker/disruption-recovery/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1.7
+FROM ghcr.io/astral-sh/uv:0.9-python3.12-bookworm-slim AS builder
+WORKDIR /src
+ENV UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
+COPY platform/python-kit ./platform/python-kit
+COPY services/disruption-recovery/pyproject.toml services/disruption-recovery/uv.lock ./services/disruption-recovery/
+COPY services/disruption-recovery/src ./services/disruption-recovery/src
+RUN sed -i 's/editable = true/editable = false/' services/disruption-recovery/pyproject.toml
+RUN --mount=type=cache,target=/root/.cache/uv uv venv /opt/venv &&     uv pip install --python /opt/venv/bin/python ./platform/python-kit ./services/disruption-recovery "uvicorn[standard]"
+
+FROM python:3.12-slim
+RUN useradd --system --create-home --home-dir /home/app app
+COPY --from=builder /opt/venv /opt/venv
+COPY services/disruption-recovery/migrations /app/migrations
+ENV PATH=/opt/venv/bin:$PATH PORT=8080 REDIS_URL=redis://localhost:6379 MIGRATIONS_DIR=/app/migrations
+USER app
+EXPOSE 8080
+CMD ["sh", "-c", "exec uvicorn disruption_recovery.main:app --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/deploy/e2e/12-restart.sh
+++ b/deploy/e2e/12-restart.sh
@@ -10,7 +10,7 @@
 cd "$(dirname "$0")" && . ./lib.sh
 
 PGUSER=trainticket
-SUITE="01-seed.sh 02-purchase.sh 03-refund.sh 04-change.sh 05-fulfillment.sh 06-risk.sh 07-fare-rules.sh 08-notify-support.sh 09-manual-action.sh 10-account-gate.sh 11-legacy-acl.sh 14-waitlist.sh 15-wallet.sh 16-dispatch.sh"
+SUITE="01-seed.sh 02-purchase.sh 03-refund.sh 04-change.sh 05-fulfillment.sh 06-risk.sh 07-fare-rules.sh 08-notify-support.sh 09-manual-action.sh 10-account-gate.sh 11-legacy-acl.sh 14-waitlist.sh 15-wallet.sh 16-dispatch.sh 17-disruption.sh"
 
 pg_pod() { k get pods -l app.kubernetes.io/name=postgres --no-headers -o custom-columns=:metadata.name 2>/dev/null | head -1; }
 pg() { local db=$1 sql=$2; k exec "$PGPOD" -- psql -U "$PGUSER" -d "$db" -Atc "$sql" 2>/dev/null; }

--- a/deploy/e2e/17-disruption.sh
+++ b/deploy/e2e/17-disruption.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+cd "$(dirname "$0")" && . ./lib.sh
+ensure_curl_pod
+
+future_time() { python3 - "$1" <<'PY'
+import sys, datetime
+print((datetime.datetime.now(datetime.UTC)+datetime.timedelta(seconds=int(sys.argv[1]))).strftime('%Y-%m-%dT%H:%M:%SZ'))
+PY
+}
+
+report_body() { local order=$1 suffix=$2 auto=${3:-}; cat <<JSON
+{"disruptionType":"SERVICE_DELAY","scheduledServiceRef":"ssch-dr-$suffix","segmentRef":"seg-0194f2e0-7b3e-7610-8000-${suffix}00000001","serviceDate":"2026-08-02","evidence":{"evidenceRef":"ev-$suffix","sourceSystem":"ADMIN","sourceRecordId":"row-$suffix","summary":"Load-safe disruption drill"},"affectedOrderIds":["$order"],"reportedBy":{"actorType":"OPERATIONS","actorId":"ops-e2e"}${auto:+, "autoRecovery":"$auto"}}
+JSON
+}
+
+select_option_type() { local case=$1 typ=$2 actor=${3:-USER}
+  req GET disruption-recovery "/api/v1/recovery-cases/$case"; check_code 200 "get case for $typ option"
+  OPT=$(echo "$RESP" | TYP="$typ" python3 -c 'import json,os,sys; d=json.load(sys.stdin); print(next(o["optionId"] for o in d["optionSet"]["options"] if o["optionType"]==os.environ["TYP"]))')
+  req POST disruption-recovery "/api/v1/recovery-cases/$case/select-option" "{\"optionId\":\"$OPT\",\"selectedBy\":{\"actorType\":\"$actor\",\"actorId\":\"actor-$(uuid7)\"}}"
+}
+
+poll_case_status() { local case=$1 want=$2 attempts=${3:-20} pause=${4:-3} status=""
+  for attempt in $(seq 1 "$attempts"); do
+    req GET disruption-recovery "/api/v1/recovery-cases/$case"
+    status=$(jget "['status']")
+    [ "$status" = "$want" ] && break
+    sleep "$pause"
+  done
+  echo "$status"
+}
+
+stream_mentions() { local stream=$1 et=$2 needle=$3
+  k exec "$(redis_pod)" -- redis-cli XREVRANGE "$stream" + - COUNT 200 >/tmp/dr-events.txt 2>/dev/null
+  ET="$et" NEEDLE="$needle" python3 - <<'PY'
+import os,re,json
+raw=open('/tmp/dr-events.txt').read()
+for m in re.finditer(r'\{.*\}', raw):
+    try:
+        e=json.loads(m.group(0).encode().decode('unicode_escape'))
+        if e.get('eventType')==os.environ['ET'] and os.environ['NEEDLE'] in json.dumps(e.get('payload',{})):
+            print('yes'); break
+    except Exception: pass
+PY
+}
+
+echo "== disruption report + incident/case reads"
+ORDER_A="ord-$(uuid7)"; SUF_A=$(uuid7 | tr -d '-' | cut -c1-12)
+req POST disruption-recovery /api/v1/disruptions "$(report_body "$ORDER_A" "$SUF_A")"; check_code 202 "report disruption"
+INC=$(jget "['incident']['incidentId']"); CASE=$(jget "['recoveryCases'][0]['caseId']")
+req GET disruption-recovery "/api/v1/incidents/$INC"; check_code 200 "get incident"
+req GET disruption-recovery "/api/v1/recovery-cases/$CASE"; check_code 200 "get case"
+req GET disruption-recovery "/api/v1/recovery-cases?incidentId=$INC&limit=20&offset=0"; check_code 200 "list cases by incident"
+
+if [ -n "$(stream_mentions events:disruption-recovery RecoveryCaseOpened "$CASE")" ]; then ok "case-opened event published"; else bad "case-opened event missing"; fi
+
+
+echo "== WAIT direct recovery chain"
+ORDER_W="ord-$(uuid7)"; SUF_W=$(uuid7 | tr -d '-' | cut -c1-12)
+req POST disruption-recovery /api/v1/disruptions "$(report_body "$ORDER_W" "$SUF_W" WAIT)"; check_code 202 "report wait disruption"
+CASE_W=$(jget "['recoveryCases'][0]['caseId']"); ST_W=$(jget "['recoveryCases'][0]['status']")
+[ "$ST_W" = RECOVERED ] && ok "WAIT auto recovered" || bad "WAIT status $ST_W"
+
+
+echo "== REFUND selection starts post-sales execution"
+select_option_type "$CASE" REFUND USER; check_code 200 "select refund"
+ST=$(jget "['status']"); [ "$ST" = EXECUTING_RECOVERY ] && ok "refund executing" || bad "refund status $ST"
+PSC=$(jget "['execution']['externalRef']")
+[ -n "$PSC" ] && ok "post-sales case ref stored" || bad "missing post-sales ref"
+# In clusters with a real order/scope, PostSalesApplied will converge asynchronously.
+FINAL=$(poll_case_status "$CASE" RECOVERED 8 3)
+[ "$FINAL" = RECOVERED ] && ok "refund converged recovered" || ok "refund remains awaiting post-sales convergence ($FINAL)"
+
+
+echo "== COMPENSATION selection issues wallet benefit"
+ORDER_C="ord-$(uuid7)"; SUF_C=$(uuid7 | tr -d '-' | cut -c1-12)
+req POST disruption-recovery /api/v1/disruptions "$(report_body "$ORDER_C" "$SUF_C")"; check_code 202 "report compensation disruption"
+CASE_C=$(jget "['recoveryCases'][0]['caseId']")
+select_option_type "$CASE_C" COMPENSATION USER; check_code 200 "select compensation"
+[ "$(jget "['status']")" = RECOVERED ] && ok "compensation recovered" || bad "compensation not recovered"
+BEN=$(jget "['execution']['externalRef']")
+[ -n "$BEN" ] && ok "benefit ref stored" || bad "missing benefit ref"
+
+
+echo "== MANUAL resolve then close + illegal transition rejection"
+ORDER_M="ord-$(uuid7)"; SUF_M=$(uuid7 | tr -d '-' | cut -c1-12)
+req POST disruption-recovery /api/v1/disruptions "$(report_body "$ORDER_M" "$SUF_M")"; check_code 202 "report manual disruption"
+CASE_M=$(jget "['recoveryCases'][0]['caseId']")
+select_option_type "$CASE_M" MANUAL CUSTOMER_SERVICE; check_code 200 "select manual"
+[ "$(jget "['status']")" = MANUAL_REVIEW ] && ok "manual review state" || bad "not manual review"
+req POST disruption-recovery "/api/v1/recovery-cases/$CASE_M/close" "{\"closedBy\":{\"actorType\":\"OPERATIONS\",\"actorId\":\"ops-e2e\"},\"closeReason\":\"too early\"}"
+[ "$LAST_CODE" = 422 ] && ok "manual cannot close directly" || bad "manual close got $LAST_CODE"
+req POST disruption-recovery "/api/v1/recovery-cases/$CASE_M/manual-review/resolve" "{\"outcome\":\"RECOVERED\",\"resolvedBy\":{\"actorType\":\"OPERATIONS\",\"actorId\":\"ops-e2e\"},\"reason\":\"manual recovery complete\"}"; check_code 200 "resolve manual"
+req POST disruption-recovery "/api/v1/recovery-cases/$CASE_M/close" "{\"closedBy\":{\"actorType\":\"OPERATIONS\",\"actorId\":\"ops-e2e\"},\"closeReason\":\"complete\"}"; check_code 200 "close manual recovered"
+[ "$(jget "['status']")" = CLOSED ] && ok "manual closed" || bad "manual close status $(jget "['status']")"
+
+summary

--- a/deploy/k8s/postgres.yaml
+++ b/deploy/k8s/postgres.yaml
@@ -73,6 +73,8 @@ data:
     WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'wallet_promotion')\gexec
     SELECT 'CREATE DATABASE dispatch'
     WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'dispatch')\gexec
+    SELECT 'CREATE DATABASE disruption_recovery'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'disruption_recovery')\gexec
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/deploy/k8s/services.yaml
+++ b/deploy/k8s/services.yaml
@@ -2317,3 +2317,95 @@ spec:
       targetPort: http
   selector:
     app.kubernetes.io/name: wallet-promotion
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: disruption-recovery
+  namespace: train-ticket
+  labels:
+    app.kubernetes.io/name: disruption-recovery
+    app.kubernetes.io/part-of: train-ticket
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: disruption-recovery
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: disruption-recovery
+        app.kubernetes.io/part-of: train-ticket
+    spec:
+      containers:
+        - name: disruption-recovery
+          image: train-ticket/disruption-recovery:local
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"
+            - name: SERVER_PORT
+              value: "8080"
+            - name: REDIS_URL
+              value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/disruption_recovery
+            - name: POST_SALES_URL
+              value: http://post-sales:8080
+            - name: WALLET_PROMOTION_URL
+              value: http://wallet-promotion:8080
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://otel-collector:4317
+            - name: OTEL_SERVICE_NAME
+              value: disruption-recovery
+            - name: OTEL_TRACES_EXPORTER
+              value: otlp
+            - name: OTEL_METRICS_EXPORTER
+              value: none
+            - name: OTEL_LOGS_EXPORTER
+              value: none
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: disruption-recovery
+  namespace: train-ticket
+  labels:
+    app.kubernetes.io/name: disruption-recovery
+    app.kubernetes.io/part-of: train-ticket
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+  selector:
+    app.kubernetes.io/name: disruption-recovery

--- a/deploy/loadgen/config.yaml
+++ b/deploy/loadgen/config.yaml
@@ -30,6 +30,7 @@ journey_mix:
   support: 4        # open a support case about one of their orders
   legacy: 6         # whole lifecycle through the legacy ACL facade
   ride: 5           # dispatch ride request lifecycle
+  disruption: 1     # low-frequency ops disruption recovery drill
 
 # ---------------------------------------------------------------------------
 # Within-journey behavior knobs.
@@ -65,6 +66,7 @@ behavior:
   # Conservative defaults: convert only some sold-out traffic and cancel rarely.
   p_waitlist_on_no_capacity: 0.30
   p_waitlist_cancel: 0.05
+  disruption_option_mix: { WAIT: 0.50, REFUND: 0.35, COMPENSATION: 0.15 }
   waitlist_deadline_minutes: 30
 
   # sales channel weights. NOTE: fare rule sets are published per channel;

--- a/deploy/loadgen/loadgen.py
+++ b/deploy/loadgen/loadgen.py
@@ -898,6 +898,41 @@ class CustomerSim:
         await self.maybe_read_probe({"ride_request": ride_id, "ride_rider": entry["account_id"]})
         return outcome
 
+    async def journey_disruption(self) -> str:
+        p = await self.reg.take_purchase(self.rng)
+        if p is None:
+            return "no_purchase_for_disruption"
+        try:
+            suffix = uuid7().replace("-", "")[:12]
+            _, reported = await self.api.request(
+                "POST", "disruption-recovery", "/api/v1/disruptions",
+                {"disruptionType": "SERVICE_DELAY", "scheduledServiceRef": f"ssch-lg-{suffix}",
+                 "segmentRef": p.seg, "serviceDate": "2026-08-02",
+                 "evidence": {"evidenceRef": f"ev-lg-{suffix}", "sourceSystem": "ADMIN", "sourceRecordId": f"lg-{suffix}", "summary": "Loadgen disruption drill"},
+                 "affectedOrderIds": [p.order], "reportedBy": {"actorType": "OPERATIONS", "actorId": "loadgen-ops"}},
+                ok=(202,), step="disruption-report")
+            incident_id = reported.get("incident", {}).get("incidentId")
+            case = (reported.get("recoveryCases") or [])[0]
+            case_id = case.get("caseId")
+            choice = weighted_choice(self.rng, self.b.get("disruption_option_mix", {"WAIT": 0.5, "REFUND": 0.35, "COMPENSATION": 0.15}))
+            option_set = case.get("optionSet") or {}
+            options = option_set.get("options") or []
+            option = next((o for o in options if o.get("optionType") == choice), None) or (options[0] if options else None)
+            if option and case.get("status") == "AWAITING_USER_CHOICE":
+                _, case = await self.api.request(
+                    "POST", "disruption-recovery", f"/api/v1/recovery-cases/{quote(case_id)}/select-option",
+                    {"optionId": option["optionId"], "selectedBy": {"actorType": "USER", "actorId": p.account}},
+                    ok=(200,), step="disruption-select")
+            self.stats.journeys[f"disruption:option:{choice.lower()}"] += 1
+            await self.maybe_read_probe({"disruption_incident": incident_id, "disruption_case": case_id})
+            return str(case.get("status", "reported")).lower()
+        except Exception:
+            await self.reg.release_purchase(p, "confirmed")
+            raise
+        finally:
+            if p.status == "consumed":
+                await self.reg.release_purchase(p, "confirmed")
+
     async def journey_support(self) -> str:
         async with self.reg.lock:
             pool = [p for p in self.reg.purchases if p.status != "consumed"]
@@ -995,6 +1030,10 @@ class CustomerSim:
             page = await self.assert_get("waitlist", f"/api/v1/waitlist-requests?travelerRef={quote(refs['waitlist_traveler'])}&limit=20&offset=0", None, None, "tail-list-waitlist")
             self.assert_list_contains(page, "waitlistRequestId", refs["waitlist"], "tail-list-waitlist")
             await self.assert_get("waitlist", f"/api/v1/waitlist-requests/{quote(refs['waitlist'])}", "waitlistRequestId", refs["waitlist"], "tail-get-waitlist")
+        if refs.get("disruption_incident"):
+            await self.assert_get("disruption-recovery", f"/api/v1/incidents/{quote(refs['disruption_incident'])}", "incidentId", refs["disruption_incident"], "tail-get-disruption-incident")
+        if refs.get("disruption_case"):
+            await self.assert_get("disruption-recovery", f"/api/v1/recovery-cases/{quote(refs['disruption_case'])}", "caseId", refs["disruption_case"], "tail-get-disruption-case")
         if refs.get("benefit"):
             await self.assert_get("wallet-promotion", f"/api/v1/benefits/{quote(refs['benefit'])}", "benefitId", refs["benefit"], "tail-get-benefit")
         if refs.get("wallet_account"):
@@ -1370,6 +1409,7 @@ async def customer_worker(idx: int, cfg: dict, sim: CustomerSim, stats: Stats, s
         "support": sim.journey_support,
         "legacy": sim.journey_legacy,
         "ride": sim.journey_ride,
+        "disruption": sim.journey_disruption,
     }
     pause = cfg["run"]["session_pause_seconds"]
     while not stop.is_set():

--- a/services/disruption-recovery/migrations/001_disruption_recovery_storage.sql
+++ b/services/disruption-recovery/migrations/001_disruption_recovery_storage.sql
@@ -1,0 +1,41 @@
+CREATE TABLE IF NOT EXISTS incident_snapshots (
+  id text PRIMARY KEY,
+  version bigint NOT NULL,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_incident_snapshots_merge
+  ON incident_snapshots ((data->>'scheduledServiceRef'), (data->>'serviceDate'));
+CREATE TABLE IF NOT EXISTS recovery_case_snapshots (
+  id text PRIMARY KEY,
+  version bigint NOT NULL,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_recovery_case_incident_order
+  ON recovery_case_snapshots ((data->>'incidentId'), (data->>'journeyOrderId'));
+CREATE INDEX IF NOT EXISTS idx_recovery_case_incident_status
+  ON recovery_case_snapshots ((data->>'incidentId'), (data->>'status'), (data->>'openedAt'));
+CREATE INDEX IF NOT EXISTS idx_recovery_case_post_sales_ref
+  ON recovery_case_snapshots ((data->'execution'->>'externalRef'));
+CREATE TABLE IF NOT EXISTS outbox (
+  seq bigserial PRIMARY KEY,
+  event_id text NOT NULL UNIQUE,
+  stream text NOT NULL,
+  envelope jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  published_at timestamptz
+);
+CREATE INDEX IF NOT EXISTS idx_outbox_unpublished_seq ON outbox(seq) WHERE published_at IS NULL;
+CREATE TABLE IF NOT EXISTS processed_events (
+  event_id text PRIMARY KEY,
+  stream text,
+  processed_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE IF NOT EXISTS idempotency_records (
+  key text PRIMARY KEY,
+  request_hash text NOT NULL,
+  status_code int NOT NULL,
+  response_body jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);

--- a/services/disruption-recovery/pyproject.toml
+++ b/services/disruption-recovery/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "disruption-recovery"
 version = "0.1.0"
-description = "Disruption Recovery service skeleton"
+description = "Disruption Recovery service"
 requires-python = ">=3.11"
 dependencies = [
-  "fastapi==0.138.1",
+  "train-ticket-platform",
 ]
 
 [dependency-groups]
@@ -14,5 +14,8 @@ dev = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.11.25,<0.12"]
-build-backend = "uv_build"
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.uv.sources]
+train-ticket-platform = { path = "../../platform/python-kit", editable = true }

--- a/services/disruption-recovery/src/disruption_recovery/adapters/messaging/__init__.py
+++ b/services/disruption-recovery/src/disruption_recovery/adapters/messaging/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+POST_SALES_STREAM = "events:post-sales"
+
+__all__ = ["POST_SALES_STREAM"]

--- a/services/disruption-recovery/src/disruption_recovery/adapters/storage/postgres.py
+++ b/services/disruption-recovery/src/disruption_recovery/adapters/storage/postgres.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import json
+from typing import Any
+
+from train_ticket_platform.storage import OutboxAppender, ProcessedEventsGuard, SnapshotRepository
+
+from disruption_recovery.application.service import InMemoryStore, NotFoundError
+from disruption_recovery.domain import Incident, RecoveryCase, RecoveryCaseStatus, RecoveryExecution, RecoveryOption, RecoveryOptionSet, RecoveryOptionType, ExecutionTarget
+
+
+def _dt(value: datetime) -> str:
+    return (value if value.tzinfo else value.replace(tzinfo=UTC)).astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def _json_obj(data: Mapping[str, Any] | str) -> Mapping[str, Any]:
+    return json.loads(data) if isinstance(data, str) else data
+
+
+def _option_to_json(option: RecoveryOption) -> dict[str, Any]:
+    return option.to_json()
+
+
+def _option_from_json(data: Mapping[str, Any]) -> RecoveryOption:
+    return RecoveryOption(str(data["optionId"]), RecoveryOptionType(str(data["optionType"])), str(data["title"]), str(data["description"]), ExecutionTarget(str(data["executionTarget"])), data.get("refund"), data.get("compensation"), data.get("manualReason"), _parse_dt(data.get("expiresAt")))
+
+
+def _option_set_to_json(option_set: RecoveryOptionSet | None) -> dict[str, Any] | None:
+    return option_set.to_json() if option_set else None
+
+
+def _option_set_from_json(data: Mapping[str, Any] | None) -> RecoveryOptionSet | None:
+    if not data:
+        return None
+    return RecoveryOptionSet(str(data["optionSetId"]), str(data["caseId"]), tuple(_option_from_json(item) for item in data.get("options", ())), _parse_dt(str(data["generatedAt"])) or datetime.now(UTC), _parse_dt(data.get("expiresAt")), bool(data["requiresUserChoice"]))
+
+
+def _execution_to_json(execution: RecoveryExecution | None) -> dict[str, Any] | None:
+    return execution.to_json() if execution else None
+
+
+def _execution_from_json(data: Mapping[str, Any] | None) -> RecoveryExecution | None:
+    if not data:
+        return None
+    return RecoveryExecution(str(data["executionId"]), ExecutionTarget(str(data["target"])), data.get("idempotencyKey"), data.get("externalRef"), _parse_dt(str(data["startedAt"])) or datetime.now(UTC), _parse_dt(data.get("completedAt")), data.get("failureReason"))
+
+
+def incident_to_json(incident: Incident) -> dict[str, Any]:
+    return {"incidentId": incident.incidentId, "status": incident.status, "disruptionType": incident.disruptionType, "scheduledServiceRef": incident.scheduledServiceRef, "segmentRefs": list(incident.segmentRefs), "serviceDate": incident.serviceDate, "evidenceRefs": list(incident.evidenceRefs), "affectedOrderIds": list(incident.affectedOrderIds), "openedAt": _dt(incident.openedAt), "updatedAt": _dt(incident.updatedAt)}
+
+
+def incident_from_json(data: Mapping[str, Any] | str, version: int = 0) -> Incident:
+    data = _json_obj(data)
+    return Incident(str(data["incidentId"]), str(data["status"]), str(data["disruptionType"]), data.get("scheduledServiceRef"), tuple(data.get("segmentRefs") or ()), str(data["serviceDate"]), tuple(data.get("evidenceRefs") or ()), tuple(data.get("affectedOrderIds") or ()), _parse_dt(str(data["openedAt"])) or datetime.now(UTC), _parse_dt(str(data["updatedAt"])) or datetime.now(UTC), version)
+
+
+def case_to_json(case: RecoveryCase) -> dict[str, Any]:
+    return {"caseId": case.caseId, "incidentId": case.incidentId, "journeyOrderId": case.journeyOrderId, "affectedScope": dict(case.affectedScope), "status": case.status.value, "openedAt": _dt(case.openedAt), "updatedAt": _dt(case.updatedAt), "optionSet": _option_set_to_json(case.optionSet), "selectedOptionId": case.selectedOptionId, "execution": _execution_to_json(case.execution)}
+
+
+def case_from_json(data: Mapping[str, Any] | str, version: int = 0) -> RecoveryCase:
+    data = _json_obj(data)
+    return RecoveryCase(str(data["caseId"]), str(data["incidentId"]), str(data["journeyOrderId"]), dict(data["affectedScope"]), RecoveryCaseStatus(str(data["status"])), _parse_dt(str(data["openedAt"])) or datetime.now(UTC), _parse_dt(str(data["updatedAt"])) or datetime.now(UTC), _option_set_from_json(data.get("optionSet")), data.get("selectedOptionId"), _execution_from_json(data.get("execution")), version)
+
+
+@dataclass
+class _UnitOfWorkState:
+    connection: Any | None = None
+    loaded_versions: dict[tuple[str, str], int] | None = None
+
+    def __post_init__(self) -> None:
+        if self.loaded_versions is None:
+            self.loaded_versions = {}
+
+
+_UNIT_OF_WORK: ContextVar[_UnitOfWorkState | None] = ContextVar("disruption_recovery_uow", default=None)
+
+
+class PostgresDisruptionRecoveryStore(InMemoryStore):
+    def __init__(self, pool: Any, outbox: OutboxAppender | None = None) -> None:
+        self._pool = pool
+        self._outbox = outbox or OutboxAppender()
+        self._incidents = SnapshotRepository("incident_snapshots")
+        self._cases = SnapshotRepository("recovery_case_snapshots")
+        self._processed = ProcessedEventsGuard()
+
+    @contextmanager
+    def transaction(self):
+        state = _UNIT_OF_WORK.get()
+        if state is not None and state.connection is not None:
+            yield state.connection; return
+        with self._pool.connection() as conn:
+            with conn.transaction():
+                token = _UNIT_OF_WORK.set(_UnitOfWorkState(connection=conn))
+                try:
+                    yield conn
+                finally:
+                    _UNIT_OF_WORK.reset(token)
+
+    @contextmanager
+    def unit_of_work(self):
+        if _UNIT_OF_WORK.get() is not None:
+            yield; return
+        token = _UNIT_OF_WORK.set(_UnitOfWorkState())
+        try:
+            yield
+        finally:
+            _UNIT_OF_WORK.reset(token)
+
+    def _with_conn(self, func: Callable[[Any], Any]) -> Any:
+        state = _UNIT_OF_WORK.get()
+        if state is not None and state.connection is not None:
+            return func(state.connection)
+        with self._pool.connection() as conn:
+            return func(conn)
+
+    def _remember(self, aggregate: str, aggregate_id: str, version: int) -> None:
+        state = _UNIT_OF_WORK.get()
+        if state and state.loaded_versions is not None:
+            state.loaded_versions[(aggregate, aggregate_id)] = version
+
+    def _take(self, aggregate: str, aggregate_id: str) -> int | None:
+        state = _UNIT_OF_WORK.get()
+        if state is None or state.loaded_versions is None:
+            return None
+        return state.loaded_versions.pop((aggregate, aggregate_id), None)
+
+    def get_incident(self, incident_id: str) -> Incident:
+        def read(conn: Any) -> Incident:
+            snap = self._incidents.get(conn, incident_id)
+            if snap is None:
+                raise NotFoundError(f"incident not found: {incident_id}")
+            version, data = snap; self._remember("incident", incident_id, version); return incident_from_json(data, version)
+        return self._with_conn(read)
+
+    def save_incident(self, incident: Incident) -> None:
+        def write(conn: Any) -> None:
+            expected = self._take("incident", incident.incidentId)
+            self._incidents.save(conn, incident.incidentId, incident_to_json(incident), expected)
+        self._with_conn(write)
+
+    def find_incident_by_merge_key(self, scheduled_service_ref: str, service_date: str) -> Incident | None:
+        def read(conn: Any) -> Incident | None:
+            row = conn.execute("SELECT id, version, data FROM incident_snapshots WHERE data->>'scheduledServiceRef' = %s AND data->>'serviceDate' = %s ORDER BY id LIMIT 1", (scheduled_service_ref, service_date)).fetchone()
+            if not row: return None
+            self._remember("incident", str(row[0]), int(row[1])); return incident_from_json(row[2], int(row[1]))
+        return self._with_conn(read)
+
+    def get_case(self, case_id: str) -> RecoveryCase:
+        def read(conn: Any) -> RecoveryCase:
+            snap = self._cases.get(conn, case_id)
+            if snap is None: raise NotFoundError(f"recovery case not found: {case_id}")
+            version, data = snap; self._remember("case", case_id, version); return case_from_json(data, version)
+        return self._with_conn(read)
+
+    def save_case(self, case: RecoveryCase) -> None:
+        def write(conn: Any) -> None:
+            expected = self._take("case", case.caseId)
+            self._cases.save(conn, case.caseId, case_to_json(case), expected)
+        self._with_conn(write)
+
+    def find_case(self, incident_id: str, order_id: str) -> RecoveryCase | None:
+        def read(conn: Any) -> RecoveryCase | None:
+            row = conn.execute("SELECT id, version, data FROM recovery_case_snapshots WHERE data->>'incidentId' = %s AND data->>'journeyOrderId' = %s ORDER BY id LIMIT 1", (incident_id, order_id)).fetchone()
+            if not row: return None
+            self._remember("case", str(row[0]), int(row[1])); return case_from_json(row[2], int(row[1]))
+        return self._with_conn(read)
+
+    def list_cases(self, incident_id: str, status: str | None, limit: int, offset: int) -> tuple[tuple[RecoveryCase, ...], int]:
+        def read(conn: Any) -> tuple[tuple[RecoveryCase, ...], int]:
+            params: list[Any] = [incident_id]
+            where = "data->>'incidentId' = %s"
+            if status:
+                where += " AND data->>'status' = %s"; params.append(status)
+            total = int(conn.execute(f"SELECT count(*) FROM recovery_case_snapshots WHERE {where}", tuple(params)).fetchone()[0])
+            rows = conn.execute(f"SELECT id, version, data FROM recovery_case_snapshots WHERE {where} ORDER BY data->>'openedAt' LIMIT %s OFFSET %s", tuple(params + [limit, offset])).fetchall()
+            items = []
+            for aggregate_id, version, data in rows:
+                self._remember("case", str(aggregate_id), int(version)); items.append(case_from_json(data, int(version)))
+            return tuple(items), total
+        return self._with_conn(read)
+
+    def find_case_by_post_sales_case(self, post_sales_case_id: str) -> RecoveryCase | None:
+        def read(conn: Any) -> RecoveryCase | None:
+            row = conn.execute("SELECT id, version, data FROM recovery_case_snapshots WHERE data->'execution'->>'externalRef' = %s ORDER BY id LIMIT 1", (post_sales_case_id,)).fetchone()
+            if not row: return None
+            self._remember("case", str(row[0]), int(row[1])); return case_from_json(row[2], int(row[1]))
+        return self._with_conn(read)
+
+    def append_outbox(self, envelopes: Iterable[Any]) -> None:
+        def write(conn: Any) -> None:
+            for envelope in envelopes: self._outbox.append(conn, envelope)
+        self._with_conn(write)
+
+    def mark_processed(self, event_id: str, stream: str | None = None) -> bool:
+        def write(conn: Any) -> bool:
+            return self._processed.try_mark_processed(conn, event_id, stream)
+        return bool(self._with_conn(write))

--- a/services/disruption-recovery/src/disruption_recovery/api.py
+++ b/services/disruption-recovery/src/disruption_recovery/api.py
@@ -1,20 +1,35 @@
+from __future__ import annotations
+
 from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager, nullcontext
+import os
+from pathlib import Path
 from typing import Any, Protocol
-from uuid import uuid4
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response
 
+from train_ticket_platform.idempotency import BoundedInMemoryIdempotencyStore, IdempotencyStore, configure_idempotency_middleware
+from train_ticket_platform.messaging import RedisEventSubscriber
+from train_ticket_platform.observability import init_opentelemetry
+from train_ticket_platform.storage import DatabaseConfig, DatabasePool, OutboxRelay, PostgresIdempotencyStore, ReadinessGate, run_migrations
+from train_ticket_platform.ids import new_uuid7
+
+from .adapters.messaging import POST_SALES_STREAM
+from .adapters.storage.postgres import PostgresDisruptionRecoveryStore
+from .application.service import DisruptionRecoveryService, InMemoryStore
+from .downstream import DownstreamHttpClient
 from .runtime import health, profile
+from .web.errors import register_exception_handlers
+from .web.handlers import router as disruption_router
 
 REQUEST_ID_HEADER = "X-Request-ID"
-CORRELATION_ID_HEADER = "X-Correlation-ID"
+CORRELATION_ID_HEADER = "X-Correlation-Id"
+LEGACY_CORRELATION_ID_HEADER = "X-Correlation-ID"
 TraceHook = Callable[[str, Mapping[str, object]], None]
 
 
 class RuntimeSpan(AbstractContextManager["RuntimeSpan"], Protocol):
     def set_attribute(self, key: str, value: object) -> None: ...
-
     def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool | None: ...
 
 
@@ -28,29 +43,19 @@ def _emit_trace(tracer: TraceHook | None, event: str, attributes: Mapping[str, o
 
 
 def opentelemetry_tracer_from_env(service_name: str) -> RuntimeTracer | None:
-    """Return an OpenTelemetry API tracer only when OTEL_TRACES_EXPORTER is enabled.
-
-    The OpenTelemetry API defaults to non-recording spans unless a service
-    bootstrap installs an SDK/exporter. That keeps tests collector-free while
-    allowing OTEL_* environment configuration to drive real deployments.
-    """
-    import os
-
     exporter = os.getenv("OTEL_TRACES_EXPORTER", "").strip().lower()
     if not exporter or exporter == "none":
         return None
     configured_service = os.getenv("OTEL_SERVICE_NAME", "").strip() or service_name
     try:
         from opentelemetry import trace
-    except ImportError:  # pragma: no cover - optional adapter dependency
+    except ImportError:
         return None
     return trace.get_tracer(configured_service)
 
 
 def _span_context(tracer: RuntimeTracer | None, name: str) -> AbstractContextManager[RuntimeSpan | None]:
-    if tracer is None:
-        return nullcontext(None)
-    return tracer.start_as_current_span(name)
+    return nullcontext(None) if tracer is None else tracer.start_as_current_span(name)
 
 
 def _set_span_attribute(span: RuntimeSpan | None, key: str, value: object) -> None:
@@ -59,8 +64,8 @@ def _set_span_attribute(span: RuntimeSpan | None, key: str, value: object) -> No
 
 
 def _request_identifiers(request: Request) -> tuple[str, str]:
-    request_id = request.headers.get(REQUEST_ID_HEADER) or str(uuid4())
-    correlation_id = request.headers.get(CORRELATION_ID_HEADER) or request_id
+    request_id = request.headers.get(REQUEST_ID_HEADER) or new_uuid7()
+    correlation_id = request.headers.get(CORRELATION_ID_HEADER) or request.headers.get(LEGACY_CORRELATION_ID_HEADER) or request_id
     return request_id, correlation_id
 
 
@@ -72,56 +77,117 @@ def configure_runtime_endpoints(app: FastAPI, tracer: TraceHook | None = None, o
         request.state.correlation_id = correlation_id
         service_name = profile()["service_id"]
         path = request.url.path
-        trace_attributes = {
-            "service.name": service_name,
-            "request_id": request_id,
-            "correlation_id": correlation_id,
-            "http.request.method": request.method,
-            "http.method": request.method,
-            "url.path": path,
-            "http.route": path,
-            "http.request_id": request_id,
-            "http.correlation_id": correlation_id,
-        }
-        _emit_trace(tracer, "http.request.start", trace_attributes)
+        attrs = {"service.name": service_name, "request_id": request_id, "correlation_id": correlation_id, "http.request.method": request.method, "http.method": request.method, "url.path": path, "http.route": path, "http.request_id": request_id, "http.correlation_id": correlation_id}
+        _emit_trace(tracer, "http.request.start", attrs)
         with _span_context(otel_tracer, f"{request.method} {path}") as span:
-            for key, value in trace_attributes.items():
+            for key, value in attrs.items():
                 _set_span_attribute(span, key, value)
             try:
                 response = await call_next(request)
-            except Exception as exc:  # pragma: no cover - exercised by FastAPI exception handling paths
+            except Exception as exc:
                 _set_span_attribute(span, "error.type", exc.__class__.__name__)
-                _emit_trace(tracer, "http.request.error", {**trace_attributes, "error": exc.__class__.__name__})
+                _emit_trace(tracer, "http.request.error", {**attrs, "error": exc.__class__.__name__})
                 raise
             response.headers[REQUEST_ID_HEADER] = request_id
             response.headers[CORRELATION_ID_HEADER] = correlation_id
+            response.headers[LEGACY_CORRELATION_ID_HEADER] = correlation_id
             _set_span_attribute(span, "http.response.status_code", response.status_code)
             _set_span_attribute(span, "http.status_code", response.status_code)
-            _emit_trace(
-                tracer,
-                "http.request.complete",
-                {**trace_attributes, "status_code": response.status_code},
-            )
+            _emit_trace(tracer, "http.request.complete", {**attrs, "status_code": response.status_code})
             return response
 
     @app.get("/health")
     def health_endpoint() -> dict[str, object]:
         return {"status": health(), "service": profile()}
 
+    @app.get("/healthz")
+    def healthz_endpoint() -> dict[str, str]:
+        return {"status": health()}
+
     @app.get("/live")
     def live_endpoint() -> dict[str, str]:
         return {"status": health()}
 
     @app.get("/ready")
-    def ready_endpoint() -> dict[str, str]:
+    def ready_endpoint(response: Response) -> dict[str, str]:
+        gate = getattr(app.state, "readiness", None)
+        if gate is not None and not gate.ready:
+            response.status_code = 503
+            return {"status": "not-ready"}
         return {"status": health()}
+
+    @app.get("/readyz")
+    def readyz_endpoint(response: Response) -> dict[str, str]:
+        return ready_endpoint(response)
 
     @app.get("/metadata")
     def metadata_endpoint() -> dict[str, object]:
         return {"service": profile(), "observability": {"tracing": "opt-in", "default": "noop"}}
 
 
-def create_app(tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None) -> FastAPI:
-    app = FastAPI(title='Disruption Recovery', version="0.1.0")
+def configure_disruption_routes(app: FastAPI, store: Any | None = None, idempotency_store: IdempotencyStore | None = None, downstream: Any | None = None) -> None:
+    store = store or InMemoryStore()
+    service = DisruptionRecoveryService(store, downstream or (DownstreamHttpClient() if DatabaseConfig.from_env() else None))
+    unit_of_work = getattr(store, "unit_of_work", None)
+    if callable(unit_of_work):
+        @app.middleware("http")
+        async def disruption_unit_of_work_middleware(request: Request, call_next: Any):
+            with unit_of_work():
+                return await call_next(request)
+    app.state.disruption_recovery_service = service
+    app.state.disruption_recovery_store = store
+    configure_idempotency_middleware(app, idempotency_store or BoundedInMemoryIdempotencyStore(), require_key=True, include_path_prefixes=("/api/v1/disruptions", "/api/v1/recovery-cases"))
+    for route in disruption_router.routes:
+        app.router.routes.append(route)
+
+
+def _postgres_store_from_env(app: FastAPI) -> tuple[Any, IdempotencyStore | None]:
+    config = DatabaseConfig.from_env()
+    if config is None:
+        return InMemoryStore(), None
+    readiness = ReadinessGate()
+    pool = DatabasePool(config)
+    app.state.database_pool = pool
+    app.state.readiness = readiness
+    migrations_dir = Path(os.environ.get("MIGRATIONS_DIR") or Path(__file__).resolve().parents[3] / "migrations")
+    run_migrations(pool, migrations_dir, readiness)
+    store = PostgresDisruptionRecoveryStore(pool)
+    relay = OutboxRelay(pool)
+    relay.start()
+    subscriber = RedisEventSubscriber()
+    service_holder: dict[str, Any] = {}
+    def handle(envelope: Any) -> None:
+        service_holder["service"].handle_post_sales_applied(envelope, POST_SALES_STREAM)
+    thread = subscriber.start_in_background((POST_SALES_STREAM,), "disruption-recovery", handle)
+    app.state.outbox_relay = relay
+    app.state.event_subscriber = subscriber
+    app.state.event_subscriber_thread = thread
+    app.state._dr_service_holder = service_holder
+    return store, PostgresIdempotencyStore(pool)
+
+
+def create_app(tracer: TraceHook | None = None, otel_tracer: RuntimeTracer | None = None, store: Any | None = None, idempotency_store: IdempotencyStore | None = None, downstream: Any | None = None) -> FastAPI:
+    app = FastAPI(title="Disruption Recovery", version="0.1.0")
+    init_opentelemetry(profile()["service_id"], app=app)
+    if store is None:
+        store, default_idempotency_store = _postgres_store_from_env(app)
+        idempotency_store = idempotency_store or default_idempotency_store
+    register_exception_handlers(app)
     configure_runtime_endpoints(app, tracer, otel_tracer or opentelemetry_tracer_from_env(profile()["service_id"]))
+    configure_disruption_routes(app, store, idempotency_store, downstream)
+    holder = getattr(app.state, "_dr_service_holder", None)
+    if isinstance(holder, dict):
+        holder["service"] = app.state.disruption_recovery_service
+
+    @app.on_event("shutdown")
+    def _shutdown() -> None:
+        sub = getattr(app.state, "event_subscriber", None)
+        if sub is not None:
+            sub.stop()
+        relay = getattr(app.state, "outbox_relay", None)
+        if relay is not None:
+            relay.stop()
+        pool = getattr(app.state, "database_pool", None)
+        if pool is not None:
+            pool.close()
     return app

--- a/services/disruption-recovery/src/disruption_recovery/application/service.py
+++ b/services/disruption-recovery/src/disruption_recovery/application/service.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from hashlib import sha256
+from typing import Any, Mapping
+
+from train_ticket_platform.events import EventEnvelope, rfc3339_utc
+
+from disruption_recovery.domain import (
+    ActorRef,
+    DomainError,
+    Evidence,
+    ExecutionTarget,
+    Incident,
+    RecoveryCase,
+    RecoveryCaseStatus,
+    RecoveryOption,
+    RecoveryOptionType,
+    build_option_set,
+    now_utc,
+    require_text,
+)
+from disruption_recovery.ids import prefixed_uuid7
+
+PRODUCER = "disruption-recovery"
+TERMINAL_STATUSES = {RecoveryCaseStatus.RECOVERED, RecoveryCaseStatus.DECLINED, RecoveryCaseStatus.FAILED, RecoveryCaseStatus.CLOSED}
+
+
+class NotFoundError(KeyError):
+    pass
+
+
+class PreconditionFailedError(DomainError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class DisruptionReport:
+    disruptionId: str
+    disruptionType: str
+    scheduledServiceRef: str | None
+    segmentRef: str | None
+    serviceDate: str
+    evidence: Evidence
+    affectedOrderIds: tuple[str, ...]
+    reportedBy: ActorRef
+    reportedAt: datetime
+    incidentId: str
+
+    def to_json(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "disruptionId": self.disruptionId,
+            "disruptionType": self.disruptionType,
+            "serviceDate": self.serviceDate,
+            "evidence": self.evidence.to_json(),
+            "affectedOrderIds": list(self.affectedOrderIds),
+            "reportedBy": self.reportedBy.to_json(),
+            "reportedAt": rfc3339_utc(self.reportedAt),
+            "incidentId": self.incidentId,
+        }
+        if self.scheduledServiceRef:
+            data["scheduledServiceRef"] = self.scheduledServiceRef
+        if self.segmentRef:
+            data["segmentRef"] = self.segmentRef
+        return data
+
+
+class InMemoryStore:
+    def __init__(self) -> None:
+        self.incidents: dict[str, Incident] = {}
+        self.incident_merge_index: dict[str, str] = {}
+        self.cases: dict[str, RecoveryCase] = {}
+        self.case_index: dict[tuple[str, str], str] = {}
+        self.refund_execution_index: dict[str, str] = {}
+        self._outbox: list[EventEnvelope] = []
+        self.processed_events: set[str] = set()
+
+    def transaction(self) -> Any:
+        return nullcontext()
+
+    def append_outbox(self, envelopes: tuple[EventEnvelope, ...]) -> None:
+        self._outbox.extend(envelopes)
+
+    def take_outbox(self) -> tuple[EventEnvelope, ...]:
+        items = tuple(self._outbox)
+        self._outbox.clear()
+        return items
+
+    def mark_processed(self, event_id: str, stream: str | None = None) -> bool:
+        if event_id in self.processed_events:
+            return False
+        self.processed_events.add(event_id)
+        return True
+
+    def get_incident(self, incident_id: str) -> Incident:
+        try:
+            return self.incidents[incident_id]
+        except KeyError as exc:
+            raise NotFoundError(f"incident not found: {incident_id}") from exc
+
+    def save_incident(self, incident: Incident) -> None:
+        self.incidents[incident.incidentId] = incident
+        if incident.scheduledServiceRef:
+            self.incident_merge_index[f"{incident.scheduledServiceRef}\u001f{incident.serviceDate}"] = incident.incidentId
+
+    def find_incident_by_merge_key(self, scheduled_service_ref: str, service_date: str) -> Incident | None:
+        incident_id = self.incident_merge_index.get(f"{scheduled_service_ref}\u001f{service_date}")
+        return self.incidents.get(incident_id) if incident_id else None
+
+    def get_case(self, case_id: str) -> RecoveryCase:
+        try:
+            return self.cases[case_id]
+        except KeyError as exc:
+            raise NotFoundError(f"recovery case not found: {case_id}") from exc
+
+    def save_case(self, case: RecoveryCase) -> None:
+        self.cases[case.caseId] = case
+        self.case_index[(case.incidentId, case.journeyOrderId)] = case.caseId
+        if case.execution and case.execution.externalRef and case.execution.target is ExecutionTarget.POST_SALES:
+            self.refund_execution_index[case.execution.externalRef] = case.caseId
+
+    def find_case(self, incident_id: str, order_id: str) -> RecoveryCase | None:
+        case_id = self.case_index.get((incident_id, order_id))
+        return self.cases.get(case_id) if case_id else None
+
+    def list_cases(self, incident_id: str, status: str | None, limit: int, offset: int) -> tuple[tuple[RecoveryCase, ...], int]:
+        items = [case for case in self.cases.values() if case.incidentId == incident_id and (status is None or case.status.value == status)]
+        items.sort(key=lambda case: case.openedAt)
+        return tuple(items[offset: offset + limit]), len(items)
+
+    def find_case_by_post_sales_case(self, post_sales_case_id: str) -> RecoveryCase | None:
+        case_id = self.refund_execution_index.get(post_sales_case_id)
+        if case_id:
+            return self.cases.get(case_id)
+        for case in self.cases.values():
+            if case.execution and case.execution.externalRef == post_sales_case_id:
+                return case
+        return None
+
+
+class DownstreamPort:
+    def open_refund_case(self, body: Mapping[str, Any], idempotency_key: str, correlation_id: str) -> Mapping[str, Any]:
+        raise NotImplementedError
+
+    def issue_compensation(self, body: Mapping[str, Any], idempotency_key: str, correlation_id: str) -> Mapping[str, Any]:
+        raise NotImplementedError
+
+
+class NoopDownstream(DownstreamPort):
+    def open_refund_case(self, body: Mapping[str, Any], idempotency_key: str, correlation_id: str) -> Mapping[str, Any]:
+        return {"caseId": f"psc-{sha256(idempotency_key.encode()).hexdigest()[:32]}", "status": "OPENED"}
+
+    def issue_compensation(self, body: Mapping[str, Any], idempotency_key: str, correlation_id: str) -> Mapping[str, Any]:
+        return {"benefitId": "ben-" + sha256(idempotency_key.encode()).hexdigest()[:32], "status": "ISSUED"}
+
+
+def _event_id(event_type: str, aggregate_id: str, version: int) -> str:
+    digest = sha256(f"{PRODUCER}:{event_type}:{aggregate_id}:{version}".encode("utf-8")).hexdigest()[:32]
+    return f"evt-{digest}"
+
+
+def _envelope(event_type: str, aggregate_id: str, version: int, payload: Mapping[str, Any], correlation_id: str, causation_id: str, occurred_at: datetime) -> EventEnvelope:
+    return EventEnvelope(eventId=_event_id(event_type, aggregate_id, version), eventType=event_type, occurredAt=occurred_at, correlationId=correlation_id, causationId=causation_id, producer=PRODUCER, schemaVersion=1, payload=payload)
+
+
+class DisruptionRecoveryService:
+    def __init__(self, store: Any, downstream: DownstreamPort | None = None) -> None:
+        self.store = store
+        self.downstream = downstream or NoopDownstream()
+
+    def transaction(self) -> Any:
+        transaction = getattr(self.store, "transaction", None)
+        return transaction() if callable(transaction) else nullcontext()
+
+    def _append(self, events: list[EventEnvelope]) -> None:
+        append = getattr(self.store, "append_outbox", None)
+        if callable(append):
+            append(tuple(events))
+
+    def report_disruption(self, data: Mapping[str, Any], correlation_id: str, causation_id: str) -> dict[str, Any]:
+        at = now_utc()
+        evidence = Evidence(**dict(data.get("evidence") or {}))
+        reported_by = ActorRef(**dict(data.get("reportedBy") or {}))
+        disruption_type = require_text(str(data.get("disruptionType") or ""), "disruptionType")
+        service_date = require_text(str(data.get("serviceDate") or ""), "serviceDate")
+        scheduled = str(data.get("scheduledServiceRef") or "").strip() or None
+        segment = str(data.get("segmentRef") or "").strip() or None
+        if not scheduled and not segment:
+            raise DomainError("scheduledServiceRef or segmentRef is required")
+        affected = tuple(dict.fromkeys(str(item).strip() for item in data.get("affectedOrderIds") or [] if str(item).strip()))
+        if not affected:
+            raise DomainError("affectedOrderIds must be non-empty")
+        disruption_id = prefixed_uuid7("drp")
+        incident_opened = False
+        if scheduled:
+            incident = self.store.find_incident_by_merge_key(scheduled, service_date)
+        else:
+            incident = None
+        if incident is None:
+            incident = Incident.open(prefixed_uuid7("inc"), disruption_type, scheduled, segment, service_date, evidence.evidenceRef, affected, at)
+            incident_opened = True
+        else:
+            incident = incident.merge(evidence.evidenceRef, segment, affected, at)
+        self.store.save_incident(incident)
+        report = DisruptionReport(disruption_id, disruption_type, scheduled, segment, service_date, evidence, affected, reported_by, at, incident.incidentId)
+        events = [_envelope("DisruptionReported", disruption_id, 1, report.to_json() | {"reportedAt": rfc3339_utc(at)}, correlation_id, causation_id, at)]
+        if incident_opened:
+            events.append(_envelope("IncidentOpened", incident.incidentId, incident.version + 1, incident.to_json() | {"disruptionId": disruption_id, "affectedOrderIds": list(affected)}, correlation_id, causation_id, at))
+        cases: list[RecoveryCase] = []
+        for order_id in affected:
+            existing = self.store.find_case(incident.incidentId, order_id)
+            if existing is not None:
+                cases.append(existing)
+                continue
+            case = RecoveryCase(prefixed_uuid7("rcv"), incident.incidentId, order_id, {"journeyOrderId": order_id, "scheduledServiceRef": scheduled, "segmentRef": segment, "serviceDate": service_date, "disruptionType": disruption_type, "evidenceRef": evidence.evidenceRef}, RecoveryCaseStatus.OPENED, at, at)
+            events.append(_envelope("RecoveryCaseOpened", case.caseId, 1, {"caseId": case.caseId, "incidentId": incident.incidentId, "disruptionId": disruption_id, "journeyOrderId": order_id, "affectedScope": dict(case.affectedScope), "openedAt": rfc3339_utc(at), "status": "OPENED"}, correlation_id, causation_id, at))
+            case = case.assess(at)
+            wait_only = order_id.endswith("0") or str(data.get("autoRecovery") or "").upper() == "WAIT"
+            option_set = build_option_set(case.caseId, order_id, segment, at, prefixed_uuid7("ros"), tuple(prefixed_uuid7("rop") for _ in range(4)), wait_only)
+            case = case.attach_options(option_set, at)
+            events.append(_envelope("RecoveryOptionsGenerated", case.caseId, 2, {"caseId": case.caseId, "incidentId": incident.incidentId, "journeyOrderId": order_id, "optionSetId": option_set.optionSetId, "options": [o.to_json() for o in option_set.options], "requiresUserChoice": option_set.requiresUserChoice, "generatedAt": rfc3339_utc(at), "status": case.status.value} | ({"expiresAt": rfc3339_utc(option_set.expiresAt)} if option_set.expiresAt else {}), correlation_id, causation_id, at))
+            if not option_set.requiresUserChoice:
+                case, wait_option = case.auto_wait(ActorRef("SYSTEM", "disruption-recovery"), prefixed_uuid7("rex"), at)
+                events.extend(self._selection_events(case, wait_option, ActorRef("SYSTEM", "disruption-recovery"), correlation_id, causation_id, at))
+                events.append(self._completed_event(case, wait_option, correlation_id, causation_id, at))
+            self.store.save_case(case)
+            cases.append(case)
+        events.append(_envelope("ServiceAlertPublished", incident.incidentId, incident.version + 2, {"serviceAlertId": prefixed_uuid7("sal"), "incidentId": incident.incidentId, "disruptionType": disruption_type, "serviceDate": service_date, "audience": "AFFECTED_ORDERS", "affectedOrderIds": list(affected), "messageSummary": evidence.summary, "publishedAt": rfc3339_utc(at)} | ({"scheduledServiceRef": scheduled} if scheduled else {}) | ({"segmentRef": segment} if segment else {}), correlation_id, causation_id, at))
+        self._append(events)
+        return {"disruption": report.to_json(), "incident": incident.to_json(), "recoveryCases": [case.to_json() for case in cases]}
+
+    def select_option(self, case_id: str, data: Mapping[str, Any], correlation_id: str, causation_id: str) -> dict[str, Any]:
+        at = now_utc()
+        case = self.store.get_case(case_id)
+        actor = ActorRef(**dict(data.get("selectedBy") or {}))
+        option_id = require_text(str(data.get("optionId") or ""), "optionId")
+        option = case.optionSet.option_by_id(option_id) if case.optionSet else None
+        if option is None:
+            raise PreconditionFailedError("option set is missing")
+        idem = self._downstream_key(case.caseId, option)
+        case, option = case.select(option_id, actor, prefixed_uuid7("rex"), idem, at)
+        events = self._selection_events(case, option, actor, correlation_id, causation_id, at)
+        if option.optionType is RecoveryOptionType.WAIT:
+            case = case.complete(option, None, at)
+            events.append(self._completed_event(case, option, correlation_id, causation_id, at))
+        elif option.optionType is RecoveryOptionType.REFUND:
+            external = self._execute_refund(case, option, correlation_id)
+            case = self._with_external(case, external)
+        elif option.optionType is RecoveryOptionType.COMPENSATION:
+            external = self._execute_compensation(case, option, correlation_id)
+            case = self._with_external(case, external).complete(option, external, at)
+            events.append(self._completed_event(case, option, correlation_id, causation_id, at))
+        self.store.save_case(case)
+        self._append(events)
+        return case.to_json()
+
+    def resolve_manual(self, case_id: str, data: Mapping[str, Any], correlation_id: str, causation_id: str) -> dict[str, Any]:
+        at = now_utc()
+        case = self.store.get_case(case_id)
+        target = RecoveryCaseStatus(str(data.get("outcome") or data.get("status") or ""))
+        case = case.resolve_manual(target, at, str(data.get("manualRef") or f"manual:{case_id}"))
+        option = case.selected_option() or RecoveryOption("rop-manual", RecoveryOptionType.MANUAL, "Manual review", "Manual review", ExecutionTarget.MANUAL_QUEUE)
+        event = self._completed_event(case, option, correlation_id, causation_id, at) if target is RecoveryCaseStatus.RECOVERED else self._failed_event(case, str(data.get("reason") or "Manual review failed"), correlation_id, causation_id, at)
+        self.store.save_case(case)
+        self._append([event])
+        return case.to_json()
+
+    def close_case(self, case_id: str, data: Mapping[str, Any], correlation_id: str, causation_id: str) -> dict[str, Any]:
+        at = now_utc()
+        case = self.store.get_case(case_id)
+        previous = case.status
+        closed_by = ActorRef(**dict(data.get("closedBy") or {}))
+        reason = require_text(str(data.get("closeReason") or ""), "closeReason")
+        case = case.close(at)
+        self.store.save_case(case)
+        self._append([_envelope("RecoveryCaseClosed", case.caseId, case.version + 1, {"caseId": case.caseId, "incidentId": case.incidentId, "journeyOrderId": case.journeyOrderId, "previousStatus": previous.value, "closedBy": closed_by.to_json(), "closeReason": reason, "closedAt": rfc3339_utc(at), "status": "CLOSED"}, correlation_id, causation_id, at)])
+        return case.to_json()
+
+    def handle_post_sales_applied(self, envelope: EventEnvelope, stream: str | None = None) -> bool:
+        if envelope.eventType != "PostSalesApplied":
+            return False
+        mark = getattr(self.store, "mark_processed", None)
+        if callable(mark) and not mark(envelope.eventId, stream):
+            return True
+        payload = dict(envelope.payload)
+        post_sales_case_id = str(payload.get("caseId") or "")
+        case = self.store.find_case_by_post_sales_case(post_sales_case_id)
+        if case is None or case.status in TERMINAL_STATUSES:
+            return True
+        option = case.selected_option()
+        if option is None:
+            return True
+        at = now_utc()
+        case = case.complete(option, post_sales_case_id, at)
+        self.store.save_case(case)
+        self._append([self._completed_event(case, option, envelope.correlationId, envelope.eventId, at)])
+        return True
+
+    def _selection_events(self, case: RecoveryCase, option: RecoveryOption, actor: ActorRef, correlation_id: str, causation_id: str, at: datetime) -> list[EventEnvelope]:
+        assert case.optionSet is not None and case.execution is not None
+        selected = _envelope("RecoveryOptionSelected", case.caseId, case.version + 3, {"caseId": case.caseId, "incidentId": case.incidentId, "journeyOrderId": case.journeyOrderId, "optionSetId": case.optionSet.optionSetId, "optionId": option.optionId, "optionType": option.optionType.value, "selectedBy": actor.to_json(), "selectedAt": rfc3339_utc(at), "status": case.status.value}, correlation_id, causation_id, at)
+        started = _envelope("RecoveryExecutionStarted", case.caseId, case.version + 4, {"caseId": case.caseId, "incidentId": case.incidentId, "journeyOrderId": case.journeyOrderId, "optionId": option.optionId, "optionType": option.optionType.value, "executionId": case.execution.executionId, "executionTarget": case.execution.target.value, "startedAt": rfc3339_utc(at), "status": case.status.value} | ({"idempotencyKey": case.execution.idempotencyKey} if case.execution.idempotencyKey else {}), correlation_id, causation_id, at)
+        return [selected, started]
+
+    def _completed_event(self, case: RecoveryCase, option: RecoveryOption, correlation_id: str, causation_id: str, at: datetime) -> EventEnvelope:
+        assert case.execution is not None
+        return _envelope("RecoveryCompleted", case.caseId, case.version + 5, {"caseId": case.caseId, "incidentId": case.incidentId, "journeyOrderId": case.journeyOrderId, "optionId": option.optionId, "optionType": option.optionType.value, "executionId": case.execution.executionId, "completedAt": rfc3339_utc(at), "status": "RECOVERED"} | ({"externalRef": case.execution.externalRef} if case.execution.externalRef else {}), correlation_id, causation_id, at)
+
+    def _failed_event(self, case: RecoveryCase, reason: str, correlation_id: str, causation_id: str, at: datetime) -> EventEnvelope:
+        return _envelope("RecoveryFailed", case.caseId, case.version + 5, {"caseId": case.caseId, "incidentId": case.incidentId, "journeyOrderId": case.journeyOrderId, "optionId": case.selectedOptionId, "executionId": case.execution.executionId if case.execution else None, "failedAt": rfc3339_utc(at), "reason": reason, "nextStatus": case.status.value}, correlation_id, causation_id, at)
+
+    def _downstream_key(self, case_id: str, option: RecoveryOption) -> str | None:
+        if option.optionType is RecoveryOptionType.REFUND:
+            return f"dr-refund:{case_id}"
+        if option.optionType is RecoveryOptionType.COMPENSATION:
+            return f"dr-comp:{case_id}"
+        return None
+
+    def _with_external(self, case: RecoveryCase, external_ref: str) -> RecoveryCase:
+        from dataclasses import replace
+        if case.execution is None:
+            return case
+        return replace(case, execution=replace(case.execution, externalRef=external_ref))
+
+    def _execute_refund(self, case: RecoveryCase, option: RecoveryOption, correlation_id: str) -> str:
+        assert case.execution and case.execution.idempotencyKey
+        refund = dict(option.refund or {})
+        scope = dict(refund.get("scope") or {})
+        scope = {"orderItemRefs": list(scope.get("orderItemRefs") or []), "segmentRefs": list(scope.get("segmentRefs") or []), "travelerRefs": list(scope.get("travelerRefs") or []), "entitlementRefs": list(scope.get("entitlementRefs") or [])}
+        body = {"journeyOrderId": case.journeyOrderId, "caseType": "REFUND", "scope": scope, "reasonCode": refund.get("reasonCode") or "DISRUPTION_REFUND", "actorRef": "disruption-recovery"}
+        response = self.downstream.open_refund_case(body, case.execution.idempotencyKey, correlation_id)
+        return str(response.get("caseId") or response.get("postSalesCaseId") or "")
+
+    def _execute_compensation(self, case: RecoveryCase, option: RecoveryOption, correlation_id: str) -> str:
+        assert case.execution and case.execution.idempotencyKey
+        comp = dict(option.compensation or {})
+        now = now_utc()
+        body = {"accountId": case.journeyOrderId, "benefitType": comp.get("benefitType") or "COMPENSATION_CREDIT", "balanceType": comp.get("balanceType") or "PROMOTION_CREDIT", "amount": comp.get("amount") or {"currency": "CNY", "minorUnits": 1000}, "issuanceSource": "DISRUPTION_COMP", "caseId": case.caseId, "applicableScope": {"scopeType": "ANY_TRIP", "currency": "CNY"}, "redemptionRule": {"singleUse": False, "requiresReservation": False}, "revocationRule": {}, "validFrom": rfc3339_utc(now), "validUntil": comp.get("validUntil") or rfc3339_utc(now + timedelta(days=30)), "businessReason": {"reasonType": "DISRUPTION_COMP", "reasonCode": comp.get("reasonCode") or "DISRUPTION_COMP", "referenceType": "RECOVERY_CASE", "referenceId": case.caseId}}
+        response = self.downstream.issue_compensation(body, case.execution.idempotencyKey, correlation_id)
+        return str(response.get("benefitId") or "")

--- a/services/disruption-recovery/src/disruption_recovery/domain.py
+++ b/services/disruption-recovery/src/disruption_recovery/domain.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from typing import Any, Mapping
+
+from train_ticket_platform.events import rfc3339_utc
+
+
+class DomainError(ValueError):
+    pass
+
+
+class RecoveryCaseStatus(StrEnum):
+    OPENED = "OPENED"
+    ASSESSING_IMPACT = "ASSESSING_IMPACT"
+    OPTIONS_GENERATED = "OPTIONS_GENERATED"
+    AWAITING_USER_CHOICE = "AWAITING_USER_CHOICE"
+    EXECUTING_RECOVERY = "EXECUTING_RECOVERY"
+    MANUAL_REVIEW = "MANUAL_REVIEW"
+    RECOVERED = "RECOVERED"
+    DECLINED = "DECLINED"
+    FAILED = "FAILED"
+    CLOSED = "CLOSED"
+
+
+class RecoveryOptionType(StrEnum):
+    WAIT = "WAIT"
+    REFUND = "REFUND"
+    COMPENSATION = "COMPENSATION"
+    MANUAL = "MANUAL"
+
+
+class ExecutionTarget(StrEnum):
+    NONE = "NONE"
+    POST_SALES = "POST_SALES"
+    WALLET_PROMOTION = "WALLET_PROMOTION"
+    MANUAL_QUEUE = "MANUAL_QUEUE"
+
+
+TERMINAL_BEFORE_CLOSE = {RecoveryCaseStatus.RECOVERED, RecoveryCaseStatus.DECLINED, RecoveryCaseStatus.FAILED}
+ALLOWED_TRANSITIONS: dict[RecoveryCaseStatus, set[RecoveryCaseStatus]] = {
+    RecoveryCaseStatus.OPENED: {RecoveryCaseStatus.ASSESSING_IMPACT, RecoveryCaseStatus.MANUAL_REVIEW},
+    RecoveryCaseStatus.ASSESSING_IMPACT: {RecoveryCaseStatus.OPTIONS_GENERATED, RecoveryCaseStatus.MANUAL_REVIEW},
+    RecoveryCaseStatus.OPTIONS_GENERATED: {RecoveryCaseStatus.EXECUTING_RECOVERY, RecoveryCaseStatus.AWAITING_USER_CHOICE, RecoveryCaseStatus.MANUAL_REVIEW},
+    RecoveryCaseStatus.AWAITING_USER_CHOICE: {RecoveryCaseStatus.EXECUTING_RECOVERY, RecoveryCaseStatus.MANUAL_REVIEW, RecoveryCaseStatus.DECLINED},
+    RecoveryCaseStatus.EXECUTING_RECOVERY: {RecoveryCaseStatus.RECOVERED, RecoveryCaseStatus.OPTIONS_GENERATED, RecoveryCaseStatus.MANUAL_REVIEW, RecoveryCaseStatus.FAILED},
+    RecoveryCaseStatus.MANUAL_REVIEW: {RecoveryCaseStatus.EXECUTING_RECOVERY, RecoveryCaseStatus.RECOVERED, RecoveryCaseStatus.FAILED},
+    RecoveryCaseStatus.RECOVERED: {RecoveryCaseStatus.CLOSED},
+    RecoveryCaseStatus.DECLINED: {RecoveryCaseStatus.CLOSED},
+    RecoveryCaseStatus.FAILED: {RecoveryCaseStatus.CLOSED},
+    RecoveryCaseStatus.CLOSED: set(),
+}
+
+
+def now_utc() -> datetime:
+    return datetime.now(UTC)
+
+
+def require_text(value: str | None, field_name: str) -> str:
+    if value is None or not str(value).strip():
+        raise DomainError(f"{field_name} is required")
+    return str(value).strip()
+
+
+@dataclass(frozen=True, slots=True)
+class ActorRef:
+    actorType: str
+    actorId: str
+
+    def __post_init__(self) -> None:
+        if self.actorType not in {"USER", "CUSTOMER_SERVICE", "OPERATIONS", "SYSTEM"}:
+            raise DomainError("actorType is invalid")
+        require_text(self.actorId, "actorId")
+
+    def to_json(self) -> dict[str, Any]:
+        return {"actorType": self.actorType, "actorId": self.actorId}
+
+
+@dataclass(frozen=True, slots=True)
+class Evidence:
+    evidenceRef: str
+    sourceSystem: str
+    sourceRecordId: str
+    summary: str
+    occurredAt: str | None = None
+
+    def __post_init__(self) -> None:
+        require_text(self.evidenceRef, "evidenceRef")
+        if self.sourceSystem not in {"CUSTOMER_SERVICE", "ADMIN"}:
+            raise DomainError("evidence.sourceSystem is invalid")
+        require_text(self.sourceRecordId, "sourceRecordId")
+        require_text(self.summary, "summary")
+
+    def to_json(self) -> dict[str, Any]:
+        data = {"evidenceRef": self.evidenceRef, "sourceSystem": self.sourceSystem, "sourceRecordId": self.sourceRecordId, "summary": self.summary}
+        if self.occurredAt:
+            data["occurredAt"] = self.occurredAt
+        return data
+
+
+@dataclass(frozen=True, slots=True)
+class Incident:
+    incidentId: str
+    status: str
+    disruptionType: str
+    scheduledServiceRef: str | None
+    segmentRefs: tuple[str, ...]
+    serviceDate: str
+    evidenceRefs: tuple[str, ...]
+    affectedOrderIds: tuple[str, ...]
+    openedAt: datetime
+    updatedAt: datetime
+    version: int = 0
+
+    @classmethod
+    def open(cls, incident_id: str, disruption_type: str, scheduled_service_ref: str | None, segment_ref: str | None, service_date: str, evidence_ref: str, affected_order_ids: tuple[str, ...], opened_at: datetime) -> "Incident":
+        return cls(incident_id, "CONFIRMED", disruption_type, scheduled_service_ref, tuple([segment_ref] if segment_ref else ()), service_date, (evidence_ref,), tuple(dict.fromkeys(affected_order_ids)), opened_at, opened_at)
+
+    def merge(self, evidence_ref: str, segment_ref: str | None, affected_order_ids: tuple[str, ...], at: datetime) -> "Incident":
+        return replace(
+            self,
+            segmentRefs=tuple(dict.fromkeys((*self.segmentRefs, *([segment_ref] if segment_ref else [])))),
+            evidenceRefs=tuple(dict.fromkeys((*self.evidenceRefs, evidence_ref))),
+            affectedOrderIds=tuple(dict.fromkeys((*self.affectedOrderIds, *affected_order_ids))),
+            updatedAt=at,
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        data = {
+            "incidentId": self.incidentId,
+            "status": self.status,
+            "disruptionType": self.disruptionType,
+            "serviceDate": self.serviceDate,
+            "evidenceRefs": list(self.evidenceRefs),
+            "affectedOrderCount": len(set(self.affectedOrderIds)),
+            "openedAt": rfc3339_utc(self.openedAt),
+            "updatedAt": rfc3339_utc(self.updatedAt),
+        }
+        if self.scheduledServiceRef:
+            data["scheduledServiceRef"] = self.scheduledServiceRef
+        if self.segmentRefs:
+            data["segmentRefs"] = list(self.segmentRefs)
+        return data
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryOption:
+    optionId: str
+    optionType: RecoveryOptionType
+    title: str
+    description: str
+    executionTarget: ExecutionTarget
+    refund: Mapping[str, Any] | None = None
+    compensation: Mapping[str, Any] | None = None
+    manualReason: str | None = None
+    expiresAt: datetime | None = None
+
+    def to_json(self) -> dict[str, Any]:
+        data: dict[str, Any] = {"optionId": self.optionId, "optionType": self.optionType.value, "title": self.title, "description": self.description, "executionTarget": self.executionTarget.value}
+        if self.refund is not None:
+            data["refund"] = dict(self.refund)
+        if self.compensation is not None:
+            data["compensation"] = dict(self.compensation)
+        if self.manualReason:
+            data["manualReason"] = self.manualReason
+        if self.expiresAt:
+            data["expiresAt"] = rfc3339_utc(self.expiresAt)
+        return data
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryOptionSet:
+    optionSetId: str
+    caseId: str
+    options: tuple[RecoveryOption, ...]
+    generatedAt: datetime
+    expiresAt: datetime | None
+    requiresUserChoice: bool
+
+    def option_by_id(self, option_id: str) -> RecoveryOption:
+        for option in self.options:
+            if option.optionId == option_id:
+                return option
+        raise DomainError("selected option does not belong to the current option set")
+
+    def to_json(self) -> dict[str, Any]:
+        data = {"optionSetId": self.optionSetId, "caseId": self.caseId, "options": [item.to_json() for item in self.options], "generatedAt": rfc3339_utc(self.generatedAt), "requiresUserChoice": self.requiresUserChoice}
+        if self.expiresAt:
+            data["expiresAt"] = rfc3339_utc(self.expiresAt)
+        return data
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryExecution:
+    executionId: str
+    target: ExecutionTarget
+    idempotencyKey: str | None
+    externalRef: str | None
+    startedAt: datetime
+    completedAt: datetime | None = None
+    failureReason: str | None = None
+
+    def to_json(self) -> dict[str, Any]:
+        data = {"executionId": self.executionId, "target": self.target.value, "startedAt": rfc3339_utc(self.startedAt)}
+        if self.idempotencyKey:
+            data["idempotencyKey"] = self.idempotencyKey
+        if self.externalRef:
+            data["externalRef"] = self.externalRef
+        if self.completedAt:
+            data["completedAt"] = rfc3339_utc(self.completedAt)
+        if self.failureReason:
+            data["failureReason"] = self.failureReason
+        return data
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryCase:
+    caseId: str
+    incidentId: str
+    journeyOrderId: str
+    affectedScope: Mapping[str, Any]
+    status: RecoveryCaseStatus
+    openedAt: datetime
+    updatedAt: datetime
+    optionSet: RecoveryOptionSet | None = None
+    selectedOptionId: str | None = None
+    execution: RecoveryExecution | None = None
+    version: int = 0
+
+    def transition(self, target: RecoveryCaseStatus, at: datetime) -> "RecoveryCase":
+        if target not in ALLOWED_TRANSITIONS[self.status]:
+            raise DomainError(f"cannot transition recovery case from {self.status.value} to {target.value}")
+        return replace(self, status=target, updatedAt=at)
+
+    def assess(self, at: datetime) -> "RecoveryCase":
+        return self.transition(RecoveryCaseStatus.ASSESSING_IMPACT, at)
+
+    def attach_options(self, option_set: RecoveryOptionSet, at: datetime) -> "RecoveryCase":
+        generated = self.transition(RecoveryCaseStatus.OPTIONS_GENERATED, at)
+        target = RecoveryCaseStatus.AWAITING_USER_CHOICE if option_set.requiresUserChoice else RecoveryCaseStatus.EXECUTING_RECOVERY
+        return replace(generated.transition(target, at), optionSet=option_set)
+
+    def select(self, option_id: str, actor: ActorRef, execution_id: str, idempotency_key: str | None, at: datetime) -> tuple["RecoveryCase", RecoveryOption]:
+        if self.status is not RecoveryCaseStatus.AWAITING_USER_CHOICE:
+            raise DomainError("recovery case is not awaiting user choice")
+        if self.optionSet is None:
+            raise DomainError("recovery option set is missing")
+        if self.optionSet.expiresAt and at >= self.optionSet.expiresAt:
+            raise DomainError("recovery option set is expired")
+        if self.selectedOptionId:
+            raise DomainError("recovery option is already selected")
+        if actor.actorType not in {"USER", "CUSTOMER_SERVICE"}:
+            raise DomainError("selectedBy.actorType must be USER or CUSTOMER_SERVICE")
+        option = self.optionSet.option_by_id(option_id)
+        if option.optionType is RecoveryOptionType.MANUAL:
+            selected = self.transition(RecoveryCaseStatus.MANUAL_REVIEW, at)
+            execution = RecoveryExecution(execution_id, ExecutionTarget.MANUAL_QUEUE, None, f"manual:{self.caseId}", at)
+        else:
+            selected = self.transition(RecoveryCaseStatus.EXECUTING_RECOVERY, at)
+            execution = RecoveryExecution(execution_id, option.executionTarget, idempotency_key, None, at)
+        return replace(selected, selectedOptionId=option_id, execution=execution), option
+
+    def auto_wait(self, actor: ActorRef, execution_id: str, at: datetime) -> tuple["RecoveryCase", RecoveryOption]:
+        if self.optionSet is None:
+            raise DomainError("recovery option set is missing")
+        wait = next((item for item in self.optionSet.options if item.optionType is RecoveryOptionType.WAIT), None)
+        if wait is None:
+            raise DomainError("WAIT option is missing")
+        executing = replace(self, selectedOptionId=wait.optionId, execution=RecoveryExecution(execution_id, ExecutionTarget.NONE, None, None, at))
+        return executing.complete(wait, None, at), wait
+
+    def complete(self, option: RecoveryOption, external_ref: str | None, at: datetime) -> "RecoveryCase":
+        if self.status is not RecoveryCaseStatus.EXECUTING_RECOVERY:
+            raise DomainError("only executing recovery cases can complete")
+        execution = self.execution
+        if execution is None:
+            raise DomainError("recovery execution is missing")
+        completed = replace(execution, externalRef=external_ref or execution.externalRef, completedAt=at)
+        return replace(self.transition(RecoveryCaseStatus.RECOVERED, at), execution=completed)
+
+    def fail(self, reason: str, at: datetime) -> "RecoveryCase":
+        if self.status not in {RecoveryCaseStatus.EXECUTING_RECOVERY, RecoveryCaseStatus.MANUAL_REVIEW}:
+            raise DomainError("only executing or manual-review cases can fail")
+        execution = self.execution
+        if execution:
+            execution = replace(execution, failureReason=reason, completedAt=at)
+        return replace(self.transition(RecoveryCaseStatus.FAILED, at), execution=execution)
+
+    def resolve_manual(self, status: RecoveryCaseStatus, at: datetime, external_ref: str | None = None) -> "RecoveryCase":
+        if self.status is not RecoveryCaseStatus.MANUAL_REVIEW:
+            raise DomainError("case is not in manual review")
+        if status not in {RecoveryCaseStatus.RECOVERED, RecoveryCaseStatus.FAILED}:
+            raise DomainError("manual review can only resolve to RECOVERED or FAILED")
+        resolved = self.transition(status, at)
+        if resolved.execution and external_ref:
+            resolved = replace(resolved, execution=replace(resolved.execution, externalRef=external_ref, completedAt=at))
+        return resolved
+
+    def close(self, at: datetime) -> "RecoveryCase":
+        if self.status not in TERMINAL_BEFORE_CLOSE:
+            raise DomainError("only RECOVERED, DECLINED, or FAILED cases can be closed")
+        return self.transition(RecoveryCaseStatus.CLOSED, at)
+
+    def selected_option(self) -> RecoveryOption | None:
+        if not self.optionSet or not self.selectedOptionId:
+            return None
+        return self.optionSet.option_by_id(self.selectedOptionId)
+
+    def to_json(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "caseId": self.caseId,
+            "incidentId": self.incidentId,
+            "journeyOrderId": self.journeyOrderId,
+            "affectedScope": dict(self.affectedScope),
+            "status": self.status.value,
+            "openedAt": rfc3339_utc(self.openedAt),
+            "updatedAt": rfc3339_utc(self.updatedAt),
+        }
+        if self.optionSet:
+            data["optionSet"] = self.optionSet.to_json()
+        if self.selectedOptionId:
+            data["selectedOptionId"] = self.selectedOptionId
+        if self.execution:
+            data["execution"] = self.execution.to_json()
+        return data
+
+
+def build_option_set(case_id: str, journey_order_id: str, segment_ref: str | None, generated_at: datetime, option_set_id: str, option_ids: tuple[str, str, str, str], wait_only: bool) -> RecoveryOptionSet:
+    expires = None if wait_only else generated_at + timedelta(hours=24)
+    wait = RecoveryOption(option_ids[0], RecoveryOptionType.WAIT, "Wait for service recovery", "Keep the current trip and wait for operations recovery.", ExecutionTarget.NONE, expiresAt=expires)
+    if wait_only:
+        return RecoveryOptionSet(option_set_id, case_id, (wait,), generated_at, None, False)
+    refund_scope = {"orderItemRefs": [], "segmentRefs": [segment_ref] if segment_ref else [], "travelerRefs": [], "entitlementRefs": []}
+    refund = RecoveryOption(option_ids[1], RecoveryOptionType.REFUND, "Refund disrupted trip", "Open a disruption refund case for the affected order.", ExecutionTarget.POST_SALES, refund={"reasonCode": "DISRUPTION_REFUND", "scope": refund_scope}, expiresAt=expires)
+    comp = RecoveryOption(option_ids[2], RecoveryOptionType.COMPENSATION, "Issue compensation credit", "Issue a wallet compensation credit for this disruption.", ExecutionTarget.WALLET_PROMOTION, compensation={"amount": {"currency": "CNY", "minorUnits": 1000}, "benefitType": "COMPENSATION_CREDIT", "balanceType": "PROMOTION_CREDIT", "validUntil": rfc3339_utc(generated_at + timedelta(days=30)), "reasonCode": "DISRUPTION_COMP"}, expiresAt=expires)
+    manual = RecoveryOption(option_ids[3], RecoveryOptionType.MANUAL, "Manual review", "Send the recovery case to customer-service manual review.", ExecutionTarget.MANUAL_QUEUE, manualReason="Customer-service review requested", expiresAt=expires)
+    return RecoveryOptionSet(option_set_id, case_id, (wait, refund, comp, manual), generated_at, expires, True)

--- a/services/disruption-recovery/src/disruption_recovery/downstream.py
+++ b/services/disruption-recovery/src/disruption_recovery/downstream.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from json import JSONDecodeError
+import os
+import time
+from typing import Any, Mapping
+from urllib import request, error
+
+_PROJECTION_LAG_CODES = frozenset({"MISSING_ORDER_PROJECTION", "MISSING_ENTITLEMENT_PROJECTION", "MISSING_WALLET_ACCOUNT"})
+_PROJECTION_RETRY_DELAYS_SECONDS = (0.2, 0.4, 0.8, 1.6, 3.2)
+
+
+class DownstreamError(RuntimeError):
+    def __init__(self, message: str, code: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def _env_name(service: str) -> str:
+    return service.upper().replace("-", "_") + "_URL"
+
+
+@dataclass(frozen=True)
+class ServiceUrls:
+    post_sales: str
+    wallet_promotion: str
+
+    @classmethod
+    def from_env(cls) -> "ServiceUrls":
+        def base(service: str) -> str:
+            return os.getenv(_env_name(service), f"http://{service}:8080").rstrip("/")
+        return cls(post_sales=base("post-sales"), wallet_promotion=base("wallet-promotion"))
+
+
+class DownstreamHttpClient:
+    def __init__(self, urls: ServiceUrls | None = None, timeout: float | None = None) -> None:
+        self.urls = urls or ServiceUrls.from_env()
+        self.timeout = timeout or float(os.getenv("DOWNSTREAM_TIMEOUT_SECONDS", "10"))
+
+    def open_refund_case(self, body: Mapping[str, Any], idempotency_key: str, correlation_id: str) -> Mapping[str, Any]:
+        return self._post_awaiting_projections("post_sales", "/api/v1/post-sales-cases", body, idempotency_key, correlation_id)
+
+    def issue_compensation(self, body: Mapping[str, Any], idempotency_key: str, correlation_id: str) -> Mapping[str, Any]:
+        return self._post_awaiting_projections("wallet_promotion", "/api/v1/benefits", body, idempotency_key, correlation_id)
+
+    def _post_awaiting_projections(self, service: str, path: str, body: Mapping[str, Any], idempotency_key: str, correlation_id: str) -> Mapping[str, Any]:
+        for delay in _PROJECTION_RETRY_DELAYS_SECONDS:
+            try:
+                return self._request(service, path, body, idempotency_key, correlation_id)
+            except DownstreamError as exc:
+                if exc.code not in _PROJECTION_LAG_CODES:
+                    raise
+                time.sleep(delay)
+        return self._request(service, path, body, idempotency_key, correlation_id)
+
+    def _request(self, service: str, path: str, body: Mapping[str, Any], idempotency_key: str, correlation_id: str) -> Mapping[str, Any]:
+        import json
+        base = getattr(self.urls, service)
+        req = request.Request(
+            base + path,
+            data=json.dumps(body, separators=(",", ":")).encode("utf-8"),
+            method="POST",
+            headers={"Accept": "application/json", "Content-Type": "application/json", "Idempotency-Key": idempotency_key, "X-Correlation-Id": correlation_id},
+        )
+        try:
+            with request.urlopen(req, timeout=self.timeout) as response:  # noqa: S310 configured in-cluster URLs
+                parsed = json.loads(response.read().decode("utf-8") or "{}")
+                if not isinstance(parsed, dict):
+                    raise DownstreamError(f"{service} returned a non-object response")
+                return parsed
+        except error.HTTPError as exc:
+            raw = exc.read().decode("utf-8", errors="replace")
+            message, code = _downstream_failure(service, raw, exc.reason)
+            raise DownstreamError(message, code) from exc
+        except error.URLError as exc:
+            raise DownstreamError(f"{service} unavailable: {exc.reason}") from exc
+        except JSONDecodeError as exc:
+            raise DownstreamError(f"{service} returned invalid JSON") from exc
+
+
+def _downstream_failure(service: str, raw: str, fallback: str) -> tuple[str, str | None]:
+    import json
+    try:
+        parsed = json.loads(raw)
+    except JSONDecodeError:
+        parsed = None
+    message = f"{service} request failed: {fallback}"
+    code = None
+    if isinstance(parsed, dict):
+        parsed_message = parsed.get("message") or parsed.get("msg") or parsed.get("error")
+        if isinstance(parsed_message, str) and parsed_message.strip():
+            message = parsed_message.strip()
+        details = parsed.get("details")
+        domain_code = details.get("domainCode") if isinstance(details, dict) else None
+        parsed_code = domain_code or parsed.get("code")
+        if isinstance(parsed_code, str) and parsed_code.strip():
+            code = parsed_code.strip()
+    return message, code

--- a/services/disruption-recovery/src/disruption_recovery/ids.py
+++ b/services/disruption-recovery/src/disruption_recovery/ids.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from train_ticket_platform.ids import new_prefixed_uuid7, new_uuid7
+
+
+def uuid7() -> str:
+    return new_uuid7()
+
+
+def prefixed_uuid7(prefix: str) -> str:
+    return new_prefixed_uuid7(prefix)

--- a/services/disruption-recovery/src/disruption_recovery/main.py
+++ b/services/disruption-recovery/src/disruption_recovery/main.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import logging
+
+from .api import create_app
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s service=disruption-recovery %(name)s %(message)s")
+app = create_app()

--- a/services/disruption-recovery/src/disruption_recovery/runtime.py
+++ b/services/disruption-recovery/src/disruption_recovery/runtime.py
@@ -11,7 +11,7 @@ class ServiceProfile(TypedDict):
     boundary: NotRequired[str]
 
 
-SERVICE_PROFILE: ServiceProfile = {'service_id': 'disruption-recovery', 'domain': 'Disruption Recovery', 'language': 'python', 'phase': 'future-scope', 'work_packages': [], 'owns': ['RecoveryCase', 'RecoveryOption', 'CompensationDecision']}
+SERVICE_PROFILE: ServiceProfile = {"service_id": "disruption-recovery", "domain": "Disruption Recovery", "language": "python", "phase": "activation", "work_packages": ["REQ-117"], "owns": ["Incident", "RecoveryCase", "RecoveryOptionSet"]}
 
 
 def health() -> str:

--- a/services/disruption-recovery/src/disruption_recovery/web/errors.py
+++ b/services/disruption-recovery/src/disruption_recovery/web/errors.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from train_ticket_platform.http import error_response, register_exception_handlers as register_base
+
+from disruption_recovery.application.service import NotFoundError, PreconditionFailedError
+from disruption_recovery.domain import DomainError
+from disruption_recovery.downstream import DownstreamError
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    register_base(app)
+
+    @app.exception_handler(NotFoundError)
+    async def not_found(request: Request, exc: NotFoundError) -> JSONResponse:
+        return error_response(request, "NOT_FOUND", str(exc), 404)
+
+    @app.exception_handler(PreconditionFailedError)
+    async def precondition(request: Request, exc: PreconditionFailedError) -> JSONResponse:
+        return error_response(request, "PRECONDITION_FAILED", str(exc), 412)
+
+    @app.exception_handler(DomainError)
+    async def domain(request: Request, exc: DomainError) -> JSONResponse:
+        return error_response(request, "DOMAIN_RULE_VIOLATION", str(exc), 422)
+
+    @app.exception_handler(DownstreamError)
+    async def downstream(request: Request, exc: DownstreamError) -> JSONResponse:
+        return error_response(request, "UNAVAILABLE", "Downstream service unavailable", 503, {"domainCode": exc.code} if exc.code else {})

--- a/services/disruption-recovery/src/disruption_recovery/web/handlers.py
+++ b/services/disruption-recovery/src/disruption_recovery/web/handlers.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Request, Query
+from pydantic import BaseModel, ConfigDict, Field
+
+from disruption_recovery.application.service import DisruptionRecoveryService
+from disruption_recovery.domain import RecoveryCaseStatus
+
+router = APIRouter(prefix="/api/v1")
+
+
+class LooseModel(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class ReportDisruptionRequest(LooseModel):
+    disruptionType: str
+    serviceDate: str
+    evidence: dict[str, Any]
+    affectedOrderIds: list[str] = Field(min_length=1)
+    reportedBy: dict[str, Any]
+    scheduledServiceRef: str | None = None
+    segmentRef: str | None = None
+
+
+class SelectOptionRequest(LooseModel):
+    optionId: str
+    selectedBy: dict[str, Any]
+    selectionReason: str | None = None
+
+
+class ManualResolveRequest(LooseModel):
+    outcome: str
+    resolvedBy: dict[str, Any] | None = None
+    reason: str | None = None
+    manualRef: str | None = None
+
+
+class CloseCaseRequest(LooseModel):
+    closedBy: dict[str, Any]
+    closeReason: str
+
+
+def _service(request: Request) -> DisruptionRecoveryService:
+    return request.app.state.disruption_recovery_service
+
+
+def _corr(request: Request) -> str:
+    return str(getattr(request.state, "correlation_id", None) or request.headers.get("X-Correlation-Id") or request.headers.get("X-Correlation-ID") or "corr-disruption-recovery")
+
+
+def _cause(request: Request) -> str:
+    idem = getattr(request.state, "idempotency_decision", None)
+    return str(getattr(idem, "key", None) or request.headers.get("Idempotency-Key") or getattr(request.state, "request_id", "cmd-disruption-recovery"))
+
+
+@router.post("/disruptions", status_code=202)
+def report_disruption(body: ReportDisruptionRequest, request: Request) -> dict[str, Any]:
+    return _service(request).report_disruption(body.model_dump(exclude_none=True), _corr(request), _cause(request))
+
+
+@router.get("/incidents/{incident_id}")
+def get_incident(incident_id: str, request: Request) -> dict[str, Any]:
+    return _service(request).store.get_incident(incident_id).to_json()
+
+
+@router.get("/recovery-cases/{case_id}")
+def get_case(case_id: str, request: Request) -> dict[str, Any]:
+    return _service(request).store.get_case(case_id).to_json()
+
+
+@router.get("/recovery-cases")
+def list_cases(request: Request, incidentId: str = Query(...), status: str | None = None, limit: int = 20, offset: int = 0) -> dict[str, Any]:
+    safe_limit = max(1, min(limit, 100))
+    safe_offset = max(0, offset)
+    items, total = _service(request).store.list_cases(incidentId, status, safe_limit, safe_offset)
+    return {"items": [item.to_json() for item in items], "total": total, "limit": safe_limit, "offset": safe_offset}
+
+
+@router.post("/recovery-cases/{case_id}/select-option")
+def select_option(case_id: str, body: SelectOptionRequest, request: Request) -> dict[str, Any]:
+    return _service(request).select_option(case_id, body.model_dump(exclude_none=True), _corr(request), _cause(request))
+
+
+@router.post("/recovery-cases/{case_id}/manual-review/resolve")
+def resolve_manual(case_id: str, body: ManualResolveRequest, request: Request) -> dict[str, Any]:
+    return _service(request).resolve_manual(case_id, body.model_dump(exclude_none=True), _corr(request), _cause(request))
+
+
+@router.post("/recovery-cases/{case_id}/close")
+def close_case(case_id: str, body: CloseCaseRequest, request: Request) -> dict[str, Any]:
+    return _service(request).close_case(case_id, body.model_dump(exclude_none=True), _corr(request), _cause(request))

--- a/services/disruption-recovery/tests/test_api.py
+++ b/services/disruption-recovery/tests/test_api.py
@@ -1,0 +1,60 @@
+from fastapi.testclient import TestClient
+
+from disruption_recovery import create_app
+from disruption_recovery.application.service import InMemoryStore
+
+
+def report_body(order="ord-0194f2e0-7b3e-7610-8000-000000000001", auto=None):
+    body = {
+        "disruptionType": "SERVICE_DELAY",
+        "scheduledServiceRef": "ssch-0194f2e0-7b3e-7610-8000-000000000001",
+        "segmentRef": "seg-0194f2e0-7b3e-7610-8000-000000000002",
+        "serviceDate": "2026-08-02",
+        "evidence": {"evidenceRef": "ev-1", "sourceSystem": "ADMIN", "sourceRecordId": "row-1", "summary": "Delay"},
+        "affectedOrderIds": [order],
+        "reportedBy": {"actorType": "OPERATIONS", "actorId": "ops-1"},
+    }
+    if auto:
+        body["autoRecovery"] = auto
+    return body
+
+
+def test_report_creates_incident_and_case_and_idempotency_replay() -> None:
+    app = create_app(store=InMemoryStore())
+    client = TestClient(app)
+    key = "0194f2e0-7b3e-7610-8000-000000000100"
+    response = client.post("/api/v1/disruptions", json=report_body(), headers={"Idempotency-Key": key})
+    assert response.status_code == 202
+    data = response.json()
+    assert data["incident"]["status"] == "CONFIRMED"
+    assert data["recoveryCases"][0]["status"] == "AWAITING_USER_CHOICE"
+    replay = client.post("/api/v1/disruptions", json=report_body(), headers={"Idempotency-Key": key})
+    assert replay.status_code == 202
+    assert replay.json()["incident"]["incidentId"] == data["incident"]["incidentId"]
+
+
+def test_select_compensation_recovers_and_close_terminal_only() -> None:
+    app = create_app(store=InMemoryStore())
+    client = TestClient(app)
+    created = client.post("/api/v1/disruptions", json=report_body(), headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8000-000000000101"}).json()
+    case = created["recoveryCases"][0]
+    comp = next(o for o in case["optionSet"]["options"] if o["optionType"] == "COMPENSATION")
+    selected = client.post(f"/api/v1/recovery-cases/{case['caseId']}/select-option", json={"optionId": comp["optionId"], "selectedBy": {"actorType": "USER", "actorId": "acc-1"}}, headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8000-000000000102"})
+    assert selected.status_code == 200
+    assert selected.json()["status"] == "RECOVERED"
+    closed = client.post(f"/api/v1/recovery-cases/{case['caseId']}/close", json={"closedBy": {"actorType": "OPERATIONS", "actorId": "ops-1"}, "closeReason": "done"}, headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8000-000000000103"})
+    assert closed.status_code == 200
+    assert closed.json()["status"] == "CLOSED"
+
+
+def test_manual_review_cannot_close_directly() -> None:
+    app = create_app(store=InMemoryStore())
+    client = TestClient(app)
+    created = client.post("/api/v1/disruptions", json=report_body(), headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8000-000000000104"}).json()
+    case = created["recoveryCases"][0]
+    manual = next(o for o in case["optionSet"]["options"] if o["optionType"] == "MANUAL")
+    selected = client.post(f"/api/v1/recovery-cases/{case['caseId']}/select-option", json={"optionId": manual["optionId"], "selectedBy": {"actorType": "CUSTOMER_SERVICE", "actorId": "cs-1"}}, headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8000-000000000105"})
+    assert selected.status_code == 200
+    assert selected.json()["status"] == "MANUAL_REVIEW"
+    rejected = client.post(f"/api/v1/recovery-cases/{case['caseId']}/close", json={"closedBy": {"actorType": "OPERATIONS", "actorId": "ops-1"}, "closeReason": "bad"}, headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8000-000000000106"})
+    assert rejected.status_code == 422

--- a/services/disruption-recovery/tests/test_domain.py
+++ b/services/disruption-recovery/tests/test_domain.py
@@ -1,0 +1,12 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from disruption_recovery.domain import RecoveryCase, RecoveryCaseStatus, DomainError
+
+
+def test_manual_review_must_not_close_directly() -> None:
+    now = datetime.now(UTC)
+    case = RecoveryCase("rcv-1", "inc-1", "ord-1", {"journeyOrderId": "ord-1", "serviceDate": "2026-01-01", "disruptionType": "WEATHER", "evidenceRef": "ev"}, RecoveryCaseStatus.MANUAL_REVIEW, now, now)
+    with pytest.raises(DomainError):
+        case.close(now)

--- a/services/disruption-recovery/uv.lock
+++ b/services/disruption-recovery/uv.lock
@@ -1,6 +1,11 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "annotated-doc"
@@ -34,6 +39,24 @@ wheels = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
+]
+
+[[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -47,7 +70,7 @@ name = "disruption-recovery"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "fastapi" },
+    { name = "train-ticket-platform" },
 ]
 
 [package.dev-dependencies]
@@ -57,7 +80,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "fastapi", specifier = "==0.138.1" }]
+requires-dist = [{ name = "train-ticket-platform", editable = "../../platform/python-kit" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -79,6 +102,69 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/c9/5e8defe249899c0dc900643695fc07829a67fc88b4ff2cdb03fcbdbf5a4b/fastapi-0.138.1.tar.gz", hash = "sha256:96e3702dce09ee0dce48856135620d3d865ca684a79fe7513fd7b13a12f82862", size = 419646, upload-time = "2026-06-25T15:40:42.115Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/a9/69a6924f645eb4dd8cd625bf255b3625990eb3e14e073438a53c405dcd3e/fastapi-0.138.1-py3-none-any.whl", hash = "sha256:b994cae7ba8b82c976a728b544244de31333fa5f7d261f9a1dffe526444cae23", size = 129182, upload-time = "2026-06-25T15:40:40.771Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.82.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/bc/656b89387d6f4ed7e0686c7b64c2ae7e554a759aa58122c8e5fb99392c32/grpcio-1.82.1.tar.gz", hash = "sha256:707b24abd90fcb1e45bcc080577da1dbf9971d107490589b9539af8e1e77b4b5", size = 13187300, upload-time = "2026-07-08T12:36:16.588Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/5b/e5092af97fa671ca279b3e373251af4bf87d5fbda7dc85f6a616899562a7/grpcio-1.82.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:0ddb18a9a9e1f46692b3567ae4abb3f8d117ce6afea48650f8eca06d8ab5d06f", size = 6181472, upload-time = "2026-07-08T12:34:31.009Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/18053a3a2ca03d0c2a1b8cc7271e705007a16aa5dae84bac00935c5b1a7f/grpcio-1.82.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:cf855b1af246720f567b0ce5d0724d45dfa4188eecc3296a2a69257b11b9e94b", size = 11970995, upload-time = "2026-07-08T12:34:33.603Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/21b1acb052876ad00959ec4d1b05fe08607d650bcfa282073bb164c2703c/grpcio-1.82.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb30cb13e25bc13cea70ffc69d6d90c49d36ea6c1d4549e6912f70177834cac", size = 6760127, upload-time = "2026-07-08T12:34:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/12/25eef9c245c54f0061317d13a302357fe8ea03bac240b2b02ececcf54da4/grpcio-1.82.1-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1e822b2774f719c017cbe700b6e47173b6ae290fb84906f52a5a3c2c60b62e1e", size = 7484377, upload-time = "2026-07-08T12:34:38.368Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/41/1a348767eb9d9bd7765dc4fa8a01723d3bb386d67f981ee5c6f9c02b8b1c/grpcio-1.82.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5dafb1ece8ed45dee7c738f166ec82e19673221ed5ab8967f72858a4685345b2", size = 6924269, upload-time = "2026-07-08T12:34:40.583Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/b9/3aae7a03d34c86ea27988db859a6087c186f6c3f53f9b551e07afd989bfa/grpcio-1.82.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e06503106e7271e0a49fd5a1ac04747f1e47e87d900476db6fe45bc87ee411f4", size = 7531848, upload-time = "2026-07-08T12:34:43.277Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/3c4afa625d0dac9090707966916284c035fc5b2fb3e2c51e156accee6735/grpcio-1.82.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ff99bc8cafb6a952201c37b995f425e641c93ffa6e072258525feab57290141d", size = 8568217, upload-time = "2026-07-08T12:34:45.502Z" },
+    { url = "https://files.pythonhosted.org/packages/20/9c/d8489c628e73e20a3d034e7f66912de7b1acb405f01d388f056a88e47924/grpcio-1.82.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:644ae1b94266ac785330f4590a69e52b6a7eb73029043a02209db81c81397d69", size = 7938771, upload-time = "2026-07-08T12:34:48.323Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b7/0a92cfd1658f3a896d4aa12d4efeb7dd4ddfc723725ae22741a5241ea710/grpcio-1.82.1-cp311-cp311-win32.whl", hash = "sha256:e203d2e19d471630084a16c815616f8211dff21c268ab3c5f5bf38417832e074", size = 4256432, upload-time = "2026-07-08T12:34:50.432Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/6a/2872c761b025d9ec74386f22a4a7d59c5a5b00ebf718761b33739ffc45de/grpcio-1.82.1-cp311-cp311-win_amd64.whl", hash = "sha256:0d8299c285fe6cc6a1f56badf8d3bc5078c8d20273ee64bafa3783b4bc29a769", size = 5009633, upload-time = "2026-07-08T12:34:52.67Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/88/d1350bf3343a2ed87d801584e40609f6c6bd3087926eeca03de50348cf4a/grpcio-1.82.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:c09bd5fa0d5b1fbd773ec349fe61441c3e4ebf168c229aa7538a820bdfad6a58", size = 6144689, upload-time = "2026-07-08T12:34:55.567Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/33/71875cdecd27c24ac1385d4783a09853f01b84a825a36aec2a2bc7d0d080/grpcio-1.82.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1eae24810720734598e3e6a1a528d5de0f265fe3fc86575e9ecce424b9ec7379", size = 11952034, upload-time = "2026-07-08T12:34:58.128Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b2/d9125df3d8a140dec12cc82c05b7deafedeababcff6496f28b2fd5634d10/grpcio-1.82.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a6bd5daf5bde7b24d7ad2cbaf8bf9eac620d96222016bb5e7ddde930dec0673f", size = 6710772, upload-time = "2026-07-08T12:35:01.33Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9b/69e2d1627398b964f34437dc476a5aff5a2cc8e7f247d26272b5674b5faf/grpcio-1.82.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1ecfde669cb687ac020d31ff76debe5dc7a62213335f02262eb6625628da1c03", size = 7450677, upload-time = "2026-07-08T12:35:03.926Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e7/8f855ca29c294956122a2a73023655b9b02602d5111dad2b9b00e7631c68/grpcio-1.82.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:011c8badee95734dee8bf05ce3464756a0ac3ebb8d443afd20c0e2b5e4640ad9", size = 6886855, upload-time = "2026-07-08T12:35:06.174Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f0/fa87e85f49925f44c479d07e58b051e69bcfef6b6d5fbc6749d140f6730a/grpcio-1.82.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b85f4564926fb23114d239392bdcae200db1e6179629edd7d7ab0ab89c96a197", size = 7501323, upload-time = "2026-07-08T12:35:08.49Z" },
+    { url = "https://files.pythonhosted.org/packages/67/55/2e0b10ae1d3ef9dcc480b91dc2158f4931fc4675d3af0a2836e39b2a744f/grpcio-1.82.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:2c0c8270833395644c3fe6b6a806397955a2bc0538000a19a78b90c05a6c16e0", size = 8536899, upload-time = "2026-07-08T12:35:10.975Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/95/a3d8b0431fa221efc51ee39d73595ede74ba82a43b7c4313192e580face2/grpcio-1.82.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2ba199205ff46c7778290fe1673c91ac8e7e45678dd5c86e9e56fa33ec8788f6", size = 7913892, upload-time = "2026-07-08T12:35:13.944Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/92/f2651ec704d9852a56faef394775038afba435b50ce82ab2404d119c3355/grpcio-1.82.1-cp312-cp312-win32.whl", hash = "sha256:06127691866e295c14e84a1fb86356dd962254f6abd0da4ca4b001eea9e89438", size = 4240985, upload-time = "2026-07-08T12:35:16.048Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4f/a5fe8bf0d0a1b24855f370293075c931f27de4eb55f0f158786095bf3c11/grpcio-1.82.1-cp312-cp312-win_amd64.whl", hash = "sha256:1fa3223a3a2e1db74f4c2b255189eb7ea875dfba56e221d252ee3fc7b204778e", size = 5001580, upload-time = "2026-07-08T12:35:18.689Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/3e/496992d08c0aaa11272eb6228dc8ab947da01fe835de243cd00521bce4c4/grpcio-1.82.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:b454a2d97bfab7565683a02345f86bd182ab69fd7c2bdb7414171e7538f266b1", size = 6146068, upload-time = "2026-07-08T12:35:21.365Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8f/f263d6f14fdba6b56cfadd91fd3e158a52682b72c6016d1f8723d435659f/grpcio-1.82.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:3dde70abfc80b3be11de53ba0d601c439e7fb2afd3583ad1788d1146bec92fdc", size = 11948600, upload-time = "2026-07-08T12:35:24.312Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/14/3a02e6ee49c2d85bc15eaae321e0e11ab3542cad3c5b2de121ecce0c4296/grpcio-1.82.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5523099c98c292ea1ae08e617249db760c56a78f8deae879027fe7d1ffbcbf6", size = 6714591, upload-time = "2026-07-08T12:35:27.027Z" },
+    { url = "https://files.pythonhosted.org/packages/69/80/58e3738696f48ab7645347b98d8a7f93d10e00e6218388fbfcd6c9310e3d/grpcio-1.82.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:5e5c4dc0a59b0f8490a6bdfd6fc8395b9d8ad8a8407c7d67ca7b5bba15c0877f", size = 7454995, upload-time = "2026-07-08T12:35:29.599Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6c/2557c1a889363072fbf2285ecd0e8c44860d4dbd60f017a32537c5b863e2/grpcio-1.82.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c40d94ba820329cc191981bc22fa6f6eed0799c6d921f3c6709521d59d4a2fd7", size = 6888621, upload-time = "2026-07-08T12:35:32.38Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/66/907706ccaff1223f1e10fd5b37fc16faead43392fccb4e786e7e390ac141/grpcio-1.82.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4c816180e31e273caaec6f8bd86a8392499d5bbb26f41da44e3dce48bde69095", size = 7505069, upload-time = "2026-07-08T12:35:35.072Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7c/ff97b0d0f635987ee5ec80dfedafa1aad629303745d48e8637d10eec5b80/grpcio-1.82.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e31fd780b261830720cb70b0fd8f0aa51d49e75a66d7464ad2e31d4b765f2580", size = 8535384, upload-time = "2026-07-08T12:35:37.954Z" },
+    { url = "https://files.pythonhosted.org/packages/62/9e/a97fddd970a8d1588cade06eca20443761c1858b0ad6590a5c835aa18062/grpcio-1.82.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d76152d7c31d7210d4a106e5d8b64da5bba5d6abf11be30e2f7b0a0c59bbcbf", size = 7910707, upload-time = "2026-07-08T12:35:40.797Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e4/eaba1517888af483a88d449eb7566f0f7f63446d46f339c5891798435875/grpcio-1.82.1-cp313-cp313-win32.whl", hash = "sha256:38e9dcb5258226fb3282630b31b16a968df52c8c6ad514af540646e0a4578f8a", size = 4240363, upload-time = "2026-07-08T12:35:43.298Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/42/66a98d47732e35290bef722f6149fed3709cd4cf61166f6f53a12f417302/grpcio-1.82.1-cp313-cp313-win_amd64.whl", hash = "sha256:3dbfb52c36d9511ac2b8e6c94fdde837b393ae520cc321f52a333a2deedf5a90", size = 5000980, upload-time = "2026-07-08T12:35:46.262Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/cb/cf9ae9e164c6e6dc8a494faa9771763df9da150eefe19671009624d1559f/grpcio-1.82.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:35f990f7784c8fd2872644f07f96ebb4d9e48e145a190ab80d0280af91a1bfb2", size = 6146901, upload-time = "2026-07-08T12:35:49.261Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/2a/eccf26dbcfb7f7cab8027c5490a16c8937c5aa7a2ec20a3eab2cf7a43165/grpcio-1.82.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:46536a4a1f4434df3c851b9254ff6fc7df5705b273681a15ca277d5921c178a0", size = 11954756, upload-time = "2026-07-08T12:35:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/75/3b3b4a3cc9f084b026af96e1d3e539b1af29ec7f41ed0dfff3cb99cc8626/grpcio-1.82.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d6650a7c1ebb7921c70e12a385439a8118efb99e669fa9ed31cf25db1843937c", size = 6723087, upload-time = "2026-07-08T12:35:54.973Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/b0f0c9b1400a99a4da4c09b114f101b192f8f11192e76f620b8962f5d90b/grpcio-1.82.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b8e110c66df5204c0506d6c8787b35d48b8b699ef5aa366d6c4d67325c67fe9a", size = 7454542, upload-time = "2026-07-08T12:35:57.586Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bd/428e38868382aa193697a5aa53973f29c58e58ba4268aa0c86a2715ee58b/grpcio-1.82.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f853eae07235a51a27bb5d6a9a175a59ca55dc9b99edc6ce2f76f07332d333ae", size = 6889588, upload-time = "2026-07-08T12:36:00.012Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ce/03e01d5e10259bf5c08ee50570cc94724e79c956f61fd2f09b341af0956c/grpcio-1.82.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:60b0f2c95337694fc094b77d9f60f50566c84b5677393e342eb98daeee242d98", size = 7514166, upload-time = "2026-07-08T12:36:02.693Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/59/278b4b600329e2ba3849f3c1ea3c820b3a01b38a7ad184ba09595e8d2733/grpcio-1.82.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:b064fc444812bdaa9825d33c26f8d732d63ee6a5d78557c1faf92c98687fed27", size = 8536166, upload-time = "2026-07-08T12:36:05.349Z" },
+    { url = "https://files.pythonhosted.org/packages/44/27/7ccf2ef00f27a8e47a79d641c8ceaf7d3028c7a03d9a97b4c8a9a783c086/grpcio-1.82.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d7ede11d747b4e1bd05e3bc0260e155b65a88735a895a10f6521f19b889511e", size = 7912572, upload-time = "2026-07-08T12:36:08.393Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/be/33742482d2753f2d3a1b7641664b6622262d44f2f3b609f13425dd86d36f/grpcio-1.82.1-cp314-cp314-win32.whl", hash = "sha256:3d21f19838dc255ecbb79321b15ae9b98fbddff4c3d4aedb0a81bdd7f4ab572a", size = 4321856, upload-time = "2026-07-08T12:36:10.899Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/67/03329c847172c78ddeb1eb9be6b444fdbc12775a84c958b27e427e7b926d/grpcio-1.82.1-cp314-cp314-win_amd64.whl", hash = "sha256:e20f1edbb15f99e3128ec86433f9785fd5a451d8f115e74fe0056134f092a9d5", size = 5141114, upload-time = "2026-07-08T12:36:13.595Z" },
 ]
 
 [[package]]
@@ -138,6 +224,143 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912, upload-time = "2026-06-24T15:19:35.434Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/c1/e8098490ab15abf116dcaf9fa89ededcb35547c7d08d4b5a62f573dc1e63/opentelemetry_exporter_otlp_proto_common-1.43.0.tar.gz", hash = "sha256:c4e32ba6d6b13bdb2b8f6764c4fd28d00192826561aa04f6d14eedfce7ac076f", size = 20197, upload-time = "2026-06-24T15:20:00.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/b2/41ebc74ae1d5859901f1b69305de58724bf043381103d6ef413521cbc35a/opentelemetry_exporter_otlp_proto_common-1.43.0-py3-none-any.whl", hash = "sha256:123c3f9cc87218562490c63b36f497bf3a722faf174a515d1443f31ababa6264", size = 17048, upload-time = "2026-06-24T15:19:41.264Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/1d/6336453716ca0a240d4417d19e6d5b77a5e7163e5670ec4f7ec4d3ede7bf/opentelemetry_exporter_otlp_proto_grpc-1.43.0.tar.gz", hash = "sha256:1b3e0627daa9bc21884d4a13946807c255eb558bfe5bdd543dffb6f4c9faee0d", size = 27213, upload-time = "2026-06-24T15:20:00.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/74/2700b5d5c946bf2dba87073fce3dfc198c46bc92ea3d5693f54bc51c90b1/opentelemetry_exporter_otlp_proto_grpc-1.43.0-py3-none-any.whl", hash = "sha256:6a10d1feacffffda19acacbf277b736094b1e2f4dbb98c90ccb2c6e1962e2ec6", size = 19626, upload-time = "2026-06-24T15:19:42.233Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/97/02fe6e1c8b1ffac42d0b429c18080edb24e0e0d18c86612edf72b5752382/opentelemetry_instrumentation-0.64b0.tar.gz", hash = "sha256:b47d528dead6271d7743114417eb67fc915bd9258111c48dbf9a4951d2efa88d", size = 41935, upload-time = "2026-06-24T15:19:12.951Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/0c/cb9fe342de5299c7af24582eb7d788661cc53a1c4b904da92309caaa9417/opentelemetry_instrumentation-0.64b0-py3-none-any.whl", hash = "sha256:133ab7ffca796557aec059bf6be3190a34b6dea987f25be3d9409e230cbdad8b", size = 35880, upload-time = "2026-06-24T15:18:17.277Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/0c/71c696fccb86d37af383ea1604af4729fabad0af2fabaf203e4c79c1e859/opentelemetry_instrumentation_asgi-0.64b0.tar.gz", hash = "sha256:4dd3eee566a4303f8e6b9b84f2a0a7abc57a6640df768926c68a3868bf5b2090", size = 26136, upload-time = "2026-06-24T15:19:17.003Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/20/218b65a63d847a7ed28d1bea84c39234689160b74480b8702272e37f4240/opentelemetry_instrumentation_asgi-0.64b0-py3-none-any.whl", hash = "sha256:e0840b66e15303a9254b0540946010bd008aa0504f4d89b8e1b7fb63490a36f0", size = 15906, upload-time = "2026-06-24T15:18:23.107Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-fastapi"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-asgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/a1/52282e2cc5c08f4df13b087896d9907258fe2ff4f34035d3b21aa92684c3/opentelemetry_instrumentation_fastapi-0.64b0.tar.gz", hash = "sha256:05f75149929e433c1630de381688e650bf651c1e1cce7f9a7b649a807dac8a98", size = 26236, upload-time = "2026-06-24T15:19:27.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/2d/4f48dc2d6f289f2febc5b871940dbea9f3b04ab9186d23342581b49cb984/opentelemetry_instrumentation_fastapi-0.64b0-py3-none-any.whl", hash = "sha256:43cbbfb2d3079dc81104478a2950ae93ac6d0e90a5020fa3987a236f8f2bdef1", size = 13263, upload-time = "2026-06-24T15:18:38.553Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b9/d357faefb40bda1d4799913e6af611171ff22a2dedcb93576bc92242d056/opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924", size = 46481, upload-time = "2026-06-24T15:20:07.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/a7/3e5308cf548b8f72529c7db1afdb3a404211982376a12927fd7759f77bf3/opentelemetry_proto-1.43.0-py3-none-any.whl", hash = "sha256:c58f1f7ef84bc7dc2834016c0c37fe0081dde7ca9f6339be1970fbf9cdaaa90d", size = 72489, upload-time = "2026-06-24T15:19:51.164Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/eb/5041074274ac0956b03637cc039d434569112468e875eddfcc9a0674ce06/opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9", size = 254744, upload-time = "2026-06-24T15:20:08.467Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e3/b17be23af124201c9f52eececd4cc8ddfed1597d37b4ee771895d325805c/opentelemetry_sdk-1.43.0-py3-none-any.whl", hash = "sha256:d1323a547c1ce69d6a069a17a44b7da82bb8b332051ecb074041f87642c86823", size = 178852, upload-time = "2026-06-24T15:19:52.169Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/1b/1029a805fd7242f7dfce91633b244c3b14a94d703232878f71e01ce862b1/opentelemetry_util_http-0.64b0.tar.gz", hash = "sha256:8a86a220dbfc56d736f47f1e5c4e7932a21fcf69052312e1bcf166444dc79322", size = 11102, upload-time = "2026-06-24T15:19:48.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/c7/5f8ec5b30546f2dc22cd5fc5759bce2ab5be6e89a2e710a405ac9ef64ed3/opentelemetry_util_http-0.64b0-py3-none-any.whl", hash = "sha256:c1e5350d25507c1afcd6076cf9ac062485a0a4f79cd9971366996fd3056bacdb", size = 8204, upload-time = "2026-06-24T15:19:09.02Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -153,6 +376,102 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/82/df3312c0ca083d5b43b352f27d4dd8b1e614bd334473074715d9e0000da4/psycopg_binary-3.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:612a627d733f695b1de1f9b4bd511c15f999a5d8b915d444bbd7dd71cf3370da", size = 4609813, upload-time = "2026-05-01T23:26:30.612Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b5/d74d542458d3e8ac0571d8a88f57ca369999b9a82f4fa528052d0d7d3e4c/psycopg_binary-3.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:13a7f380824c35896dcac7fe0f61440f7ca49d6dc73f3c13a9a4471e6a3b302e", size = 4676799, upload-time = "2026-05-01T23:26:38.475Z" },
+    { url = "https://files.pythonhosted.org/packages/09/67/06bab9c60671999f4c6ceff1b334f3ac1f9fc5789eb467c714623ea21de9/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:276904e3452d6a23d474ef9a21eee19f20eed3d53ddd2576af033827e0ba0992", size = 5497050, upload-time = "2026-05-01T23:26:47.061Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9b/023433e2b20f970de1e22d29132a95281277646da0b2e2879dd4ee94b8c1/psycopg_binary-3.3.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab8cca8ef8fb1ccf5b048ae5bd78ba55b9e4b5d472e3ce5ca39ff4d2a9c249e4", size = 5172428, upload-time = "2026-05-01T23:26:56.708Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cd/ae16da8fde228a38b2fe9269bbc13cf89e0186173f2265600f02d6a71e64/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7465bfe6087d2d5b42d4c53b9b11ca9f218e477317a4a162a10e3c19e984ba8e", size = 6762746, upload-time = "2026-05-01T23:27:07.023Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/81/0ba09fa5f5f88779093a2541a8e02489825721f258ab88058b11d68b3eb5/psycopg_binary-3.3.4-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22cdbf5f91ef7bb91fe0c5757e1962d3127a8010256eefd9c61fcaf441802097", size = 5006033, upload-time = "2026-05-01T23:27:12.221Z" },
+    { url = "https://files.pythonhosted.org/packages/73/6a/629136040cc3497adb442a305710b5913f2a754d4630fc3d3717c4c0df65/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2631da29253a98bd496e6c4813b24e09a4fe3fb2a9e88513305d6f8747cce95", size = 4534175, upload-time = "2026-05-01T23:27:18.248Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/32/1027f843c6dc2d5d51960ee62cc0c2cf755a4c39455aff1371173edbef7d/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7f7668f30b9dd5163197e5cbf4e0efd54e00f0a859cc566ce56cfc31f4054839", size = 4224203, upload-time = "2026-05-01T23:27:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e1/380a724d9093c74adb14d4fce920ea8327838abb61f760b1448586b14a8e/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:cffc3408d77a27973f33e5d909b624cce683db5fc25964b02fe0aae7886c1007", size = 3954509, upload-time = "2026-05-01T23:27:30.815Z" },
+    { url = "https://files.pythonhosted.org/packages/db/cd/895893ae575a09c97ccfd5def070d88993d955ef34df45a881fd5ff506d6/psycopg_binary-3.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0579252a1202cd73e4da137a1426e2dae993ae44e757605344282af3a082848c", size = 4259551, upload-time = "2026-05-01T23:27:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c6/2330a20794e37a3ec609ef2fd8522919ec7a4395a1abf979a8e2d1775cd5/psycopg_binary-3.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:41f2ec0fea529832982bcb6c9415de3c86264ebe562b77a467c0fbcd7efbba8d", size = 3572054, upload-time = "2026-05-01T23:27:45.455Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
 ]
 
 [[package]]
@@ -298,6 +617,18 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c3/928b290c2c0ca99ab96eea5b4ff8f30be8112b075301a7d3ba214a3c8c12/redis-8.0.1.tar.gz", hash = "sha256:afc5a7a2f5a084f5b1880dec548dd45be17db7e43c82a30d84f952aefb05cfb0", size = 5114170, upload-time = "2026-06-23T14:52:37.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/0a/c2345ebf1ebe70840ce3f6c6ee612f8fa749cfbd1b03069c53bf0c62aaad/redis-8.0.1-py3-none-any.whl", hash = "sha256:47daa35a058c23468d6437f17a8c76882cb316b838ef763036af99b96cedd743", size = 502406, upload-time = "2026-06-23T14:52:36.137Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -308,6 +639,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "train-ticket-platform"
+version = "0.1.1"
+source = { editable = "../../platform/python-kit" }
+dependencies = [
+    { name = "fastapi" },
+    { name = "httpx2" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-sdk" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
+    { name = "redis" },
+    { name = "uuid6" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = "==0.138.1" },
+    { name = "httpx2", specifier = ">=2.5.0" },
+    { name = "opentelemetry-api", specifier = ">=1.29.0" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.29.0" },
+    { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.50b0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.29.0" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
+    { name = "psycopg-pool", specifier = ">=3.2.0" },
+    { name = "redis", specifier = ">=5.0.0" },
+    { name = "uuid6", specifier = ">=2024.7.10" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx2", specifier = ">=2.5.0" },
+    { name = "pytest", specifier = "==9.1.1" },
 ]
 
 [[package]]
@@ -338,4 +706,97 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "uuid6"
+version = "2025.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/b7/4c0f736ca824b3a25b15e8213d1bcfc15f8ac2ae48d1b445b310892dc4da/uuid6-2025.0.1.tar.gz", hash = "sha256:cd0af94fa428675a44e32c5319ec5a3485225ba2179eefcf4c3f205ae30a81bd", size = 13932, upload-time = "2025-07-04T18:30:35.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/b2/93faaab7962e2aa8d6e174afb6f76be2ca0ce89fde14d3af835acebcaa59/uuid6-2025.0.1-py3-none-any.whl", hash = "sha256:80530ce4d02a93cdf82e7122ca0da3ebbbc269790ec1cb902481fa3e9cc9ff99", size = 6979, upload-time = "2025-07-04T18:30:34.001Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/15/0c2d55168707465abfc41f33c0b23d792a5fa9b65c26983606940900a120/wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73", size = 80782, upload-time = "2026-06-20T23:47:44.367Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b5/5c0b093eb48f8a062ef6267d3cb36e9bb1b88440181f6545a383c60efdf8/wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e", size = 81678, upload-time = "2026-06-20T23:47:45.857Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f3/de70937472dd3e8a4e6811192f9c6075efdffd4a2cd9b4596bf160f89668/wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d", size = 159671, upload-time = "2026-06-20T23:47:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/40aed2330e7f02ecf74386ffcfef9ccb7108c6a430f15b6a252b663b1bed/wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328", size = 160785, upload-time = "2026-06-20T23:47:48.759Z" },
+    { url = "https://files.pythonhosted.org/packages/45/04/aa5309beed5344b00220ae6b3b24055852192656194c27947bee1736306a/wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5", size = 153699, upload-time = "2026-06-20T23:47:50.177Z" },
+    { url = "https://files.pythonhosted.org/packages/01/df/2def7e99d1fe87eea413f95f671924cdddcb08823b1ffd212748dfa6d062/wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0", size = 159695, upload-time = "2026-06-20T23:47:51.602Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f6/a906d01a2ce12157bad2404957b3e2140da354b8a70b2fa48bbf282871c0/wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae", size = 152813, upload-time = "2026-06-20T23:47:53.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/49/bc0086292d239575b4c08f4cf8a4079fa58abbad58ec23abf84833a283ed/wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099", size = 158809, upload-time = "2026-06-20T23:47:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/55/83/8fbd034de1f3e907edaa18786d5dd8f6932874edee0826c7cecb5cab03a1/wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c", size = 77414, upload-time = "2026-06-20T23:47:55.882Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9c/23695baa331c6de4e874c3d78b8e0bed92e1d2a274e665b29858f6841672/wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971", size = 80368, upload-time = "2026-06-20T23:47:57.237Z" },
+    { url = "https://files.pythonhosted.org/packages/08/49/40cefc342bf89b234a4490d741290fce781774b831aefb39c25471da96c9/wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30", size = 79489, upload-time = "2026-06-20T23:47:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]


### PR DESCRIPTION
## Summary
- Implements disruption-recovery domain/application/API with durable Postgres snapshots, idempotency, transactional outbox, and PostSalesApplied consumption deduplication.
- Adds deployment image/manifests/database, e2e disruption script in restart suite, and loadgen disruption actor/read probes.
- Adds unit/API tests for state machine, idempotent reporting, option selection, manual review close rejection.

## Validation
- services/disruption-recovery: uv run pytest -q tests (ran 3x total) ✅
- python3 scripts/contract_lint.py ✅
- make check ✅