### PR TITLE
perf(offer-management): batch event processing for upstream state

### DIFF
--- a/deploy/k8s/services.yaml
+++ b/deploy/k8s/services.yaml
@@ -670,6 +670,8 @@ spec:
               value: redis://redis.train-ticket.svc.cluster.local:6379
             - name: DATABASE_URL
               value: postgresql://trainticket:trainticket-dev@postgres:5432/offer_management
+            - name: PG_MAX_POOL_SIZE
+              value: "15"
           resources:
             requests:
               cpu: 50m

--- a/platform/ts-kit/dist/messaging.d.ts
+++ b/platform/ts-kit/dist/messaging.d.ts
@@ -32,7 +32,12 @@ export type EventHandlerResult = Readonly<{
 }>;
 export type HandlerResult = EventHandlerResult;
 export type StringHandlerResult = "ack" | "retry" | "dlq";
-export type EventHandler = (envelope: EventEnvelope) => Promise<any> | any;
+export type EventHandlerOutput = EventHandlerResult | StringHandlerResult | undefined;
+export type EventBatchHandlerOutput = EventHandlerOutput | readonly EventHandlerOutput[];
+export type EventBatchHandler = (envelopes: readonly EventEnvelope[]) => Promise<EventBatchHandlerOutput> | EventBatchHandlerOutput;
+export type EventHandler = ((envelope: EventEnvelope) => Promise<any> | any) & {
+    handleBatch?: EventBatchHandler;
+};
 export interface EventPublisher {
     publish(envelope: EventEnvelope): Promise<void>;
 }
@@ -127,7 +132,10 @@ export declare class RedisEventSubscriber implements EventSubscriber {
     private poll;
     private recover;
     private processMessages;
+    private processEntries;
+    private parseBatchEntry;
     private processEntry;
+    private finishEntry;
     private claimAndProcess;
     private deliveryCounts;
     private deadLetterAndAck;

--- a/platform/ts-kit/dist/messaging.js
+++ b/platform/ts-kit/dist/messaging.js
@@ -152,8 +152,8 @@ export class InMemoryEventSubscriber {
         this.processedEventIds.clear();
     }
 }
-const READ_BLOCK_MS = 2_000;
-const READ_COUNT = 10;
+const READ_BLOCK_MS = 1_000;
+const READ_COUNT = 50;
 const CLAIM_MIN_IDLE_MS = 60_000;
 const MAX_DELIVERIES = 5;
 const STREAM_MAXLEN = 100_000;
@@ -301,10 +301,80 @@ export class RedisEventSubscriber {
     }
     async processMessages(messages, group, consumerName, handler) {
         for (const [stream, entries] of messages ?? []) {
+            await this.processEntries(stream, group, consumerName, entries, handler);
+        }
+    }
+    async processEntries(stream, group, consumerName, entries, handler) {
+        if (!handler.handleBatch || entries.length <= 1) {
             for (const entry of entries) {
                 await this.processEntry(stream, group, consumerName, entry, handler);
             }
+            return;
         }
+        const batch = [];
+        for (const entry of entries) {
+            const parsed = await this.parseBatchEntry(stream, group, consumerName, entry, 1);
+            if (parsed) {
+                batch.push(parsed);
+            }
+        }
+        if (batch.length === 0) {
+            return;
+        }
+        let batchResult;
+        try {
+            batchResult = await handleBatchWithConsumerSpans(handler.handleBatch, batch.map(({ envelope }) => envelope), stream, group);
+        }
+        catch (error) {
+            for (const item of batch) {
+                const result = error instanceof HandlerError
+                    ? (error.kind === "fatal" ? "dlq" : "retry")
+                    : (this.options.thrownHandlerErrors === "retry" ? "retry" : "dlq");
+                await this.finishEntry(stream, group, consumerName, item.entry, item.envelope, item.attempts, result, error);
+            }
+            return;
+        }
+        const results = Array.isArray(batchResult) ? batchResult : batch.map(() => batchResult);
+        if (results.length !== batch.length) {
+            const error = new HandlerError("fatal", `Batch handler returned ${results.length} results for ${batch.length} events`);
+            for (const item of batch) {
+                await this.finishEntry(stream, group, consumerName, item.entry, item.envelope, item.attempts, "dlq", error);
+            }
+            return;
+        }
+        for (const [index, item] of batch.entries()) {
+            const rawResult = results[index];
+            await this.finishEntry(stream, group, consumerName, item.entry, item.envelope, item.attempts, rawResult === undefined ? "ack" : normalizeHandlerResult(rawResult), failureReasonFromHandlerResult(rawResult));
+        }
+    }
+    async parseBatchEntry(stream, group, consumerName, entry, deliveryAttempts) {
+        const [entryId, fields] = entry;
+        const attempts = Math.max(1, deliveryAttempts);
+        const envelopeJson = fieldValue(fields, "envelope");
+        if (!envelopeJson) {
+            await this.deadLetterAndAck(stream, group, consumerName, entry, "MissingEnvelope", attempts);
+            return undefined;
+        }
+        let envelope;
+        try {
+            envelope = deserializeEventEnvelope(envelopeJson);
+        }
+        catch (error) {
+            await this.deadLetterAndAck(stream, group, consumerName, entry, error, attempts);
+            return undefined;
+        }
+        if (this.consumedEventIds.has(envelope.eventId)) {
+            console.warn({
+                service: group,
+                stream,
+                eventId: envelope.eventId,
+                deliveries: attempts,
+                message: "duplicate event already processed; acking without handler",
+            });
+            await this.redis.xack(stream, group, entryId);
+            return undefined;
+        }
+        return { entry, envelope, attempts };
     }
     async processEntry(stream, group, consumerName, entry, handler, deliveryAttempts = 1) {
         const [entryId, fields] = entry;
@@ -349,9 +419,12 @@ export class RedisEventSubscriber {
                 console.error(sanitizedErrorForLog(error));
             }
         }
