### PR TITLE
feat(risk+loadgen): scalper anti-detection evasion + risk threshold tuning

### DIFF
--- a/deploy/loadgen/loadgen.py
+++ b/deploy/loadgen/loadgen.py
@@ -1361,11 +1361,11 @@ class ScalperSim:
     """Simulates a ticket scalper who grabs tickets as fast as possible.
 
     Key differences from a regular customer:
-    - Zero think time between API calls
-    - Targets only the first N bootstrap segments (hottest routes)
-    - Rotates through a pool of pre-registered accounts
-    - Retries immediately on purchase failure
-    - Keeps buying the same segment until capacity is exhausted
+    - Mostly bursty pacing with occasional slowdowns to evade simple rate limits
+    - Diversifies across multiple bootstrap segments/routes
+    - Rotates through a pool of pre-registered accounts and source IPs
+    - Mixes browser/session fingerprints between grab attempts
+    - Retries quickly on purchase failure
     - Never triggers post-purchase journeys (hoarding)
     - Pre-generates identity documents to avoid verification delays
     """
@@ -1385,16 +1385,25 @@ class ScalperSim:
         self.redis = aioredis.from_url(cfg["target"]["redis_url"], decode_responses=True)
 
         self.accounts_per_worker = int(self.scalper_cfg.get("accounts_per_worker", 5))
-        self.target_segment_count = int(self.scalper_cfg.get("target_segments", 2))
+        self.target_segment_count = int(self.scalper_cfg.get("target_segments", 8))
         self.retry_on_failure = float(self.scalper_cfg.get("retry_on_failure", 0.8))
         self.retry_same_key = bool(self.scalper_cfg.get("retry_same_key", True))
         self.batch_size = int(self.scalper_cfg.get("purchase_batch_size", 4))
         self.ip_pool = self._build_ip_pool()
         self.ip_cursor = worker_idx % len(self.ip_pool)
         self.current_ip: str | None = None
-        self.user_agent = self._pick_user_agent()
+        self.user_agents = self._build_user_agents()
+        self.fingerprints = self._build_fingerprints()
+        self.current_fingerprint: dict[str, str] | None = None
         self.burst_gap_seconds = max(
             0.0, float(self.scalper_cfg.get("burst_gap_ms", 50)) / 1000.0)
+        self.slowdown_probability = max(
+            0.0, min(1.0, float(self.scalper_cfg.get("slowdown_probability", 0.12))))
+        self.slowdown_min_seconds = max(
+            0.0, float(self.scalper_cfg.get("slowdown_min_ms", 250)) / 1000.0)
+        self.slowdown_max_seconds = max(
+            self.slowdown_min_seconds,
+            float(self.scalper_cfg.get("slowdown_max_ms", 1600)) / 1000.0)
 
         # runtime state filled by prepare()
         self.account_pool: list[dict] = []
@@ -1415,7 +1424,7 @@ class ScalperSim:
         start = int(self.scalper_cfg.get("ip_start", 10))
         return [f"{prefix}.{start + offset}" for offset in range(pool_size)]
 
-    def _pick_user_agent(self) -> str:
+    def _build_user_agents(self) -> list[str]:
         configured = self.scalper_cfg.get("user_agents")
         if isinstance(configured, list):
             agents = [str(agent).strip() for agent in configured if str(agent).strip()]
@@ -1435,8 +1444,31 @@ class ScalperSim:
                 "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 "
                 "(KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36",
             ]
