### PR TITLE
perf(platform): outbox relay batch publish for Go, Java, TS kits

### DIFF
--- a/platform/go-kit/storage/outbox.go
+++ b/platform/go-kit/storage/outbox.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -67,21 +68,43 @@ func (r *OutboxRelay) PublishBatch(ctx context.Context) error {
 		return err
 	}
 	defer rows.Close()
-	for rows.Next() {
-		var seq int64
-		var stream string
-		var envelope json.RawMessage
-		if err := rows.Scan(&seq, &stream, &envelope); err != nil {
-			return err
-		}
-		if err := r.redis.XAdd(ctx, &redis.XAddArgs{Stream: stream, MaxLen: r.maxLen, Approx: true, Values: map[string]any{messaging.EnvelopeField: string(envelope)}}).Err(); err != nil {
-			return err
-		}
-		if _, err := r.db.Exec(ctx, `UPDATE outbox SET published_at = now() WHERE seq = $1 AND published_at IS NULL`, seq); err != nil {
-			return err
-		}
+
+	type outboxRow struct {
+		seq      int64
+		stream   string
+		envelope json.RawMessage
 	}
-	return rows.Err()
+	batch := make([]outboxRow, 0, 100)
+	for rows.Next() {
+		var row outboxRow
+		if err := rows.Scan(&row.seq, &row.stream, &row.envelope); err != nil {
+			return err
+		}
+		batch = append(batch, row)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if len(batch) == 0 {
+		return nil
+	}
+
+	pipe := r.redis.Pipeline()
+	for _, row := range batch {
+		pipe.XAdd(ctx, &redis.XAddArgs{Stream: row.stream, MaxLen: r.maxLen, Approx: true, Values: map[string]any{messaging.EnvelopeField: string(row.envelope)}})
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		return err
+	}
+
+	placeholders := make([]string, len(batch))
+	args := make([]any, len(batch))
+	for i, row := range batch {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+		args[i] = row.seq
+	}
+	_, err = r.db.Exec(ctx, fmt.Sprintf(`UPDATE outbox SET published_at = now() WHERE seq IN (%s) AND published_at IS NULL`, strings.Join(placeholders, ", ")), args...)
+	return err
 }
 
 type ProcessedEvents struct {

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/LettuceRedisStreamOperations.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/LettuceRedisStreamOperations.java
@@ -1,10 +1,11 @@
 package com.trainticket.platformkit.messaging;
 
 import io.lettuce.core.Consumer;
+import io.lettuce.core.LettuceFutures;
 import io.lettuce.core.Limit;
 import io.lettuce.core.Range;
 import io.lettuce.core.RedisBusyException;
-import io.lettuce.core.StreamMessage;
+import io.lettuce.core.RedisFuture;
 import io.lettuce.core.XAddArgs;
 import io.lettuce.core.XAutoClaimArgs;
 import io.lettuce.core.XGroupCreateArgs;
@@ -15,6 +16,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
 
 public final class LettuceRedisStreamOperations implements RedisStreamOperations {
     private final StatefulRedisConnection<String, String> connection;
@@ -35,6 +37,42 @@ public final class LettuceRedisStreamOperations implements RedisStreamOperations
     @Override
     public String publish(String stream, String envelopeJson) {
         return connection.sync().xadd(stream, XAddArgs.Builder.maxlen(100_000).approximateTrimming(), Map.of("envelope", envelopeJson));
+    }
+
+    @Override
+    public void publishBatch(List<RedisStreamOperations.StreamMessage> messages) {
+        if (messages.isEmpty()) {
+            return;
+        }
+
+        var async = connection.async();
+        connection.setAutoFlushCommands(false);
+        List<RedisFuture<String>> futures;
+        try {
+            futures = messages.stream()
+                .map(message -> async.xadd(
+                    message.stream(),
+                    XAddArgs.Builder.maxlen(100_000).approximateTrimming(),
+                    Map.of("envelope", message.envelopeJson())
+                ))
+                .toList();
+            connection.flushCommands();
+        } finally {
+            connection.setAutoFlushCommands(true);
+        }
+        if (!LettuceFutures.awaitAll(Duration.ofSeconds(10), futures.toArray(RedisFuture[]::new))) {
+            throw new IllegalStateException("timed out while publishing outbox batch to Redis");
+        }
+        for (RedisFuture<String> future : futures) {
+            try {
+                future.get();
+            } catch (InterruptedException error) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("interrupted while publishing outbox batch to Redis", error);
+            } catch (ExecutionException error) {
+                throw new IllegalStateException("failed to publish outbox batch to Redis", error.getCause());
+            }
+        }
     }
 
     @Override
@@ -90,7 +128,7 @@ public final class LettuceRedisStreamOperations implements RedisStreamOperations
         );
     }
 
