### PR TITLE
feat(marketing-campaign): domain layer — 6 aggregates + state machines

### DIFF
--- a/services/marketing-campaign/pom.xml
+++ b/services/marketing-campaign/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>4.1.0</version>
+    <relativePath/>
+  </parent>
+  <groupId>com.trainticket</groupId>
+  <artifactId>marketing-campaign</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <name>Marketing Campaign service domain</name>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <java.version>25</java.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>com.trainticket</groupId>
+      <artifactId>java-kit</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/Campaign.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/Campaign.java
@@ -1,0 +1,132 @@
+package com.trainticket.marketingcampaign.domain;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public final class Campaign {
+    private final String campaignId;
+    private final String externalKey;
+    private final String name;
+    private final CampaignWindow window;
+    private final String targetRuleSetId;
+    private final String budgetId;
+    private final String approvalRef;
+    private final CampaignStatus status;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+    private final long version;
+    private final List<DomainEvent> domainEvents;
+
+    private Campaign(String campaignId, String externalKey, String name, CampaignWindow window, String targetRuleSetId,
+                     String budgetId, String approvalRef, CampaignStatus status, Instant createdAt, Instant updatedAt,
+                     long version, List<DomainEvent> domainEvents) {
+        this.campaignId = Require.text(campaignId, "campaignId");
+        this.externalKey = Require.text(externalKey, "externalKey");
+        this.name = Require.text(name, "name");
+        this.window = Objects.requireNonNull(window, "window");
+        this.targetRuleSetId = targetRuleSetId;
+        this.budgetId = budgetId;
+        this.approvalRef = approvalRef;
+        this.status = Objects.requireNonNull(status, "status");
+        this.createdAt = Objects.requireNonNull(createdAt, "createdAt");
+        this.updatedAt = Objects.requireNonNull(updatedAt, "updatedAt");
+        this.version = version;
+        this.domainEvents = List.copyOf(domainEvents);
+    }
+
+    public static Campaign draft(String campaignId, String externalKey, String name, CampaignWindow window, Instant now) {
+        List<DomainEvent> events = List.of(new CampaignDrafted(campaignId, externalKey, name, window, now, 1));
+        return new Campaign(campaignId, externalKey, name, window, null, null, null, CampaignStatus.DRAFT, now, now, 1, events);
+    }
+
+    public Campaign withLaunchReadiness(String budgetId, String targetRuleSetId) {
+        requireMutable();
+        return new Campaign(campaignId, externalKey, name, window, Require.text(targetRuleSetId, "targetRuleSetId"),
+            Require.text(budgetId, "budgetId"), approvalRef, status, createdAt, updatedAt, version, domainEvents);
+    }
+
+    public Campaign submitForReview(Instant now) {
+        return transition(CampaignStatus.IN_REVIEW, now, new CampaignSubmittedForReview(campaignId, now, version + 1), approvalRef);
+    }
+
+    public Campaign reject(String reviewRef, Instant now) {
+        return transition(CampaignStatus.REJECTED, now, new CampaignRejected(campaignId, Require.text(reviewRef, "reviewRef"), now, version + 1), approvalRef);
+    }
+
+    public Campaign reviseDraft(Instant now) {
+        return transition(CampaignStatus.DRAFT, now, new CampaignReopenedAsDraft(campaignId, now, version + 1), approvalRef);
+    }
+
+    public Campaign approve(String approvalRef, Instant now) {
+        String checkedApprovalRef = Require.text(approvalRef, "approvalRef");
+        return transition(CampaignStatus.APPROVED, now, new CampaignApproved(campaignId, checkedApprovalRef, now, version + 1), checkedApprovalRef);
+    }
+
+    public Campaign schedule(Instant now) {
+        status.requireCanTransitionTo(CampaignStatus.SCHEDULED);
+        requireLaunchReadiness();
+        return transition(CampaignStatus.SCHEDULED, now, new CampaignScheduled(campaignId, window, now, version + 1), approvalRef);
+    }
+
+    public Campaign start(Instant now) {
+        if (now.isBefore(window.validFrom())) throw new DomainException("campaign cannot start before validFrom");
+        return transition(CampaignStatus.ACTIVE, now, new CampaignStarted(campaignId, now, version + 1), approvalRef);
+    }
+
+    public Campaign pause(String reason, String operatorRef, Instant now) {
+        return transition(CampaignStatus.PAUSED, now, new CampaignPaused(campaignId, Require.text(reason, "reason"), Require.text(operatorRef, "operatorRef"), now, version + 1), approvalRef);
+    }
+
+    public Campaign resume(String reason, String operatorRef, Instant now) {
+        return transition(CampaignStatus.ACTIVE, now, new CampaignResumed(campaignId, Require.text(reason, "reason"), Require.text(operatorRef, "operatorRef"), now, version + 1), approvalRef);
+    }
+
+    public Campaign beginCompletion(String reason, Instant now) {
+        return transition(CampaignStatus.COMPLETING, now, new CampaignCompletionStarted(campaignId, Require.text(reason, "reason"), now, version + 1), approvalRef);
+    }
+
+    public Campaign complete(String reason, Instant now) {
+        return transition(CampaignStatus.COMPLETED, now, new CampaignCompleted(campaignId, Require.text(reason, "reason"), now, version + 1), approvalRef);
+    }
+
+    public Campaign fail(String failureCode, Instant now) {
+        return transition(CampaignStatus.FAILED, now, new CampaignFailed(campaignId, Require.text(failureCode, "failureCode"), now, version + 1), approvalRef);
+    }
+
+    public Campaign cancel(String reason, String operatorRef, Instant now) {
+        return transition(CampaignStatus.CANCELLED, now, new CampaignCancelled(campaignId, Require.text(reason, "reason"), Require.text(operatorRef, "operatorRef"), now, version + 1), approvalRef);
+    }
+
+    private Campaign transition(CampaignStatus next, Instant now, DomainEvent event, String nextApprovalRef) {
+        status.requireCanTransitionTo(next);
+        ArrayList<DomainEvent> events = new ArrayList<>(domainEvents);
+        events.add(event);
+        return new Campaign(campaignId, externalKey, name, window, targetRuleSetId, budgetId, nextApprovalRef, next,
+            createdAt, Objects.requireNonNull(now, "now"), version + 1, events);
+    }
+
+    private void requireLaunchReadiness() {
+        Require.text(budgetId, "budgetId");
+        Require.text(targetRuleSetId, "targetRuleSetId");
+        Require.text(approvalRef, "approvalRef");
+    }
+
+    private void requireMutable() {
+        if (status.isTerminal()) throw new DomainException("terminal campaign cannot be changed");
+    }
+
+    public String campaignId() { return campaignId; }
+    public String externalKey() { return externalKey; }
+    public String name() { return name; }
+    public CampaignWindow window() { return window; }
+    public String targetRuleSetId() { return targetRuleSetId; }
+    public String budgetId() { return budgetId; }
+    public String approvalRef() { return approvalRef; }
+    public CampaignStatus status() { return status; }
+    public Instant createdAt() { return createdAt; }
+    public Instant updatedAt() { return updatedAt; }
+    public long version() { return version; }
+    public List<DomainEvent> domainEvents() { return domainEvents; }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CampaignBudget.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CampaignBudget.java
@@ -1,0 +1,97 @@
+package com.trainticket.marketingcampaign.domain;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public final class CampaignBudget {
+    private final String budgetId;
+    private final String campaignId;
+    private final Money totalBudget;
+    private final Money reservedAmount;
+    private final Money consumedAmount;
+    private final boolean closed;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+    private final long version;
+    private final List<DomainEvent> domainEvents;
+
+    private CampaignBudget(String budgetId, String campaignId, Money totalBudget, Money reservedAmount, Money consumedAmount,
+                           boolean closed, Instant createdAt, Instant updatedAt, long version, List<DomainEvent> domainEvents) {
+        this.budgetId = Require.text(budgetId, "budgetId");
+        this.campaignId = Require.text(campaignId, "campaignId");
+        this.totalBudget = Objects.requireNonNull(totalBudget, "totalBudget");
+        this.reservedAmount = Objects.requireNonNull(reservedAmount, "reservedAmount");
+        this.consumedAmount = Objects.requireNonNull(consumedAmount, "consumedAmount");
+        totalBudget.requirePositive("totalBudget");
+        totalBudget.requireSameCurrency(reservedAmount);
+        totalBudget.requireSameCurrency(consumedAmount);
+        reservedAmount.requireNonNegative("reservedAmount");
+        consumedAmount.requireNonNegative("consumedAmount");
+        if (reservedAmount.minorUnits() + consumedAmount.minorUnits() > totalBudget.minorUnits()) {
+            throw new DomainException("reservedAmount + consumedAmount exceeds totalBudget");
+        }
+        this.closed = closed;
+        this.createdAt = Objects.requireNonNull(createdAt, "createdAt");
+        this.updatedAt = Objects.requireNonNull(updatedAt, "updatedAt");
+        this.version = version;
+        this.domainEvents = List.copyOf(domainEvents);
+    }
+
+    public static CampaignBudget set(String budgetId, String campaignId, Money totalBudget, Instant now) {
+        totalBudget.requirePositive("totalBudget");
+        List<DomainEvent> events = List.of(new CampaignBudgetSet(budgetId, campaignId, totalBudget, now, 1));
+        return new CampaignBudget(budgetId, campaignId, totalBudget, Money.zero(totalBudget.currency()), Money.zero(totalBudget.currency()), false, now, now, 1, events);
+    }
+
+    public CampaignBudget reserve(Money amount, String sourceRef, Instant now) {
+        requireOpen();
+        amount.requirePositive("amount");
+        Money nextReserved = reservedAmount.plus(amount);
+        return change(nextReserved, consumedAmount, now, new CampaignBudgetReserved(budgetId, campaignId, amount, Require.text(sourceRef, "sourceRef"), now, version + 1), false);
+    }
+
+    public CampaignBudget consume(Money amount, String benefitId, Instant now) {
+        requireOpen();
+        amount.requirePositive("amount");
+        if (reservedAmount.minorUnits() < amount.minorUnits()) throw new DomainException("consume amount exceeds reserved amount");
+        Money nextReserved = reservedAmount.minus(amount);
+        Money nextConsumed = consumedAmount.plus(amount);
+        return change(nextReserved, nextConsumed, now, new CampaignBudgetConsumed(budgetId, campaignId, amount, Require.text(benefitId, "benefitId"), now, version + 1), false);
+    }
+
+    public CampaignBudget release(Money amount, String reason, Instant now) {
+        requireOpen();
+        amount.requirePositive("amount");
+        if (reservedAmount.minorUnits() < amount.minorUnits()) throw new DomainException("release amount exceeds reserved amount");
+        Money nextReserved = reservedAmount.minus(amount);
+        return change(nextReserved, consumedAmount, now, new CampaignBudgetReleased(budgetId, campaignId, amount, Require.text(reason, "reason"), now, version + 1), false);
+    }
+
+    public CampaignBudget close(String reason, Instant now) {
+        requireOpen();
+        return change(reservedAmount, consumedAmount, now, new CampaignBudgetClosed(budgetId, campaignId, Require.text(reason, "reason"), now, version + 1), true);
+    }
+
+    private CampaignBudget change(Money nextReserved, Money nextConsumed, Instant now, DomainEvent event, boolean nextClosed) {
+        ArrayList<DomainEvent> events = new ArrayList<>(domainEvents);
+        events.add(event);
+        return new CampaignBudget(budgetId, campaignId, totalBudget, nextReserved, nextConsumed, nextClosed, createdAt, Objects.requireNonNull(now, "now"), version + 1, events);
+    }
+
+    private void requireOpen() {
+        if (closed) throw new DomainException("closed budget cannot be changed");
+    }
+
+    public String budgetId() { return budgetId; }
+    public String campaignId() { return campaignId; }
+    public Money totalBudget() { return totalBudget; }
+    public Money reservedAmount() { return reservedAmount; }
+    public Money consumedAmount() { return consumedAmount; }
+    public boolean closed() { return closed; }
+    public Instant createdAt() { return createdAt; }
+    public Instant updatedAt() { return updatedAt; }
+    public long version() { return version; }
+    public List<DomainEvent> domainEvents() { return domainEvents; }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CampaignBudgetEvents.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CampaignBudgetEvents.java
@@ -1,0 +1,9 @@
+package com.trainticket.marketingcampaign.domain;
+
+import java.time.Instant;
+
+record CampaignBudgetSet(String aggregateId, String campaignId, Money totalBudget, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CampaignBudgetReserved(String aggregateId, String campaignId, Money amount, String sourceRef, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CampaignBudgetConsumed(String aggregateId, String campaignId, Money amount, String benefitId, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CampaignBudgetReleased(String aggregateId, String campaignId, Money amount, String reason, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CampaignBudgetClosed(String aggregateId, String campaignId, String reason, Instant occurredAt, long aggregateVersion) implements DomainEvent {}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CampaignEvents.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CampaignEvents.java
@@ -1,0 +1,17 @@
+package com.trainticket.marketingcampaign.domain;
+
+import java.time.Instant;
+
+record CampaignDrafted(String aggregateId, String externalKey, String name, CampaignWindow window, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CampaignSubmittedForReview(String aggregateId, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CampaignRejected(String aggregateId, String reviewRef, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CampaignReopenedAsDraft(String aggregateId, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CampaignApproved(String aggregateId, String approvalRef, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CampaignScheduled(String aggregateId, CampaignWindow window, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CampaignStarted(String aggregateId, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CampaignPaused(String aggregateId, String reason, String operatorRef, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CampaignResumed(String aggregateId, String reason, String operatorRef, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CampaignCompletionStarted(String aggregateId, String reason, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CampaignCompleted(String aggregateId, String reason, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CampaignFailed(String aggregateId, String failureCode, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CampaignCancelled(String aggregateId, String reason, String operatorRef, Instant occurredAt, long aggregateVersion) implements DomainEvent {}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CampaignStatus.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CampaignStatus.java
@@ -1,0 +1,47 @@
+package com.trainticket.marketingcampaign.domain;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Set;
+
+public enum CampaignStatus {
+    DRAFT,
+    IN_REVIEW,
+    REJECTED,
+    APPROVED,
+    SCHEDULED,
+    ACTIVE,
+    PAUSED,
+    COMPLETING,
+    COMPLETED,
+    FAILED,
+    CANCELLED;
+
+    private static final EnumMap<CampaignStatus, Set<CampaignStatus>> TRANSITIONS = new EnumMap<>(CampaignStatus.class);
+
+    static {
+        TRANSITIONS.put(DRAFT, EnumSet.of(IN_REVIEW, CANCELLED));
+        TRANSITIONS.put(IN_REVIEW, EnumSet.of(APPROVED, REJECTED, DRAFT, CANCELLED));
+        TRANSITIONS.put(REJECTED, EnumSet.of(DRAFT, CANCELLED));
+        TRANSITIONS.put(APPROVED, EnumSet.of(SCHEDULED, CANCELLED));
+        TRANSITIONS.put(SCHEDULED, EnumSet.of(ACTIVE, CANCELLED, FAILED));
+        TRANSITIONS.put(ACTIVE, EnumSet.of(PAUSED, COMPLETING, FAILED, CANCELLED));
+        TRANSITIONS.put(PAUSED, EnumSet.of(ACTIVE, COMPLETING, FAILED, CANCELLED));
+        TRANSITIONS.put(COMPLETING, EnumSet.of(COMPLETED, FAILED));
+        TRANSITIONS.put(COMPLETED, EnumSet.noneOf(CampaignStatus.class));
+        TRANSITIONS.put(FAILED, EnumSet.noneOf(CampaignStatus.class));
+        TRANSITIONS.put(CANCELLED, EnumSet.noneOf(CampaignStatus.class));
+    }
+
+    public boolean canTransitionTo(CampaignStatus next) {
+        return TRANSITIONS.get(this).contains(next);
+    }
+
+    public boolean isTerminal() {
+        return this == COMPLETED || this == FAILED || this == CANCELLED;
+    }
+
+    public void requireCanTransitionTo(CampaignStatus next) {
+        if (!canTransitionTo(next)) throw new DomainException("invalid campaign transition " + this + " -> " + next);
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CampaignWindow.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CampaignWindow.java
@@ -1,0 +1,22 @@
+package com.trainticket.marketingcampaign.domain;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record CampaignWindow(Instant validFrom, Instant validUntil) {
+    public CampaignWindow {
+        Objects.requireNonNull(validFrom, "validFrom");
+        Objects.requireNonNull(validUntil, "validUntil");
+        if (!validUntil.isAfter(validFrom)) throw new DomainException("validUntil must be after validFrom");
+    }
+
+    public boolean contains(Instant instant) {
+        Objects.requireNonNull(instant, "instant");
+        return !instant.isBefore(validFrom) && instant.isBefore(validUntil);
+    }
+
+    public boolean contains(CampaignWindow other) {
+        Objects.requireNonNull(other, "other");
+        return !other.validFrom.isBefore(validFrom) && !other.validUntil.isAfter(validUntil);
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CouponTemplate.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CouponTemplate.java
@@ -1,0 +1,117 @@
+package com.trainticket.marketingcampaign.domain;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public final class CouponTemplate {
+    private final String templateId;
+    private final String campaignId;
+    private final String templateCode;
+    private final int templateVersion;
+    private final CouponTemplateStatus status;
+    private final Money faceValue;
+    private final Money minimumSpend;
+    private final String applicableScope;
+    private final String redemptionRule;
+    private final CampaignWindow validityWindow;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+    private final long version;
+    private final List<DomainEvent> domainEvents;
+
+    private CouponTemplate(String templateId, String campaignId, String templateCode, int templateVersion, CouponTemplateStatus status,
+                           Money faceValue, Money minimumSpend, String applicableScope, String redemptionRule, CampaignWindow validityWindow,
+                           Instant createdAt, Instant updatedAt, long version, List<DomainEvent> domainEvents) {
+        this.templateId = Require.text(templateId, "templateId");
+        this.campaignId = Require.text(campaignId, "campaignId");
+        this.templateCode = Require.text(templateCode, "templateCode");
+        if (templateVersion <= 0) throw new DomainException("templateVersion must be positive");
+        this.templateVersion = templateVersion;
+        this.status = Objects.requireNonNull(status, "status");
+        this.faceValue = Objects.requireNonNull(faceValue, "faceValue");
+        this.minimumSpend = Objects.requireNonNull(minimumSpend, "minimumSpend");
+        faceValue.requirePositive("faceValue");
+        minimumSpend.requireNonNegative("minimumSpend");
+        faceValue.requireSameCurrency(minimumSpend);
+        this.applicableScope = Require.text(applicableScope, "applicableScope");
+        this.redemptionRule = Require.text(redemptionRule, "redemptionRule");
+        this.validityWindow = Objects.requireNonNull(validityWindow, "validityWindow");
+        this.createdAt = Objects.requireNonNull(createdAt, "createdAt");
+        this.updatedAt = Objects.requireNonNull(updatedAt, "updatedAt");
+        this.version = version;
+        this.domainEvents = List.copyOf(domainEvents);
+    }
+
+    public static CouponTemplate draft(String templateId, String campaignId, String templateCode, int templateVersion,
+                                       Money faceValue, Money minimumSpend, String applicableScope, String redemptionRule,
+                                       CampaignWindow validityWindow, CampaignWindow campaignWindow, Instant now) {
+        requireWithinCampaign(validityWindow, campaignWindow);
+        List<DomainEvent> events = List.of(new CouponTemplateDrafted(templateId, campaignId, templateCode, templateVersion, now, 1));
+        return new CouponTemplate(templateId, campaignId, templateCode, templateVersion, CouponTemplateStatus.DRAFT, faceValue,
+            minimumSpend, applicableScope, redemptionRule, validityWindow, now, now, 1, events);
+    }
+
+    public CouponTemplate revise(Money faceValue, Money minimumSpend, String applicableScope, String redemptionRule,
+                                 CampaignWindow validityWindow, CampaignWindow campaignWindow, Instant now) {
+        requireDraftMutable();
+        requireWithinCampaign(validityWindow, campaignWindow);
+        return new CouponTemplate(templateId, campaignId, templateCode, templateVersion, status, faceValue, minimumSpend,
+            applicableScope, redemptionRule, validityWindow, createdAt, Objects.requireNonNull(now, "now"), version + 1, domainEvents);
+    }
+
+    public CouponTemplate validate(Instant now) {
+        return transition(CouponTemplateStatus.VALIDATED, now, new CouponTemplateValidated(templateId, campaignId, now, version + 1));
+    }
+
+    public CouponTemplate returnToDraft(Instant now) {
+        return transition(CouponTemplateStatus.DRAFT, now, new CouponTemplateReopenedAsDraft(templateId, campaignId, now, version + 1));
+    }
+
+    public CouponTemplate publish(String approvalRef, Instant now) {
+        return transition(CouponTemplateStatus.PUBLISHED, now, new CouponTemplatePublished(templateId, campaignId, templateCode, templateVersion, Require.text(approvalRef, "approvalRef"), now, version + 1));
+    }
+
+    public CouponTemplate supersede(String replacementTemplateId, Instant now) {
+        return transition(CouponTemplateStatus.SUPERSEDED, now, new CouponTemplateSuperseded(templateId, campaignId, Require.text(replacementTemplateId, "replacementTemplateId"), now, version + 1));
+    }
+
+    public CouponTemplate retire(String reason, Instant now) {
+        return transition(CouponTemplateStatus.RETIRED, now, new CouponTemplateRetired(templateId, campaignId, Require.text(reason, "reason"), now, version + 1));
+    }
+
+    private CouponTemplate transition(CouponTemplateStatus next, Instant now, DomainEvent event) {
+        status.requireCanTransitionTo(next);
+        ArrayList<DomainEvent> events = new ArrayList<>(domainEvents);
+        events.add(event);
+        return new CouponTemplate(templateId, campaignId, templateCode, templateVersion, next, faceValue, minimumSpend,
+            applicableScope, redemptionRule, validityWindow, createdAt, Objects.requireNonNull(now, "now"), version + 1, events);
+    }
+
+    private void requireDraftMutable() {
+        if (status.isPublishedImmutable()) throw new DomainException("published template changes require a new version");
+        if (status != CouponTemplateStatus.DRAFT) throw new DomainException("template can only be revised in DRAFT");
+    }
+
+    private static void requireWithinCampaign(CampaignWindow validityWindow, CampaignWindow campaignWindow) {
+        Objects.requireNonNull(validityWindow, "validityWindow");
+        Objects.requireNonNull(campaignWindow, "campaignWindow");
+        if (!campaignWindow.contains(validityWindow)) throw new DomainException("template validityWindow must be within campaign window");
+    }
+
+    public String templateId() { return templateId; }
+    public String campaignId() { return campaignId; }
+    public String templateCode() { return templateCode; }
+    public int templateVersion() { return templateVersion; }
+    public CouponTemplateStatus status() { return status; }
+    public Money faceValue() { return faceValue; }
+    public Money minimumSpend() { return minimumSpend; }
+    public String applicableScope() { return applicableScope; }
+    public String redemptionRule() { return redemptionRule; }
+    public CampaignWindow validityWindow() { return validityWindow; }
+    public Instant createdAt() { return createdAt; }
+    public Instant updatedAt() { return updatedAt; }
+    public long version() { return version; }
+    public List<DomainEvent> domainEvents() { return domainEvents; }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CouponTemplateEvents.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CouponTemplateEvents.java
@@ -1,0 +1,10 @@
+package com.trainticket.marketingcampaign.domain;
+
+import java.time.Instant;
+
+record CouponTemplateDrafted(String aggregateId, String campaignId, String templateCode, int templateVersion, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CouponTemplateValidated(String aggregateId, String campaignId, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CouponTemplateReopenedAsDraft(String aggregateId, String campaignId, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CouponTemplatePublished(String aggregateId, String campaignId, String templateCode, int templateVersion, String approvalRef, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CouponTemplateSuperseded(String aggregateId, String campaignId, String replacementTemplateId, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CouponTemplateRetired(String aggregateId, String campaignId, String reason, Instant occurredAt, long aggregateVersion) implements DomainEvent {}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CouponTemplateStatus.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CouponTemplateStatus.java
@@ -1,0 +1,35 @@
+package com.trainticket.marketingcampaign.domain;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Set;
+
+public enum CouponTemplateStatus {
+    DRAFT,
+    VALIDATED,
+    PUBLISHED,
+    SUPERSEDED,
+    RETIRED;
+
+    private static final EnumMap<CouponTemplateStatus, Set<CouponTemplateStatus>> TRANSITIONS = new EnumMap<>(CouponTemplateStatus.class);
+
+    static {
+        TRANSITIONS.put(DRAFT, EnumSet.of(VALIDATED, RETIRED));
+        TRANSITIONS.put(VALIDATED, EnumSet.of(PUBLISHED, DRAFT, RETIRED));
+        TRANSITIONS.put(PUBLISHED, EnumSet.of(RETIRED, SUPERSEDED));
+        TRANSITIONS.put(SUPERSEDED, EnumSet.of(RETIRED));
+        TRANSITIONS.put(RETIRED, EnumSet.noneOf(CouponTemplateStatus.class));
+    }
+
+    boolean canTransitionTo(CouponTemplateStatus next) {
+        return TRANSITIONS.get(this).contains(next);
+    }
+
+    boolean isPublishedImmutable() {
+        return this == PUBLISHED || this == SUPERSEDED || this == RETIRED;
+    }
+
+    void requireCanTransitionTo(CouponTemplateStatus next) {
+        if (!canTransitionTo(next)) throw new DomainException("invalid coupon template transition " + this + " -> " + next);
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/DomainEvent.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/DomainEvent.java
@@ -1,0 +1,9 @@
+package com.trainticket.marketingcampaign.domain;
+
+import java.time.Instant;
+
+public interface DomainEvent {
+    String aggregateId();
+    Instant occurredAt();
+    long aggregateVersion();
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/DomainException.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/DomainException.java
@@ -1,0 +1,5 @@
+package com.trainticket.marketingcampaign.domain;
+
+public class DomainException extends RuntimeException {
+    public DomainException(String message) { super(message); }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/IssuanceBatch.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/IssuanceBatch.java
@@ -1,0 +1,178 @@
+package com.trainticket.marketingcampaign.domain;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class IssuanceBatch {
+    private final String issuanceBatchId;
+    private final String campaignId;
+    private final String templateId;
+    private final String audienceSnapshotId;
+    private final IssuanceBatchStatus status;
+    private final Map<String, IssuanceItem> itemsById;
+    private final Instant plannedAt;
+    private final Instant updatedAt;
+    private final long version;
+    private final List<DomainEvent> domainEvents;
+
+    private IssuanceBatch(String issuanceBatchId, String campaignId, String templateId, String audienceSnapshotId,
+                          IssuanceBatchStatus status, Map<String, IssuanceItem> itemsById, Instant plannedAt,
+                          Instant updatedAt, long version, List<DomainEvent> domainEvents) {
+        this.issuanceBatchId = Require.text(issuanceBatchId, "issuanceBatchId");
+        this.campaignId = Require.text(campaignId, "campaignId");
+        this.templateId = Require.text(templateId, "templateId");
+        this.audienceSnapshotId = Require.text(audienceSnapshotId, "audienceSnapshotId");
+        this.status = Objects.requireNonNull(status, "status");
+        this.itemsById = Map.copyOf(itemsById);
+        enforceActiveItemUniqueness(this.itemsById);
+        this.plannedAt = Objects.requireNonNull(plannedAt, "plannedAt");
+        this.updatedAt = Objects.requireNonNull(updatedAt, "updatedAt");
+        this.version = version;
+        this.domainEvents = List.copyOf(domainEvents);
+    }
+
+    public static IssuanceBatch plan(String issuanceBatchId, String campaignId, String templateId, String audienceSnapshotId, Instant now) {
+        List<DomainEvent> events = List.of(new IssuanceBatchPlanned(issuanceBatchId, campaignId, templateId, audienceSnapshotId, now, 1));
+        return new IssuanceBatch(issuanceBatchId, campaignId, templateId, audienceSnapshotId, IssuanceBatchStatus.PLANNED,
+            Map.of(), now, now, 1, events);
+    }
+
+    public IssuanceBatch start(Instant now) {
+        return transition(IssuanceBatchStatus.RUNNING, now, new IssuanceBatchStarted(issuanceBatchId, now, version + 1));
+    }
+
+    public IssuanceBatch pause(String reason, Instant now) {
+        return transition(IssuanceBatchStatus.PAUSED, now, new IssuanceBatchPaused(issuanceBatchId, Require.text(reason, "reason"), now, version + 1));
+    }
+
+    public IssuanceBatch markPartiallySucceeded(Instant now) {
+        return transition(IssuanceBatchStatus.PARTIALLY_SUCCEEDED, now, new IssuanceBatchProgressChanged(issuanceBatchId, IssuanceBatchStatus.PARTIALLY_SUCCEEDED, now, version + 1));
+    }
+
+    public IssuanceBatch markSucceeded(Instant now) {
+        return transition(IssuanceBatchStatus.SUCCEEDED, now, new IssuanceBatchProgressChanged(issuanceBatchId, IssuanceBatchStatus.SUCCEEDED, now, version + 1));
+    }
+
+    public IssuanceBatch markPartiallyFailed(Instant now) {
+        return transition(IssuanceBatchStatus.PARTIALLY_FAILED, now, new IssuanceBatchProgressChanged(issuanceBatchId, IssuanceBatchStatus.PARTIALLY_FAILED, now, version + 1));
+    }
+
+    public IssuanceBatch fail(String failureCode, Instant now) {
+        return transition(IssuanceBatchStatus.FAILED, now, new IssuanceBatchFailed(issuanceBatchId, Require.text(failureCode, "failureCode"), now, version + 1));
+    }
+
+    public IssuanceBatch miss(String reason, Instant now) {
+        return transition(IssuanceBatchStatus.MISSED, now, new IssuanceBatchMissed(issuanceBatchId, Require.text(reason, "reason"), now, version + 1));
+    }
+
+    public IssuanceBatch cancel(String reason, Instant now) {
+        return transition(IssuanceBatchStatus.CANCELLED, now, new IssuanceBatchCancelled(issuanceBatchId, Require.text(reason, "reason"), now, version + 1));
+    }
+
+    public IssuanceBatch close(String reason, Instant now) {
+        return transition(IssuanceBatchStatus.CLOSED, now, new IssuanceBatchClosed(issuanceBatchId, Require.text(reason, "reason"), status, now, version + 1));
+    }
+
+    public IssueItemResult issueCampaignCoupon(String issuanceItemId, String accountId, String idempotencyKey, Money amount,
+                                               CampaignWindow benefitWindow, Instant now) {
+        requireRunningForItemChanges();
+        Optional<IssuanceItem> replay = findByIdempotencyKey(idempotencyKey);
+        if (replay.isPresent()) return new IssueItemResult(this, replay.get(), true);
+        IssuanceItem item = new IssuanceItem(issuanceItemId, campaignId, templateId, accountId, audienceSnapshotId,
+            idempotencyKey, amount, benefitWindow, IssuanceItemStatus.REQUESTED, null, null, 0, now, now);
+        Map<String, IssuanceItem> nextItems = new LinkedHashMap<>(itemsById);
+        if (nextItems.containsKey(item.issuanceItemId())) throw new DomainException("issuanceItemId already exists");
+        nextItems.put(item.issuanceItemId(), item);
+        return new IssueItemResult(changeItems(nextItems, now, new CampaignCouponIssueRequested(issuanceBatchId, item.issuanceItemId(), item.accountId(), item.idempotencyKey(), now, version + 1)), item, false);
+    }
+
+    public IssuanceBatch recordWalletIssuanceAccepted(String issuanceItemId, String walletBenefitId, Instant now) {
+        requireNotClosed();
+        IssuanceItem item = requireItem(issuanceItemId).accepted(walletBenefitId, now);
+        return replaceItem(item, now, new WalletIssuanceAccepted(issuanceBatchId, issuanceItemId, walletBenefitId, now, version + 1));
+    }
+
+    public IssuanceBatch recordIssuanceItemFailed(String issuanceItemId, String failureCode, Instant now) {
+        requireNotClosed();
+        IssuanceItem item = requireItem(issuanceItemId).failed(failureCode, now);
+        return replaceItem(item, now, new IssuanceItemFailed(issuanceBatchId, issuanceItemId, failureCode, now, version + 1));
+    }
+
+    public IssuanceBatch retryIssuanceItem(String issuanceItemId, int retryAttemptNo, Instant now) {
+        requireRunningForItemChanges();
+        IssuanceItem item = requireItem(issuanceItemId).retry(retryAttemptNo, now);
+        return replaceItem(item, now, new IssuanceItemRetryScheduled(issuanceBatchId, issuanceItemId, retryAttemptNo, now, version + 1));
+    }
+
+    private IssuanceBatch transition(IssuanceBatchStatus next, Instant now, DomainEvent event) {
+        status.requireCanTransitionTo(next);
+        return changeItems(itemsById, now, event, next);
+    }
+
+    private IssuanceBatch replaceItem(IssuanceItem item, Instant now, DomainEvent event) {
+        Map<String, IssuanceItem> nextItems = new LinkedHashMap<>(itemsById);
+        nextItems.put(item.issuanceItemId(), item);
+        return changeItems(nextItems, now, event);
+    }
+
+    private IssuanceBatch changeItems(Map<String, IssuanceItem> nextItems, Instant now, DomainEvent event) {
+        return changeItems(nextItems, now, event, status);
+    }
+
+    private IssuanceBatch changeItems(Map<String, IssuanceItem> nextItems, Instant now, DomainEvent event, IssuanceBatchStatus nextStatus) {
+        ArrayList<DomainEvent> events = new ArrayList<>(domainEvents);
+        events.add(event);
+        return new IssuanceBatch(issuanceBatchId, campaignId, templateId, audienceSnapshotId, nextStatus, nextItems,
+            plannedAt, Objects.requireNonNull(now, "now"), version + 1, events);
+    }
+
+    private void requireRunningForItemChanges() {
+        if (!(status == IssuanceBatchStatus.RUNNING || status == IssuanceBatchStatus.PARTIALLY_SUCCEEDED)) {
+            throw new DomainException("issuance items cannot be changed while batch is " + status);
+        }
+    }
+
+    private void requireNotClosed() {
+        if (status.isClosedRestingState()) throw new DomainException("closed batch cannot be changed");
+    }
+
+    private IssuanceItem requireItem(String issuanceItemId) {
+        IssuanceItem item = itemsById.get(Require.text(issuanceItemId, "issuanceItemId"));
+        if (item == null) throw new DomainException("issuance item not found");
+        return item;
+    }
+
+    private Optional<IssuanceItem> findByIdempotencyKey(String idempotencyKey) {
+        String checked = Require.text(idempotencyKey, "idempotencyKey");
+        return itemsById.values().stream().filter(item -> item.idempotencyKey().equals(checked)).findFirst();
+    }
+
+    private static void enforceActiveItemUniqueness(Map<String, IssuanceItem> items) {
+        List<IssuanceItemKey> activeKeys = new ArrayList<>();
+        for (IssuanceItem item : items.values()) {
+            if (item.status().isActive()) {
+                IssuanceItemKey key = item.activeKey();
+                if (activeKeys.contains(key)) throw new DomainException("active issuance item already exists for campaign/template/account/audience");
+                activeKeys.add(key);
+            }
+        }
+    }
+
+    public String issuanceBatchId() { return issuanceBatchId; }
+    public String campaignId() { return campaignId; }
+    public String templateId() { return templateId; }
+    public String audienceSnapshotId() { return audienceSnapshotId; }
+    public IssuanceBatchStatus status() { return status; }
+    public Map<String, IssuanceItem> itemsById() { return itemsById; }
+    public Instant plannedAt() { return plannedAt; }
+    public Instant updatedAt() { return updatedAt; }
+    public long version() { return version; }
+    public List<DomainEvent> domainEvents() { return domainEvents; }
+
+    public record IssueItemResult(IssuanceBatch batch, IssuanceItem item, boolean replayed) {}
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/IssuanceBatchEvents.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/IssuanceBatchEvents.java
@@ -1,0 +1,16 @@
+package com.trainticket.marketingcampaign.domain;
+
+import java.time.Instant;
+
+record IssuanceBatchPlanned(String aggregateId, String campaignId, String templateId, String audienceSnapshotId, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record IssuanceBatchStarted(String aggregateId, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record IssuanceBatchPaused(String aggregateId, String reason, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record IssuanceBatchProgressChanged(String aggregateId, IssuanceBatchStatus finalStatus, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record IssuanceBatchFailed(String aggregateId, String failureCode, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record IssuanceBatchMissed(String aggregateId, String reason, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record IssuanceBatchCancelled(String aggregateId, String reason, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record CampaignCouponIssueRequested(String aggregateId, String issuanceItemId, String accountId, String idempotencyKey, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record WalletIssuanceAccepted(String aggregateId, String issuanceItemId, String walletBenefitId, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record IssuanceItemFailed(String aggregateId, String issuanceItemId, String failureCode, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record IssuanceItemRetryScheduled(String aggregateId, String issuanceItemId, int retryAttemptNo, Instant occurredAt, long aggregateVersion) implements DomainEvent {}
+record IssuanceBatchClosed(String aggregateId, String reason, IssuanceBatchStatus finalStatus, Instant occurredAt, long aggregateVersion) implements DomainEvent {}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/IssuanceBatchStatus.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/IssuanceBatchStatus.java
@@ -1,0 +1,39 @@
+package com.trainticket.marketingcampaign.domain;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Set;
+
+public enum IssuanceBatchStatus {
+    PLANNED,
+    RUNNING,
+    PAUSED,
+    PARTIALLY_SUCCEEDED,
+    SUCCEEDED,
+    PARTIALLY_FAILED,
+    FAILED,
+    MISSED,
+    CANCELLED,
+    CLOSED;
+
+    private static final EnumMap<IssuanceBatchStatus, Set<IssuanceBatchStatus>> TRANSITIONS = new EnumMap<>(IssuanceBatchStatus.class);
+
+    static {
+        TRANSITIONS.put(PLANNED, EnumSet.of(RUNNING, CANCELLED, MISSED));
+        TRANSITIONS.put(RUNNING, EnumSet.of(PARTIALLY_SUCCEEDED, SUCCEEDED, PARTIALLY_FAILED, FAILED, PAUSED));
+        TRANSITIONS.put(PAUSED, EnumSet.of(RUNNING, CANCELLED, MISSED));
+        TRANSITIONS.put(PARTIALLY_SUCCEEDED, EnumSet.of(RUNNING, PARTIALLY_FAILED, SUCCEEDED, CLOSED));
+        TRANSITIONS.put(SUCCEEDED, EnumSet.of(CLOSED));
+        TRANSITIONS.put(PARTIALLY_FAILED, EnumSet.of(CLOSED));
+        TRANSITIONS.put(FAILED, EnumSet.of(CLOSED));
+        TRANSITIONS.put(MISSED, EnumSet.of(CLOSED));
+        TRANSITIONS.put(CANCELLED, EnumSet.of(CLOSED));
+        TRANSITIONS.put(CLOSED, EnumSet.noneOf(IssuanceBatchStatus.class));
+    }
+
+    boolean canTransitionTo(IssuanceBatchStatus next) { return TRANSITIONS.get(this).contains(next); }
+    boolean isClosedRestingState() { return this == CLOSED; }
+    void requireCanTransitionTo(IssuanceBatchStatus next) {
+        if (!canTransitionTo(next)) throw new DomainException("invalid issuance batch transition " + this + " -> " + next);
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/IssuanceItem.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/IssuanceItem.java
@@ -1,0 +1,58 @@
+package com.trainticket.marketingcampaign.domain;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record IssuanceItem(
+    String issuanceItemId,
+    String campaignId,
+    String templateId,
+    String accountId,
+    String audienceSnapshotId,
+    String idempotencyKey,
+    Money amount,
+    CampaignWindow benefitWindow,
+    IssuanceItemStatus status,
+    String walletBenefitId,
+    String failureCode,
+    int retryAttemptNo,
+    Instant createdAt,
+    Instant updatedAt
+) {
+    public IssuanceItem {
+        issuanceItemId = Require.text(issuanceItemId, "issuanceItemId");
+        campaignId = Require.text(campaignId, "campaignId");
+        templateId = Require.text(templateId, "templateId");
+        accountId = Require.text(accountId, "accountId");
+        audienceSnapshotId = Require.text(audienceSnapshotId, "audienceSnapshotId");
+        idempotencyKey = Require.text(idempotencyKey, "idempotencyKey");
+        Objects.requireNonNull(amount, "amount").requirePositive("amount");
+        Objects.requireNonNull(benefitWindow, "benefitWindow");
+        Objects.requireNonNull(status, "status");
+        Objects.requireNonNull(createdAt, "createdAt");
+        Objects.requireNonNull(updatedAt, "updatedAt");
+        if (status == IssuanceItemStatus.ACCEPTED) Require.text(walletBenefitId, "walletBenefitId");
+        if (status == IssuanceItemStatus.FAILED) Require.text(failureCode, "failureCode");
+    }
+
+    IssuanceItemKey activeKey() { return new IssuanceItemKey(campaignId, templateId, accountId, audienceSnapshotId); }
+
+    IssuanceItem accepted(String walletBenefitId, Instant now) {
+        if (status == IssuanceItemStatus.FAILED) throw new DomainException("failed issuance item cannot be accepted");
+        return new IssuanceItem(issuanceItemId, campaignId, templateId, accountId, audienceSnapshotId, idempotencyKey, amount,
+            benefitWindow, IssuanceItemStatus.ACCEPTED, walletBenefitId, null, retryAttemptNo, createdAt, now);
+    }
+
+    IssuanceItem failed(String failureCode, Instant now) {
+        if (status == IssuanceItemStatus.ACCEPTED) throw new DomainException("accepted issuance item cannot fail");
+        return new IssuanceItem(issuanceItemId, campaignId, templateId, accountId, audienceSnapshotId, idempotencyKey, amount,
+            benefitWindow, IssuanceItemStatus.FAILED, walletBenefitId, failureCode, retryAttemptNo, createdAt, now);
+    }
+
+    IssuanceItem retry(int retryAttemptNo, Instant now) {
+        if (status != IssuanceItemStatus.FAILED) throw new DomainException("only failed issuance items can be retried");
+        if (retryAttemptNo <= this.retryAttemptNo) throw new DomainException("retryAttemptNo must increase");
+        return new IssuanceItem(issuanceItemId, campaignId, templateId, accountId, audienceSnapshotId, idempotencyKey, amount,
+            benefitWindow, IssuanceItemStatus.RETRY_SCHEDULED, walletBenefitId, null, retryAttemptNo, createdAt, now);
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/IssuanceItemKey.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/IssuanceItemKey.java
@@ -1,0 +1,10 @@
+package com.trainticket.marketingcampaign.domain;
+
+record IssuanceItemKey(String campaignId, String templateId, String accountId, String audienceSnapshotId) {
+    IssuanceItemKey {
+        campaignId = Require.text(campaignId, "campaignId");
+        templateId = Require.text(templateId, "templateId");
+        accountId = Require.text(accountId, "accountId");
+        audienceSnapshotId = Require.text(audienceSnapshotId, "audienceSnapshotId");
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/IssuanceItemStatus.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/IssuanceItemStatus.java
@@ -1,0 +1,12 @@
+package com.trainticket.marketingcampaign.domain;
+
+public enum IssuanceItemStatus {
+    REQUESTED,
+    ACCEPTED,
+    FAILED,
+    RETRY_SCHEDULED;
+
+    boolean isActive() {
+        return this == REQUESTED || this == RETRY_SCHEDULED;
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/Money.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/Money.java
@@ -1,0 +1,16 @@
+package com.trainticket.marketingcampaign.domain;
+
+import java.util.Objects;
+
+public record Money(String currency, long minorUnits) {
+    public Money {
+        if (currency == null || currency.isBlank()) throw new DomainException("currency is required");
+        currency = currency.toUpperCase();
+    }
+    public static Money zero(String currency) { return new Money(currency, 0); }
+    public void requirePositive(String field) { if (minorUnits <= 0) throw new DomainException(field + " must be positive"); }
+    public void requireNonNegative(String field) { if (minorUnits < 0) throw new DomainException(field + " must not be negative"); }
+    public void requireSameCurrency(Money other) { if (!currency.equals(Objects.requireNonNull(other).currency())) throw new DomainException("currency mismatch"); }
+    public Money plus(Money other) { requireSameCurrency(other); return new Money(currency, minorUnits + other.minorUnits); }
+    public Money minus(Money other) { requireSameCurrency(other); return new Money(currency, minorUnits - other.minorUnits); }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/Require.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/Require.java
@@ -1,0 +1,9 @@
+package com.trainticket.marketingcampaign.domain;
+
+final class Require {
+    private Require() {}
+    static String text(String value, String field) {
+        if (value == null || value.isBlank()) throw new DomainException(field + " is required");
+        return value;
+    }
+}

--- a/services/marketing-campaign/src/test/java/com/trainticket/marketingcampaign/domain/CampaignBudgetTest.java
+++ b/services/marketing-campaign/src/test/java/com/trainticket/marketingcampaign/domain/CampaignBudgetTest.java
@@ -1,0 +1,53 @@
+package com.trainticket.marketingcampaign.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class CampaignBudgetTest {
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+
+    @Test void reservesConsumesAndReleasesBudget() {
+        CampaignBudget budget = CampaignBudget.set("budget-1", "campaign-1", new Money("usd", 1_000), T0)
+            .reserve(new Money("USD", 400), "item-1", T0.plusSeconds(1));
+
+        assertThat(budget.reservedAmount()).isEqualTo(new Money("USD", 400));
+
+        budget = budget.consume(new Money("USD", 150), "benefit-1", T0.plusSeconds(2))
+            .release(new Money("USD", 250), "wallet_failed", T0.plusSeconds(3));
+
+        assertThat(budget.reservedAmount()).isEqualTo(new Money("USD", 0));
+        assertThat(budget.consumedAmount()).isEqualTo(new Money("USD", 150));
+        assertThat(budget.domainEvents()).hasSize(4);
+    }
+
+    @Test void preventsOverdraftAndNegativeBalances() {
+        CampaignBudget budget = CampaignBudget.set("budget-1", "campaign-1", new Money("USD", 100), T0);
+
+        assertThatThrownBy(() -> budget.reserve(new Money("USD", 101), "item-1", T0.plusSeconds(1)))
+            .isInstanceOf(DomainException.class)
+            .hasMessageContaining("exceeds totalBudget");
+
+        CampaignBudget reserved = budget.reserve(new Money("USD", 80), "item-1", T0.plusSeconds(1));
+        assertThatThrownBy(() -> reserved.consume(new Money("USD", 81), "benefit-1", T0.plusSeconds(2)))
+            .isInstanceOf(DomainException.class)
+            .hasMessageContaining("exceeds reserved amount");
+        assertThatThrownBy(() -> reserved.release(new Money("USD", 81), "release", T0.plusSeconds(3)))
+            .isInstanceOf(DomainException.class)
+            .hasMessageContaining("exceeds reserved amount");
+        assertThatThrownBy(() -> reserved.reserve(new Money("EUR", 1), "item-2", T0.plusSeconds(4)))
+            .isInstanceOf(DomainException.class)
+            .hasMessageContaining("currency mismatch");
+    }
+
+    @Test void closedBudgetIsReadOnly() {
+        CampaignBudget closed = CampaignBudget.set("budget-1", "campaign-1", new Money("USD", 100), T0)
+            .close("campaign_cancelled", T0.plusSeconds(1));
+
+        assertThat(closed.closed()).isTrue();
+        assertThatThrownBy(() -> closed.reserve(new Money("USD", 1), "item-1", T0.plusSeconds(2)))
+            .isInstanceOf(DomainException.class)
+            .hasMessageContaining("closed budget");
+    }
+}

--- a/services/marketing-campaign/src/test/java/com/trainticket/marketingcampaign/domain/CampaignTest.java
+++ b/services/marketing-campaign/src/test/java/com/trainticket/marketingcampaign/domain/CampaignTest.java
@@ -1,0 +1,50 @@
+package com.trainticket.marketingcampaign.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class CampaignTest {
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+    private static final CampaignWindow WINDOW = new CampaignWindow(T0, Instant.parse("2026-02-01T00:00:00Z"));
+
+    @Test void followsApprovalSchedulingAndCompletionLifecycle() {
+        Campaign campaign = Campaign.draft("campaign-1", "spring-sale-v1", "Spring Sale", WINDOW, T0)
+            .submitForReview(T0.plusSeconds(1))
+            .approve("approval-1", T0.plusSeconds(2))
+            .withLaunchReadiness("budget-1", "rules-1")
+            .schedule(T0.plusSeconds(3))
+            .start(T0.plusSeconds(4))
+            .pause("downstream_unavailable", "operator-1", T0.plusSeconds(5))
+            .resume("wallet_recovered", "operator-1", T0.plusSeconds(6))
+            .beginCompletion("window_elapsed", T0.plusSeconds(7))
+            .complete("all_batches_closed", T0.plusSeconds(8));
+
+        assertThat(campaign.status()).isEqualTo(CampaignStatus.COMPLETED);
+        assertThat(campaign.version()).isEqualTo(9);
+        assertThat(campaign.domainEvents()).hasSize(9);
+    }
+
+    @Test void rejectsInvalidTransitionsAndTerminalReopening() {
+        Campaign draft = Campaign.draft("campaign-1", "spring-sale-v1", "Spring Sale", WINDOW, T0);
+
+        assertThatThrownBy(() -> draft.schedule(T0)).isInstanceOf(DomainException.class)
+            .hasMessageContaining("invalid campaign transition");
+        assertThatThrownBy(() -> draft.start(T0.minusSeconds(1))).isInstanceOf(DomainException.class)
+            .hasMessageContaining("before validFrom");
+
+        Campaign cancelled = draft.cancel("duplicate", "operator-1", T0.plusSeconds(1));
+        assertThatThrownBy(() -> cancelled.submitForReview(T0.plusSeconds(2))).isInstanceOf(DomainException.class);
+        assertThatThrownBy(() -> cancelled.withLaunchReadiness("budget-1", "rules-1")).isInstanceOf(DomainException.class);
+    }
+
+    @Test void requiresLaunchReadinessBeforeSchedulingApprovedCampaign() {
+        Campaign approved = Campaign.draft("campaign-1", "spring-sale-v1", "Spring Sale", WINDOW, T0)
+            .submitForReview(T0.plusSeconds(1))
+            .approve("approval-1", T0.plusSeconds(2));
+
+        assertThatThrownBy(() -> approved.schedule(T0.plusSeconds(3))).isInstanceOf(DomainException.class)
+            .hasMessageContaining("budgetId is required");
+    }
+}

--- a/services/marketing-campaign/src/test/java/com/trainticket/marketingcampaign/domain/CouponTemplateTest.java
+++ b/services/marketing-campaign/src/test/java/com/trainticket/marketingcampaign/domain/CouponTemplateTest.java
@@ -1,0 +1,46 @@
+package com.trainticket.marketingcampaign.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class CouponTemplateTest {
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+    private static final CampaignWindow CAMPAIGN_WINDOW = new CampaignWindow(T0, Instant.parse("2026-03-01T00:00:00Z"));
+    private static final CampaignWindow TEMPLATE_WINDOW = new CampaignWindow(T0.plusSeconds(60), Instant.parse("2026-02-01T00:00:00Z"));
+
+    @Test void followsValidationPublishSupersedeRetireLifecycle() {
+        CouponTemplate template = template()
+            .validate(T0.plusSeconds(1))
+            .publish("approval-1", T0.plusSeconds(2))
+            .supersede("template-2", T0.plusSeconds(3))
+            .retire("new_version_live", T0.plusSeconds(4));
+
+        assertThat(template.status()).isEqualTo(CouponTemplateStatus.RETIRED);
+        assertThat(template.domainEvents()).hasSize(5);
+    }
+
+    @Test void publishedTemplatesAreImmutable() {
+        CouponTemplate published = template().validate(T0.plusSeconds(1)).publish("approval-1", T0.plusSeconds(2));
+
+        assertThatThrownBy(() -> published.revise(new Money("USD", 200), Money.zero("USD"), "ANY_TRIP", "single-use", TEMPLATE_WINDOW, CAMPAIGN_WINDOW, T0.plusSeconds(3)))
+            .isInstanceOf(DomainException.class)
+            .hasMessageContaining("new version");
+        assertThatThrownBy(() -> published.validate(T0.plusSeconds(4)))
+            .isInstanceOf(DomainException.class)
+            .hasMessageContaining("invalid coupon template transition");
+    }
+
+    @Test void validityMustStayWithinCampaignWindow() {
+        CampaignWindow outside = new CampaignWindow(T0.minusSeconds(1), T0.plusSeconds(10));
+
+        assertThatThrownBy(() -> CouponTemplate.draft("template-1", "campaign-1", "WELCOME", 1, new Money("USD", 100), Money.zero("USD"), "ANY_TRIP", "single-use", outside, CAMPAIGN_WINDOW, T0))
+            .isInstanceOf(DomainException.class)
+            .hasMessageContaining("within campaign window");
+    }
+
+    private static CouponTemplate template() {
+        return CouponTemplate.draft("template-1", "campaign-1", "WELCOME", 1, new Money("USD", 100), Money.zero("USD"), "ANY_TRIP", "single-use", TEMPLATE_WINDOW, CAMPAIGN_WINDOW, T0);
+    }
+}

--- a/services/marketing-campaign/src/test/java/com/trainticket/marketingcampaign/domain/IssuanceBatchTest.java
+++ b/services/marketing-campaign/src/test/java/com/trainticket/marketingcampaign/domain/IssuanceBatchTest.java
@@ -1,0 +1,58 @@
+package com.trainticket.marketingcampaign.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class IssuanceBatchTest {
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+    private static final CampaignWindow BENEFIT_WINDOW = new CampaignWindow(T0, Instant.parse("2026-02-01T00:00:00Z"));
+
+    @Test void runsItemsAndClosesSucceededBatch() {
+        IssuanceBatch batch = IssuanceBatch.plan("batch-1", "campaign-1", "template-1", "audience-1", T0)
+            .start(T0.plusSeconds(1));
+        IssuanceBatch.IssueItemResult issued = batch.issueCampaignCoupon("item-1", "account-1", "idem-1", new Money("USD", 100), BENEFIT_WINDOW, T0.plusSeconds(2));
+
+        assertThat(issued.replayed()).isFalse();
+        batch = issued.batch().recordWalletIssuanceAccepted("item-1", "benefit-1", T0.plusSeconds(3))
+            .markSucceeded(T0.plusSeconds(4))
+            .close("all_items_accepted", T0.plusSeconds(5));
+
+        assertThat(batch.status()).isEqualTo(IssuanceBatchStatus.CLOSED);
+        assertThat(batch.itemsById().get("item-1").status()).isEqualTo(IssuanceItemStatus.ACCEPTED);
+    }
+
+    @Test void replaysSameIdempotencyMaterialAndRejectsDuplicateActiveRecipient() {
+        IssuanceBatch batch = IssuanceBatch.plan("batch-1", "campaign-1", "template-1", "audience-1", T0)
+            .start(T0.plusSeconds(1));
+        IssuanceBatch.IssueItemResult first = batch.issueCampaignCoupon("item-1", "account-1", "idem-1", new Money("USD", 100), BENEFIT_WINDOW, T0.plusSeconds(2));
+        IssuanceBatch.IssueItemResult replay = first.batch().issueCampaignCoupon("item-2", "account-1", "idem-1", new Money("USD", 100), BENEFIT_WINDOW, T0.plusSeconds(3));
+
+        assertThat(replay.replayed()).isTrue();
+        assertThat(replay.item().issuanceItemId()).isEqualTo("item-1");
+        assertThat(replay.batch().itemsById()).hasSize(1);
+        assertThatThrownBy(() -> replay.batch().issueCampaignCoupon("item-2", "account-1", "idem-2", new Money("USD", 100), BENEFIT_WINDOW, T0.plusSeconds(4)))
+            .isInstanceOf(DomainException.class)
+            .hasMessageContaining("active issuance item already exists");
+    }
+
+    @Test void supportsFailureRetryAndIrreversibleRestingStates() {
+        IssuanceBatch batch = IssuanceBatch.plan("batch-1", "campaign-1", "template-1", "audience-1", T0)
+            .start(T0.plusSeconds(1));
+        batch = batch.issueCampaignCoupon("item-1", "account-1", "idem-1", new Money("USD", 100), BENEFIT_WINDOW, T0.plusSeconds(2)).batch()
+            .recordIssuanceItemFailed("item-1", "BLOCKED_BY_CONTRACT", T0.plusSeconds(3))
+            .retryIssuanceItem("item-1", 1, T0.plusSeconds(4));
+
+        assertThat(batch.itemsById().get("item-1").status()).isEqualTo(IssuanceItemStatus.RETRY_SCHEDULED);
+
+        IssuanceBatch closedFailure = IssuanceBatch.plan("batch-2", "campaign-1", "template-1", "audience-1", T0)
+            .start(T0.plusSeconds(1))
+            .fail("wallet_down", T0.plusSeconds(2))
+            .close("manual_case_opened", T0.plusSeconds(3));
+
+        assertThatThrownBy(() -> closedFailure.markSucceeded(T0.plusSeconds(4)))
+            .isInstanceOf(DomainException.class)
+            .hasMessageContaining("invalid issuance batch transition");
+    }
+}


### PR DESCRIPTION
## Summary
AgentM/GPT REQ-220: Marketing-campaign domain layer (+1076 lines, Java).

**Aggregates**:
- Campaign (10-state: DRAFT→IN_REVIEW→APPROVED→SCHEDULED→ACTIVE→PAUSED→COMPLETING→COMPLETED/FAILED/CANCELLED)
- CampaignBudget (reserve/consume/release, `reserved + consumed <= total` invariant)
- CouponTemplate (5-state: DRAFT→VALIDATED→PUBLISHED→SUPERSEDED→RETIRED)
- IssuanceBatch (10-state: PLANNED→RUNNING→SUCCEEDED/FAILED/MISSED→CLOSED)

**Tests**: 207 lines covering state transitions, budget overdraft, template immutability, batch idempotency.

Task 1/3 for marketing-campaign. REQ-221 (API+infra) and REQ-222 (events+ACL) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code) + AgentM/GPT