-        base_agent = agents[self.worker_idx % len(agents)]
-        return f"{base_agent} tt-scalper/{self.worker_idx}"
+        return agents
+
+    def _build_fingerprints(self) -> list[dict[str, str]]:
+        languages = ["zh-CN,zh;q=0.9", "zh-CN,zh;q=0.8,en;q=0.6", "en-US,en;q=0.7"]
+        platforms = ['"Windows"', '"macOS"', '"Linux"', '"Android"', '"iOS"']
+        fingerprints = []
+        pool_size = max(len(self.user_agents), int(self.scalper_cfg.get("fingerprint_pool_size", 12)))
+        for index in range(pool_size):
+            user_agent = self.user_agents[(self.worker_idx + index) % len(self.user_agents)]
+            session_id = uuid7().replace("-", "")[:20]
+            fingerprints.append({
+                "User-Agent": user_agent,
+                "Accept-Language": languages[index % len(languages)],
+                "Sec-CH-UA-Platform": platforms[index % len(platforms)],
+                "DNT": "1" if index % 3 == 0 else "0",
+                "Cookie": f"tt_session={session_id}; tt_fp={hashlib.sha256(session_id.encode()).hexdigest()[:16]}",
+            })
+        return fingerprints
+
+    def _mix_session_fingerprint(self) -> None:
+        base = dict(self.rng.choice(self.fingerprints))
+        nonce = uuid7().replace("-", "")[:10]
+        base["Cookie"] = f"{base['Cookie']}; tt_try={nonce}"
+        base["X-Client-Trace"] = f"sc-{self.worker_idx}-{nonce}"
+        self.current_fingerprint = base
 
     def _next_headers(self, headers: dict | None = None) -> dict:
         next_ip = self.ip_pool[self.ip_cursor % len(self.ip_pool)]
@@ -1445,9 +1477,9 @@ class ScalperSim:
             self.stats.scalper_ip_rotations += 1
         self.current_ip = next_ip
 
-        merged = dict(headers or {})
+        merged = dict(self.current_fingerprint or self.rng.choice(self.fingerprints))
+        merged.update(headers or {})
         merged["X-Forwarded-For"] = next_ip
-        merged["User-Agent"] = self.user_agent
         return merged
 
     async def request(self, *args: Any, **kwargs: Any) -> tuple[int, Any]:
@@ -1455,6 +1487,9 @@ class ScalperSim:
         return await self.api.request(*args, headers=headers, **kwargs)
 
     async def burst_pause(self) -> None:
+        if self.rng.random() < self.slowdown_probability:
+            await asyncio.sleep(self.rng.uniform(self.slowdown_min_seconds, self.slowdown_max_seconds))
+            return
         if self.burst_gap_seconds <= 0:
             return
         await asyncio.sleep(self.rng.uniform(0.0, self.burst_gap_seconds))
@@ -1483,10 +1518,29 @@ class ScalperSim:
             self.identity_cache[tvl] = identity_refs
             self.account_pool.append(entry)
 
-        # select the hottest segments (first N bootstrap routes)
+        # select a diversified target set instead of hammering only the first hot routes.
         async with self.reg.lock:
             routes = list(self.reg.routes)
-        self.target_segments = routes[:self.target_segment_count] if routes else []
+        self.target_segments = self._diversified_segments(routes)
+
+    def _diversified_segments(self, routes: list[dict]) -> list[dict]:
+        if not routes:
+            return []
+        buckets: dict[tuple[str, str], list[dict]] = defaultdict(list)
+        for route in routes:
+            key = (str(route.get("origin_place", "")), str(route.get("dest_place", "")))
+            buckets[key].append(route)
+        diversified: list[dict] = []
+        while len(diversified) < self.target_segment_count and buckets:
+            for key in list(buckets):
+                bucket = buckets[key]
+                if bucket:
+                    diversified.append(bucket.pop(0))
+                    if len(diversified) >= self.target_segment_count:
+                        break
+                if not bucket:
+                    del buckets[key]
+        return diversified
 
     def next_account(self) -> dict:
         """Round-robin through the account pool."""