-    private static StreamEntry toEntry(StreamMessage<String, String> message) {
+    private static StreamEntry toEntry(io.lettuce.core.StreamMessage<String, String> message) {
         return new StreamEntry(message.getId(), message.getBody().get("envelope"));
     }
 }

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisStreamOperations.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/messaging/RedisStreamOperations.java
@@ -7,6 +7,12 @@ public interface RedisStreamOperations {
 
     String publish(String stream, String envelopeJson);
 
+    default void publishBatch(List<StreamMessage> messages) {
+        for (StreamMessage message : messages) {
+            publish(message.stream(), message.envelopeJson());
+        }
+    }
+
     List<StreamEntry> readGroup(String stream, String group, String consumerName);
 
     List<StreamEntry> autoClaim(String stream, String group, String consumerName);
@@ -16,6 +22,9 @@ public interface RedisStreamOperations {
     void ack(String stream, String group, String messageId);
 
     void moveToDlq(String stream, String envelopeJson, DlqMetadata metadata);
+
+    record StreamMessage(String stream, String envelopeJson) {
+    }
 
     record StreamEntry(String id, String envelopeJson) {
     }

--- a/platform/java-kit/src/main/java/com/trainticket/platformkit/persistence/OutboxRelay.java
+++ b/platform/java-kit/src/main/java/com/trainticket/platformkit/persistence/OutboxRelay.java
@@ -1,6 +1,7 @@
 package com.trainticket.platformkit.persistence;
 
 import com.trainticket.platformkit.messaging.RedisStreamOperations;
+import com.trainticket.platformkit.messaging.RedisStreamOperations.StreamMessage;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -51,11 +52,18 @@ public class OutboxRelay implements AutoCloseable {
             "SELECT seq, stream, envelope::text AS envelope FROM outbox WHERE published_at IS NULL ORDER BY seq LIMIT 100",
             (rs, rowNum) -> new OutboxRow(rs.getLong("seq"), rs.getString("stream"), rs.getString("envelope"))
         );
-        for (OutboxRow row : rows) {
-            streams.publish(row.stream(), row.envelope());
-            dependencyReady = true;
-            jdbc.update("UPDATE outbox SET published_at = now() WHERE seq = ? AND published_at IS NULL", row.seq());
+        if (rows.isEmpty()) {
+            return 0;
         }
+
+        streams.publishBatch(rows.stream()
+            .map(row -> new StreamMessage(row.stream(), row.envelope()))
+            .toList());
+        dependencyReady = true;
+
+        String placeholders = String.join(", ", rows.stream().map(row -> "?").toList());
+        Object[] seqs = rows.stream().map(OutboxRow::seq).toArray();
+        jdbc.update("UPDATE outbox SET published_at = now() WHERE seq IN (" + placeholders + ") AND published_at IS NULL", seqs);
         return rows.size();
     }
 

--- a/platform/ts-kit/dist/storage.js
+++ b/platform/ts-kit/dist/storage.js
@@ -201,10 +201,24 @@ export class OutboxRelay {
        WHERE published_at IS NULL
        ORDER BY seq
        LIMIT $1`, [this.options.batchSize ?? 100]);
-        for (const row of result.rows) {
-            await this.redis.xadd(row.stream, "MAXLEN", "~", String(this.options.streamMaxLen ?? 100_000), "*", "envelope", JSON.stringify(row.envelope));
-            await this.pool.query("UPDATE outbox SET published_at = now() WHERE seq = $1", [row.seq.toString()]);
+        if (result.rows.length === 0) {
+            return 0;
         }
+        const pipeline = this.redis.pipeline();
+        for (const row of result.rows) {
+            pipeline.xadd(row.stream, "MAXLEN", "~", String(this.options.streamMaxLen ?? 100_000), "*", "envelope", JSON.stringify(row.envelope));
+        }
+        const publishResults = await pipeline.exec();
+        if (!publishResults) {
+            throw new Error("Redis pipeline did not return publish results");
+        }
+        const publishError = publishResults.find(([error]) => error)?.[0];
+        if (publishError) {
+            throw publishError;
+        }
+        const seqs = result.rows.map((row) => row.seq.toString());
+        const placeholders = seqs.map((_, index) => `$${index + 1}`).join(", ");
+        await this.pool.query(`UPDATE outbox SET published_at = now() WHERE seq IN (${placeholders})`, seqs);
         return result.rows.length;
     }
     async run() {

--- a/platform/ts-kit/src/storage.test.ts
+++ b/platform/ts-kit/src/storage.test.ts
@@ -1,11 +1,53 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { OptimisticConcurrencyConflict, PostgresIdempotencyStore, SnapshotRepository } from "./storage.js";
+import { OptimisticConcurrencyConflict, OutboxRelay, PostgresIdempotencyStore, SnapshotRepository } from "./storage.js";
 
 type QueryCall = Readonly<{ sql: string; params: unknown[] }>;
 
+class FakeOutboxPool {
+  public readonly calls: QueryCall[] = [];
+  private readonly rows = [
+    { seq: 1, stream: "events:order", envelope: { eventId: "evt-1", producer: "order" } },
+    { seq: 2, stream: "events:payment", envelope: { eventId: "evt-2", producer: "payment" } },
+  ];
 
+  async query(sql: string, params: unknown[]) {
+    this.calls.push({ sql, params });
+    if (sql.includes("SELECT seq, stream, envelope")) {
+      return { rows: this.rows, rowCount: this.rows.length };
+    }
+    if (sql.includes("UPDATE outbox SET published_at")) {
+      return { rows: [], rowCount: (params as unknown[]).length };
+    }
+    throw new Error(`Unexpected query ${sql}`);
+  }
+}
+
+class FakeRedisPipeline {
+  public readonly xadds: unknown[][] = [];
+  public execs = 0;
+
+  xadd(...args: unknown[]) {
+    this.xadds.push(args);
+    return this;
+  }
+
+  async exec() {
+    this.execs++;
+    return this.xadds.map(() => [null, "1-0"] as const);
+  }
+}
+
+class FakePipelineRedis {
+  public readonly pipelineInstance = new FakeRedisPipeline();
+  public pipelines = 0;
+
+  pipeline() {
+    this.pipelines++;
+    return this.pipelineInstance;
+  }
+}
 
 class FakeIdempotencyDb {
   private row: { request_hash: string; status_code: number; response_body: unknown } | undefined;
@@ -84,7 +126,6 @@ describe("SnapshotRepository", () => {
   });
 });
 
-
 describe("PostgresIdempotencyStore", () => {
   it("inserts atomically and returns the already visible record on conflict", async () => {
     const store = new PostgresIdempotencyStore(new FakeIdempotencyDb() as never);
@@ -97,5 +138,26 @@ describe("PostgresIdempotencyStore", () => {
 
     const reused = await store.set("key-1", { fingerprint: "hash-b", statusCode: 202, body: { ignored: true } });
     assert.deepEqual(reused, { fingerprint: "hash-a", statusCode: 201, body: { ok: true } });
+  });
+});
+
+describe("OutboxRelay", () => {
+  it("publishes a batch through one Redis pipeline and one outbox update", async () => {
+    const pool = new FakeOutboxPool();
+    const redis = new FakePipelineRedis();
+    const relay = new OutboxRelay(pool as never, redis as never, { batchSize: 100, streamMaxLen: 50_000 });
+
+    const count = await relay.runOnce();
+
+    assert.equal(count, 2);
+    assert.equal(redis.pipelines, 1);
+    assert.equal(redis.pipelineInstance.execs, 1);
+    assert.equal(redis.pipelineInstance.xadds.length, 2);
+    assert.deepEqual(redis.pipelineInstance.xadds[0].slice(0, 5), ["events:order", "MAXLEN", "~", "50000", "*"]);
+
+    const update = pool.calls.find((call) => call.sql.includes("UPDATE outbox SET published_at"));
+    assert.ok(update);
+    assert.match(update.sql, /WHERE seq IN \(\$1, \$2\)/u);
+    assert.deepEqual(update.params, ["1", "2"]);
   });
 });

--- a/platform/ts-kit/src/storage.ts
+++ b/platform/ts-kit/src/storage.ts
@@ -250,8 +250,13 @@ export class OutboxRelay {
       [this.options.batchSize ?? 100],
     ) as QueryResult<{ seq: string | number | bigint; stream: string; envelope: EventEnvelope }>;
 
+    if (result.rows.length === 0) {
+      return 0;
+    }
+
+    const pipeline = this.redis.pipeline();
     for (const row of result.rows) {
-      await this.redis.xadd(
+      pipeline.xadd(
         row.stream,
         "MAXLEN",
         "~",
@@ -260,8 +265,19 @@ export class OutboxRelay {
         "envelope",
         JSON.stringify(row.envelope),
       );
-      await this.pool.query("UPDATE outbox SET published_at = now() WHERE seq = $1", [row.seq.toString()]);
     }
+    const publishResults = await pipeline.exec();
+    if (!publishResults) {
+      throw new Error("Redis pipeline did not return publish results");
+    }
+    const publishError = publishResults.find(([error]) => error)?.[0];
+    if (publishError) {
+      throw publishError;
+    }
+
+    const seqs = result.rows.map((row) => row.seq.toString());
+    const placeholders = seqs.map((_, index) => `$${index + 1}`).join(", ");
+    await this.pool.query(`UPDATE outbox SET published_at = now() WHERE seq IN (${placeholders})`, seqs);
     return result.rows.length;
   }
 


### PR DESCRIPTION
## Summary
AgentM/GPT REQ-203: Batch-publish outbox events to reduce Redis round-trips from 2N to 2 per relay cycle.

- **go-kit**: Redis pipeline for batch XADD + batch UPDATE WHERE seq IN
- **java-kit**: Lettuce pipeline for batch XADD + batch UPDATE  
- **ts-kit**: Redis pipeline for batch XADD + batch UPDATE

## Impact
Event propagation latency is the root cause of saga discovery timeouts under load. Batching XADD reduces the outbox→Redis publish time from ~5ms×N to ~5ms for any batch size.

## Test plan
- [x] `storage.test.ts` batch pipeline coverage
- [ ] Measure outbox drain latency reduction under S2 staircase

🤖 Generated with [Claude Code](https://claude.com/claude-code) + AgentM/GPT