### PR TITLE
fix(ts-kit): log pg pool reconnect recovery

### DIFF
--- a/platform/ts-kit/dist/storage.js
+++ b/platform/ts-kit/dist/storage.js
@@ -26,11 +26,32 @@ export function createPostgresPool(config = databaseUrl()) {
         idleTimeoutMillis: base.idleTimeoutMillis ?? 300_000,
         connectionTimeoutMillis: base.connectionTimeoutMillis ?? 5_000,
     });
+    let backgroundErrorCount = 0;
     pool.on("error", (err) => {
-        console.error({ name: "pg.Pool", message: `background connection error: ${err.message}` });
+        backgroundErrorCount += 1;
+        console.error({
+            name: "pg.Pool",
+            message: "background PostgreSQL connection error; idle client will be replaced on demand",
+            error: sanitizedPostgresPoolError(err),
+            totalCount: pool.totalCount,
+            idleCount: pool.idleCount,
+            waitingCount: pool.waitingCount,
+        });
     });
     pool.on("connect", () => {
-        console.log({ name: "pg.Pool", message: "new connection established" });
+        const reconnected = backgroundErrorCount > 0;
+        if (reconnected) {
+            backgroundErrorCount = 0;
+        }
+        console.info({
+            name: "pg.Pool",
+            message: reconnected
+                ? "PostgreSQL pool connection re-established after background error"
+                : "PostgreSQL pool connection established",
+            totalCount: pool.totalCount,
+            idleCount: pool.idleCount,
+            waitingCount: pool.waitingCount,
+        });
     });
     return pool;
 }
@@ -293,6 +314,14 @@ export class PostgresIdempotencyStore {
         }
         return existing;
     }
+}
+function sanitizedPostgresPoolError(error) {
+    const errorWithCode = error;
+    return {
+        name: error.name || "Error",
+        message: error.message || "PostgreSQL pool connection error",
+        code: typeof errorWithCode.code === "string" ? errorWithCode.code : undefined,
+    };
 }
 function assertSqlIdentifier(identifier, label) {
     if (!/^[a-z][a-z0-9_]*$/u.test(identifier)) {

--- a/platform/ts-kit/src/storage.test.ts
+++ b/platform/ts-kit/src/storage.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import { describe, it } from "node:test";
 
-import { OptimisticConcurrencyConflict, OutboxRelay, PostgresIdempotencyStore, SnapshotRepository } from "./storage.js";
+import { createPostgresPool, OptimisticConcurrencyConflict, OutboxRelay, PostgresIdempotencyStore, SnapshotRepository } from "./storage.js";
 
 type QueryCall = Readonly<{ sql: string; params: unknown[] }>;
 
@@ -97,6 +98,63 @@ class FakeSnapshotDb {
     throw new Error(`Unexpected query ${sql}`);
   }
 }
+
+describe("createPostgresPool", () => {
+  it("attaches background error and connect listeners without replacing pg.Pool reconnect behavior", async () => {
+    const pool = createPostgresPool({ connectionString: "postgres://localhost:1/test", max: 1 });
+    const loggedErrors: unknown[] = [];
+    const loggedInfos: unknown[] = [];
+    const originalConsoleError = console.error;
+    const originalConsoleInfo = console.info;
+
+    console.error = (value?: unknown) => {
+      loggedErrors.push(value);
+    };
+    console.info = (value?: unknown) => {
+      loggedInfos.push(value);
+    };
+
+    try {
+      assert.equal(pool.listenerCount("error"), 1);
+      assert.equal(pool.listenerCount("connect"), 1);
+
+      const backgroundError = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:5432"), {
+        code: "ECONNREFUSED",
+      });
+      pool.emit("error", backgroundError, new EventEmitter());
+      pool.emit("connect", new EventEmitter());
+
+      await assert.rejects(
+        () => pool.connect(),
+        (error: unknown) => error instanceof Error
+          && error.name === "AggregateError"
+          && "code" in error
+          && error.code === "ECONNREFUSED",
+      );
+    } finally {
+      console.error = originalConsoleError;
+      console.info = originalConsoleInfo;
+      await pool.end();
+    }
+
+    assert.equal(loggedErrors.length, 1);
+    assert.deepEqual(loggedErrors[0], {
+      name: "pg.Pool",
+      message: "background PostgreSQL connection error; idle client will be replaced on demand",
+      error: { name: "Error", message: "connect ECONNREFUSED 127.0.0.1:5432", code: "ECONNREFUSED" },
+      totalCount: 0,
+      idleCount: 0,
+      waitingCount: 0,
+    });
+    assert.deepEqual(loggedInfos[0], {
+      name: "pg.Pool",
+      message: "PostgreSQL pool connection re-established after background error",
+      totalCount: 0,
+      idleCount: 0,
+      waitingCount: 0,
+    });
+  });
+});
 
 describe("SnapshotRepository", () => {
   it("inserts new snapshots, updates by expected version, and detects optimistic conflicts", async () => {

--- a/platform/ts-kit/src/storage.ts
+++ b/platform/ts-kit/src/storage.ts
@@ -42,11 +42,32 @@ export function createPostgresPool(config: PoolConfig | string = databaseUrl()):
     idleTimeoutMillis: base.idleTimeoutMillis ?? 300_000,
     connectionTimeoutMillis: base.connectionTimeoutMillis ?? 5_000,
   });
+  let backgroundErrorCount = 0;
   pool.on("error", (err: Error) => {
-    console.error({ name: "pg.Pool", message: `background connection error: ${err.message}` });
+    backgroundErrorCount += 1;
+    console.error({
+      name: "pg.Pool",
+      message: "background PostgreSQL connection error; idle client will be replaced on demand",
+      error: sanitizedPostgresPoolError(err),
+      totalCount: pool.totalCount,
+      idleCount: pool.idleCount,
+      waitingCount: pool.waitingCount,
+    });
   });
   pool.on("connect", () => {
-    console.log({ name: "pg.Pool", message: "new connection established" });
+    const reconnected = backgroundErrorCount > 0;
+    if (reconnected) {
+      backgroundErrorCount = 0;
+    }
+    console.info({
+      name: "pg.Pool",
+      message: reconnected
+        ? "PostgreSQL pool connection re-established after background error"
+        : "PostgreSQL pool connection established",
+      totalCount: pool.totalCount,
+      idleCount: pool.idleCount,
+      waitingCount: pool.waitingCount,
+    });
   });
   return pool;
 }
@@ -382,6 +403,15 @@ export class PostgresIdempotencyStore implements IdempotencyStore {
     }
     return existing;
   }
+}
+
+function sanitizedPostgresPoolError(error: Error): Readonly<{ name: string; message: string; code?: string }> {
+  const errorWithCode = error as Error & { code?: unknown };
+  return {
+    name: error.name || "Error",
+    message: error.message || "PostgreSQL pool connection error",
+    code: typeof errorWithCode.code === "string" ? errorWithCode.code : undefined,
+  };
 }
 
 function assertSqlIdentifier(identifier: string, label: string): string {


### PR DESCRIPTION
## Summary
- enhance ts-kit createPostgresPool error/connect handlers with sanitized background error and reconnect logs
- add a focused pg.Pool test covering listener installation and ECONNREFUSED connect behavior
- update built ts-kit dist storage output

## Validation
- cd platform/ts-kit && npm test