@@ -1635,6 +1689,7 @@ class ScalperSim:
         confirm.  Zero think time and no staff workers.
         """
         self.stats.scalper_attempts += 1
+        self._mix_session_fingerprint()
         acct = self.next_account()
         tvl = acct["travelers"][0] if acct["travelers"] else None
         if tvl is None:
@@ -1643,9 +1698,13 @@ class ScalperSim:
         if not self.target_segments:
             raise StepFailed("scalper-grab", "no target segments available")
         seg_route = self.target_segments[self.current_target % len(self.target_segments)]
+        if self.rng.random() < 0.25:
+            self.current_target = self.rng.randrange(len(self.target_segments))
+        else:
+            self.current_target = (self.current_target + 1) % len(self.target_segments)
 
         channel = "WEB"
-        # search -- zero think time
+        # search -- bursty pacing with occasional slowdown
         _, search_data = await self.request(
             "POST", "trip-planning", "/api/v1/itineraries/search",
             {"originRef": seg_route["origin_place"],
@@ -1667,7 +1726,7 @@ class ScalperSim:
                  "origin_node": leg.get("originStopRef") or seg_route.get("origin_node"),
                  "dest_node": leg.get("destinationStopRef") or seg_route.get("dest_node")}
 
-        # quote -- no think time, no abandonment
+        # quote -- no abandonment, evasive pacing
         _, fare_quote = await self.request(
             "POST", "fare-pricing", "/api/v1/fare-quotes",
             {"travelerRefs": [tvl], "channel": channel,
@@ -1718,7 +1777,7 @@ class ScalperSim:
             self.current_target += 1
             return "capacity_exhausted"
 
-        # payment -- zero think time
+        # payment -- evasive pacing
         total_minor = int(offer["total"]["minorUnits"])
         _, intent = await self.request(
             "POST", "payment", "/api/v1/payment-intents",
@@ -1789,8 +1848,7 @@ async def scalper_worker(idx: int, cfg: dict, sim: ScalperSim,
                     except asyncio.TimeoutError:
                         # refresh targets from registry
                         async with sim.reg.lock:
-                            sim.target_segments = list(sim.reg.routes)[
-                                :sim.target_segment_count]
+                            sim.target_segments = sim._diversified_segments(list(sim.reg.routes))
                         sim.current_target = 0
                     break
             except StepFailed as exc:
@@ -1803,7 +1861,7 @@ async def scalper_worker(idx: int, cfg: dict, sim: ScalperSim,
                 stats.journeys["scalper:crashed"] += 1
                 print(f"[scalper{idx}] crashed — {type(exc).__name__}: {str(exc)[:180]}")
                 break
-        # tight burst pacing: tiny randomized pause before the next batch.
+        # burst pacing: tiny randomized pause before the next batch.
         if not stop.is_set():
             timeout = sim.rng.uniform(0.0, sim.burst_gap_seconds)
             if timeout <= 0:

--- a/services/risk-compliance/src/risk_compliance/adapters/storage/postgres.py
+++ b/services/risk-compliance/src/risk_compliance/adapters/storage/postgres.py
@@ -6,7 +6,14 @@ from contextvars import ContextVar
 from datetime import UTC, datetime
 from typing import Any, Mapping
 
-from risk_compliance.application import AssessmentNotFoundError, BlockNotFoundError, FREQUENCY_WINDOW, RiskAssessmentResult, RiskBlockApplied
+from risk_compliance.application import (
+    AssessmentNotFoundError,
+    BlockNotFoundError,
+    FREQUENCY_WINDOW,
+    IP_FREQUENCY_DECAY_HALF_LIFE,
+    RiskAssessmentResult,
+    RiskBlockApplied,
+)
 from train_ticket_platform.events import EventEnvelope
 from train_ticket_platform.storage import OutboxAppender, ProcessedEventsGuard, SnapshotRepository
 
@@ -189,17 +196,22 @@ class PostgresAssessmentRepository:
             return int(row[0])
         return self.with_connection(write)
 
-    def record_ip_order_attempt(self, source_ip: str, account_id: str, occurred_at: datetime) -> tuple[int, int]:
+    def record_ip_order_attempt(self, source_ip: str, account_id: str, occurred_at: datetime) -> tuple[int, float, int]:
         occurred_at = _coerce_dt(occurred_at)
         window_start = occurred_at - FREQUENCY_WINDOW
-        def write(conn: Any) -> tuple[int, int]:
+        def write(conn: Any) -> tuple[int, float, int]:
             conn.execute(
                 "INSERT INTO risk_ip_order_attempts(source_ip, account_id, occurred_at) VALUES (%s, %s, %s) ON CONFLICT DO NOTHING",
                 (source_ip, account_id, occurred_at),
             )
-            row = conn.execute(
-                "SELECT count(*), count(DISTINCT account_id) FROM risk_ip_order_attempts WHERE source_ip = %s AND occurred_at >= %s AND occurred_at <= %s",
+            rows = conn.execute(
+                "SELECT account_id, occurred_at FROM risk_ip_order_attempts WHERE source_ip = %s AND occurred_at >= %s AND occurred_at <= %s",
                 (source_ip, window_start, occurred_at),
-            ).fetchone()
-            return int(row[0]), int(row[1])
+            ).fetchall()
+            half_life_seconds = IP_FREQUENCY_DECAY_HALF_LIFE.total_seconds()
+            weighted_attempts = sum(
+                0.5 ** ((occurred_at - _coerce_dt(row[1])).total_seconds() / half_life_seconds)
+                for row in rows
+            )
+            return len(rows), weighted_attempts, len({str(row[0]) for row in rows})
         return self.with_connection(write)

--- a/services/risk-compliance/src/risk_compliance/application.py
+++ b/services/risk-compliance/src/risk_compliance/application.py
@@ -30,7 +30,10 @@ SCHEMA_VERSION = 1
 DEFAULT_POLICY_VERSION = PolicyVersionRef(policy_set_id="risk-rules", version="1.0.0")
 FREQUENCY_WINDOW = timedelta(minutes=int(os.environ.get("RISK_FREQUENCY_WINDOW_MINUTES", "5")))
 FREQUENCY_THRESHOLD = int(os.environ.get("RISK_FREQUENCY_THRESHOLD", "2"))
-IP_FREQUENCY_THRESHOLD = int(os.environ.get("RISK_IP_FREQUENCY_THRESHOLD", "10"))
+IP_FREQUENCY_THRESHOLD = int(os.environ.get("RISK_IP_FREQUENCY_THRESHOLD", "25"))
+IP_FREQUENCY_DECAY_HALF_LIFE = timedelta(
+    seconds=max(1, int(os.environ.get("RISK_IP_FREQUENCY_DECAY_HALF_LIFE_SECONDS", "120")))
+)
 BLOCKING_DECISIONS = {Decision.DENY, Decision.CHALLENGE}
 BLOCKING_DECISION_VALUES = {decision.value for decision in BLOCKING_DECISIONS}
 RiskScenario: TypeAlias = str
@@ -206,21 +209,21 @@ class InMemoryAssessmentRepository:
         self._account_order_times[account_id] = attempts
         return len(attempts)
 
-    def record_ip_order_attempt(self, source_ip: str, account_id: str, occurred_at: datetime) -> tuple[int, int]:
+    def record_ip_order_attempt(self, source_ip: str, account_id: str, occurred_at: datetime) -> tuple[int, float, int]:
         attempts = [
             seen_at for seen_at in self._ip_order_times.get(source_ip, [])
-            if occurred_at - seen_at <= FREQUENCY_WINDOW
+            if timedelta(0) <= occurred_at - seen_at <= FREQUENCY_WINDOW
         ]
         attempts.append(occurred_at)
         self._ip_order_times[source_ip] = attempts
         accounts = {
             seen_account: seen_at
             for seen_account, seen_at in self._ip_accounts.get(source_ip, {}).items()
-            if occurred_at - seen_at <= FREQUENCY_WINDOW
+            if timedelta(0) <= occurred_at - seen_at <= FREQUENCY_WINDOW
         }
         accounts[account_id] = occurred_at
         self._ip_accounts[source_ip] = accounts
-        return len(attempts), len(accounts)
+        return len(attempts), _decayed_attempt_count(attempts, occurred_at), len(accounts)
 
 
 @dataclass(slots=True)
@@ -374,10 +377,16 @@ class RiskComplianceService:
         context["orderAttemptCount10m"] = self.repository.record_order_attempt(account_id, occurred_at)
         source_ip = _source_ip_from_envelope(envelope)
         if source_ip is not None:
-            ip_attempt_count, ip_account_count = self.repository.record_ip_order_attempt(source_ip, account_id, occurred_at)
             context["sourceIp"] = source_ip
-            context["sourceIpAttemptCount10m"] = ip_attempt_count
-            context["sourceIpAccountCount10m"] = ip_account_count
+            if _is_whitelisted_ip(source_ip):
+                context["sourceIpWhitelisted"] = True
+            else:
+                ip_attempt_count, ip_weighted_attempt_count, ip_account_count = self.repository.record_ip_order_attempt(
+                    source_ip, account_id, occurred_at
+                )
+                context["sourceIpAttemptCount10m"] = ip_attempt_count
+                context["sourceIpWeightedAttemptCount10m"] = round(ip_weighted_attempt_count, 3)
+                context["sourceIpAccountCount10m"] = ip_account_count
         assessment = assess_risk(
             assessment_id=assessment_id,
             subject_ref=order_id,
@@ -464,15 +473,19 @@ def _score(assessment: RiskAssessment) -> int:
     attempt_count = context.get("orderAttemptCount10m")
     if isinstance(attempt_count, int) and attempt_count > FREQUENCY_THRESHOLD:
         return 900
+    if context.get("sourceIpWhitelisted") is True:
+        digest = assessment.input_snapshot.digest
+        return int(digest[:8], 16) % 350
     ip_attempt_count = context.get("sourceIpAttemptCount10m")
-    if isinstance(ip_attempt_count, int) and ip_attempt_count > IP_FREQUENCY_THRESHOLD:
+    ip_weighted_attempt_count = context.get("sourceIpWeightedAttemptCount10m", ip_attempt_count)
+    if isinstance(ip_weighted_attempt_count, (int, float)) and ip_weighted_attempt_count > IP_FREQUENCY_THRESHOLD:
         return 900
     ip_account_count = context.get("sourceIpAccountCount10m")
     if (
         isinstance(ip_account_count, int)
-        and isinstance(ip_attempt_count, int)
-        and ip_account_count >= 3
-        and ip_attempt_count >= ip_account_count * 2
+        and isinstance(ip_weighted_attempt_count, (int, float))
+        and ip_account_count >= 5
+        and ip_weighted_attempt_count >= max(10.0, ip_account_count * 1.8)
     ):
         return 900
     digest = assessment.input_snapshot.digest
@@ -542,6 +555,32 @@ def _normalize_source_ip(value: str) -> str | None:
         return str(ipaddress.ip_address(first_hop))
     except ValueError:
         return None
+
+
+def _decayed_attempt_count(attempts: list[datetime], occurred_at: datetime) -> float:
+    half_life_seconds = IP_FREQUENCY_DECAY_HALF_LIFE.total_seconds()
+    return sum(0.5 ** ((occurred_at - seen_at).total_seconds() / half_life_seconds) for seen_at in attempts)
+
+
+def _ip_whitelist_ranges() -> tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...]:
+    ranges = []
+    for value in os.environ.get("RISK_IP_WHITELIST_CIDRS", "").split(","):
+        value = value.strip()
+        if not value:
+            continue
+        try:
+            ranges.append(ipaddress.ip_network(value, strict=False))
+        except ValueError:
+            continue
+    return tuple(ranges)
+
+
+def _is_whitelisted_ip(source_ip: str) -> bool:
+    try:
+        address = ipaddress.ip_address(source_ip)
+    except ValueError:
+        return False
+    return any(address in network for network in _ip_whitelist_ranges())
 
 
 def _required_payload_text(payload: Mapping[str, Any], field_name: str) -> str:

--- a/services/risk-compliance/tests/test_api_and_messaging.py
+++ b/services/risk-compliance/tests/test_api_and_messaging.py
@@ -517,14 +517,39 @@ def test_journey_order_created_blocks_ip_high_frequency_across_accounts() -> Non
         )
         service.handle_event(envelope)
 
+    last_assessment = publisher.envelopes[-1]
+    assert last_assessment.eventType == "RiskAssessmentResult"
+    assert last_assessment.payload["subjectRef"] == "ord-ip-frequency-10"
+    assert last_assessment.payload["decision"] == "ALLOW"
+    assert [event.eventType for event in publisher.envelopes].count("RiskBlockApplied") == 0
+
+    for index in range(15, 32):
+        envelope = journey_order_created_envelope(
+            f"evt-{uuid7()}",
+            f"ord-ip-frequency-{index}",
+            f"acct-ip-frequency-{index}",
+            "2026-07-05T10:30:00.000Z",
+        )
+        envelope = EventEnvelope(
+            eventId=envelope.eventId,
+            eventType=envelope.eventType,
+            occurredAt=envelope.occurredAt,
+            correlationId=envelope.correlationId,
+            causationId=envelope.causationId,
+            producer=envelope.producer,
+            schemaVersion=envelope.schemaVersion,
+            payload={**envelope.payload, "sourceIp": "203.0.113.10"},
+        )
+        service.handle_event(envelope)
+
     last_assessment = publisher.envelopes[-2]
     last_block = publisher.envelopes[-1]
     assert last_assessment.eventType == "RiskAssessmentResult"
-    assert last_assessment.payload["subjectRef"] == "ord-ip-frequency-10"
+    assert last_assessment.payload["subjectRef"] == "ord-ip-frequency-31"
     assert last_assessment.payload["score"] == 900
     assert last_assessment.payload["decision"] == "DENY"
     assert last_block.eventType == "RiskBlockApplied"
-    assert last_block.payload["subjectRef"] == "ord-ip-frequency-10"
+    assert last_block.payload["subjectRef"] == "ord-ip-frequency-31"
 
 
 def test_journey_order_created_correlates_multiple_accounts_sharing_ip_pattern() -> None:
@@ -532,8 +557,8 @@ def test_journey_order_created_correlates_multiple_accounts_sharing_ip_pattern()
     service = RiskComplianceService(publisher, InMemoryAssessmentRepository())
     source_ip = "203.0.113.11"
 
-    for index in range(6):
-        account_id = f"acct-shared-ip-{index % 3}"
+    for index in range(12):
+        account_id = f"acct-shared-ip-{index % 6}"
         envelope = journey_order_created_envelope(
             f"evt-{uuid7()}",
             f"ord-shared-ip-{index}",
@@ -555,7 +580,7 @@ def test_journey_order_created_correlates_multiple_accounts_sharing_ip_pattern()
     assert publisher.envelopes[-1].eventType == "RiskBlockApplied"
     last_assessment = publisher.envelopes[-2]
     assert last_assessment.eventType == "RiskAssessmentResult"
-    assert last_assessment.payload["subjectRef"] == "ord-shared-ip-5"
+    assert last_assessment.payload["subjectRef"] == "ord-shared-ip-11"
     assert last_assessment.payload["score"] == 900
     assert last_assessment.payload["decision"] == "DENY"
 
@@ -584,4 +609,67 @@ def test_journey_order_created_allows_low_frequency_distinct_ips() -> None:
         service.handle_event(envelope)
 
     assert [event.eventType for event in publisher.envelopes].count("RiskBlockApplied") == 0
-    assert all(event.payload["decision"] == "ALLOW" for event in publisher.envelopes)
+    assert all(
+        event.payload["decision"] == "ALLOW"
+        for event in publisher.envelopes
+        if event.eventType == "RiskAssessmentResult"
+    )
+
+
+def test_ip_frequency_uses_time_decay_for_older_attempts() -> None:
+    publisher = InMemoryEventPublisher()
+    service = RiskComplianceService(publisher, InMemoryAssessmentRepository())
+    source_ip = "203.0.113.40"
+
+    for index in range(30):
+        minute = index * 10
+        envelope = journey_order_created_envelope(
+            f"evt-{uuid7()}",
+            f"ord-decayed-ip-{index}",
+            f"acct-decayed-ip-{index}",
+            f"2026-07-05T10:{minute // 60:02d}:{minute % 60:02d}.000Z",
+        )
+        envelope = EventEnvelope(
+            eventId=envelope.eventId,
+            eventType=envelope.eventType,
+            occurredAt=envelope.occurredAt,
+            correlationId=envelope.correlationId,
+            causationId=envelope.causationId,
+            producer=envelope.producer,
+            schemaVersion=envelope.schemaVersion,
+            payload={**envelope.payload, "sourceIp": source_ip},
+        )
+        service.handle_event(envelope)
+
+    last_assessment = publisher.envelopes[-1]
+    assert last_assessment.eventType == "RiskAssessmentResult"
+    assert last_assessment.payload["subjectRef"] == "ord-decayed-ip-29"
+    assert last_assessment.payload["decision"] == "ALLOW"
+    assert [event.eventType for event in publisher.envelopes].count("RiskBlockApplied") == 0
+
+
+def test_ip_frequency_whitelist_bypasses_known_good_range(monkeypatch) -> None:
+    monkeypatch.setenv("RISK_IP_WHITELIST_CIDRS", "198.51.100.0/24")
+    publisher = InMemoryEventPublisher()
+    service = RiskComplianceService(publisher, InMemoryAssessmentRepository())
+
+    for index in range(30):
+        envelope = journey_order_created_envelope(
+            f"evt-{uuid7()}",
+            f"ord-whitelisted-ip-{index}",
+            f"acct-whitelisted-ip-{index}",
+            "2026-07-05T10:30:00.000Z",
+        )
+        envelope = EventEnvelope(
+            eventId=envelope.eventId,
+            eventType=envelope.eventType,
+            occurredAt=envelope.occurredAt,
+            correlationId=envelope.correlationId,
+            causationId=envelope.causationId,
+            producer=envelope.producer,
+            schemaVersion=envelope.schemaVersion,
+            payload={**envelope.payload, "sourceIp": "198.51.100.15"},
+        )
+        service.handle_event(envelope)
+
+    assert [event.eventType for event in publisher.envelopes].count("RiskBlockApplied") == 0


### PR DESCRIPTION
## Summary
AgentM/GPT REQ-212: Balance scalper detection — catch bots, allow legitimate users.

**Risk tuning**:
- `RISK_IP_FREQUENCY_THRESHOLD` 10→25 (was catching 57% of ALL traffic including legitimate)
- Time-decay weighting: recent requests count more than stale ones
- Configurable IP whitelist for known-good ranges

**Scalper evasion** (more realistic simulation):
- Request spacing variation: scalpers occasionally slow down
- Session fingerprint mixing: vary cookies/headers
- Segment diversification: spread across more routes

**Tests**: 100+ lines of new IP frequency + time-decay coverage

## Test plan
- [x] `test_api_and_messaging.py` passes with new thresholds
- [ ] Risk DENY rate < 20% overall (was 57%)
- [ ] Scalper still detected at high frequency

🤖 Generated with [Claude Code](https://claude.com/claude-code) + AgentM/GPT