### PR TITLE
feat(post-sales): concurrent refund safety with 409/422 error codes

### DIFF
--- a/docs/08-contracts/api/post-sales.md
+++ b/docs/08-contracts/api/post-sales.md
@@ -39,7 +39,7 @@ timestamps, and Money.
 | `status` | enum | `OPENED`, `EVALUATING`, `APPROVED`, `REJECTED`, `APPLIED`, `FAILED` |
 | `createdAt` | timestamp | Creation time. |
 
-**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `DOMAIN_RULE_VIOLATION`
+**Error codes:** `VALIDATION_FAILED`, `NOT_FOUND`, `REFUND_ALREADY_IN_PROGRESS`, `ORDER_NOT_REFUNDABLE`, `DOMAIN_RULE_VIOLATION`
 
 ### Evaluate Post-Sales Eligibility
 
@@ -57,7 +57,7 @@ timestamps, and Money.
 | `refundableAmount` | object | Amount refundable (Money). |
 | `amountDue` | object | Amount due (Money). |
 
-**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `UNAVAILABLE`
+**Error codes:** `NOT_FOUND`, `ORDER_NOT_REFUNDABLE`, `PRECONDITION_FAILED`, `UNAVAILABLE`
 
 ### Approve Post-Sales Case
 
@@ -72,7 +72,7 @@ timestamps, and Money.
 | `caseId` | string | Case ID. |
 | `status` | enum | `APPROVED` |
 