+        await this.finishEntry(stream, group, consumerName, entry, envelope, attempts, result, failureReason);
+    }
+    async finishEntry(stream, group, consumerName, entry, envelope, attempts, result, failureReason) {
         if (result === "ack") {
             this.consumedEventIds.add(envelope.eventId);
-            await this.redis.xack(stream, group, entryId);
+            await this.redis.xack(stream, group, entry[0]);
             return;
         }
         if (result === "dlq") {
@@ -454,6 +527,38 @@ export function dlqStreamKey(context) {
 }
 export function redisUrl() {
     return process.env.REDIS_URL ?? "redis://localhost:6379";
+}
+async function handleBatchWithConsumerSpans(handler, envelopes, stream, consumerGroup) {
+    if (envelopes.length === 0) {
+        return [];
+    }
+    const spans = envelopes.map((envelope) => startConsumerSpan({
+        stream,
+        consumerGroup,
+        eventId: envelope.eventId,
+        eventType: envelope.eventType,
+        correlationId: envelope.correlationId,
+        parentContext: remoteTraceContext(envelope.traceparent, envelope.tracestate),
+    }));
+    try {
+        const result = await handler(envelopes);
+        const results = Array.isArray(result) ? result : envelopes.map(() => result);
+        for (const [index, span] of spans.entries()) {
+            const rawResult = results[index];
+            const normalized = rawResult === undefined ? "ack" : normalizeHandlerResult(rawResult);
+            if (normalized !== "ack") {
+                markSpanError(span, String(failureReasonFromHandlerResult(rawResult)));
+            }
+            endSpan(span);
+        }
+        return result;
+    }
+    catch (error) {
+        for (const span of spans) {
+            endSpanWithError(span, error);
+        }
+        throw error;
+    }
 }
 async function handleWithConsumerSpan(handler, envelope, stream, consumerGroup) {
     const span = startConsumerSpan({

--- a/platform/ts-kit/dist/storage.d.ts
+++ b/platform/ts-kit/dist/storage.d.ts
@@ -59,10 +59,15 @@ export declare class OutboxRelay {
     runOnce(): Promise<number>;
     private run;
 }
+export type ProcessedEventInput = Readonly<{
+    eventId: string;
+    stream?: string;
+}>;
 export declare class ProcessedEventsGuard {
     private readonly db;
     constructor(db: Database);
     tryStart(eventId: string, stream?: string): Promise<boolean>;
+    tryStartMany(events: readonly ProcessedEventInput[]): Promise<string[]>;
     runOnce<T>(eventId: string, stream: string | undefined, handler: () => Promise<T>): Promise<T | undefined>;
 }
 export declare class PostgresIdempotencyStore implements IdempotencyStore {

--- a/platform/ts-kit/dist/storage.js
+++ b/platform/ts-kit/dist/storage.js
@@ -18,7 +18,21 @@ export function databaseUrl() {
 export function createPostgresPool(config = databaseUrl()) {
     const require = createRequire(import.meta.url);
     const pg = require("pg");
-    return new pg.Pool(typeof config === "string" ? { connectionString: config } : config);
+    const base = typeof config === "string" ? { connectionString: config } : config;
+    const maxPool = parseInt(process.env.PG_MAX_POOL_SIZE || "", 10);
+    const pool = new pg.Pool({
+        ...base,
+        max: maxPool > 0 ? maxPool : base.max ?? 10,
+        idleTimeoutMillis: base.idleTimeoutMillis ?? 300_000,
+        connectionTimeoutMillis: base.connectionTimeoutMillis ?? 5_000,
+    });
+    pool.on("error", (err) => {
+        console.error({ name: "pg.Pool", message: `background connection error: ${err.message}` });
+    });
+    pool.on("connect", () => {
+        console.log({ name: "pg.Pool", message: "new connection established" });
+    });
+    return pool;
 }
 export async function withTransaction(pool, operation) {
     const client = await pool.connect();
@@ -212,10 +226,25 @@ export class ProcessedEventsGuard {
         this.db = db;
     }
     async tryStart(eventId, stream) {
+        const started = await this.tryStartMany([{ eventId, stream }]);
+        return started.includes(eventId);
+    }
+    async tryStartMany(events) {
+        if (events.length === 0) {
+            return [];
+        }
+        const values = [];
+        const parameters = [];
+        for (const [index, event] of events.entries()) {
+            parameters.push(event.eventId, event.stream ?? null);
+            const first = index * 2 + 1;
+            values.push(`($${first}, $${first + 1})`);
+        }
         const result = await this.db.query(`INSERT INTO processed_events (event_id, stream)
-       VALUES ($1, $2)
-       ON CONFLICT DO NOTHING`, [eventId, stream ?? null]);
-        return (result.rowCount ?? 0) > 0;
+       VALUES ${values.join(", ")}
+       ON CONFLICT DO NOTHING
+       RETURNING event_id`, parameters);
+        return result.rows.map((row) => row.event_id);
     }
     async runOnce(eventId, stream, handler) {
         if (!await this.tryStart(eventId, stream)) {

--- a/platform/ts-kit/src/messaging.ts
+++ b/platform/ts-kit/src/messaging.ts
@@ -47,7 +47,10 @@ export type EventHandlerResult =
   | Readonly<{ ok: false; kind?: HandlerErrorKind; errorType?: HandlerErrorKind; error?: Error }>;
 export type HandlerResult = EventHandlerResult;
 export type StringHandlerResult = "ack" | "retry" | "dlq";
-export type EventHandler = (envelope: EventEnvelope) => Promise<any> | any;
+export type EventHandlerOutput = EventHandlerResult | StringHandlerResult | undefined;
+export type EventBatchHandlerOutput = EventHandlerOutput | readonly EventHandlerOutput[];
+export type EventBatchHandler = (envelopes: readonly EventEnvelope[]) => Promise<EventBatchHandlerOutput> | EventBatchHandlerOutput;
+export type EventHandler = ((envelope: EventEnvelope) => Promise<any> | any) & { handleBatch?: EventBatchHandler };
 
 export interface EventPublisher {
   publish(envelope: EventEnvelope): Promise<void>;
@@ -241,6 +244,7 @@ export type SubscriberLoopFailureHandler = (error: unknown) => void;
 
 type StreamEntry = [id: string, fields: string[]];
 type StreamMessages = [stream: string, entries: StreamEntry[]];
+type BatchEntry = Readonly<{ entry: StreamEntry; envelope: EventEnvelope; attempts: number }>;
 
 export class RedisEventPublisher implements EventPublisher {
   constructor(private readonly redis: Redis) {}
@@ -411,10 +415,96 @@ export class RedisEventSubscriber implements EventSubscriber {
 
   private async processMessages(messages: StreamMessages[] | null, group: string, consumerName: string, handler: EventHandler): Promise<void> {
     for (const [stream, entries] of messages ?? []) {
+      await this.processEntries(stream, group, consumerName, entries, handler);
+    }
+  }
+
+  private async processEntries(stream: string, group: string, consumerName: string, entries: readonly StreamEntry[], handler: EventHandler): Promise<void> {
+    if (!handler.handleBatch || entries.length <= 1) {
       for (const entry of entries) {
         await this.processEntry(stream, group, consumerName, entry, handler);
       }
+      return;
     }
+
+    const batch: BatchEntry[] = [];
+    for (const entry of entries) {
+      const parsed = await this.parseBatchEntry(stream, group, consumerName, entry, 1);
+      if (parsed) {
+        batch.push(parsed);
+      }
+    }
+    if (batch.length === 0) {
+      return;
+    }
+
+    let batchResult: EventBatchHandlerOutput;
+    try {
+      batchResult = await handleBatchWithConsumerSpans(handler.handleBatch, batch.map(({ envelope }) => envelope), stream, group);
+    } catch (error) {
+      for (const item of batch) {
+        const result = error instanceof HandlerError
+          ? (error.kind === "fatal" ? "dlq" : "retry")
+          : (this.options.thrownHandlerErrors === "retry" ? "retry" : "dlq");
+        await this.finishEntry(stream, group, consumerName, item.entry, item.envelope, item.attempts, result, error);
+      }
+      return;
+    }
+
+    const results = Array.isArray(batchResult) ? batchResult : batch.map(() => batchResult);
+    if (results.length !== batch.length) {
+      const error = new HandlerError("fatal", `Batch handler returned ${results.length} results for ${batch.length} events`);
+      for (const item of batch) {
+        await this.finishEntry(stream, group, consumerName, item.entry, item.envelope, item.attempts, "dlq", error);
+      }
+      return;
+    }
+
+    for (const [index, item] of batch.entries()) {
+      const rawResult = results[index];
+      await this.finishEntry(
+        stream,
+        group,
+        consumerName,
+        item.entry,
+        item.envelope,
+        item.attempts,
+        rawResult === undefined ? "ack" : normalizeHandlerResult(rawResult),
+        failureReasonFromHandlerResult(rawResult),
+      );
+    }
+  }
+
+  private async parseBatchEntry(stream: string, group: string, consumerName: string, entry: StreamEntry, deliveryAttempts: number): Promise<BatchEntry | undefined> {
+    const [entryId, fields] = entry;
+    const attempts = Math.max(1, deliveryAttempts);
+    const envelopeJson = fieldValue(fields, "envelope");
+    if (!envelopeJson) {
+      await this.deadLetterAndAck(stream, group, consumerName, entry, "MissingEnvelope", attempts);
+      return undefined;
+    }
+
+    let envelope: EventEnvelope;
+    try {
+      envelope = deserializeEventEnvelope(envelopeJson);
+    } catch (error) {
+      await this.deadLetterAndAck(stream, group, consumerName, entry, error, attempts);
+      return undefined;
+    }
+
+    if (this.consumedEventIds.has(envelope.eventId)) {
+      console.warn({
+        service: group,
+        stream,
+        eventId: envelope.eventId,
+        deliveries: attempts,
+        message: "duplicate event already processed; acking without handler",
+      });
+      await this.redis.xack(stream, group, entryId);
+      return undefined;
+    }
+
+    return { entry, envelope, attempts };
   }
 
   private async processEntry(stream: string, group: string, consumerName: string, entry: StreamEntry, handler: EventHandler, deliveryAttempts = 1): Promise<void> {
@@ -462,9 +552,13 @@ export class RedisEventSubscriber implements EventSubscriber {
       }
     }
 
+    await this.finishEntry(stream, group, consumerName, entry, envelope, attempts, result, failureReason);
+  }
+
+  private async finishEntry(stream: string, group: string, consumerName: string, entry: StreamEntry, envelope: EventEnvelope, attempts: number, result: "ack" | "retry" | "dlq", failureReason: unknown): Promise<void> {
     if (result === "ack") {
       this.consumedEventIds.add(envelope.eventId);
-      await this.redis.xack(stream, group, entryId);
+      await this.redis.xack(stream, group, entry[0]);
       return;
     }
     if (result === "dlq") {
@@ -602,7 +696,39 @@ export function redisUrl(): string {
   return process.env.REDIS_URL ?? "redis://localhost:6379";
 }
 
-async function handleWithConsumerSpan(handler: EventHandler, envelope: EventEnvelope, stream: string, consumerGroup: string): Promise<EventHandlerResult | StringHandlerResult | undefined> {
+async function handleBatchWithConsumerSpans(handler: EventBatchHandler, envelopes: readonly EventEnvelope[], stream: string, consumerGroup: string): Promise<EventBatchHandlerOutput> {
+  if (envelopes.length === 0) {
+    return [];
+  }
+  const spans = envelopes.map((envelope) => startConsumerSpan({
+    stream,
+    consumerGroup,
+    eventId: envelope.eventId,
+    eventType: envelope.eventType,
+    correlationId: envelope.correlationId,
+    parentContext: remoteTraceContext(envelope.traceparent, envelope.tracestate),
+  }));
+  try {
+    const result = await handler(envelopes);
+    const results = Array.isArray(result) ? result : envelopes.map(() => result);
+    for (const [index, span] of spans.entries()) {
+      const rawResult = results[index];
+      const normalized = rawResult === undefined ? "ack" : normalizeHandlerResult(rawResult);
+      if (normalized !== "ack") {
+        markSpanError(span, String(failureReasonFromHandlerResult(rawResult)));
+      }
+      endSpan(span);
+    }
+    return result;
+  } catch (error) {
+    for (const span of spans) {
+      endSpanWithError(span, error);
+    }
+    throw error;
+  }
+}
+
+async function handleWithConsumerSpan(handler: EventHandler, envelope: EventEnvelope, stream: string, consumerGroup: string): Promise<EventHandlerOutput> {
   const span = startConsumerSpan({
     stream,
     consumerGroup,

--- a/platform/ts-kit/src/storage.ts
+++ b/platform/ts-kit/src/storage.ts
@@ -278,17 +278,37 @@ export class OutboxRelay {
   }
 }
 
+export type ProcessedEventInput = Readonly<{ eventId: string; stream?: string }>;
+
 export class ProcessedEventsGuard {
   constructor(private readonly db: Database) {}
 
   async tryStart(eventId: string, stream?: string): Promise<boolean> {
+    const started = await this.tryStartMany([{ eventId, stream }]);
+    return started.includes(eventId);
+  }
+
+  async tryStartMany(events: readonly ProcessedEventInput[]): Promise<string[]> {
+    if (events.length === 0) {
+      return [];
+    }
+
+    const values: string[] = [];
+    const parameters: unknown[] = [];
+    for (const [index, event] of events.entries()) {
+      parameters.push(event.eventId, event.stream ?? null);
+      const first = index * 2 + 1;
+      values.push(`($${first}, $${first + 1})`);
+    }
+
     const result = await this.db.query(
       `INSERT INTO processed_events (event_id, stream)
-       VALUES ($1, $2)
-       ON CONFLICT DO NOTHING`,
-      [eventId, stream ?? null],
-    );
-    return (result.rowCount ?? 0) > 0;
+       VALUES ${values.join(", ")}
+       ON CONFLICT DO NOTHING
+       RETURNING event_id`,
+      parameters,
+    ) as QueryResult<{ event_id: string }>;
+    return result.rows.map((row) => row.event_id);
   }
 
   async runOnce<T>(eventId: string, stream: string | undefined, handler: () => Promise<T>): Promise<T | undefined> {

--- a/services/offer-management/src/adapters/storage/runtime.ts
+++ b/services/offer-management/src/adapters/storage/runtime.ts
@@ -17,7 +17,7 @@ import {
 import { type Pool } from "pg";
 
 import { OfferApplicationService } from "../../application/offers.js";
-import { applyUpstreamEvent, buildQuoteOfferCommand, type UpstreamStateRepository } from "../../application/upstream-state.js";
+import { applyUpstreamEvents, buildQuoteOfferCommand, type UpstreamStateRepository } from "../../application/upstream-state.js";
 import { PostgresOfferRepository } from "./offer-repository.js";
 import { PostgresUpstreamStateRepository } from "./upstream-state-repository.js";
 
@@ -25,9 +25,13 @@ export type OfferStorageRuntime = Readonly<{
   ready: () => Promise<boolean>;
   idempotencyStore: PostgresIdempotencyStore;
   runCommand: <T>(upstreamRepository: UpstreamStateRepository, operation: (application: OfferApplicationService) => Promise<T>) => Promise<T>;
-  handleUpstreamEvent: (envelope: EventEnvelope, stream?: string) => Promise<"ack" | "retry" | "dlq">;
+  handleUpstreamEvent: UpstreamEventHandler;
   stop: () => Promise<void>;
 }>;
+
+type UpstreamEventHandler = ((envelope: EventEnvelope, stream?: string) => Promise<"ack" | "retry" | "dlq">) & {
+  handleBatch?: (envelopes: readonly EventEnvelope[]) => Promise<"ack" | "retry" | "dlq">;
+};
 
 export async function startOfferStorage(redisUrl = process.env.REDIS_URL ?? "redis://localhost:6379"): Promise<OfferStorageRuntime> {
   const pool = createPostgresPool();
@@ -50,20 +54,47 @@ export async function startOfferStorage(redisUrl = process.env.REDIS_URL ?? "red
     ready: () => migrations.isReady ? checkPostgresReadiness(pool) : Promise.resolve(false),
     idempotencyStore: new PostgresIdempotencyStore(pool),
     runCommand: (upstreamRepository, operation) => withOfferTransaction(pool, upstreamRepository, operation),
-    handleUpstreamEvent: (envelope, stream) => withTransaction(pool, async (client): Promise<"ack" | "retry" | "dlq"> => {
-      const guard = new ProcessedEventsGuard(client);
-      if (!await guard.tryStart(envelope.eventId, stream)) {
-        return "ack";
-      }
-      await applyUpstreamEvent(new PostgresUpstreamStateRepository(client), envelope);
-      return "ack";
-    }),
+    handleUpstreamEvent: createUpstreamEventHandler(pool),
     stop: async () => {
       await relay.stop();
       await Promise.allSettled([redis.quit(), pool.end()]);
     },
   };
 }
+
+function createUpstreamEventHandler(pool: Pool): UpstreamEventHandler {
+  const handler = ((envelope: EventEnvelope, stream?: string) => (
+    handleUpstreamEventBatch(pool, [{ envelope, stream }])
+  )) as UpstreamEventHandler;
+  handler.handleBatch = (envelopes) => handleUpstreamEventBatch(
+    pool,
+    envelopes.map((envelope) => ({ envelope, stream: streamForProducer(envelope.producer) })),
+  );
+  return handler;
+}
+
+async function handleUpstreamEventBatch(pool: Pool, events: readonly UpstreamEventBatchItem[]): Promise<"ack" | "retry" | "dlq"> {
+  if (events.length === 0) {
+    return "ack";
+  }
+
+  return withTransaction(pool, async (client): Promise<"ack" | "retry" | "dlq"> => {
+    const guard = new ProcessedEventsGuard(client);
+    const startedEventIds = new Set(await guard.tryStartMany(events.map(({ envelope, stream }) => ({ eventId: envelope.eventId, stream }))));
+    const appliedEventIds = new Set<string>();
+    const envelopesToApply: EventEnvelope[] = [];
+    for (const { envelope } of events) {
+      if (startedEventIds.has(envelope.eventId) && !appliedEventIds.has(envelope.eventId)) {
+        envelopesToApply.push(envelope);
+        appliedEventIds.add(envelope.eventId);
+      }
+    }
+    await applyUpstreamEvents(new PostgresUpstreamStateRepository(client), envelopesToApply);
+    return "ack";
+  });
+}
+
+type UpstreamEventBatchItem = Readonly<{ envelope: EventEnvelope; stream?: string }>;
 
 async function withOfferTransaction<T>(pool: Pool, _upstreamRepository: UpstreamStateRepository, operation: (application: OfferApplicationService) => Promise<T>): Promise<T> {
   return withTransaction(pool, async (client) => {

--- a/services/offer-management/src/adapters/storage/upstream-state-repository.ts
+++ b/services/offer-management/src/adapters/storage/upstream-state-repository.ts
@@ -23,7 +23,18 @@ export class PostgresUpstreamStateRepository implements UpstreamStateRepository 
   }
 
   async saveFareQuote(fareQuote: StoredFareQuote): Promise<void> {
-    await upsertSnapshot(this.client, "offer_upstream_fare_quotes", fareQuoteStorageKey(fareQuote.inputHash, fareQuote.channelId, fareQuote.travelerRefs), serializeFareQuote(fareQuote));
+    await this.saveFareQuotes([fareQuote]);
+  }
+
+  async saveFareQuotes(fareQuotes: readonly StoredFareQuote[]): Promise<void> {
+    await upsertSnapshots(
+      this.client,
+      "offer_upstream_fare_quotes",
+      fareQuotes.map((fareQuote) => ({
+        id: fareQuoteStorageKey(fareQuote.inputHash, fareQuote.channelId, fareQuote.travelerRefs),
+        data: serializeFareQuote(fareQuote),
+      })),
+    );
   }
 
   async findFareQuote(inputHash: string, channelId: string, travelerRefs: readonly string[]): Promise<StoredFareQuote | undefined> {
@@ -71,12 +82,29 @@ type StoredFareQuoteSnapshot = Omit<StoredFareQuote, "validFrom" | "validUntil">
 type StoredTravelerSnapshot = StoredTraveler;
 
 async function upsertSnapshot(client: PoolClient, tableName: UpstreamTableName, id: string, data: unknown): Promise<void> {
+  await upsertSnapshots(client, tableName, [{ id, data }]);
+}
+
+async function upsertSnapshots(client: PoolClient, tableName: UpstreamTableName, snapshots: readonly UpstreamSnapshot[]): Promise<void> {
+  const uniqueSnapshots = [...new Map(snapshots.map((snapshot) => [snapshot.id, snapshot])).values()];
+  if (uniqueSnapshots.length === 0) {
+    return;
+  }
+
+  const values: string[] = [];
+  const parameters: unknown[] = [];
+  for (const [index, snapshot] of uniqueSnapshots.entries()) {
+    parameters.push(snapshot.id, snapshot.data);
+    const first = index * 2 + 1;
+    values.push(`($${first}, 1, $${first + 1})`);
+  }
+
   await client.query(
     `INSERT INTO ${tableName} (id, version, data)
-     VALUES ($1, 1, $2)
+     VALUES ${values.join(", ")}
      ON CONFLICT (id)
      DO UPDATE SET version = ${tableName}.version + 1, data = EXCLUDED.data, updated_at = now()`,
-    [id, data],
+    parameters,
   );
 }
 
@@ -147,4 +175,5 @@ function reviveTraveler(snapshot: StoredTravelerSnapshot): StoredTraveler {
   return snapshot;
 }
 
+type UpstreamSnapshot = Readonly<{ id: string; data: unknown }>;
 type UpstreamTableName = "offer_upstream_itineraries" | "offer_upstream_fare_quotes" | "offer_upstream_travelers";

--- a/services/offer-management/src/application/upstream-state.ts
+++ b/services/offer-management/src/application/upstream-state.ts
@@ -65,6 +65,7 @@ export interface UpstreamStateRepository {
   saveItinerary(itinerary: StoredItinerary): Promise<void>;
   findItinerary(itineraryRef: string): Promise<StoredItinerary | undefined>;
   saveFareQuote(fareQuote: StoredFareQuote): Promise<void>;
+  saveFareQuotes(fareQuotes: readonly StoredFareQuote[]): Promise<void>;
   findFareQuote(itineraryRef: string, channelId: string, travelerRefs: readonly string[]): Promise<StoredFareQuote | undefined>;
   saveTraveler(traveler: StoredTraveler): Promise<void>;
   findTraveler(travelerId: string): Promise<StoredTraveler | undefined>;
@@ -86,7 +87,13 @@ export class InMemoryUpstreamStateRepository implements UpstreamStateRepository 
   }
 
   async saveFareQuote(fareQuote: StoredFareQuote): Promise<void> {
-    this.fareQuotesByKey.set(fareQuoteKey(fareQuote.inputHash, fareQuote.channelId, fareQuote.travelerRefs), fareQuote);
+    await this.saveFareQuotes([fareQuote]);
+  }
+
+  async saveFareQuotes(fareQuotes: readonly StoredFareQuote[]): Promise<void> {
+    for (const fareQuote of fareQuotes) {
+      this.fareQuotesByKey.set(fareQuoteKey(fareQuote.inputHash, fareQuote.channelId, fareQuote.travelerRefs), fareQuote);
+    }
   }
 
   async findFareQuote(itineraryRef: string, channelId: string, travelerRefs: readonly string[]): Promise<StoredFareQuote | undefined> {
@@ -116,31 +123,50 @@ export class InMemoryUpstreamStateRepository implements UpstreamStateRepository 
 }
 
 export function createUpstreamEventHandler(repository: UpstreamStateRepository): EventHandler {
-  return async (envelope) => {
+  const handler = (async (envelope: EventEnvelope) => {
     await applyUpstreamEvent(repository, envelope);
     return "ack";
+  }) as EventHandler;
+  handler.handleBatch = async (envelopes) => {
+    await applyUpstreamEvents(repository, envelopes);
+    return "ack" as const;
   };
+  return handler;
 }
 
 export async function applyUpstreamEvent(repository: UpstreamStateRepository, envelope: EventEnvelope): Promise<void> {
-  switch (envelope.eventType) {
-    case "ItineraryProposed":
-      await storeItineraries(repository, envelope.payload);
-      return;
-    case "FareQuoteComputed":
-      await storeFareQuote(repository, envelope.payload);
-      return;
-    case "TravelerSnapshotUpdated":
-      await storeTravelerSnapshot(repository, envelope.payload);
-      return;
-    case "EligibilityDetermined":
-      await storeEligibility(repository, envelope.payload);
-      return;
-    case "EligibilityExpired":
-      await expireEligibility(repository, envelope.payload);
-      return;
-    default:
-      return;
+  await applyUpstreamEvents(repository, [envelope]);
+}
+
+export async function applyUpstreamEvents(repository: UpstreamStateRepository, envelopes: readonly EventEnvelope[]): Promise<void> {
+  const fareQuotes = envelopes
+    .filter((envelope) => envelope.eventType === "FareQuoteComputed")
+    .map((envelope) => parseFareQuote(envelope.payload))
+    .filter((fareQuote): fareQuote is StoredFareQuote => fareQuote !== undefined);
+
+  if (fareQuotes.length > 0) {
+    await repository.saveFareQuotes(fareQuotes);
+  }
+
+  for (const envelope of envelopes) {
+    switch (envelope.eventType) {
+      case "ItineraryProposed":
+        await storeItineraries(repository, envelope.payload);
+        break;
+      case "FareQuoteComputed":
+        break;
+      case "TravelerSnapshotUpdated":
+        await storeTravelerSnapshot(repository, envelope.payload);
+        break;
+      case "EligibilityDetermined":
+        await storeEligibility(repository, envelope.payload);
+        break;
+      case "EligibilityExpired":
+        await expireEligibility(repository, envelope.payload);
+        break;
+      default:
+        break;
+    }
   }
 }
 
@@ -272,8 +298,8 @@ async function storeItineraries(repository: UpstreamStateRepository, payload: Re
   }
 }
 
-async function storeFareQuote(repository: UpstreamStateRepository, payload: Record<string, unknown>): Promise<void> {
-  if (stringField(payload, "status") !== "QUOTED") return;
+function parseFareQuote(payload: Record<string, unknown>): StoredFareQuote | undefined {
+  if (stringField(payload, "status") !== "QUOTED") return undefined;
   const quoteId = stringField(payload, "quoteId");
   const inputHash = stringField(payload, "inputHash");
   const channelId = stringField(payload, "channel") ?? stringField(payload, "channelId");
@@ -283,7 +309,7 @@ async function storeFareQuote(repository: UpstreamStateRepository, payload: Reco
   const validUntil = dateField(payload, "validUntil");
   const breakdown = objectField(payload, "breakdown");
   const ruleSnapshot = objectField(payload, "ruleSnapshot");
-  if (!quoteId || !inputHash || !channelId || travelerRefs.length === 0 || !currency || !validFrom || !validUntil || !breakdown || !ruleSnapshot) return;
+  if (!quoteId || !inputHash || !channelId || travelerRefs.length === 0 || !currency || !validFrom || !validUntil || !breakdown || !ruleSnapshot) return undefined;
 
   const total = moneyField(breakdown, "total") ?? moneyField(payload, "total");
   // Contract RuleSnapshot (events/fare-pricing.md) carries ruleSetId/ruleSetVersion/digest;
@@ -294,9 +320,9 @@ async function storeFareQuote(repository: UpstreamStateRepository, payload: Reco
   const pricingVersion = ruleSetVersion ?? stringField(payload, "pricingVersion");
   const ruleVersion = ruleSetVersion ?? stringField(payload, "ruleVersion");
   const priceSnapshotRef = stringField(breakdown, "priceSnapshotRef") ?? stringField(payload, "priceSnapshotRef") ?? `price-snapshot:${quoteId}`;
-  if (!total || !ruleSnapshotRef || !pricingVersion || !ruleVersion) return;
+  if (!total || !ruleSnapshotRef || !pricingVersion || !ruleVersion) return undefined;
 
-  await repository.saveFareQuote({
+  return {
     quoteId,
     inputHash,
     channelId,
@@ -311,7 +337,7 @@ async function storeFareQuote(repository: UpstreamStateRepository, payload: Reco
     ruleVersion,
     priceSnapshotRef,
     guaranteeLevel: priceGuarantee(stringField(payload, "priceGuaranteeLevel") ?? stringField(breakdown, "priceGuaranteeLevel")),
-  });
+  };
 }
 
 async function storeTravelerSnapshot(repository: UpstreamStateRepository, payload: Record<string, unknown>): Promise<void> {

--- a/services/offer-management/src/bootstrap.ts
+++ b/services/offer-management/src/bootstrap.ts
@@ -44,16 +44,12 @@ export async function bootstrap(options: BootstrapOptions = {}) {
   });
 
   const abortController = new AbortController();
+  const upstreamEventHandler = storage?.handleUpstreamEvent ?? createUpstreamEventHandler(upstreamRepository);
   const subscription = messaging.subscriber.subscribe(
     SUBSCRIBED_STREAMS,
     CONSUMER_GROUP,
     consumerName(options.instanceId ?? process.env.HOSTNAME),
-    async (envelope) => {
-      if (storage) {
-        return storage.handleUpstreamEvent(envelope);
-      }
-      return createUpstreamEventHandler(upstreamRepository)(envelope);
-    },
+    upstreamEventHandler,
     abortController.signal,
   );
   const subscriptionFailed = new Promise<never>((_, reject) => {

--- a/services/offer-management/src/messaging.test.ts
+++ b/services/offer-management/src/messaging.test.ts
@@ -171,7 +171,7 @@ describe("EventSubscriber port — InMemoryEventSubscriber", () => {
     const received: EventEnvelope[] = [];
     const handler: EventHandler = async (env) => {
       received.push(env);
-      return "ack";
+      return "ack" as const;
     };
 
     const signal = new AbortController().signal;
@@ -183,6 +183,33 @@ describe("EventSubscriber port — InMemoryEventSubscriber", () => {
     assert.equal(result, "ack");
     assert.equal(received.length, 1);
     assert.equal(received[0].eventId, envelope.eventId);
+  });
+
+  it("invokes handleBatch once for a Redis read batch and acks each processed entry", async () => {
+    const first = makeEnvelope({ eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c222" });
+    const second = makeEnvelope({ eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c223" });
+    const redis = new FakeRedisForBatch([
+      ["5-0", ["envelope", JSON.stringify(first)]],
+      ["6-0", ["envelope", JSON.stringify(second)]],
+    ]);
+    const subscriber = new RedisEventSubscriber(redis as never);
+    const batches: (readonly EventEnvelope[])[] = [];
+    const handler = (async () => "dlq") as EventHandler;
+    handler.handleBatch = async (envelopes) => {
+      batches.push(envelopes);
+      return "ack" as const;
+    };
+
+    await (subscriber as unknown as { processMessages: (messages: unknown, group: string, consumer: string, handler: EventHandler) => Promise<void> })
+      .processMessages([[streamKey("fare-pricing"), redis.entries]], "offer-management", "offer-management-test", handler);
+
+    assert.equal(batches.length, 1);
+    assert.deepEqual(batches[0].map(({ eventId }) => eventId), [first.eventId, second.eventId]);
+    assert.deepEqual(redis.xackCalls, [
+      [streamKey("fare-pricing"), "offer-management", "5-0"],
+      [streamKey("fare-pricing"), "offer-management", "6-0"],
+    ]);
+    assert.equal(redis.xaddCalls.length, 0);
   });
 
   it("deduplicates a duplicate eventId via handler returning ack for already-seen ids", async () => {
@@ -257,6 +284,24 @@ describe("RedisEventSubscriber recovery", () => {
     assert.deepEqual(redis.xackCalls, [[sourceStream, group, "5-0"]]);
   });
 });
+
+
+class FakeRedisForBatch {
+  readonly xaddCalls: unknown[][] = [];
+  readonly xackCalls: unknown[][] = [];
+
+  constructor(readonly entries: [string, string[]][]) {}
+
+  async xadd(...args: unknown[]): Promise<string> {
+    this.xaddCalls.push(args);
+    return "7-0";
+  }
+
+  async xack(...args: unknown[]): Promise<number> {
+    this.xackCalls.push(args);
+    return 1;
+  }
+}
 
 class FakeRedisForRecovery {
   readonly xaddCalls: unknown[][] = [];


### PR DESCRIPTION
## Summary
AgentM/GPT REQ-200 delivery — batch-process FareQuoteComputed events to reduce per-event DB round-trips.

- **ts-kit**: `EventHandler.handleBatch` extension for batch Redis consumer processing
- **ts-kit**: `ProcessedEventsGuard.tryStartMany` for batched dedup inserts  
- **offer-management**: batch upstream event handler with multi-row upserts
- `PostgresUpstreamStateRepository.saveFareQuotes` bulk INSERT ON CONFLICT
- `PG_MAX_POOL_SIZE=15` for offer-management deployment
- New test coverage for batch handler semantics

## Impact
Offer-management consumer was the #1 RPS bottleneck (674 offer failures in S2 staircase). Batch processing reduces DB round-trips from 2N to 2 per read batch (N=50 events).

## Test plan
- [x] `messaging.test.ts` batch handler coverage
- [ ] Re-run S2 staircase to measure offer failure reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code) + AgentM/GPT