### PR TITLE
feat(marketing-campaign): application + API + persistence + deployment

### DIFF
--- a/deploy/build-images.sh
+++ b/deploy/build-images.sh
@@ -36,6 +36,7 @@ services=(
   legacy-acl
   waitlist
   wallet-promotion
+  marketing-campaign
   dispatch
   disruption-recovery
   transfer-management

--- a/deploy/docker/marketing-campaign/Dockerfile
+++ b/deploy/docker/marketing-campaign/Dockerfile
@@ -1,0 +1,6 @@
+FROM eclipse-temurin:25-jre
+WORKDIR /app
+COPY services/marketing-campaign/target/marketing-campaign.jar /app/marketing-campaign.jar
+COPY services/marketing-campaign/migrations /app/migrations
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app/marketing-campaign.jar"]

--- a/deploy/k8s/services.yaml
+++ b/deploy/k8s/services.yaml
@@ -3136,6 +3136,94 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: marketing-campaign
+  namespace: train-ticket
+  labels:
+    app.kubernetes.io/name: marketing-campaign
+    app.kubernetes.io/part-of: train-ticket
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: marketing-campaign
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: marketing-campaign
+        app.kubernetes.io/part-of: train-ticket
+    spec:
+      containers:
+        - name: marketing-campaign
+          image: train-ticket/marketing-campaign:local
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"
+            - name: SERVER_PORT
+              value: "8080"
+            - name: REDIS_URL
+              value: redis://redis.train-ticket.svc.cluster.local:6379
+            - name: DATABASE_URL
+              value: postgresql://trainticket:trainticket-dev@postgres:5432/marketing_campaign
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://otel-collector:4317
+            - name: OTEL_SERVICE_NAME
+              value: marketing-campaign
+            - name: OTEL_TRACES_EXPORTER
+              value: otlp
+            - name: OTEL_METRICS_EXPORTER
+              value: none
+            - name: OTEL_LOGS_EXPORTER
+              value: none
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: marketing-campaign
+  namespace: train-ticket
+  labels:
+    app.kubernetes.io/name: marketing-campaign
+    app.kubernetes.io/part-of: train-ticket
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+  selector:
+    app.kubernetes.io/name: marketing-campaign
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: group-booking
   namespace: train-ticket
   labels:

--- a/services/marketing-campaign/migrations/001_marketing_campaign.sql
+++ b/services/marketing-campaign/migrations/001_marketing_campaign.sql
@@ -1,0 +1,125 @@
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version varchar(128) PRIMARY KEY,
+    applied_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS campaigns (
+    campaign_id varchar(96) PRIMARY KEY,
+    version bigint NOT NULL,
+    data jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS campaigns_external_key_idx ON campaigns ((data->>'externalKey'));
+CREATE INDEX IF NOT EXISTS campaigns_status_idx ON campaigns ((data->>'status'));
+
+CREATE TABLE IF NOT EXISTS campaign_budgets (
+    budget_id varchar(96) PRIMARY KEY,
+    campaign_id varchar(96) NOT NULL,
+    version bigint NOT NULL,
+    data jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT campaign_budgets_campaign_fk FOREIGN KEY (campaign_id) REFERENCES campaigns(campaign_id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS campaign_budgets_campaign_id_idx ON campaign_budgets (campaign_id);
+
+CREATE TABLE IF NOT EXISTS targeting_rule_sets (
+    rule_set_id varchar(96) PRIMARY KEY,
+    campaign_id varchar(96) NOT NULL,
+    version bigint NOT NULL DEFAULT 1,
+    data jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT targeting_rule_sets_campaign_fk FOREIGN KEY (campaign_id) REFERENCES campaigns(campaign_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS targeting_rule_sets_campaign_id_idx ON targeting_rule_sets (campaign_id);
+
+CREATE TABLE IF NOT EXISTS coupon_templates (
+    template_id varchar(96) PRIMARY KEY,
+    campaign_id varchar(96) NOT NULL,
+    version bigint NOT NULL,
+    data jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT coupon_templates_campaign_fk FOREIGN KEY (campaign_id) REFERENCES campaigns(campaign_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS coupon_templates_campaign_id_idx ON coupon_templates (campaign_id);
+CREATE UNIQUE INDEX IF NOT EXISTS coupon_templates_code_version_idx ON coupon_templates ((data->>'templateCode'), ((data->>'templateVersion')::integer));
+
+CREATE TABLE IF NOT EXISTS issuance_batches (
+    batch_id varchar(96) PRIMARY KEY,
+    campaign_id varchar(96) NOT NULL,
+    template_id varchar(96) NOT NULL,
+    version bigint NOT NULL,
+    data jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT issuance_batches_campaign_fk FOREIGN KEY (campaign_id) REFERENCES campaigns(campaign_id) ON DELETE CASCADE,
+    CONSTRAINT issuance_batches_template_fk FOREIGN KEY (template_id) REFERENCES coupon_templates(template_id) ON DELETE RESTRICT
+);
+
+CREATE INDEX IF NOT EXISTS issuance_batches_campaign_id_idx ON issuance_batches (campaign_id);
+CREATE INDEX IF NOT EXISTS issuance_batches_template_id_idx ON issuance_batches (template_id);
+CREATE INDEX IF NOT EXISTS issuance_batches_status_idx ON issuance_batches ((data->>'status'));
+
+CREATE TABLE IF NOT EXISTS issuance_items (
+    item_id varchar(96) PRIMARY KEY,
+    batch_id varchar(96) NOT NULL,
+    campaign_id varchar(96) NOT NULL,
+    template_id varchar(96) NOT NULL,
+    account_id varchar(128) NOT NULL,
+    idempotency_key varchar(160) NOT NULL,
+    status varchar(48) NOT NULL,
+    data jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT issuance_items_batch_fk FOREIGN KEY (batch_id) REFERENCES issuance_batches(batch_id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS issuance_items_idempotency_idx ON issuance_items (batch_id, idempotency_key);
+CREATE INDEX IF NOT EXISTS issuance_items_campaign_idx ON issuance_items (campaign_id, template_id, account_id);
+
+CREATE TABLE IF NOT EXISTS redemption_validations (
+    validation_id varchar(96) PRIMARY KEY,
+    campaign_id varchar(96) NOT NULL,
+    template_id varchar(96) NOT NULL,
+    account_id varchar(128) NOT NULL,
+    benefit_id varchar(128) NOT NULL,
+    status varchar(48) NOT NULL,
+    data jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS redemption_validations_benefit_idx ON redemption_validations (benefit_id);
+CREATE INDEX IF NOT EXISTS redemption_validations_campaign_idx ON redemption_validations (campaign_id, template_id);
+
+CREATE TABLE IF NOT EXISTS outbox (
+    seq bigserial PRIMARY KEY,
+    event_id text NOT NULL UNIQUE,
+    stream text NOT NULL,
+    envelope jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    published_at timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS outbox_unpublished_idx ON outbox (seq) WHERE published_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS processed_events (
+    event_id text PRIMARY KEY,
+    stream text,
+    processed_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS idempotency_records (
+    key text PRIMARY KEY,
+    request_hash text NOT NULL,
+    status_code int NOT NULL,
+    response_body jsonb,
+    created_at timestamptz NOT NULL DEFAULT now()
+);

--- a/services/marketing-campaign/pom.xml
+++ b/services/marketing-campaign/pom.xml
@@ -11,7 +11,7 @@
   <groupId>com.trainticket</groupId>
   <artifactId>marketing-campaign</artifactId>
   <version>0.1.0-SNAPSHOT</version>
-  <name>Marketing Campaign service domain</name>
+  <name>Marketing Campaign service</name>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>25</java.version>
@@ -24,8 +24,47 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-webmvc-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <finalName>marketing-campaign</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/Application.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/Application.java
@@ -1,0 +1,22 @@
+package com.trainticket.marketingcampaign;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+    public static ServiceProfile profile() {
+        return new ServiceProfile(
+            "marketing-campaign",
+            "Marketing Campaign",
+            "java",
+            "phase-1-commercial",
+            "REQ-221",
+            "Campaign, CampaignBudget, CouponTemplate, IssuanceBatch"
+        );
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/HealthController.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/HealthController.java
@@ -1,0 +1,41 @@
+package com.trainticket.marketingcampaign;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+    private final Clock clock;
+
+    HealthController() {
+        this(Clock.systemUTC());
+    }
+
+    HealthController(Clock clock) {
+        this.clock = clock;
+    }
+
+    @GetMapping({"/health", "/healthz"})
+    public Map<String, Object> health() {
+        return Map.of("status", "ok", "service", Application.profile());
+    }
+
+    @GetMapping({"/live", "/livez"})
+    public Map<String, Object> live() {
+        return Map.of("status", "live", "serviceId", Application.profile().serviceId());
+    }
+
+    @GetMapping({"/ready", "/readyz"})
+    public ResponseEntity<Map<String, Object>> ready() {
+        return ResponseEntity.ok(Map.of("status", "ready", "serviceId", Application.profile().serviceId()));
+    }
+
+    @GetMapping("/metadata")
+    public Map<String, Object> metadata() {
+        return Map.of("service", Application.profile(), "generatedAt", Instant.now(clock).toString());
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/ServiceProfile.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/ServiceProfile.java
@@ -1,0 +1,3 @@
+package com.trainticket.marketingcampaign;
+
+public record ServiceProfile(String serviceId, String name, String runtime, String domain, String requirement, String aggregates) {}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/api/CampaignApiSupport.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/api/CampaignApiSupport.java
@@ -1,0 +1,48 @@
+package com.trainticket.marketingcampaign.api;
+
+import com.trainticket.marketingcampaign.application.NotFoundException;
+import com.trainticket.marketingcampaign.domain.CampaignWindow;
+import com.trainticket.marketingcampaign.domain.DomainException;
+import com.trainticket.marketingcampaign.domain.Money;
+import com.trainticket.platformkit.messaging.PrefixedIds;
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+abstract class CampaignApiSupport {
+    protected static String correlationId(HttpServletRequest request) {
+        String header = request.getHeader("X-Correlation-Id");
+        return PrefixedIds.isCorrelationId(header) ? header : PrefixedIds.newCorrelationId();
+    }
+
+    protected static void requireText(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new DomainException(name + " is required");
+        }
+    }
+
+    @ExceptionHandler(DomainException.class)
+    ResponseEntity<Map<String, String>> domainError(DomainException exception) {
+        return ResponseEntity.badRequest().body(Map.of("error", "VALIDATION_FAILED", "message", exception.getMessage()));
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    ResponseEntity<Map<String, String>> notFound(NotFoundException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", "NOT_FOUND", "message", exception.getMessage()));
+    }
+
+    record MoneyRequest(String currency, long minorUnits) {
+        Money toMoney() {
+            return new Money(currency, minorUnits);
+        }
+    }
+
+    record WindowRequest(Instant validFrom, Instant validUntil) {
+        CampaignWindow toWindow() {
+            return new CampaignWindow(validFrom, validUntil);
+        }
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/api/CampaignController.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/api/CampaignController.java
@@ -1,0 +1,114 @@
+package com.trainticket.marketingcampaign.api;
+
+import com.trainticket.marketingcampaign.application.MarketingCampaignService;
+import com.trainticket.marketingcampaign.application.MarketingCampaignService.CampaignDetail;
+import com.trainticket.marketingcampaign.domain.DomainException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/campaigns")
+public class CampaignController extends CampaignApiSupport {
+    private final MarketingCampaignService service;
+
+    public CampaignController(MarketingCampaignService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    public ResponseEntity<CampaignDetail> draft(@RequestBody DraftCampaignRequest request, HttpServletRequest httpRequest) {
+        request.validate();
+        CampaignDetail detail = service.draftCampaign(
+            new MarketingCampaignService.DraftCampaignCommand(request.externalKey(), request.name(), request.window().toWindow()),
+            correlationId(httpRequest)
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(detail);
+    }
+
+    @GetMapping("/{campaignId}")
+    public CampaignDetail get(@PathVariable String campaignId) {
+        return service.get(campaignId);
+    }
+
+    @PostMapping("/{campaignId}/submit")
+    public CampaignDetail submit(@PathVariable String campaignId, HttpServletRequest httpRequest) {
+        return service.submitCampaign(campaignId, correlationId(httpRequest));
+    }
+
+    @PostMapping("/{campaignId}/approve")
+    public CampaignDetail approve(@PathVariable String campaignId, @RequestBody ApprovalRequest request, HttpServletRequest httpRequest) {
+        request.validate();
+        return service.approveCampaign(campaignId, new MarketingCampaignService.ApproveCampaignCommand(request.approvalRef()), correlationId(httpRequest));
+    }
+
+    @PostMapping("/{campaignId}/schedule")
+    public CampaignDetail schedule(@PathVariable String campaignId, HttpServletRequest httpRequest) {
+        return service.scheduleCampaign(campaignId, correlationId(httpRequest));
+    }
+
+    @PostMapping("/{campaignId}/start")
+    public CampaignDetail start(@PathVariable String campaignId, HttpServletRequest httpRequest) {
+        return service.startCampaign(campaignId, correlationId(httpRequest));
+    }
+
+    @PostMapping("/{campaignId}/pause")
+    public CampaignDetail pause(@PathVariable String campaignId, @RequestBody OperatorReasonRequest request, HttpServletRequest httpRequest) {
+        request.validate();
+        return service.pauseCampaign(campaignId, new MarketingCampaignService.OperatorReasonCommand(request.reason(), request.operatorRef()), correlationId(httpRequest));
+    }
+
+    @PostMapping("/{campaignId}/complete")
+    public CampaignDetail complete(@PathVariable String campaignId, @RequestBody ReasonRequest request, HttpServletRequest httpRequest) {
+        request.validate();
+        return service.completeCampaign(campaignId, new MarketingCampaignService.ReasonCommand(request.reason()), correlationId(httpRequest));
+    }
+
+    @PostMapping("/{campaignId}/cancel")
+    public CampaignDetail cancel(@PathVariable String campaignId, @RequestBody OperatorReasonRequest request, HttpServletRequest httpRequest) {
+        request.validate();
+        return service.cancelCampaign(campaignId, new MarketingCampaignService.OperatorReasonCommand(request.reason(), request.operatorRef()), correlationId(httpRequest));
+    }
+
+    @PostMapping("/{campaignId}/budget")
+    public CampaignDetail setBudget(@PathVariable String campaignId, @RequestBody SetBudgetRequest request, HttpServletRequest httpRequest) {
+        request.validate();
+        return service.setBudget(campaignId, new MarketingCampaignService.SetBudgetCommand(request.totalBudget().toMoney(), request.targetRuleSetId()), correlationId(httpRequest));
+    }
+
+    public record DraftCampaignRequest(String externalKey, String name, WindowRequest window) {
+        void validate() {
+            requireText(externalKey, "externalKey");
+            requireText(name, "name");
+            if (window == null) throw new DomainException("window is required");
+        }
+    }
+
+    public record ApprovalRequest(String approvalRef) {
+        void validate() { requireText(approvalRef, "approvalRef"); }
+    }
+
+    public record ReasonRequest(String reason) {
+        void validate() { requireText(reason, "reason"); }
+    }
+
+    public record OperatorReasonRequest(String reason, String operatorRef) {
+        void validate() {
+            requireText(reason, "reason");
+            requireText(operatorRef, "operatorRef");
+        }
+    }
+
+    public record SetBudgetRequest(MoneyRequest totalBudget, String targetRuleSetId) {
+        void validate() {
+            if (totalBudget == null) throw new DomainException("totalBudget is required");
+            requireText(targetRuleSetId, "targetRuleSetId");
+        }
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/api/CouponTemplateController.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/api/CouponTemplateController.java
@@ -1,0 +1,77 @@
+package com.trainticket.marketingcampaign.api;
+
+import com.trainticket.marketingcampaign.application.MarketingCampaignService;
+import com.trainticket.marketingcampaign.application.MarketingCampaignService.TemplateDetail;
+import com.trainticket.marketingcampaign.domain.DomainException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CouponTemplateController extends CampaignApiSupport {
+    private final MarketingCampaignService service;
+
+    public CouponTemplateController(MarketingCampaignService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/api/v1/campaigns/{campaignId}/templates")
+    public ResponseEntity<TemplateDetail> draft(@PathVariable String campaignId, @RequestBody DraftTemplateRequest request, HttpServletRequest httpRequest) {
+        request.validate();
+        TemplateDetail detail = service.draftTemplate(
+            campaignId,
+            new MarketingCampaignService.DraftTemplateCommand(
+                request.templateCode(),
+                request.templateVersion(),
+                request.faceValue().toMoney(),
+                request.minimumSpend().toMoney(),
+                request.applicableScope(),
+                request.redemptionRule(),
+                request.validityWindow().toWindow()
+            ),
+            correlationId(httpRequest)
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(detail);
+    }
+
+    @PostMapping("/api/v1/templates/{templateId}/validate")
+    public TemplateDetail validate(@PathVariable String templateId, HttpServletRequest httpRequest) {
+        return service.validateTemplate(templateId, correlationId(httpRequest));
+    }
+
+    @PostMapping("/api/v1/templates/{templateId}/publish")
+    public TemplateDetail publish(@PathVariable String templateId, @RequestBody ApprovalRequest request, HttpServletRequest httpRequest) {
+        request.validate();
+        return service.publishTemplate(templateId, new MarketingCampaignService.ApproveCampaignCommand(request.approvalRef()), correlationId(httpRequest));
+    }
+
+    @PostMapping("/api/v1/templates/{templateId}/retire")
+    public TemplateDetail retire(@PathVariable String templateId, @RequestBody ReasonRequest request, HttpServletRequest httpRequest) {
+        request.validate();
+        return service.retireTemplate(templateId, new MarketingCampaignService.ReasonCommand(request.reason()), correlationId(httpRequest));
+    }
+
+    public record DraftTemplateRequest(String templateCode, int templateVersion, MoneyRequest faceValue, MoneyRequest minimumSpend, String applicableScope, String redemptionRule, WindowRequest validityWindow) {
+        void validate() {
+            requireText(templateCode, "templateCode");
+            if (templateVersion <= 0) throw new DomainException("templateVersion must be positive");
+            if (faceValue == null) throw new DomainException("faceValue is required");
+            if (minimumSpend == null) throw new DomainException("minimumSpend is required");
+            requireText(applicableScope, "applicableScope");
+            requireText(redemptionRule, "redemptionRule");
+            if (validityWindow == null) throw new DomainException("validityWindow is required");
+        }
+    }
+
+    public record ApprovalRequest(String approvalRef) {
+        void validate() { requireText(approvalRef, "approvalRef"); }
+    }
+
+    public record ReasonRequest(String reason) {
+        void validate() { requireText(reason, "reason"); }
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/api/IssuanceBatchController.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/api/IssuanceBatchController.java
@@ -1,0 +1,49 @@
+package com.trainticket.marketingcampaign.api;
+
+import com.trainticket.marketingcampaign.application.MarketingCampaignService;
+import com.trainticket.marketingcampaign.application.MarketingCampaignService.BatchDetail;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class IssuanceBatchController extends CampaignApiSupport {
+    private final MarketingCampaignService service;
+
+    public IssuanceBatchController(MarketingCampaignService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/api/v1/campaigns/{campaignId}/batches")
+    public ResponseEntity<BatchDetail> plan(@PathVariable String campaignId, @RequestBody PlanBatchRequest request, HttpServletRequest httpRequest) {
+        request.validate();
+        BatchDetail detail = service.planBatch(campaignId, new MarketingCampaignService.PlanBatchCommand(request.templateId(), request.audienceSnapshotId()), correlationId(httpRequest));
+        return ResponseEntity.status(HttpStatus.CREATED).body(detail);
+    }
+
+    @PostMapping("/api/v1/batches/{batchId}/start")
+    public BatchDetail start(@PathVariable String batchId, HttpServletRequest httpRequest) {
+        return service.startBatch(batchId, correlationId(httpRequest));
+    }
+
+    @PostMapping("/api/v1/batches/{batchId}/close")
+    public BatchDetail close(@PathVariable String batchId, @RequestBody ReasonRequest request, HttpServletRequest httpRequest) {
+        request.validate();
+        return service.closeBatch(batchId, new MarketingCampaignService.ReasonCommand(request.reason()), correlationId(httpRequest));
+    }
+
+    public record PlanBatchRequest(String templateId, String audienceSnapshotId) {
+        void validate() {
+            requireText(templateId, "templateId");
+            requireText(audienceSnapshotId, "audienceSnapshotId");
+        }
+    }
+
+    public record ReasonRequest(String reason) {
+        void validate() { requireText(reason, "reason"); }
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/application/CampaignRepository.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/application/CampaignRepository.java
@@ -1,0 +1,25 @@
+package com.trainticket.marketingcampaign.application;
+
+import com.trainticket.marketingcampaign.domain.Campaign;
+import com.trainticket.marketingcampaign.domain.CampaignBudget;
+import com.trainticket.marketingcampaign.domain.CouponTemplate;
+import com.trainticket.marketingcampaign.domain.IssuanceBatch;
+import java.util.List;
+import java.util.Optional;
+
+public interface CampaignRepository {
+    void saveCampaign(Campaign campaign);
+    Optional<Campaign> findCampaign(String campaignId);
+
+    void saveBudget(CampaignBudget budget);
+    Optional<CampaignBudget> findBudget(String budgetId);
+    Optional<CampaignBudget> findBudgetByCampaignId(String campaignId);
+
+    void saveTemplate(CouponTemplate template);
+    Optional<CouponTemplate> findTemplate(String templateId);
+    List<CouponTemplate> findTemplatesByCampaignId(String campaignId);
+
+    void saveBatch(IssuanceBatch batch);
+    Optional<IssuanceBatch> findBatch(String issuanceBatchId);
+    List<IssuanceBatch> findBatchesByCampaignId(String campaignId);
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/application/DefaultEventPublisherConfiguration.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/application/DefaultEventPublisherConfiguration.java
@@ -1,0 +1,16 @@
+package com.trainticket.marketingcampaign.application;
+
+import com.trainticket.platformkit.messaging.EventPublisher;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DefaultEventPublisherConfiguration {
+    @Bean
+    @ConditionalOnMissingBean(EventPublisher.class)
+    EventPublisher inMemoryEventPublisher() {
+        return envelope -> {
+        };
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/application/DomainEventPayloads.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/application/DomainEventPayloads.java
@@ -1,0 +1,30 @@
+package com.trainticket.marketingcampaign.application;
+
+import com.trainticket.marketingcampaign.domain.DomainEvent;
+import java.lang.reflect.RecordComponent;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class DomainEventPayloads {
+    private DomainEventPayloads() {}
+
+    public static Map<String, Object> toMap(DomainEvent event) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("eventType", event.getClass().getSimpleName());
+        if (event.getClass().isRecord()) {
+            for (RecordComponent component : event.getClass().getRecordComponents()) {
+                try {
+                    component.getAccessor().setAccessible(true);
+                    payload.put(component.getName(), component.getAccessor().invoke(event));
+                } catch (ReflectiveOperationException exception) {
+                    throw new IllegalStateException("domain event payload could not be read", exception);
+                }
+            }
+        } else {
+            payload.put("aggregateId", event.aggregateId());
+            payload.put("occurredAt", event.occurredAt());
+            payload.put("aggregateVersion", event.aggregateVersion());
+        }
+        return payload;
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/application/InMemoryCampaignRepository.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/application/InMemoryCampaignRepository.java
@@ -1,0 +1,76 @@
+package com.trainticket.marketingcampaign.application;
+
+import com.trainticket.marketingcampaign.domain.Campaign;
+import com.trainticket.marketingcampaign.domain.CampaignBudget;
+import com.trainticket.marketingcampaign.domain.CouponTemplate;
+import com.trainticket.marketingcampaign.domain.IssuanceBatch;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@ConditionalOnExpression("'${DATABASE_URL:}' == ''")
+public class InMemoryCampaignRepository implements CampaignRepository {
+    private final ConcurrentMap<String, Campaign> campaigns = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, CampaignBudget> budgets = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, CouponTemplate> templates = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, IssuanceBatch> batches = new ConcurrentHashMap<>();
+
+    @Override
+    public void saveCampaign(Campaign campaign) {
+        campaigns.put(campaign.campaignId(), campaign);
+    }
+
+    @Override
+    public Optional<Campaign> findCampaign(String campaignId) {
+        return Optional.ofNullable(campaigns.get(campaignId));
+    }
+
+    @Override
+    public void saveBudget(CampaignBudget budget) {
+        budgets.put(budget.budgetId(), budget);
+    }
+
+    @Override
+    public Optional<CampaignBudget> findBudget(String budgetId) {
+        return Optional.ofNullable(budgets.get(budgetId));
+    }
+
+    @Override
+    public Optional<CampaignBudget> findBudgetByCampaignId(String campaignId) {
+        return budgets.values().stream().filter(budget -> budget.campaignId().equals(campaignId)).findFirst();
+    }
+
+    @Override
+    public void saveTemplate(CouponTemplate template) {
+        templates.put(template.templateId(), template);
+    }
+
+    @Override
+    public Optional<CouponTemplate> findTemplate(String templateId) {
+        return Optional.ofNullable(templates.get(templateId));
+    }
+
+    @Override
+    public List<CouponTemplate> findTemplatesByCampaignId(String campaignId) {
+        return templates.values().stream().filter(template -> template.campaignId().equals(campaignId)).toList();
+    }
+
+    @Override
+    public void saveBatch(IssuanceBatch batch) {
+        batches.put(batch.issuanceBatchId(), batch);
+    }
+
+    @Override
+    public Optional<IssuanceBatch> findBatch(String issuanceBatchId) {
+        return Optional.ofNullable(batches.get(issuanceBatchId));
+    }
+
+    @Override
+    public List<IssuanceBatch> findBatchesByCampaignId(String campaignId) {
+        return batches.values().stream().filter(batch -> batch.campaignId().equals(campaignId)).toList();
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/application/MarketingCampaignService.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/application/MarketingCampaignService.java
@@ -1,0 +1,324 @@
+package com.trainticket.marketingcampaign.application;
+
+import com.trainticket.marketingcampaign.domain.Campaign;
+import com.trainticket.marketingcampaign.domain.CampaignBudget;
+import com.trainticket.marketingcampaign.domain.CampaignWindow;
+import com.trainticket.marketingcampaign.domain.CouponTemplate;
+import com.trainticket.marketingcampaign.domain.DomainEvent;
+import com.trainticket.marketingcampaign.domain.IssuanceBatch;
+import com.trainticket.marketingcampaign.domain.Money;
+import com.trainticket.platformkit.idempotency.UuidV7;
+import com.trainticket.platformkit.messaging.EventEnvelopeFactory;
+import com.trainticket.platformkit.messaging.EventPublisher;
+import com.trainticket.platformkit.messaging.PrefixedIds;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MarketingCampaignService {
+    private static final String PRODUCER = "marketing-campaign";
+
+    private final Clock clock;
+    private final CampaignRepository repository;
+    private final EventPublisher publisher;
+    private final EventEnvelopeFactory envelopeFactory;
+
+    @Autowired
+    public MarketingCampaignService(CampaignRepository repository, EventPublisher publisher) {
+        this(Clock.systemUTC(), repository, publisher);
+    }
+
+    public MarketingCampaignService(Clock clock, CampaignRepository repository, EventPublisher publisher) {
+        this.clock = Objects.requireNonNull(clock, "clock is required");
+        this.repository = Objects.requireNonNull(repository, "repository is required");
+        this.publisher = Objects.requireNonNull(publisher, "publisher is required");
+        this.envelopeFactory = new EventEnvelopeFactory(PRODUCER, clock);
+    }
+
+    public CampaignDetail draftCampaign(DraftCampaignCommand command, String correlationId) {
+        Objects.requireNonNull(command, "command is required");
+        Campaign campaign = Campaign.draft(
+            "mc-" + UuidV7.generate(),
+            command.externalKey(),
+            command.name(),
+            command.window(),
+            clock.instant()
+        );
+        repository.saveCampaign(campaign);
+        publish(campaign.domainEvents(), correlationId);
+        return detail(campaign);
+    }
+
+    public CampaignDetail submitCampaign(String campaignId, String correlationId) {
+        Campaign previous = getCampaign(campaignId);
+        Campaign campaign = previous.submitForReview(clock.instant());
+        repository.saveCampaign(campaign);
+        publishSince(campaign.domainEvents(), previous.version(), correlationId);
+        return detail(campaign);
+    }
+
+    public CampaignDetail approveCampaign(String campaignId, ApproveCampaignCommand command, String correlationId) {
+        Objects.requireNonNull(command, "command is required");
+        Campaign previous = getCampaign(campaignId);
+        Campaign campaign = previous.approve(command.approvalRef(), clock.instant());
+        repository.saveCampaign(campaign);
+        publishSince(campaign.domainEvents(), previous.version(), correlationId);
+        return detail(campaign);
+    }
+
+    public CampaignDetail scheduleCampaign(String campaignId, String correlationId) {
+        Campaign previous = getCampaign(campaignId);
+        Campaign campaign = previous.schedule(clock.instant());
+        repository.saveCampaign(campaign);
+        publishSince(campaign.domainEvents(), previous.version(), correlationId);
+        return detail(campaign);
+    }
+
+    public CampaignDetail startCampaign(String campaignId, String correlationId) {
+        Campaign previous = getCampaign(campaignId);
+        Campaign campaign = previous.start(clock.instant());
+        repository.saveCampaign(campaign);
+        publishSince(campaign.domainEvents(), previous.version(), correlationId);
+        return detail(campaign);
+    }
+
+    public CampaignDetail pauseCampaign(String campaignId, OperatorReasonCommand command, String correlationId) {
+        Objects.requireNonNull(command, "command is required");
+        Campaign previous = getCampaign(campaignId);
+        Campaign campaign = previous.pause(command.reason(), command.operatorRef(), clock.instant());
+        repository.saveCampaign(campaign);
+        publishSince(campaign.domainEvents(), previous.version(), correlationId);
+        return detail(campaign);
+    }
+
+    public CampaignDetail completeCampaign(String campaignId, ReasonCommand command, String correlationId) {
+        Objects.requireNonNull(command, "command is required");
+        Instant now = clock.instant();
+        Campaign previous = getCampaign(campaignId);
+        Campaign campaign = previous.beginCompletion(command.reason(), now).complete(command.reason(), now);
+        repository.saveCampaign(campaign);
+        publishSince(campaign.domainEvents(), previous.version(), correlationId);
+        return detail(campaign);
+    }
+
+    public CampaignDetail cancelCampaign(String campaignId, OperatorReasonCommand command, String correlationId) {
+        Objects.requireNonNull(command, "command is required");
+        Campaign previous = getCampaign(campaignId);
+        Campaign campaign = previous.cancel(command.reason(), command.operatorRef(), clock.instant());
+        repository.saveCampaign(campaign);
+        publishSince(campaign.domainEvents(), previous.version(), correlationId);
+        return detail(campaign);
+    }
+
+    public CampaignDetail setBudget(String campaignId, SetBudgetCommand command, String correlationId) {
+        Objects.requireNonNull(command, "command is required");
+        Campaign campaign = getCampaign(campaignId);
+        String budgetId = "mcb-" + UuidV7.generate();
+        CampaignBudget budget = CampaignBudget.set(budgetId, campaignId, command.totalBudget(), clock.instant());
+        Campaign readyCampaign = campaign.withLaunchReadiness(budgetId, command.targetRuleSetId(), clock.instant());
+        repository.saveBudget(budget);
+        repository.saveCampaign(readyCampaign);
+        publish(budget.domainEvents(), correlationId);
+        return detail(readyCampaign);
+    }
+
+    public BudgetDetail reserveBudget(String budgetId, MoneyCommand command, String correlationId) {
+        Objects.requireNonNull(command, "command is required");
+        CampaignBudget previous = getBudget(budgetId);
+        CampaignBudget budget = previous.reserve(command.amount(), command.reference(), clock.instant());
+        repository.saveBudget(budget);
+        publishSince(budget.domainEvents(), previous.version(), correlationId);
+        return BudgetDetail.from(budget);
+    }
+
+    public BudgetDetail consumeBudget(String budgetId, MoneyCommand command, String correlationId) {
+        Objects.requireNonNull(command, "command is required");
+        CampaignBudget previous = getBudget(budgetId);
+        CampaignBudget budget = previous.consume(command.amount(), command.reference(), clock.instant());
+        repository.saveBudget(budget);
+        publishSince(budget.domainEvents(), previous.version(), correlationId);
+        return BudgetDetail.from(budget);
+    }
+
+    public BudgetDetail releaseBudget(String budgetId, MoneyCommand command, String correlationId) {
+        Objects.requireNonNull(command, "command is required");
+        CampaignBudget previous = getBudget(budgetId);
+        CampaignBudget budget = previous.release(command.amount(), command.reference(), clock.instant());
+        repository.saveBudget(budget);
+        publishSince(budget.domainEvents(), previous.version(), correlationId);
+        return BudgetDetail.from(budget);
+    }
+
+    public TemplateDetail draftTemplate(String campaignId, DraftTemplateCommand command, String correlationId) {
+        Objects.requireNonNull(command, "command is required");
+        Campaign campaign = getCampaign(campaignId);
+        CouponTemplate template = CouponTemplate.draft(
+            "mct-" + UuidV7.generate(),
+            campaignId,
+            command.templateCode(),
+            command.templateVersion(),
+            command.faceValue(),
+            command.minimumSpend(),
+            command.applicableScope(),
+            command.redemptionRule(),
+            command.validityWindow(),
+            campaign.window(),
+            clock.instant()
+        );
+        repository.saveTemplate(template);
+        publish(template.domainEvents(), correlationId);
+        return TemplateDetail.from(template);
+    }
+
+    public TemplateDetail validateTemplate(String templateId, String correlationId) {
+        CouponTemplate previous = getTemplate(templateId);
+        CouponTemplate template = previous.validate(clock.instant());
+        repository.saveTemplate(template);
+        publishSince(template.domainEvents(), previous.version(), correlationId);
+        return TemplateDetail.from(template);
+    }
+
+    public TemplateDetail publishTemplate(String templateId, ApproveCampaignCommand command, String correlationId) {
+        Objects.requireNonNull(command, "command is required");
+        CouponTemplate previous = getTemplate(templateId);
+        CouponTemplate template = previous.publish(command.approvalRef(), clock.instant());
+        repository.saveTemplate(template);
+        publishSince(template.domainEvents(), previous.version(), correlationId);
+        return TemplateDetail.from(template);
+    }
+
+    public TemplateDetail retireTemplate(String templateId, ReasonCommand command, String correlationId) {
+        Objects.requireNonNull(command, "command is required");
+        CouponTemplate previous = getTemplate(templateId);
+        CouponTemplate template = previous.retire(command.reason(), clock.instant());
+        repository.saveTemplate(template);
+        publishSince(template.domainEvents(), previous.version(), correlationId);
+        return TemplateDetail.from(template);
+    }
+
+    public BatchDetail planBatch(String campaignId, PlanBatchCommand command, String correlationId) {
+        Objects.requireNonNull(command, "command is required");
+        getCampaign(campaignId);
+        getTemplate(command.templateId());
+        IssuanceBatch batch = IssuanceBatch.plan(
+            "mcbat-" + UuidV7.generate(),
+            campaignId,
+            command.templateId(),
+            command.audienceSnapshotId(),
+            clock.instant()
+        );
+        repository.saveBatch(batch);
+        publish(batch.domainEvents(), correlationId);
+        return BatchDetail.from(batch);
+    }
+
+    public BatchDetail startBatch(String issuanceBatchId, String correlationId) {
+        IssuanceBatch previous = getBatch(issuanceBatchId);
+        IssuanceBatch batch = previous.start(clock.instant());
+        repository.saveBatch(batch);
+        publishSince(batch.domainEvents(), previous.version(), correlationId);
+        return BatchDetail.from(batch);
+    }
+
+    public BatchDetail closeBatch(String issuanceBatchId, ReasonCommand command, String correlationId) {
+        Objects.requireNonNull(command, "command is required");
+        IssuanceBatch previous = getBatch(issuanceBatchId);
+        IssuanceBatch batch = previous.close(command.reason(), clock.instant());
+        repository.saveBatch(batch);
+        publishSince(batch.domainEvents(), previous.version(), correlationId);
+        return BatchDetail.from(batch);
+    }
+
+    public CampaignDetail get(String campaignId) {
+        return detail(getCampaign(campaignId));
+    }
+
+    private Campaign getCampaign(String campaignId) {
+        return repository.findCampaign(campaignId).orElseThrow(() -> new NotFoundException("campaign not found: " + campaignId));
+    }
+
+    private CampaignBudget getBudget(String budgetId) {
+        return repository.findBudget(budgetId).orElseThrow(() -> new NotFoundException("campaign budget not found: " + budgetId));
+    }
+
+    private CouponTemplate getTemplate(String templateId) {
+        return repository.findTemplate(templateId).orElseThrow(() -> new NotFoundException("coupon template not found: " + templateId));
+    }
+
+    private IssuanceBatch getBatch(String issuanceBatchId) {
+        return repository.findBatch(issuanceBatchId).orElseThrow(() -> new NotFoundException("issuance batch not found: " + issuanceBatchId));
+    }
+
+    private CampaignDetail detail(Campaign campaign) {
+        return CampaignDetail.from(
+            campaign,
+            repository.findBudgetByCampaignId(campaign.campaignId()).map(BudgetDetail::from).orElse(null),
+            repository.findTemplatesByCampaignId(campaign.campaignId()).stream().map(TemplateDetail::from).toList(),
+            repository.findBatchesByCampaignId(campaign.campaignId()).stream().map(BatchDetail::from).toList()
+        );
+    }
+
+    private void publishSince(List<DomainEvent> events, long previousVersion, String correlationId) {
+        publish(events.stream().filter(event -> event.aggregateVersion() > previousVersion).toList(), correlationId);
+    }
+
+    private void publish(List<DomainEvent> events, String correlationId) {
+        String normalizedCorrelationId = PrefixedIds.isCorrelationId(correlationId) ? correlationId : PrefixedIds.newCorrelationId();
+        String causationId = PrefixedIds.newCommandId();
+        for (DomainEvent event : events) {
+            publisher.publish(envelopeFactory.create(event.getClass().getSimpleName(), normalizedCorrelationId, causationId, DomainEventPayloads.toMap(event)));
+        }
+    }
+
+    public record DraftCampaignCommand(String externalKey, String name, CampaignWindow window) {}
+    public record ApproveCampaignCommand(String approvalRef) {}
+    public record ReasonCommand(String reason) {}
+    public record OperatorReasonCommand(String reason, String operatorRef) {}
+    public record SetBudgetCommand(Money totalBudget, String targetRuleSetId) {}
+    public record MoneyCommand(Money amount, String reference) {}
+    public record DraftTemplateCommand(String templateCode, int templateVersion, Money faceValue, Money minimumSpend, String applicableScope, String redemptionRule, CampaignWindow validityWindow) {}
+    public record PlanBatchCommand(String templateId, String audienceSnapshotId) {}
+
+    public record CampaignDetail(
+        String campaignId,
+        String externalKey,
+        String name,
+        CampaignWindow window,
+        String targetRuleSetId,
+        String budgetId,
+        String approvalRef,
+        String status,
+        Instant createdAt,
+        Instant updatedAt,
+        long version,
+        BudgetDetail budget,
+        List<TemplateDetail> templates,
+        List<BatchDetail> batches
+    ) {
+        static CampaignDetail from(Campaign campaign, BudgetDetail budget, List<TemplateDetail> templates, List<BatchDetail> batches) {
+            return new CampaignDetail(campaign.campaignId(), campaign.externalKey(), campaign.name(), campaign.window(), campaign.targetRuleSetId(), campaign.budgetId(), campaign.approvalRef(), campaign.status().name(), campaign.createdAt(), campaign.updatedAt(), campaign.version(), budget, templates, batches);
+        }
+    }
+
+    public record BudgetDetail(String budgetId, String campaignId, Money totalBudget, Money reservedAmount, Money consumedAmount, boolean closed, Instant createdAt, Instant updatedAt, long version) {
+        static BudgetDetail from(CampaignBudget budget) {
+            return new BudgetDetail(budget.budgetId(), budget.campaignId(), budget.totalBudget(), budget.reservedAmount(), budget.consumedAmount(), budget.closed(), budget.createdAt(), budget.updatedAt(), budget.version());
+        }
+    }
+
+    public record TemplateDetail(String templateId, String campaignId, String templateCode, int templateVersion, String status, Money faceValue, Money minimumSpend, String applicableScope, String redemptionRule, CampaignWindow validityWindow, Instant createdAt, Instant updatedAt, long version) {
+        static TemplateDetail from(CouponTemplate template) {
+            return new TemplateDetail(template.templateId(), template.campaignId(), template.templateCode(), template.templateVersion(), template.status().name(), template.faceValue(), template.minimumSpend(), template.applicableScope(), template.redemptionRule(), template.validityWindow(), template.createdAt(), template.updatedAt(), template.version());
+        }
+    }
+
+    public record BatchDetail(String issuanceBatchId, String campaignId, String templateId, String audienceSnapshotId, String status, int itemCount, Instant plannedAt, Instant updatedAt, long version) {
+        static BatchDetail from(IssuanceBatch batch) {
+            return new BatchDetail(batch.issuanceBatchId(), batch.campaignId(), batch.templateId(), batch.audienceSnapshotId(), batch.status().name(), batch.itemsById().size(), batch.plannedAt(), batch.updatedAt(), batch.version());
+        }
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/application/NotFoundException.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/application/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.trainticket.marketingcampaign.application;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/Campaign.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/Campaign.java
@@ -47,6 +47,12 @@ public final class Campaign {
             Require.text(budgetId, "budgetId"), approvalRef, status, createdAt, updatedAt, version, domainEvents);
     }
 
+    public Campaign withLaunchReadiness(String budgetId, String targetRuleSetId, Instant now) {
+        requireMutable();
+        return new Campaign(campaignId, externalKey, name, window, Require.text(targetRuleSetId, "targetRuleSetId"),
+            Require.text(budgetId, "budgetId"), approvalRef, status, createdAt, Objects.requireNonNull(now, "now"), version + 1, domainEvents);
+    }
+
     public Campaign submitForReview(Instant now) {
         return transition(CampaignStatus.IN_REVIEW, now, new CampaignSubmittedForReview(campaignId, now, version + 1), approvalRef);
     }
@@ -115,6 +121,13 @@ public final class Campaign {
 
     private void requireMutable() {
         if (status.isTerminal()) throw new DomainException("terminal campaign cannot be changed");
+    }
+
+    public static Campaign restore(String campaignId, String externalKey, String name, CampaignWindow window, String targetRuleSetId,
+                                   String budgetId, String approvalRef, CampaignStatus status, Instant createdAt, Instant updatedAt,
+                                   long version) {
+        return new Campaign(campaignId, externalKey, name, window, targetRuleSetId, budgetId, approvalRef, status, createdAt, updatedAt,
+            version, List.of());
     }
 
     public String campaignId() { return campaignId; }

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CampaignBudget.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CampaignBudget.java
@@ -84,6 +84,12 @@ public final class CampaignBudget {
         if (closed) throw new DomainException("closed budget cannot be changed");
     }
 
+    public static CampaignBudget restore(String budgetId, String campaignId, Money totalBudget, Money reservedAmount, Money consumedAmount,
+                                         boolean closed, Instant createdAt, Instant updatedAt, long version) {
+        return new CampaignBudget(budgetId, campaignId, totalBudget, reservedAmount, consumedAmount, closed, createdAt, updatedAt,
+            version, List.of());
+    }
+
     public String budgetId() { return budgetId; }
     public String campaignId() { return campaignId; }
     public Money totalBudget() { return totalBudget; }

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CouponTemplate.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/CouponTemplate.java
@@ -100,6 +100,14 @@ public final class CouponTemplate {
         if (!campaignWindow.contains(validityWindow)) throw new DomainException("template validityWindow must be within campaign window");
     }
 
+    public static CouponTemplate restore(String templateId, String campaignId, String templateCode, int templateVersion,
+                                         CouponTemplateStatus status, Money faceValue, Money minimumSpend, String applicableScope,
+                                         String redemptionRule, CampaignWindow validityWindow, Instant createdAt, Instant updatedAt,
+                                         long version) {
+        return new CouponTemplate(templateId, campaignId, templateCode, templateVersion, status, faceValue, minimumSpend,
+            applicableScope, redemptionRule, validityWindow, createdAt, updatedAt, version, List.of());
+    }
+
     public String templateId() { return templateId; }
     public String campaignId() { return campaignId; }
     public String templateCode() { return templateCode; }

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/IssuanceBatch.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/domain/IssuanceBatch.java
@@ -163,6 +163,13 @@ public final class IssuanceBatch {
         }
     }
 
+    public static IssuanceBatch restore(String issuanceBatchId, String campaignId, String templateId, String audienceSnapshotId,
+                                        IssuanceBatchStatus status, Map<String, IssuanceItem> itemsById, Instant plannedAt,
+                                        Instant updatedAt, long version) {
+        return new IssuanceBatch(issuanceBatchId, campaignId, templateId, audienceSnapshotId, status, itemsById, plannedAt,
+            updatedAt, version, List.of());
+    }
+
     public String issuanceBatchId() { return issuanceBatchId; }
     public String campaignId() { return campaignId; }
     public String templateId() { return templateId; }

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/infrastructure/persistence/DeterministicEventIds.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/infrastructure/persistence/DeterministicEventIds.java
@@ -1,0 +1,12 @@
+package com.trainticket.marketingcampaign.infrastructure.persistence;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+final class DeterministicEventIds {
+    private DeterministicEventIds() {}
+
+    static String forTransition(String eventType, String aggregateId, long version) {
+        return "evt-" + UUID.nameUUIDFromBytes((eventType + ":" + aggregateId + ":" + version).getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/infrastructure/persistence/MarketingCampaignPersistenceConfiguration.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/infrastructure/persistence/MarketingCampaignPersistenceConfiguration.java
@@ -1,0 +1,79 @@
+package com.trainticket.marketingcampaign.infrastructure.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.marketingcampaign.application.CampaignRepository;
+import com.trainticket.platformkit.idempotency.IdempotencyStore;
+import com.trainticket.platformkit.persistence.DataSources;
+import com.trainticket.platformkit.persistence.DbIdempotencyStore;
+import com.trainticket.platformkit.persistence.LazyRedisOutboxRelayLifecycle;
+import com.trainticket.platformkit.persistence.MigrationRunner;
+import com.trainticket.platformkit.persistence.OutboxAppender;
+import jakarta.annotation.PostConstruct;
+import java.nio.file.Path;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableTransactionManagement
+@ConditionalOnExpression("'${DATABASE_URL:}' != ''")
+public class MarketingCampaignPersistenceConfiguration {
+    @Bean(destroyMethod = "close")
+    @Primary
+    DataSource marketingCampaignDataSource(@Value("${DATABASE_URL:}") String databaseUrl) {
+        return DataSources.fromDatabaseUrl(databaseUrl);
+    }
+
+    @Bean
+    @Primary
+    PlatformTransactionManager marketingCampaignTransactionManager(DataSource dataSource) {
+        return new DataSourceTransactionManager(dataSource);
+    }
+
+    @Bean
+    MigrationRunner marketingCampaignMigrationRunner(DataSource dataSource, PlatformTransactionManager transactionManager) {
+        MigrationRunner runner = new MigrationRunner(dataSource, transactionManager);
+        runner.run(Path.of("migrations"));
+        return runner;
+    }
+
+    @Bean
+    @Primary
+    IdempotencyStore marketingCampaignDbIdempotencyStore(DataSource dataSource, ObjectMapper mapper) {
+        return new DbIdempotencyStore(dataSource, mapper);
+    }
+
+    @Bean
+    CampaignRepository postgresCampaignRepository(DataSource dataSource, ObjectMapper mapper) {
+        return new PostgresCampaignRepository(dataSource, mapper, new OutboxAppender(dataSource, mapper));
+    }
+
+    @Bean(destroyMethod = "close")
+    RelayLifecycle marketingCampaignOutboxRelayLifecycle(DataSource dataSource, @Value("${REDIS_URL:redis://localhost:6379}") String redisUrl) {
+        return new RelayLifecycle(dataSource, redisUrl);
+    }
+
+    static final class RelayLifecycle implements AutoCloseable {
+        private final LazyRedisOutboxRelayLifecycle relay;
+
+        RelayLifecycle(DataSource dataSource, String redisUrl) {
+            relay = new LazyRedisOutboxRelayLifecycle(dataSource, redisUrl);
+        }
+
+        @PostConstruct
+        void start() {
+            relay.start();
+        }
+
+        @Override
+        public void close() {
+            relay.close();
+        }
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/infrastructure/persistence/PostgresCampaignRepository.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/infrastructure/persistence/PostgresCampaignRepository.java
@@ -1,0 +1,151 @@
+package com.trainticket.marketingcampaign.infrastructure.persistence;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.marketingcampaign.application.CampaignRepository;
+import com.trainticket.marketingcampaign.application.DomainEventPayloads;
+import com.trainticket.marketingcampaign.domain.Campaign;
+import com.trainticket.marketingcampaign.domain.CampaignBudget;
+import com.trainticket.marketingcampaign.domain.CouponTemplate;
+import com.trainticket.marketingcampaign.domain.DomainEvent;
+import com.trainticket.marketingcampaign.domain.IssuanceBatch;
+import com.trainticket.platformkit.messaging.EventEnvelope;
+import com.trainticket.platformkit.messaging.PrefixedIds;
+import com.trainticket.platformkit.persistence.OptimisticConcurrencyException;
+import com.trainticket.platformkit.persistence.OutboxAppender;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class PostgresCampaignRepository implements CampaignRepository {
+    private final JdbcOperations jdbc;
+    private final ObjectMapper mapper;
+    private final OutboxAppender outbox;
+
+    public PostgresCampaignRepository(DataSource dataSource, ObjectMapper mapper, OutboxAppender outbox) {
+        this(new JdbcTemplate(dataSource), mapper, outbox);
+    }
+
+    PostgresCampaignRepository(JdbcOperations jdbc, ObjectMapper mapper, OutboxAppender outbox) {
+        this.jdbc = jdbc;
+        this.mapper = mapper;
+        this.outbox = outbox;
+    }
+
+    @Override
+    public void saveCampaign(Campaign campaign) {
+        saveSnapshot("campaigns", "campaign_id", campaign.campaignId(), campaign.version(), campaign);
+        appendEvents(campaign.domainEvents());
+    }
+
+    @Override
+    public Optional<Campaign> findCampaign(String campaignId) {
+        return findSnapshot("SELECT data::text FROM campaigns WHERE campaign_id = ?", SnapshotMapper::campaign, campaignId);
+    }
+
+    @Override
+    public void saveBudget(CampaignBudget budget) {
+        saveSnapshot("campaign_budgets", "budget_id", budget.budgetId(), budget.version(), budget);
+        appendEvents(budget.domainEvents());
+    }
+
+    @Override
+    public Optional<CampaignBudget> findBudget(String budgetId) {
+        return findSnapshot("SELECT data::text FROM campaign_budgets WHERE budget_id = ?", SnapshotMapper::budget, budgetId);
+    }
+
+    @Override
+    public Optional<CampaignBudget> findBudgetByCampaignId(String campaignId) {
+        return findSnapshot("SELECT data::text FROM campaign_budgets WHERE campaign_id = ? LIMIT 1", SnapshotMapper::budget, campaignId);
+    }
+
+    @Override
+    public void saveTemplate(CouponTemplate template) {
+        saveSnapshot("coupon_templates", "template_id", template.templateId(), template.version(), template);
+        appendEvents(template.domainEvents());
+    }
+
+    @Override
+    public Optional<CouponTemplate> findTemplate(String templateId) {
+        return findSnapshot("SELECT data::text FROM coupon_templates WHERE template_id = ?", SnapshotMapper::template, templateId);
+    }
+
+    @Override
+    public List<CouponTemplate> findTemplatesByCampaignId(String campaignId) {
+        return jdbc.query("SELECT data::text FROM coupon_templates WHERE campaign_id = ? ORDER BY template_id", (rs, row) -> read(rs.getString(1), SnapshotMapper::template), campaignId);
+    }
+
+    @Override
+    public void saveBatch(IssuanceBatch batch) {
+        saveSnapshot("issuance_batches", "batch_id", batch.issuanceBatchId(), batch.version(), batch);
+        appendEvents(batch.domainEvents());
+    }
+
+    @Override
+    public Optional<IssuanceBatch> findBatch(String issuanceBatchId) {
+        return findSnapshot("SELECT data::text FROM issuance_batches WHERE batch_id = ?", SnapshotMapper::batch, issuanceBatchId);
+    }
+
+    @Override
+    public List<IssuanceBatch> findBatchesByCampaignId(String campaignId) {
+        return jdbc.query("SELECT data::text FROM issuance_batches WHERE campaign_id = ? ORDER BY batch_id", (rs, row) -> read(rs.getString(1), SnapshotMapper::batch), campaignId);
+    }
+
+    private <T> Optional<T> findSnapshot(String sql, java.util.function.Function<com.fasterxml.jackson.databind.JsonNode, T> decoder, String id) {
+        return jdbc.query(sql, rs -> rs.next() ? Optional.of(read(rs.getString(1), decoder)) : Optional.empty(), id);
+    }
+
+    private void saveSnapshot(String table, String idColumn, String id, long newVersion, Object data) {
+        long expectedVersion = newVersion - 1;
+        if (expectedVersion < 0) {
+            throw new OptimisticConcurrencyException("snapshot version conflict for " + id);
+        }
+        int rows = expectedVersion == 0
+            ? insertSnapshot(table, idColumn, id, newVersion, data)
+            : updateSnapshot(table, idColumn, id, expectedVersion, newVersion, data);
+        if (rows == 0) {
+            throw new OptimisticConcurrencyException("snapshot version conflict for " + id);
+        }
+    }
+
+    private int insertSnapshot(String table, String idColumn, String id, long newVersion, Object data) {
+        return jdbc.update("INSERT INTO " + table + "(" + idColumn + ", version, data) VALUES (?, ?, ?::jsonb) ON CONFLICT DO NOTHING", id, newVersion, json(data));
+    }
+
+    private int updateSnapshot(String table, String idColumn, String id, long expectedVersion, long newVersion, Object data) {
+        return jdbc.update("UPDATE " + table + " SET version = ?, data = ?::jsonb, updated_at = now() WHERE " + idColumn + " = ? AND version = ?", newVersion, json(data), id, expectedVersion);
+    }
+
+    private void appendEvents(List<DomainEvent> events) {
+        for (DomainEvent event : events) {
+            outbox.append(new EventEnvelope(
+                DeterministicEventIds.forTransition(event.getClass().getSimpleName(), event.aggregateId(), event.aggregateVersion()),
+                event.getClass().getSimpleName(),
+                event.occurredAt(),
+                PrefixedIds.newCorrelationId(),
+                null,
+                "marketing-campaign",
+                1,
+                DomainEventPayloads.toMap(event)
+            ));
+        }
+    }
+
+    private <T> T read(String json, java.util.function.Function<com.fasterxml.jackson.databind.JsonNode, T> decoder) {
+        try {
+            return decoder.apply(mapper.readTree(json));
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("stored JSON could not be decoded", exception);
+        }
+    }
+
+    private String json(Object value) {
+        try {
+            return mapper.writeValueAsString(value);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalArgumentException("value could not be encoded as JSON", exception);
+        }
+    }
+}

--- a/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/infrastructure/persistence/SnapshotMapper.java
+++ b/services/marketing-campaign/src/main/java/com/trainticket/marketingcampaign/infrastructure/persistence/SnapshotMapper.java
@@ -1,0 +1,128 @@
+package com.trainticket.marketingcampaign.infrastructure.persistence;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.trainticket.marketingcampaign.domain.Campaign;
+import com.trainticket.marketingcampaign.domain.CampaignBudget;
+import com.trainticket.marketingcampaign.domain.CampaignStatus;
+import com.trainticket.marketingcampaign.domain.CampaignWindow;
+import com.trainticket.marketingcampaign.domain.CouponTemplate;
+import com.trainticket.marketingcampaign.domain.CouponTemplateStatus;
+import com.trainticket.marketingcampaign.domain.IssuanceBatch;
+import com.trainticket.marketingcampaign.domain.IssuanceBatchStatus;
+import com.trainticket.marketingcampaign.domain.IssuanceItem;
+import com.trainticket.marketingcampaign.domain.IssuanceItemStatus;
+import com.trainticket.marketingcampaign.domain.Money;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+final class SnapshotMapper {
+    private SnapshotMapper() {}
+
+    static Campaign campaign(JsonNode node) {
+        return Campaign.restore(
+            text(node, "campaignId"),
+            text(node, "externalKey"),
+            text(node, "name"),
+            window(node.path("window")),
+            nullableText(node, "targetRuleSetId"),
+            nullableText(node, "budgetId"),
+            nullableText(node, "approvalRef"),
+            CampaignStatus.valueOf(text(node, "status")),
+            instant(node, "createdAt"),
+            instant(node, "updatedAt"),
+            node.path("version").asLong()
+        );
+    }
+
+    static CampaignBudget budget(JsonNode node) {
+        return CampaignBudget.restore(
+            text(node, "budgetId"),
+            text(node, "campaignId"),
+            money(node.path("totalBudget")),
+            money(node.path("reservedAmount")),
+            money(node.path("consumedAmount")),
+            node.path("closed").asBoolean(),
+            instant(node, "createdAt"),
+            instant(node, "updatedAt"),
+            node.path("version").asLong()
+        );
+    }
+
+    static CouponTemplate template(JsonNode node) {
+        return CouponTemplate.restore(
+            text(node, "templateId"),
+            text(node, "campaignId"),
+            text(node, "templateCode"),
+            node.path("templateVersion").asInt(),
+            CouponTemplateStatus.valueOf(text(node, "status")),
+            money(node.path("faceValue")),
+            money(node.path("minimumSpend")),
+            text(node, "applicableScope"),
+            text(node, "redemptionRule"),
+            window(node.path("validityWindow")),
+            instant(node, "createdAt"),
+            instant(node, "updatedAt"),
+            node.path("version").asLong()
+        );
+    }
+
+    static IssuanceBatch batch(JsonNode node) {
+        Map<String, IssuanceItem> items = new LinkedHashMap<>();
+        JsonNode itemsNode = node.path("itemsById");
+        if (itemsNode.isObject()) {
+            itemsNode.properties().forEach(entry -> items.put(entry.getKey(), item(entry.getValue())));
+        }
+        return IssuanceBatch.restore(
+            text(node, "issuanceBatchId"),
+            text(node, "campaignId"),
+            text(node, "templateId"),
+            text(node, "audienceSnapshotId"),
+            IssuanceBatchStatus.valueOf(text(node, "status")),
+            items,
+            instant(node, "plannedAt"),
+            instant(node, "updatedAt"),
+            node.path("version").asLong()
+        );
+    }
+
+    private static IssuanceItem item(JsonNode node) {
+        return new IssuanceItem(
+            text(node, "issuanceItemId"),
+            text(node, "campaignId"),
+            text(node, "templateId"),
+            text(node, "accountId"),
+            text(node, "audienceSnapshotId"),
+            text(node, "idempotencyKey"),
+            money(node.path("amount")),
+            window(node.path("benefitWindow")),
+            IssuanceItemStatus.valueOf(text(node, "status")),
+            nullableText(node, "walletBenefitId"),
+            nullableText(node, "failureCode"),
+            node.path("retryAttemptNo").asInt(),
+            instant(node, "createdAt"),
+            instant(node, "updatedAt")
+        );
+    }
+
+    private static CampaignWindow window(JsonNode node) {
+        return new CampaignWindow(Instant.parse(text(node, "validFrom")), Instant.parse(text(node, "validUntil")));
+    }
+
+    private static Money money(JsonNode node) {
+        return new Money(text(node, "currency"), node.path("minorUnits").asLong());
+    }
+
+    private static Instant instant(JsonNode node, String field) {
+        return Instant.parse(text(node, field));
+    }
+
+    private static String text(JsonNode node, String field) {
+        return node.path(field).asText();
+    }
+
+    private static String nullableText(JsonNode node, String field) {
+        JsonNode value = node.path(field);
+        return value.isMissingNode() || value.isNull() ? null : value.asText();
+    }
+}

--- a/services/marketing-campaign/src/main/resources/application.properties
+++ b/services/marketing-campaign/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.application.name=marketing-campaign
+server.port=${PORT:${SERVER_PORT:8080}}
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.probes.enabled=true

--- a/services/marketing-campaign/src/test/java/com/trainticket/marketingcampaign/api/CampaignControllerTest.java
+++ b/services/marketing-campaign/src/test/java/com/trainticket/marketingcampaign/api/CampaignControllerTest.java
@@ -1,0 +1,65 @@
+package com.trainticket.marketingcampaign.api;
+
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.trainticket.marketingcampaign.Application;
+import com.trainticket.platformkit.idempotency.UuidV7;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest(classes = Application.class)
+@AutoConfigureMockMvc
+class CampaignControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void healthRespondsOk() throws Exception {
+        mockMvc.perform(get("/health"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("ok"))
+            .andExpect(jsonPath("$.service.serviceId").value("marketing-campaign"));
+    }
+
+    @Test
+    void draftCampaignCreatesReadableResource() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/v1/campaigns")
+                .header("Idempotency-Key", UuidV7.generate())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "externalKey":"summer-2026",
+                      "name":"Summer sale",
+                      "window":{"validFrom":"2026-06-01T00:00:00Z","validUntil":"2026-09-01T00:00:00Z"}
+                    }
+                    """))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.campaignId", startsWith("mc-")))
+            .andExpect(jsonPath("$.status").value("DRAFT"))
+            .andReturn();
+
+        String id = com.jayway.jsonpath.JsonPath.read(result.getResponse().getContentAsString(), "$.campaignId");
+        mockMvc.perform(get("/api/v1/campaigns/{id}", id))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.externalKey").value("summer-2026"));
+    }
+
+    @Test
+    void draftCampaignRequiresWindow() throws Exception {
+        mockMvc.perform(post("/api/v1/campaigns")
+                .header("Idempotency-Key", UuidV7.generate())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"externalKey\":\"bad\",\"name\":\"Bad\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.error").value("VALIDATION_FAILED"));
+    }
+}

--- a/services/marketing-campaign/src/test/java/com/trainticket/marketingcampaign/application/MarketingCampaignServiceTest.java
+++ b/services/marketing-campaign/src/test/java/com/trainticket/marketingcampaign/application/MarketingCampaignServiceTest.java
@@ -1,0 +1,88 @@
+package com.trainticket.marketingcampaign.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.trainticket.marketingcampaign.domain.CampaignWindow;
+import com.trainticket.marketingcampaign.domain.Money;
+import com.trainticket.platformkit.messaging.EventPublisher;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+class MarketingCampaignServiceTest {
+    private final InMemoryCampaignRepository repository = new InMemoryCampaignRepository();
+    private final EventPublisher publisher = envelope -> {};
+    private final MarketingCampaignService service = new MarketingCampaignService(
+        Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC),
+        repository,
+        publisher
+    );
+
+    @Test
+    void draftsCampaignAndAddsBudgetReadiness() {
+        MarketingCampaignService.CampaignDetail campaign = service.draftCampaign(
+            new MarketingCampaignService.DraftCampaignCommand("winter-2026", "Winter", window()),
+            null
+        );
+
+        MarketingCampaignService.CampaignDetail ready = service.setBudget(
+            campaign.campaignId(),
+            new MarketingCampaignService.SetBudgetCommand(new Money("usd", 100_00), "trs-winter"),
+            null
+        );
+
+        assertThat(ready.status()).isEqualTo("DRAFT");
+        assertThat(ready.budgetId()).startsWith("mcb-");
+        assertThat(ready.targetRuleSetId()).isEqualTo("trs-winter");
+        assertThat(ready.budget().totalBudget().currency()).isEqualTo("USD");
+    }
+
+    @Test
+    void draftsValidatesAndPublishesTemplate() {
+        MarketingCampaignService.CampaignDetail campaign = service.draftCampaign(
+            new MarketingCampaignService.DraftCampaignCommand("spring-2026", "Spring", window()),
+            null
+        );
+        MarketingCampaignService.TemplateDetail draft = service.draftTemplate(
+            campaign.campaignId(),
+            new MarketingCampaignService.DraftTemplateCommand(
+                "SPRING10",
+                1,
+                new Money("USD", 1_000),
+                Money.zero("USD"),
+                "TRAIN_TICKET",
+                "minimum spend",
+                window()
+            ),
+            null
+        );
+
+        MarketingCampaignService.TemplateDetail validated = service.validateTemplate(draft.templateId(), null);
+        MarketingCampaignService.TemplateDetail published = service.publishTemplate(validated.templateId(), new MarketingCampaignService.ApproveCampaignCommand("apr-1"), null);
+
+        assertThat(published.status()).isEqualTo("PUBLISHED");
+    }
+
+    @Test
+    void plansAndStartsBatch() {
+        MarketingCampaignService.CampaignDetail campaign = service.draftCampaign(
+            new MarketingCampaignService.DraftCampaignCommand("batch-2026", "Batch", window()),
+            null
+        );
+        MarketingCampaignService.TemplateDetail template = service.draftTemplate(
+            campaign.campaignId(),
+            new MarketingCampaignService.DraftTemplateCommand("BATCH10", 1, new Money("USD", 1_000), Money.zero("USD"), "TRAIN_TICKET", "rule", window()),
+            null
+        );
+
+        MarketingCampaignService.BatchDetail planned = service.planBatch(campaign.campaignId(), new MarketingCampaignService.PlanBatchCommand(template.templateId(), "aud-1"), null);
+        MarketingCampaignService.BatchDetail running = service.startBatch(planned.issuanceBatchId(), null);
+
+        assertThat(running.status()).isEqualTo("RUNNING");
+    }
+
+    private static CampaignWindow window() {
+        return new CampaignWindow(Instant.parse("2026-01-01T00:00:00Z"), Instant.parse("2026-12-31T00:00:00Z"));
+    }
+}


### PR DESCRIPTION
## Summary
AgentM/GPT REQ-221: Marketing-campaign service scaffold (+1653 lines, Java). Task 2/3.

- **MarketingCampaignService** (324 lines): campaign CRUD, budget management, template lifecycle, batch orchestration
- **API**: CampaignController, CouponTemplateController, IssuanceBatchController
- **Persistence**: PostgresCampaignRepository + SnapshotMapper + outbox
- **Migration**: campaigns, budgets, templates, batches, items tables
- **Tests**: controller (65) + service (88)
- **Infra**: Dockerfile + k8s deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code) + AgentM/GPT