-**Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`
+**Error codes:** `NOT_FOUND`, `ORDER_NOT_REFUNDABLE`, `PRECONDITION_FAILED`
 
 ### Get Post-Sales Case
 

--- a/services/post-sales/migrations/001_post_sales_persistence.sql
+++ b/services/post-sales/migrations/001_post_sales_persistence.sql
@@ -6,6 +6,13 @@ CREATE TABLE IF NOT EXISTS post_sales_case_snapshots (
 );
 CREATE INDEX IF NOT EXISTS idx_post_sales_case_snapshots_idempotency_key ON post_sales_case_snapshots ((data->>'idempotencyKey'));
 CREATE INDEX IF NOT EXISTS idx_post_sales_case_snapshots_scope_order_items ON post_sales_case_snapshots USING gin ((data->'scope'->'orderItemRefs'));
+
+CREATE TABLE IF NOT EXISTS post_sales_active_refunds (
+  journey_order_id text PRIMARY KEY,
+  case_id text NOT NULL UNIQUE,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_post_sales_active_refunds_case_id ON post_sales_active_refunds(case_id);
 CREATE TABLE IF NOT EXISTS outbox (seq bigserial PRIMARY KEY, event_id text NOT NULL UNIQUE, stream text NOT NULL, envelope jsonb NOT NULL, created_at timestamptz NOT NULL DEFAULT now(), published_at timestamptz);
 CREATE INDEX IF NOT EXISTS idx_outbox_unpublished_seq ON outbox (seq) WHERE published_at IS NULL;
 CREATE TABLE IF NOT EXISTS processed_events (event_id text PRIMARY KEY, stream text, processed_at timestamptz NOT NULL DEFAULT now());

--- a/services/post-sales/src/main/java/com/trainticket/postsales/api/PostSalesExceptionHandler.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/api/PostSalesExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.trainticket.postsales.api;
+
+import com.trainticket.platformkit.http.ApiError;
+import com.trainticket.platformkit.http.CorrelationIds;
+import com.trainticket.postsales.application.OrderNotRefundableException;
+import com.trainticket.postsales.application.PostSalesConcurrencyException;
+import com.trainticket.postsales.application.RefundAlreadyInProgressException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackageClasses = PostSalesController.class)
+public class PostSalesExceptionHandler {
+    @ExceptionHandler(RefundAlreadyInProgressException.class)
+    public ResponseEntity<ApiError> handleRefundAlreadyInProgress(RefundAlreadyInProgressException exception, HttpServletRequest request) {
+        Map<String, ?> details = exception.existingCaseId() == null ? Map.of() : Map.of("existingCaseId", prefixed(exception.existingCaseId()));
+        return error(HttpStatus.CONFLICT, "REFUND_ALREADY_IN_PROGRESS", exception.getMessage(), request, details);
+    }
+
+    @ExceptionHandler(PostSalesConcurrencyException.class)
+    public ResponseEntity<ApiError> handleConcurrency(PostSalesConcurrencyException exception, HttpServletRequest request) {
+        return error(HttpStatus.CONFLICT, "REFUND_ALREADY_IN_PROGRESS", exception.getMessage(), request, Map.of());
+    }
+
+    @ExceptionHandler(OrderNotRefundableException.class)
+    public ResponseEntity<ApiError> handleOrderNotRefundable(OrderNotRefundableException exception, HttpServletRequest request) {
+        return error(HttpStatus.UNPROCESSABLE_ENTITY, "ORDER_NOT_REFUNDABLE", exception.getMessage(), request, Map.of());
+    }
+
+    private static ResponseEntity<ApiError> error(HttpStatus status, String code, String message, HttpServletRequest request, Map<String, ?> details) {
+        return ResponseEntity.status(status).body(new ApiError(code, message, CorrelationIds.from(request), details));
+    }
+
+    private static String prefixed(String caseId) {
+        return caseId == null || caseId.startsWith("psc-") ? caseId : "psc-" + caseId;
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/InMemoryPostSalesRepository.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/InMemoryPostSalesRepository.java
@@ -1,6 +1,9 @@
 package com.trainticket.postsales.application;
 
+import com.trainticket.platformkit.persistence.OptimisticConcurrencyException;
 import com.trainticket.postsales.domain.PostSalesCase;
+import com.trainticket.postsales.domain.PostSalesCaseStatus;
+import com.trainticket.postsales.domain.PostSalesCaseType;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -10,11 +13,27 @@ import org.springframework.stereotype.Repository;
 public class InMemoryPostSalesRepository implements PostSalesRepository {
     private final ConcurrentMap<String, PostSalesCase> byId = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, String> caseIdByIdempotencyKey = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, String> activeRefundCaseIdByOrderId = new ConcurrentHashMap<>();
 
     @Override
     public void save(PostSalesCase postSalesCase) {
-        byId.put(postSalesCase.caseId(), postSalesCase);
+        if (isRefundConflictCase(postSalesCase) && isActive(postSalesCase)) {
+            String existingCaseId = activeRefundCaseIdByOrderId.putIfAbsent(postSalesCase.journeyOrderId(), postSalesCase.caseId());
+            if (existingCaseId != null && !existingCaseId.equals(postSalesCase.caseId())) {
+                throw new RefundAlreadyInProgressException(existingCaseId);
+            }
+        }
+        if (postSalesCase.version() == 0 && byId.putIfAbsent(postSalesCase.caseId(), postSalesCase) != null) {
+            throw new OptimisticConcurrencyException("snapshot version conflict for " + postSalesCase.caseId());
+        }
+        if (postSalesCase.version() > 0 && byId.replace(postSalesCase.caseId(), postSalesCase) == null) {
+            throw new OptimisticConcurrencyException("snapshot version conflict for " + postSalesCase.caseId());
+        }
+        postSalesCase.withVersion(postSalesCase.version() + 1);
         caseIdByIdempotencyKey.put(postSalesCase.idempotencyKey(), postSalesCase.caseId());
+        if (isRefundConflictCase(postSalesCase) && !isActive(postSalesCase)) {
+            activeRefundCaseIdByOrderId.remove(postSalesCase.journeyOrderId(), postSalesCase.caseId());
+        }
     }
 
     @Override
@@ -28,7 +47,25 @@ public class InMemoryPostSalesRepository implements PostSalesRepository {
     }
 
     @Override
+    public Optional<PostSalesCase> findActiveRefundCaseForOrder(String journeyOrderId) {
+        return Optional.ofNullable(activeRefundCaseIdByOrderId.get(journeyOrderId)).flatMap(this::findById);
+    }
+
+    @Override
     public java.util.List<PostSalesCase> findAll() {
         return java.util.List.copyOf(byId.values());
+    }
+
+    private static boolean isRefundConflictCase(PostSalesCase postSalesCase) {
+        return postSalesCase.caseType() == PostSalesCaseType.REFUND
+            || postSalesCase.caseType() == PostSalesCaseType.CANCELLATION
+            || postSalesCase.caseType() == PostSalesCaseType.REBOOK
+            || postSalesCase.caseType() == PostSalesCaseType.CHANGE;
+    }
+
+    private static boolean isActive(PostSalesCase postSalesCase) {
+        return postSalesCase.status() != PostSalesCaseStatus.REJECTED
+            && postSalesCase.status() != PostSalesCaseStatus.CANCELLED
+            && postSalesCase.status() != PostSalesCaseStatus.FAILED;
     }
 }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/OrderNotRefundableException.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/OrderNotRefundableException.java
@@ -1,0 +1,7 @@
+package com.trainticket.postsales.application;
+
+public class OrderNotRefundableException extends RuntimeException {
+    public OrderNotRefundableException() {
+        super("Order is not in a refundable state");
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
@@ -7,10 +7,12 @@ import com.trainticket.postsales.domain.DecisionKind;
 import com.trainticket.postsales.domain.Money;
 import com.trainticket.postsales.domain.PostSalesCase;
 import com.trainticket.postsales.domain.PostSalesCaseType;
+import com.trainticket.postsales.domain.PostSalesCaseStatus;
 import com.trainticket.postsales.domain.PostSalesDecision;
 import com.trainticket.postsales.domain.PostSalesEvent;
 import com.trainticket.postsales.domain.PostSalesScope;
 import com.trainticket.postsales.domain.RuleEvaluationSnapshot;
+import com.trainticket.platformkit.persistence.OptimisticConcurrencyException;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
@@ -36,27 +38,14 @@ public class PostSalesApplicationService {
 
     public PostSalesCase open(OpenCaseCommand command) {
         return repository.findByIdempotencyKey(command.idempotencyKey())
-            .orElseGet(() -> {
-                Instant now = clock.instant();
-                PostSalesCase postSalesCase = PostSalesCase.open(
-                    command.journeyOrderId(),
-                    command.caseType(),
-                    command.scope(),
-                    command.reasonCode(),
-                    command.actorRef(),
-                    command.commandId(),
-                    now,
-                    command.commandId(),
-                    command.correlationId()
-                );
-                repository.save(postSalesCase);
-                publishNewEvents(postSalesCase);
-                return postSalesCase;
-            });
+            .orElseGet(() -> openNewCase(command));
     }
 
     public PostSalesCase evaluate(String caseId, String sourceCommandId, String correlationId) {
         PostSalesCase postSalesCase = get(caseId);
+        if (isTerminalNonRefundable(postSalesCase)) {
+            throw new OrderNotRefundableException();
+        }
         if (postSalesCase.decision() != null) {
             return postSalesCase;
         }
@@ -78,6 +67,9 @@ public class PostSalesApplicationService {
 
     public PostSalesCase approve(String caseId, String sourceCommandId, String correlationId) {
         PostSalesCase postSalesCase = get(caseId);
+        if (isTerminalNonRefundable(postSalesCase)) {
+            throw new OrderNotRefundableException();
+        }
         if (postSalesCase.status().name().equals("APPROVED")) {
             return postSalesCase;
         }
@@ -94,6 +86,48 @@ public class PostSalesApplicationService {
     public PostSalesCase get(String caseId) {
         return repository.findById(PostSalesMapper.stripCasePrefix(caseId))
             .orElseThrow(() -> new CaseNotFoundException(caseId));
+    }
+
+
+    private PostSalesCase openNewCase(OpenCaseCommand command) {
+        if (requiresExclusiveRefundSlot(command.caseType())) {
+            repository.findActiveRefundCaseForOrder(command.journeyOrderId())
+                .ifPresent(existing -> {
+                    throw new RefundAlreadyInProgressException(existing.caseId());
+                });
+        }
+        Instant now = clock.instant();
+        PostSalesCase postSalesCase = PostSalesCase.open(
+            command.journeyOrderId(),
+            command.caseType(),
+            command.scope(),
+            command.reasonCode(),
+            command.actorRef(),
+            command.idempotencyKey(),
+            now,
+            command.commandId(),
+            command.correlationId()
+        );
+        try {
+            repository.save(postSalesCase);
+        } catch (OptimisticConcurrencyException exception) {
+            throw new PostSalesConcurrencyException("Concurrent post-sales update conflicted", exception);
+        }
+        publishNewEvents(postSalesCase);
+        return postSalesCase;
+    }
+
+    private static boolean requiresExclusiveRefundSlot(PostSalesCaseType caseType) {
+        return caseType == PostSalesCaseType.REFUND
+            || caseType == PostSalesCaseType.CANCELLATION
+            || caseType == PostSalesCaseType.REBOOK
+            || caseType == PostSalesCaseType.CHANGE;
+    }
+
+    private static boolean isTerminalNonRefundable(PostSalesCase postSalesCase) {
+        return postSalesCase.status() == PostSalesCaseStatus.REJECTED
+            || postSalesCase.status() == PostSalesCaseStatus.CANCELLED
+            || postSalesCase.status() == PostSalesCaseStatus.FAILED;
     }
 
     private PostSalesDecision decisionFor(PostSalesCase postSalesCase, Instant now) {

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesConcurrencyException.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesConcurrencyException.java
@@ -1,0 +1,7 @@
+package com.trainticket.postsales.application;
+
+public class PostSalesConcurrencyException extends RuntimeException {
+    public PostSalesConcurrencyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesRepository.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesRepository.java
@@ -7,5 +7,6 @@ public interface PostSalesRepository {
     void save(PostSalesCase postSalesCase);
     Optional<PostSalesCase> findById(String caseId);
     Optional<PostSalesCase> findByIdempotencyKey(String idempotencyKey);
+    Optional<PostSalesCase> findActiveRefundCaseForOrder(String journeyOrderId);
     java.util.List<PostSalesCase> findAll();
 }

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/RefundAlreadyInProgressException.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/RefundAlreadyInProgressException.java
@@ -1,0 +1,14 @@
+package com.trainticket.postsales.application;
+
+public class RefundAlreadyInProgressException extends RuntimeException {
+    private final String existingCaseId;
+
+    public RefundAlreadyInProgressException(String existingCaseId) {
+        super("A refund or change case is already in progress for this order");
+        this.existingCaseId = existingCaseId;
+    }
+
+    public String existingCaseId() {
+        return existingCaseId;
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/PostgresPostSalesRepository.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/PostgresPostSalesRepository.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.trainticket.platformkit.persistence.SnapshotRepository;
+import com.trainticket.postsales.application.RefundAlreadyInProgressException;
 import com.trainticket.postsales.application.PostSalesRepository;
 import com.trainticket.postsales.domain.*;
 import java.time.Instant;
@@ -34,8 +35,14 @@ public class PostgresPostSalesRepository implements PostSalesRepository {
     }
 
     @Override public void save(PostSalesCase postSalesCase) {
+        if (isRefundConflictCase(postSalesCase) && isActive(postSalesCase)) {
+            reserveActiveRefundSlot(postSalesCase);
+        }
         long version = snapshots.save(postSalesCase.caseId(), postSalesCase.version(), snapshot(postSalesCase));
         postSalesCase.withVersion(version);
+        if (isRefundConflictCase(postSalesCase) && !isActive(postSalesCase)) {
+            releaseActiveRefundSlot(postSalesCase);
+        }
     }
 
     @Override public Optional<PostSalesCase> findById(String caseId) {
@@ -46,8 +53,56 @@ public class PostgresPostSalesRepository implements PostSalesRepository {
         return jdbc.query("SELECT id FROM post_sales_case_snapshots WHERE data->>'idempotencyKey' = ? LIMIT 1", rs -> rs.next() ? findById(rs.getString("id")) : Optional.empty(), idempotencyKey);
     }
 
+    @Override public Optional<PostSalesCase> findActiveRefundCaseForOrder(String journeyOrderId) {
+        return jdbc.query("""
+            SELECT s.id
+              FROM post_sales_active_refunds a
+              JOIN post_sales_case_snapshots s ON s.id = a.case_id
+             WHERE a.journey_order_id = ?
+             LIMIT 1
+            """, rs -> rs.next() ? findById(rs.getString("id")) : Optional.empty(), journeyOrderId);
+    }
+
     @Override public List<PostSalesCase> findAll() {
         return jdbc.query("SELECT version, data::text AS data FROM post_sales_case_snapshots", (rs, rowNum) -> toCase(readSnapshot(rs.getString("data"))).withVersion(rs.getLong("version")));
+    }
+
+
+    private void reserveActiveRefundSlot(PostSalesCase postSalesCase) {
+        try {
+            jdbc.update(
+                "INSERT INTO post_sales_active_refunds (journey_order_id, case_id) VALUES (?, ?) ON CONFLICT (journey_order_id) DO UPDATE SET case_id = EXCLUDED.case_id, updated_at = now() WHERE post_sales_active_refunds.case_id = EXCLUDED.case_id",
+                postSalesCase.journeyOrderId(),
+                postSalesCase.caseId()
+            );
+        } catch (org.springframework.dao.DuplicateKeyException exception) {
+            throw new RefundAlreadyInProgressException(existingActiveRefundCaseId(postSalesCase.journeyOrderId()).orElse(null));
+        }
+        String reservedCaseId = existingActiveRefundCaseId(postSalesCase.journeyOrderId()).orElse(null);
+        if (!postSalesCase.caseId().equals(reservedCaseId)) {
+            throw new RefundAlreadyInProgressException(reservedCaseId);
+        }
+    }
+
+    private void releaseActiveRefundSlot(PostSalesCase postSalesCase) {
+        jdbc.update("DELETE FROM post_sales_active_refunds WHERE journey_order_id = ? AND case_id = ?", postSalesCase.journeyOrderId(), postSalesCase.caseId());
+    }
+
+    private Optional<String> existingActiveRefundCaseId(String journeyOrderId) {
+        return jdbc.query("SELECT case_id FROM post_sales_active_refunds WHERE journey_order_id = ?", rs -> rs.next() ? Optional.of(rs.getString("case_id")) : Optional.empty(), journeyOrderId);
+    }
+
+    private static boolean isRefundConflictCase(PostSalesCase postSalesCase) {
+        return postSalesCase.caseType() == PostSalesCaseType.REFUND
+            || postSalesCase.caseType() == PostSalesCaseType.CANCELLATION
+            || postSalesCase.caseType() == PostSalesCaseType.REBOOK
+            || postSalesCase.caseType() == PostSalesCaseType.CHANGE;
+    }
+
+    private static boolean isActive(PostSalesCase postSalesCase) {
+        return postSalesCase.status() != PostSalesCaseStatus.REJECTED
+            && postSalesCase.status() != PostSalesCaseStatus.CANCELLED
+            && postSalesCase.status() != PostSalesCaseStatus.FAILED;
     }
 
     private PostSalesSnapshot readSnapshot(String json) {

--- a/services/post-sales/src/test/java/com/trainticket/postsales/api/PostSalesControllerTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/api/PostSalesControllerTest.java
@@ -9,6 +9,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,6 +24,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import com.trainticket.postsales.application.PostSalesRepository;
+import com.trainticket.postsales.domain.PostSalesCase;
+import com.trainticket.postsales.domain.PostSalesCaseType;
+import com.trainticket.postsales.domain.PostSalesScope;
 
 @SpringBootTest(properties = "post-sales.messaging.redis.enabled=false")
 class PostSalesControllerTest {
@@ -28,8 +39,12 @@ class PostSalesControllerTest {
     private static final String REUSED_KEY = "01890f47-9b7c-7cc2-98c4-dc0c0c073006";
     private static final String GENERATED_CORRELATION_KEY = "01890f47-9b7c-7cc2-98c4-dc0c0c073007";
     private static final String UUID4_KEY = "550e8400-e29b-41d4-a716-446655440000";
+    private static final String CONFLICT_KEY = "01890f47-9b7c-7cc2-98c4-dc0c0c073008";
+    private static final String CHANGE_RACE_KEY = "01890f47-9b7c-7cc2-98c4-dc0c0c073009";
 
     private MockMvc mockMvc;
+    @Autowired
+    private PostSalesRepository repository;
 
     @Autowired
     void setApplicationContext(WebApplicationContext context) {
@@ -91,15 +106,15 @@ class PostSalesControllerTest {
 
     @Test
     void idempotentReplayReturnsOriginalOpenResult() throws Exception {
-        MvcResult first = openCase(REPLAY_KEY).andExpect(status().isCreated()).andReturn();
-        openCase(REPLAY_KEY)
+        MvcResult first = openCase(REPLAY_KEY, "ord-replay-1").andExpect(status().isCreated()).andReturn();
+        openCase(REPLAY_KEY, "ord-replay-1")
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.caseId", equalTo(first.getResponse().getContentAsString().split("\"caseId\":\"")[1].split("\"")[0])));
     }
 
     @Test
     void idempotencyKeyReuseWithDifferentBodyReturns422() throws Exception {
-        openCase(REUSED_KEY).andExpect(status().isCreated());
+        openCase(REUSED_KEY, "ord-reused-1").andExpect(status().isCreated());
 
         mockMvc.perform(post("/api/v1/post-sales-cases")
                 .header("Idempotency-Key", REUSED_KEY)
@@ -122,6 +137,85 @@ class PostSalesControllerTest {
             .andExpect(status().isUnprocessableEntity())
             .andExpect(jsonPath("$.code", equalTo("IDEMPOTENCY_KEY_REUSED")))
             .andExpect(jsonPath("$.correlationId", equalTo("corr-test-1")));
+    }
+
+
+    @Test
+    void differentIdempotencyKeyForSameRefundOrderReturns409() throws Exception {
+        openCase(CONFLICT_KEY, "ord-conflict-1").andExpect(status().isCreated());
+
+        openCase("01890f47-9b7c-7cc2-98c4-dc0c0c073010", "ord-conflict-1")
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code", equalTo("REFUND_ALREADY_IN_PROGRESS")))
+            .andExpect(jsonPath("$.details.existingCaseId", notNullValue()));
+    }
+
+    @Test
+    void refundAndChangeRaceUsesSameOrderConflictSlot() throws Exception {
+        openCase(CHANGE_RACE_KEY, "ord-change-race-1").andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/v1/post-sales-cases")
+                .header("Idempotency-Key", "01890f47-9b7c-7cc2-98c4-dc0c0c073011")
+                .header("X-Correlation-Id", "corr-test-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(openCaseJson("ord-change-race-1", "CHANGE")))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code", equalTo("REFUND_ALREADY_IN_PROGRESS")));
+    }
+
+    @Test
+    void concurrentRefundsForSameOrderAllowExactlyOneSuccess() throws Exception {
+        int workers = 8;
+        CountDownLatch start = new CountDownLatch(1);
+        var executor = Executors.newFixedThreadPool(workers);
+        List<Callable<Integer>> calls = new ArrayList<>();
+        for (int i = 0; i < workers; i++) {
+            final int index = i;
+            calls.add(() -> {
+                start.await(5, TimeUnit.SECONDS);
+                return mockMvc.perform(post("/api/v1/post-sales-cases")
+                        .header("Idempotency-Key", "01890f47-9b7c-7cc2-98c4-dc0c0c0731%02d".formatted(index))
+                        .header("X-Correlation-Id", "corr-concurrent")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(openCaseJson("ord-concurrent-refund-1", "REFUND")))
+                    .andReturn().getResponse().getStatus();
+            });
+        }
+
+        var futures = calls.stream().map(executor::submit).toList();
+        start.countDown();
+        List<Integer> statuses = new ArrayList<>();
+        for (var future : futures) {
+            statuses.add(future.get(10, TimeUnit.SECONDS));
+        }
+        executor.shutdownNow();
+
+        org.junit.jupiter.api.Assertions.assertEquals(1, statuses.stream().filter(status -> status == 201).count());
+        org.junit.jupiter.api.Assertions.assertEquals(workers - 1, statuses.stream().filter(status -> status == 409).count());
+    }
+
+
+    @Test
+    void evaluatingNonRefundableCaseReturns422MachineCode() throws Exception {
+        PostSalesCase postSalesCase = PostSalesCase.open(
+            "ord-non-refundable-1",
+            PostSalesCaseType.REFUND,
+            PostSalesScope.ticket("oi-non-refundable-1", "seg-non-refundable-1", "tvl-non-refundable-1", "ent-non-refundable-1"),
+            "CUSTOMER_REQUEST",
+            "acct-test-1",
+            "01890f47-9b7c-7cc2-98c4-dc0c0c073012",
+            Instant.parse("2026-07-05T10:30:00Z"),
+            "cmd-non-refundable",
+            "corr-test-1"
+        );
+        postSalesCase.reject("RULE_BLOCKED", Instant.parse("2026-07-05T10:31:00Z"), "cmd-reject", "cmd-non-refundable", "corr-test-1");
+        repository.save(postSalesCase);
+
+        mockMvc.perform(post("/api/v1/post-sales-cases/{caseId}/evaluate", "psc-" + postSalesCase.caseId())
+                .header("Idempotency-Key", "01890f47-9b7c-7cc2-98c4-dc0c0c073013")
+                .header("X-Correlation-Id", "corr-test-1"))
+            .andExpect(status().isUnprocessableEntity())
+            .andExpect(jsonPath("$.code", equalTo("ORDER_NOT_REFUNDABLE")));
     }
 
     @Test
@@ -205,14 +299,22 @@ class PostSalesControllerTest {
     }
 
     private org.springframework.test.web.servlet.ResultActions openCase(String idempotencyKey) throws Exception {
+        return openCase(idempotencyKey, "ord-test-1");
+    }
+
+    private org.springframework.test.web.servlet.ResultActions openCase(String idempotencyKey, String orderId) throws Exception {
         return mockMvc.perform(post("/api/v1/post-sales-cases")
             .header("Idempotency-Key", idempotencyKey)
             .header("X-Correlation-Id", "corr-test-1")
             .contentType(MediaType.APPLICATION_JSON)
-            .content("""
+            .content(openCaseJson(orderId, "REFUND")));
+    }
+
+    private static String openCaseJson(String orderId, String caseType) {
+        return """
                 {
-                  "journeyOrderId": "ord-test-1",
-                  "caseType": "REFUND",
+                  "journeyOrderId": "%s",
+                  "caseType": "%s",
                   "scope": {
                     "orderItemRefs": ["oi-test-1"],
                     "segmentRefs": ["seg-test-1"],
@@ -222,6 +324,6 @@ class PostSalesControllerTest {
                   "reasonCode": "CUSTOMER_REQUEST",
                   "actorRef": "acct-test-1"
                 }
-                """));
+                """.formatted(orderId, caseType);
     }
 }


### PR DESCRIPTION
## Summary
AgentM/GPT REQ-202: Harden post-sales for concurrent refund storms (S3 scenario).

- **One active refund per order**: atomic DB reservation prevents parallel refunds
- **409 REFUND_ALREADY_IN_PROGRESS**: concurrent duplicate refund requests
- **422 ORDER_NOT_REFUNDABLE**: non-refundable order states
- **Idempotency-key replay**: same key returns original case without double-effect
- `post_sales_active_refunds` table with unique order constraint
- Expanded controller tests for concurrency scenarios

## Test plan
- [x] `PostSalesControllerTest` covers concurrent refund, duplicate, and idempotency
- [ ] S3 refund storm scenario with 10% duplicate submissions

🤖 Generated with [Claude Code](https://claude.com/claude-code) + AgentM/GPT