### PR TITLE
REQ-300 implement fare pricing dynamic engine

### DIFF
--- a/services/fare-pricing/migrations/002_pricing_enrichment.sql
+++ b/services/fare-pricing/migrations/002_pricing_enrichment.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS capacity_snapshot_cache (
+  segment_ref text NOT NULL,
+  departure_date date NOT NULL,
+  total_capacity integer NOT NULL CHECK (total_capacity > 0),
+  remaining_capacity integer NOT NULL CHECK (remaining_capacity >= 0),
+  snapshot_version bigint NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (segment_ref, departure_date),
+  CHECK (remaining_capacity <= total_capacity)
+);
+
+CREATE INDEX IF NOT EXISTS idx_capacity_snapshot_cache_departure
+  ON capacity_snapshot_cache(departure_date, segment_ref);

--- a/services/fare-pricing/src/fare_pricing/__init__.py
+++ b/services/fare-pricing/src/fare_pricing/__init__.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from .api import create_app
 from .domain import (
     AdjustmentQuote,
+    SeatClassMultiplier,
+    PeakPricingRule,
+    DynamicPricingBand,
+    CapacitySnapshot,
+    AdvancePurchaseTier,
     AssessmentPurpose,
     FareBreakdown,
     FareQuote,
@@ -26,6 +31,11 @@ from .runtime import SERVICE_PROFILE, ServiceProfile, health, profile
 
 __all__ = [
     'AdjustmentQuote',
+    'SeatClassMultiplier',
+    'PeakPricingRule',
+    'DynamicPricingBand',
+    'CapacitySnapshot',
+    'AdvancePurchaseTier',
     'AssessmentPurpose',
     'FareBreakdown',
     'FareQuote',

--- a/services/fare-pricing/src/fare_pricing/adapters/storage/postgres.py
+++ b/services/fare-pricing/src/fare_pricing/adapters/storage/postgres.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Iterable, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 import json
 from typing import Any
 
@@ -13,6 +13,8 @@ from train_ticket_platform.storage import OptimisticConcurrencyError, OutboxAppe
 from fare_pricing.domain import (
     AdjustmentQuote,
     AssessmentPurpose,
+    AdvancePurchaseTier,
+    CapacitySnapshot,
     FareBreakdown,
     FareQuote,
     FareRule,
@@ -22,6 +24,8 @@ from fare_pricing.domain import (
     PriceComponent,
     PriceExplanation,
     QuoteStatus,
+    DEFAULT_ADVANCE_PURCHASE_TIERS,
+    DEFAULT_SEAT_CLASS_MULTIPLIERS,
     RuleKind,
     RuleSetStatus,
     RuleSnapshot,
@@ -82,6 +86,8 @@ def _breakdown_to_json(breakdown: FareBreakdown | None) -> dict[str, Any] | None
         "taxes": [_component_to_json(item) for item in breakdown.taxes],
         "fees": [_component_to_json(item) for item in breakdown.fees],
         "discounts": [_component_to_json(item) for item in breakdown.discounts],
+        "dynamicAdjustments": [_component_to_json(item) for item in breakdown.dynamic_adjustments],
+        "pricingComponents": dict(breakdown.pricing_components),
     }
 
 
@@ -93,6 +99,8 @@ def _breakdown_from_json(data: Mapping[str, Any] | None) -> FareBreakdown | None
         tuple(_component_from_json(item) for item in data.get("taxes", ())),
         tuple(_component_from_json(item) for item in data.get("fees", ())),
         tuple(_component_from_json(item) for item in data.get("discounts", ())),
+        tuple(_component_from_json(item) for item in data.get("dynamicAdjustments", ())),
+        data.get("pricingComponents") or {},
     )
 
 
@@ -129,6 +137,11 @@ def _rule_to_json(rule: FareRule) -> dict[str, Any]:
         "amount": _money_to_json(rule.amount),
         "explanation": _explanation_to_json(rule.explanation),
         "refundable": rule.refundable,
+        "seatClassMultipliers": {key: str(value) for key, value in rule.seat_class_multipliers.items()},
+        "perKmRate": str(rule.per_km_rate) if rule.per_km_rate is not None else None,
+        "minimumFare": _money_to_json(rule.minimum_fare) if rule.minimum_fare is not None else None,
+        "distanceDiscountThresholdKm": str(rule.distance_discount_threshold_km) if rule.distance_discount_threshold_km is not None else None,
+        "distanceDiscountPct": rule.distance_discount_pct,
     }
 
 
@@ -139,6 +152,11 @@ def _rule_from_json(data: Mapping[str, Any]) -> FareRule:
         amount=_money_from_json(data["amount"]),
         explanation=_explanation_from_json(data["explanation"]),
         refundable=bool(data["refundable"]),
+        seat_class_multipliers={str(key): value for key, value in (data.get("seatClassMultipliers") or DEFAULT_SEAT_CLASS_MULTIPLIERS).items()},
+        per_km_rate=data.get("perKmRate"),
+        minimum_fare=_money_from_json(data["minimumFare"]) if data.get("minimumFare") else None,
+        distance_discount_threshold_km=data.get("distanceDiscountThresholdKm"),
+        distance_discount_pct=int(data.get("distanceDiscountPct") or 0),
     )
 
 
@@ -155,6 +173,15 @@ def _rule_set_to_json(rule_set: FareRuleSet) -> dict[str, Any]:
         "rules": [_rule_to_json(rule) for rule in rule_set.rules],
         "status": rule_set.status.value,
         "publishedAt": _dt(rule_set.published_at) if rule_set.published_at else None,
+        "advancePurchaseTiers": [
+            {
+                "minDaysBefore": tier.min_days_before,
+                "maxDaysBefore": tier.max_days_before,
+                "multiplier": str(tier.multiplier),
+                "explanationCode": tier.explanation_code,
+            }
+            for tier in rule_set.advance_purchase_tiers
+        ],
     }
 
 
@@ -177,6 +204,15 @@ def _rule_set_from_json(data: Mapping[str, Any] | str) -> FareRuleSet:
         status=RuleSetStatus(str(data["status"])),
         published_at=_parse_dt(str(data["publishedAt"])) if data.get("publishedAt") else None,
         contract_id=str(data.get("contractId") or ""),
+        advance_purchase_tiers=tuple(
+            AdvancePurchaseTier(
+                int(item["minDaysBefore"]),
+                int(item["maxDaysBefore"]) if item.get("maxDaysBefore") is not None else None,
+                item["multiplier"],
+                str(item["explanationCode"]),
+            )
+            for item in data.get("advancePurchaseTiers", ())
+        ) or DEFAULT_ADVANCE_PURCHASE_TIERS,
     )
 
 
@@ -475,6 +511,45 @@ class PostgresFarePricingStore:
                 (list(refs), len(refs)),
             ).fetchone()
             return str(row[0]) if row else None
+
+        return self._with_conn(read)
+
+    def upsert_capacity_snapshot(self, snapshot: CapacitySnapshot) -> None:
+        def write(conn: Any) -> None:
+            conn.execute(
+                "INSERT INTO capacity_snapshot_cache(segment_ref, departure_date, total_capacity, remaining_capacity, snapshot_version) "
+                "VALUES (%s, %s, %s, %s, %s) "
+                "ON CONFLICT (segment_ref, departure_date) DO UPDATE SET "
+                "total_capacity = EXCLUDED.total_capacity, remaining_capacity = EXCLUDED.remaining_capacity, "
+                "snapshot_version = EXCLUDED.snapshot_version, updated_at = now() "
+                "WHERE capacity_snapshot_cache.snapshot_version <= EXCLUDED.snapshot_version",
+                (
+                    snapshot.segment_ref,
+                    snapshot.departure_date,
+                    snapshot.total_capacity,
+                    snapshot.remaining_capacity,
+                    snapshot.snapshot_version,
+                ),
+            )
+
+        self._with_conn(write)
+
+    def capacity_snapshots_for(self, segment_refs: Iterable[str], departure_date: str | None) -> tuple[CapacitySnapshot, ...]:
+        refs = tuple(sorted({ref.strip() for ref in segment_refs if ref.strip()}))
+        if not refs or departure_date is None:
+            return ()
+        target_date = date.fromisoformat(departure_date)
+
+        def read(conn: Any) -> tuple[CapacitySnapshot, ...]:
+            rows = conn.execute(
+                "SELECT segment_ref, departure_date, total_capacity, remaining_capacity, snapshot_version "
+                "FROM capacity_snapshot_cache WHERE segment_ref = ANY(%s) AND departure_date = %s",
+                (list(refs), target_date),
+            ).fetchall()
+            return tuple(
+                CapacitySnapshot(str(row[0]), row[1], int(row[2]), int(row[3]), int(row[4]))
+                for row in rows
+            )
 
         return self._with_conn(read)
 

--- a/services/fare-pricing/src/fare_pricing/api.py
+++ b/services/fare-pricing/src/fare_pricing/api.py
@@ -25,7 +25,9 @@ from .application.service import FarePricingService, InMemoryStore
 from .identity import HttpEligibilityCertificateAdapter
 from .adapters.storage import PostgresFarePricingStore
 from .adapters.messaging.publisher import RedisEventPublisher
+from train_ticket_platform.messaging import RedisEventSubscriber, default_consumer_name
 from .ports.messaging import EventPublisher
+from .handlers import CAPACITY_STREAM, handle_capacity_snapshot_updated
 from .web.errors import register_exception_handlers
 from .web.handlers import router as fare_pricing_router
 
@@ -188,6 +190,15 @@ def configure_fare_pricing_routes(
         require_key=True,
         include_path_prefixes=("/api/v1/fare-quotes", "/api/v1/adjustment-quotes", "/api/v1/fare-rule-sets"),
     )
+    if isinstance(store, PostgresFarePricingStore) and os.getenv("FARE_PRICING_DISABLE_SUBSCRIBER", "").lower() not in {"1", "true", "yes"}:
+        subscriber = RedisEventSubscriber()
+        subscriber.start_in_background(
+            (CAPACITY_STREAM,),
+            "fare-pricing",
+            lambda envelope: handle_capacity_snapshot_updated(service, envelope),
+            consumer_name=default_consumer_name("fare-pricing"),
+        )
+        app.state.capacity_subscriber = subscriber
     app.include_router(fare_pricing_router)
 
 
@@ -228,6 +239,10 @@ def _install_default_rule_sets(store: Any) -> None:
                     kind=RuleKind.BASE_FARE,
                     amount=Money(Decimal("100.00"), "CNY"),
                     explanation=PriceExplanation("fare.base", {"rule": "base"}),
+                    per_km_rate=Decimal("0.15"),
+                    minimum_fare=Money(Decimal("5.00"), "CNY"),
+                    distance_discount_threshold_km=Decimal("500"),
+                    distance_discount_pct=10,
                 ),
                 FareRule(
                     rule_id="tax",
@@ -297,6 +312,9 @@ def create_app(
         relay = getattr(app.state, "outbox_relay", None)
         if relay is not None:
             relay.stop()
+        subscriber = getattr(app.state, "capacity_subscriber", None)
+        if subscriber is not None:
+            subscriber.stop()
         pool = getattr(app.state, "database_pool", None)
         if pool is not None:
             pool.close()

--- a/services/fare-pricing/src/fare_pricing/application/service.py
+++ b/services/fare-pricing/src/fare_pricing/application/service.py
@@ -9,6 +9,7 @@ from fare_pricing.domain import (
     AdjustmentQuote,
     AssessmentPurpose,
     FareQuote,
+    CapacitySnapshot,
     FareRuleSet,
     RuleSetStatus,
     PricingError,
@@ -38,6 +39,7 @@ class InMemoryStore:
     fare_quotes: dict[str, FareQuote] = field(default_factory=dict)
     adjustment_quotes: dict[str, AdjustmentQuote] = field(default_factory=dict)
     fare_quote_segment_links: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    capacity_snapshots: dict[tuple[str, str], CapacitySnapshot] = field(default_factory=dict)
 
     def transaction(self) -> Any:
         return nullcontext()
@@ -79,6 +81,21 @@ class InMemoryStore:
             raise AdjustmentQuoteNotFoundError(f"Adjustment quote not found: {adjustment_quote_id}")
         return self.adjustment_quotes[adjustment_quote_id]
 
+    def upsert_capacity_snapshot(self, snapshot: CapacitySnapshot) -> None:
+        key = (snapshot.segment_ref, snapshot.departure_date.isoformat())
+        current = self.capacity_snapshots.get(key)
+        if current is None or snapshot.snapshot_version >= current.snapshot_version:
+            self.capacity_snapshots[key] = snapshot
+
+    def capacity_snapshots_for(self, segment_refs: list[str], departure_date: str | None) -> tuple[CapacitySnapshot, ...]:
+        if departure_date is None:
+            return ()
+        return tuple(
+            snapshot
+            for segment_ref in segment_refs
+            if (snapshot := self.capacity_snapshots.get((segment_ref, departure_date))) is not None
+        )
+
 
 class EligibilityCertificatePort:
     def has_active_certificate(self, traveler_id: str, eligibility_type: str, journey_date: str, product_code: str) -> bool:
@@ -112,12 +129,17 @@ class FarePricingService:
         segment_refs: list[str] | None = None,
         quoted_at: datetime | None = None,
         ttl: timedelta | None = None,
+        seat_class: str = "SECOND_CLASS",
+        distance_km: float | str | None = None,
+        departure_time: datetime | None = None,
     ) -> FareQuote:
         now = quoted_at or datetime.now(timezone.utc)
         ttl = ttl or timedelta(minutes=15)
         rule_set = self._store.get_rule_set(rule_set_id)
 
         active_discount_types = self._active_discount_types(rule_set, traveler_refs, now.date().isoformat())
+        departure_date = departure_time.astimezone(UTC).date().isoformat() if departure_time is not None else None
+        capacity_snapshots = self.capacity_snapshots_for(segment_refs or [], departure_date)
         quote = calculate_fare_quote(
             quote_id=quote_id,
             input_hash=input_hash,
@@ -128,6 +150,10 @@ class FarePricingService:
             quoted_at=now,
             ttl=ttl,
             active_discount_types=active_discount_types,
+            seat_class=seat_class,
+            distance_km=distance_km,
+            departure_time=departure_time,
+            capacity_snapshots=capacity_snapshots,
         )
         self._store.save_quote(quote)
         self.link_fare_quote_to_segments(quote.quote_id, segment_refs or [])
@@ -279,3 +305,16 @@ class FarePricingService:
 
     def get_adjustment_quote(self, adjustment_quote_id: str) -> AdjustmentQuote:
         return self._store.get_adjustment_quote(adjustment_quote_id)
+
+    def upsert_capacity_snapshot(self, snapshot: CapacitySnapshot) -> None:
+        upsert = getattr(self._store, "upsert_capacity_snapshot", None)
+        if callable(upsert):
+            upsert(snapshot)
+
+    def capacity_snapshots_for(self, segment_refs: list[str], departure_date: str | None) -> tuple[CapacitySnapshot, ...]:
+        if departure_date is None:
+            return ()
+        lookup = getattr(self._store, "capacity_snapshots_for", None)
+        if callable(lookup):
+            return lookup(segment_refs, departure_date)
+        return ()

--- a/services/fare-pricing/src/fare_pricing/domain.py
+++ b/services/fare-pricing/src/fare_pricing/domain.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 from decimal import Decimal, ROUND_HALF_UP
 from enum import Enum
 from hashlib import sha256
@@ -43,6 +43,31 @@ class QuoteStatus(str, Enum):
 class AssessmentPurpose(str, Enum):
     REFUND = "refund"
     CHANGE = "change"
+
+
+DEFAULT_SEAT_CLASS_MULTIPLIERS: Mapping[str, Decimal] = MappingProxyType(
+    {
+        "SECOND_CLASS": Decimal("1.0"),
+        "FIRST_CLASS": Decimal("1.6"),
+        "BUSINESS_CLASS": Decimal("2.8"),
+        "STANDING": Decimal("0.7"),
+        "SLEEPER_HARD": Decimal("1.8"),
+        "SLEEPER_SOFT": Decimal("2.5"),
+    }
+)
+
+
+class SeatClassMultiplier(str, Enum):
+    SECOND_CLASS = "SECOND_CLASS"
+    FIRST_CLASS = "FIRST_CLASS"
+    BUSINESS_CLASS = "BUSINESS_CLASS"
+    STANDING = "STANDING"
+    SLEEPER_HARD = "SLEEPER_HARD"
+    SLEEPER_SOFT = "SLEEPER_SOFT"
+
+    @property
+    def multiplier(self) -> Decimal:
+        return DEFAULT_SEAT_CLASS_MULTIPLIERS[self.value]
 
 
 @dataclass(frozen=True, slots=True)
@@ -119,18 +144,154 @@ class PriceExplanation:
 
 
 @dataclass(frozen=True, slots=True)
+class AdvancePurchaseTier:
+    min_days_before: int
+    max_days_before: int | None
+    multiplier: Decimal
+    explanation_code: str
+
+    def __post_init__(self) -> None:
+        if self.min_days_before < 0:
+            raise PricingError("advance purchase tier minimum days cannot be negative")
+        if self.max_days_before is not None and self.max_days_before < self.min_days_before:
+            raise PricingError("advance purchase tier maximum days must be >= minimum days")
+        object.__setattr__(self, "multiplier", Decimal(str(self.multiplier)))
+        if self.multiplier < Decimal("0.00"):
+            raise PricingError("advance purchase multiplier cannot be negative")
+        if not self.explanation_code.strip():
+            raise PricingError("advance purchase explanation code is required")
+
+    def matches(self, days_before_departure: int) -> bool:
+        return days_before_departure >= self.min_days_before and (
+            self.max_days_before is None or days_before_departure <= self.max_days_before
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PeakPricingRule:
+    date_ranges: tuple[tuple[date, date], ...] = field(default_factory=tuple)
+    hour_ranges: tuple[tuple[int, int], ...] = ((7, 9), (17, 19))
+    date_surcharge_pct: int = 30
+    hour_surcharge_pct: int = 15
+    offpeak_discount_pct: int = 10
+
+    def __post_init__(self) -> None:
+        for start, end in self.date_ranges:
+            if end < start:
+                raise PricingError("peak date range must end on or after its start")
+        for start_hour, end_hour in self.hour_ranges:
+            if not 0 <= start_hour <= 23 or not 0 <= end_hour <= 24 or end_hour <= start_hour:
+                raise PricingError("peak hour range must be within 00-24 and end after start")
+        for pct in (self.date_surcharge_pct, self.hour_surcharge_pct, self.offpeak_discount_pct):
+            if pct < 0:
+                raise PricingError("peak pricing percentages cannot be negative")
+
+    def is_peak_date(self, departure_date: date) -> bool:
+        return departure_date.weekday() >= 5 or any(start <= departure_date <= end for start, end in self.date_ranges)
+
+    def is_peak_hour(self, departure_time: time) -> bool:
+        return any(start <= departure_time.hour < end for start, end in self.hour_ranges)
+
+
+@dataclass(frozen=True, slots=True)
+class DynamicPricingBand:
+    min_remaining_pct: Decimal
+    max_remaining_pct: Decimal
+    adjustment_pct: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "min_remaining_pct", Decimal(str(self.min_remaining_pct)))
+        object.__setattr__(self, "max_remaining_pct", Decimal(str(self.max_remaining_pct)))
+        if self.min_remaining_pct < Decimal("0") or self.max_remaining_pct > Decimal("100"):
+            raise PricingError("dynamic pricing bands must stay within 0-100 percent")
+        if self.max_remaining_pct < self.min_remaining_pct:
+            raise PricingError("dynamic pricing band max must be >= min")
+        if self.adjustment_pct < 0:
+            raise PricingError("dynamic pricing adjustment cannot be negative")
+
+    def matches(self, remaining_pct: Decimal) -> bool:
+        return self.min_remaining_pct <= remaining_pct < self.max_remaining_pct
+
+
+@dataclass(frozen=True, slots=True)
+class CapacitySnapshot:
+    segment_ref: str
+    departure_date: date
+    total_capacity: int
+    remaining_capacity: int
+    snapshot_version: int
+
+    def __post_init__(self) -> None:
+        if not self.segment_ref.strip():
+            raise PricingError("capacity snapshot segment ref is required")
+        if self.total_capacity <= 0:
+            raise PricingError("capacity snapshot total capacity must be positive")
+        if self.remaining_capacity < 0 or self.remaining_capacity > self.total_capacity:
+            raise PricingError("capacity snapshot remaining capacity must be within total capacity")
+        if self.snapshot_version < 0:
+            raise PricingError("capacity snapshot version cannot be negative")
+
+    @property
+    def remaining_pct(self) -> Decimal:
+        return (Decimal(self.remaining_capacity) * Decimal("100") / Decimal(self.total_capacity)).quantize(Decimal("0.01"))
+
+
+DEFAULT_ADVANCE_PURCHASE_TIERS: tuple[AdvancePurchaseTier, ...] = (
+    AdvancePurchaseTier(21, None, Decimal("0.70"), "ADVANCE_PURCHASE_TIER_1"),
+    AdvancePurchaseTier(14, 20, Decimal("0.80"), "ADVANCE_PURCHASE_TIER_2"),
+    AdvancePurchaseTier(7, 13, Decimal("0.90"), "ADVANCE_PURCHASE_TIER_3"),
+    AdvancePurchaseTier(3, 6, Decimal("1.00"), "ADVANCE_PURCHASE_TIER_4"),
+    AdvancePurchaseTier(0, 2, Decimal("1.20"), "ADVANCE_PURCHASE_TIER_5"),
+)
+
+
+DEFAULT_PEAK_PRICING = PeakPricingRule(
+    date_ranges=(
+        (date(2026, 2, 15), date(2026, 2, 23)),
+        (date(2026, 5, 1), date(2026, 5, 5)),
+        (date(2026, 10, 1), date(2026, 10, 7)),
+    )
+)
+
+
+DEFAULT_DYNAMIC_PRICING_BANDS: tuple[DynamicPricingBand, ...] = (
+    DynamicPricingBand(Decimal("0"), Decimal("10"), 50),
+    DynamicPricingBand(Decimal("10"), Decimal("30"), 30),
+    DynamicPricingBand(Decimal("30"), Decimal("50"), 15),
+    DynamicPricingBand(Decimal("50"), Decimal("70.01"), 5),
+)
+
+
+@dataclass(frozen=True, slots=True)
 class FareRule:
     rule_id: str
     kind: RuleKind
     amount: Money
     explanation: PriceExplanation
     refundable: bool = True
+    seat_class_multipliers: Mapping[str, Decimal] = field(default_factory=lambda: dict(DEFAULT_SEAT_CLASS_MULTIPLIERS))
+    per_km_rate: Decimal | None = None
+    minimum_fare: Money | None = None
+    distance_discount_threshold_km: Decimal | None = None
+    distance_discount_pct: int = 0
 
     def __post_init__(self) -> None:
         if not self.rule_id.strip():
             raise PricingError("fare rule id is required")
         if self.amount.amount < Decimal("0.00"):
             raise PricingError("fare rule amount cannot be negative")
+        if self.minimum_fare is not None and self.minimum_fare.currency != self.amount.currency:
+            raise PricingError("minimum fare currency must match rule amount currency")
+        if self.per_km_rate is not None and self.per_km_rate < Decimal("0.00"):
+            raise PricingError("per-km rate cannot be negative")
+        if self.distance_discount_threshold_km is not None and self.distance_discount_threshold_km < Decimal("0.00"):
+            raise PricingError("distance discount threshold cannot be negative")
+        if self.distance_discount_pct < 0 or self.distance_discount_pct > 100:
+            raise PricingError("distance discount percentage must be between 0 and 100")
+        normalized = {str(key).strip().upper(): Decimal(str(value)) for key, value in self.seat_class_multipliers.items()}
+        if any(value < Decimal("0.00") for value in normalized.values()):
+            raise PricingError("seat class multipliers cannot be negative")
+        object.__setattr__(self, "seat_class_multipliers", MappingProxyType(normalized))
 
 
 @dataclass(frozen=True, slots=True)
@@ -147,12 +308,17 @@ class FareBreakdown:
     taxes: tuple[PriceComponent, ...] = field(default_factory=tuple)
     fees: tuple[PriceComponent, ...] = field(default_factory=tuple)
     discounts: tuple[PriceComponent, ...] = field(default_factory=tuple)
+    dynamic_adjustments: tuple[PriceComponent, ...] = field(default_factory=tuple)
+    pricing_components: Mapping[str, object] = field(default_factory=dict)
     total: Money = field(init=False)
 
     def __post_init__(self) -> None:
         currency = self.base_fare.currency
+        if isinstance(self.dynamic_adjustments, Mapping):
+            object.__setattr__(self, "pricing_components", self.dynamic_adjustments)
+            object.__setattr__(self, "dynamic_adjustments", ())
         total = self.base_fare
-        for component in self.taxes + self.fees + self.discounts:
+        for component in self.taxes + self.fees + self.discounts + self.dynamic_adjustments:
             if component.amount.currency != currency:
                 raise PricingError("all fare breakdown components must share one currency")
             if component.amount.amount < Decimal("0.00"):
@@ -163,8 +329,11 @@ class FareBreakdown:
             total = total + fee.amount
         for discount in self.discounts:
             total = total - discount.amount
+        for adjustment in self.dynamic_adjustments:
+            total = total + adjustment.amount
         if total.amount < Decimal("0.00"):
             raise PricingError("fare breakdown total cannot be negative")
+        object.__setattr__(self, "pricing_components", MappingProxyType(dict(self.pricing_components)))
         object.__setattr__(self, "total", total)
 
 
@@ -181,6 +350,9 @@ class FareRuleSet:
     status: RuleSetStatus = RuleSetStatus.DRAFT
     published_at: datetime | None = None
     contract_id: str = ""
+    advance_purchase_tiers: tuple[AdvancePurchaseTier, ...] = DEFAULT_ADVANCE_PURCHASE_TIERS
+    peak_pricing: PeakPricingRule | None = DEFAULT_PEAK_PRICING
+    dynamic_pricing_bands: tuple[DynamicPricingBand, ...] = DEFAULT_DYNAMIC_PRICING_BANDS
 
     def __post_init__(self) -> None:
         required_fields = {
@@ -214,6 +386,9 @@ class FareRuleSet:
             RuleSetStatus.DRAFT,
             None,
             self.contract_id,
+            self.advance_purchase_tiers,
+            self.peak_pricing,
+            self.dynamic_pricing_bands,
         )
 
     def validate_for_publication(self) -> Self:
@@ -230,6 +405,9 @@ class FareRuleSet:
             RuleSetStatus.VALIDATED,
             None,
             self.contract_id,
+            self.advance_purchase_tiers,
+            self.peak_pricing,
+            self.dynamic_pricing_bands,
         )
 
     def publish(self, approved_at: datetime | None = None) -> Self:
@@ -247,6 +425,9 @@ class FareRuleSet:
             RuleSetStatus.PUBLISHED,
             published_at,
             self.contract_id,
+            self.advance_purchase_tiers,
+            self.peak_pricing,
+            self.dynamic_pricing_bands,
         )
 
     def supersede(self) -> Self:
@@ -264,6 +445,9 @@ class FareRuleSet:
             RuleSetStatus.SUPERSEDED,
             self.published_at,
             self.contract_id,
+            self.advance_purchase_tiers,
+            self.peak_pricing,
+            self.dynamic_pricing_bands,
         )
 
     def is_effective(self, when: datetime) -> bool:
@@ -433,6 +617,10 @@ def calculate_fare_quote(
     quoted_at: datetime,
     ttl: timedelta,
     active_discount_types: set[str] | None = None,
+    seat_class: str = "SECOND_CLASS",
+    distance_km: Decimal | int | str | None = None,
+    departure_time: datetime | None = None,
+    capacity_snapshots: Iterable[CapacitySnapshot] | None = None,
 ) -> FareQuote:
     normalized_currency = requested_currency.strip().upper()
     quote_until = min(quoted_at + ttl, rule_set.effective_window.ends_at)
@@ -454,11 +642,53 @@ def calculate_fare_quote(
         )
 
     base_rule = next(rule for rule in rule_set.rules if rule.kind is RuleKind.BASE_FARE)
+    base_fare, pricing_components = _base_fare_for_distance(base_rule, distance_km)
+    explanations: list[PriceExplanation] = [rule.explanation for rule in rule_set.rules]
+
+    seat_class_code = (seat_class or "SECOND_CLASS").strip().upper()
+    seat_multiplier = _seat_class_multiplier(base_rule, seat_class_code)
+    base_fare = _multiply_money(base_fare, seat_multiplier)
+    pricing_components["seatClassMultiplier"] = {"seatClass": seat_class_code, "multiplier": str(seat_multiplier)}
+    explanations.append(PriceExplanation("SEAT_CLASS_MULTIPLIER", {"seatClass": seat_class_code, "multiplier": seat_multiplier}))
+
+    advance_tier = _advance_purchase_tier(rule_set, quoted_at, departure_time)
+    if advance_tier is not None:
+        base_fare = _multiply_money(base_fare, advance_tier.multiplier)
+        pricing_components["advancePurchaseTier"] = {
+            "tierName": advance_tier.explanation_code,
+            "multiplier": str(advance_tier.multiplier),
+        }
+        explanations.append(
+            PriceExplanation(
+                advance_tier.explanation_code,
+                {"minDaysBefore": advance_tier.min_days_before, "multiplier": advance_tier.multiplier},
+            )
+        )
+    else:
+        pricing_components["advancePurchaseTier"] = None
+
+    peak_adjustment_pct = _peak_adjustment_pct(rule_set.peak_pricing, departure_time)
+    if peak_adjustment_pct is not None:
+        base_fare = _multiply_money(base_fare, Decimal("1") + (Decimal(peak_adjustment_pct["totalAdjustmentPct"]) / Decimal("100")))
+        pricing_components["peakAdjustment"] = peak_adjustment_pct
+        explanations.append(PriceExplanation("PEAK_PRICING_ADJUSTMENT", peak_adjustment_pct))
+    else:
+        pricing_components["peakAdjustment"] = None
+
     taxes = tuple(_component(rule) for rule in rule_set.rules if rule.kind is RuleKind.TAX)
     fees = tuple(_component(rule) for rule in rule_set.rules if rule.kind is RuleKind.FEE)
     active_discount_types = active_discount_types or set()
     discounts = tuple(_component(rule) for rule in rule_set.rules if rule.kind is RuleKind.DISCOUNT and _discount_allowed(rule, active_discount_types))
-    breakdown = FareBreakdown(base_rule.amount, taxes, fees, discounts)
+    subtotal = FareBreakdown(base_fare, taxes, fees, discounts, pricing_components=pricing_components).total
+    dynamic_adjustment, capacity_component = _dynamic_capacity_adjustment(subtotal, rule_set.dynamic_pricing_bands, capacity_snapshots)
+    if dynamic_adjustment is not None:
+        explanations.append(dynamic_adjustment.explanation)
+        pricing_components["dynamicCapacityAdjustment"] = capacity_component
+        dynamic_adjustments = (dynamic_adjustment,)
+    else:
+        pricing_components["dynamicCapacityAdjustment"] = capacity_component
+        dynamic_adjustments = ()
+    breakdown = FareBreakdown(base_fare, taxes, fees, discounts, dynamic_adjustments, pricing_components)
     snapshot = RuleSnapshot.from_rule_set(rule_set, quoted_at)
     return FareQuote(
         quote_id,
@@ -472,7 +702,101 @@ def calculate_fare_quote(
         quote_until,
         snapshot,
         breakdown,
-        tuple(rule.explanation for rule in rule_set.rules),
+        tuple(explanations),
+    )
+
+
+def _multiply_money(money: Money, multiplier: Decimal) -> Money:
+    return Money(money.amount * multiplier, money.currency)
+
+
+def _base_fare_for_distance(base_rule: FareRule, distance_km: Decimal | int | str | None) -> tuple[Money, dict[str, object]]:
+    if base_rule.per_km_rate is None or distance_km is None:
+        return base_rule.amount, {"baseFlat": {"amount": base_rule.amount.amount_minor, "currency": base_rule.amount.currency}}
+    distance = Decimal(str(distance_km))
+    if distance < Decimal("0"):
+        raise PricingError("distance_km cannot be negative")
+    threshold = base_rule.distance_discount_threshold_km
+    discount_pct = Decimal(base_rule.distance_discount_pct) / Decimal("100")
+    charged_km = distance
+    discounted_km = Decimal("0")
+    if threshold is not None and distance > threshold and discount_pct > Decimal("0"):
+        discounted_km = distance - threshold
+        charged_km = threshold + (discounted_km * (Decimal("1") - discount_pct))
+    distance_amount = charged_km * base_rule.per_km_rate
+    minimum = base_rule.minimum_fare or Money.zero(base_rule.amount.currency)
+    fare = Money(max(distance_amount, minimum.amount), base_rule.amount.currency)
+    return fare, {
+        "baseDistanceFare": {
+            "distanceKm": str(distance),
+            "perKmRate": str(base_rule.per_km_rate),
+            "minimumFare": minimum.amount_minor,
+            "discountThresholdKm": str(threshold) if threshold is not None else None,
+            "discountPct": base_rule.distance_discount_pct,
+        }
+    }
+
+
+def _seat_class_multiplier(base_rule: FareRule, seat_class: str) -> Decimal:
+    try:
+        return Decimal(str(base_rule.seat_class_multipliers[seat_class]))
+    except KeyError as exc:
+        raise PricingError(f"unsupported seat class: {seat_class}") from exc
+
+
+def _advance_purchase_tier(rule_set: FareRuleSet, quoted_at: datetime, departure_time: datetime | None) -> AdvancePurchaseTier | None:
+    if departure_time is None:
+        return None
+    departure = departure_time.astimezone(UTC) if departure_time.tzinfo is not None else departure_time.replace(tzinfo=UTC)
+    quoted = quoted_at.astimezone(UTC) if quoted_at.tzinfo is not None else quoted_at.replace(tzinfo=UTC)
+    days_before = max((departure.date() - quoted.date()).days, 0)
+    return next((tier for tier in rule_set.advance_purchase_tiers if tier.matches(days_before)), None)
+
+
+def _peak_adjustment_pct(peak_pricing: PeakPricingRule | None, departure_time: datetime | None) -> dict[str, int] | None:
+    if peak_pricing is None or departure_time is None:
+        return None
+    departure = departure_time.astimezone(UTC) if departure_time.tzinfo is not None else departure_time.replace(tzinfo=UTC)
+    date_adjustment = peak_pricing.date_surcharge_pct if peak_pricing.is_peak_date(departure.date()) else 0
+    hour_adjustment = peak_pricing.hour_surcharge_pct if peak_pricing.is_peak_hour(departure.time()) else 0
+    offpeak_discount = peak_pricing.offpeak_discount_pct if date_adjustment == 0 and hour_adjustment == 0 else 0
+    total = date_adjustment + hour_adjustment - offpeak_discount
+    return {
+        "dateAdjustment": date_adjustment,
+        "hourAdjustment": hour_adjustment,
+        "offpeakDiscount": offpeak_discount,
+        "totalAdjustmentPct": total,
+    }
+
+
+def _dynamic_capacity_adjustment(
+    subtotal: Money,
+    bands: tuple[DynamicPricingBand, ...],
+    capacity_snapshots: Iterable[CapacitySnapshot] | None,
+) -> tuple[PriceComponent | None, dict[str, object] | None]:
+    snapshots = tuple(capacity_snapshots or ())
+    if not snapshots:
+        return None, None
+    lowest = min(snapshots, key=lambda item: item.remaining_pct)
+    remaining_pct = lowest.remaining_pct
+    band = next((candidate for candidate in bands if candidate.matches(remaining_pct)), None)
+    adjustment_pct = band.adjustment_pct if band is not None else 0
+    component_data = {
+        "segmentRef": lowest.segment_ref,
+        "remainingPct": str(remaining_pct),
+        "adjustmentPct": adjustment_pct,
+    }
+    if adjustment_pct == 0:
+        return None, component_data
+    amount = _multiply_money(subtotal, Decimal(adjustment_pct) / Decimal("100"))
+    return (
+        PriceComponent(
+            "dynamic-capacity",
+            amount,
+            PriceExplanation("DYNAMIC_CAPACITY_ADJUSTMENT", component_data),
+            False,
+        ),
+        component_data,
     )
 
 

--- a/services/fare-pricing/src/fare_pricing/handlers.py
+++ b/services/fare-pricing/src/fare_pricing/handlers.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Mapping
+
+from fare_pricing.application.service import FarePricingService
+from fare_pricing.domain import CapacitySnapshot, PricingError
+from fare_pricing.ports import EventEnvelope
+
+CAPACITY_STREAM = "events:capacity-availability"
+CAPACITY_EVENT_TYPE = "CapacitySnapshotUpdated"
+
+
+def handle_capacity_snapshot_updated(service: FarePricingService, envelope: EventEnvelope) -> None:
+    """Cache CapacitySnapshotUpdated events for quote-time dynamic pricing."""
+    if envelope.event_type != CAPACITY_EVENT_TYPE:
+        return
+    snapshot = capacity_snapshot_from_payload(envelope.payload)
+    service.upsert_capacity_snapshot(snapshot)
+
+
+def capacity_snapshot_from_payload(payload: Mapping[str, Any]) -> CapacitySnapshot:
+    try:
+        return CapacitySnapshot(
+            segment_ref=str(payload["segmentRef"]),
+            departure_date=date.fromisoformat(str(payload["departureDate"])),
+            total_capacity=int(payload["totalCapacity"]),
+            remaining_capacity=int(payload["remainingCapacity"]),
+            snapshot_version=int(payload["snapshotVersion"]),
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise PricingError("invalid CapacitySnapshotUpdated payload") from exc

--- a/services/fare-pricing/src/fare_pricing/web/handlers.py
+++ b/services/fare-pricing/src/fare_pricing/web/handlers.py
@@ -61,7 +61,9 @@ def _breakdown_to_schema(bd: FareBreakdown) -> dict[str, Any]:
         "taxes": [_component_to_schema(t) for t in bd.taxes],
         "fees": [_component_to_schema(f) for f in bd.fees],
         "discounts": [_component_to_schema(d) for d in bd.discounts],
+        "dynamicAdjustments": [_component_to_schema(d) for d in bd.dynamic_adjustments],
         "total": _money_to_schema(bd.total),
+        **dict(bd.pricing_components),
     }
 
 
@@ -259,6 +261,9 @@ def compute_fare_quote(
                 rule_set_id=rule_set_id,
                 requested_currency="CNY",
                 segment_refs=req.segmentRefs,
+                seat_class=req.seatClass,
+                distance_km=req.distanceKm,
+                departure_time=_effective_datetime(req.departureTime) if req.departureTime is not None else None,
             )
             envelope = _event_envelope(request, "FareQuoteComputed", causation_id, _fare_quote_event_payload(quote))
             service.append_outbox((envelope,))

--- a/services/fare-pricing/src/fare_pricing/web/schemas.py
+++ b/services/fare-pricing/src/fare_pricing/web/schemas.py
@@ -39,6 +39,13 @@ class FareBreakdownSchema(BaseModel):
     taxes: list[PriceComponentSchema] = Field(default_factory=list)
     fees: list[PriceComponentSchema] = Field(default_factory=list)
     discounts: list[PriceComponentSchema] = Field(default_factory=list)
+    dynamicAdjustments: list[PriceComponentSchema] = Field(default_factory=list)
+    baseDistanceFare: dict[str, Any] | None = None
+    baseFlat: dict[str, Any] | None = None
+    seatClassMultiplier: dict[str, Any] | None = None
+    advancePurchaseTier: dict[str, Any] | None = None
+    peakAdjustment: dict[str, Any] | None = None
+    dynamicCapacityAdjustment: dict[str, Any] | None = None
     total: MoneySchema
 
 
@@ -85,6 +92,9 @@ class FareQuoteRequest(BaseModel):
     segmentRefs: list[str] = Field(..., min_length=1)
     productCode: str = Field(default="rail-standard", min_length=1)
     fareRuleRefs: list[str] | None = None
+    seatClass: str = Field(default="SECOND_CLASS", min_length=1)
+    distanceKm: float | None = Field(default=None, ge=0)
+    departureTime: datetime | None = None
 
 
 class FareQuoteResponse(BaseModel):

--- a/services/fare-pricing/tests/test_domain.py
+++ b/services/fare-pricing/tests/test_domain.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 from fare_pricing import (
     AssessmentPurpose,
+    CapacitySnapshot,
     FareQuote,
     FareRule,
     FareRuleSet,
@@ -27,13 +28,25 @@ from fare_pricing import (
 NOW = datetime(2026, 7, 3, 12, 0, tzinfo=UTC)
 
 
-def rule(rule_id: str, kind: RuleKind, amount: str, *, refundable: bool = True) -> FareRule:
+def rule(
+    rule_id: str,
+    kind: RuleKind,
+    amount: str,
+    *,
+    refundable: bool = True,
+    per_km_rate: str | None = None,
+    minimum_fare: str | None = None,
+) -> FareRule:
     return FareRule(
         rule_id=rule_id,
         kind=kind,
         amount=Money(amount, "USD"),
         explanation=PriceExplanation(f"fare.{rule_id}", {"rule": rule_id}),
         refundable=refundable,
+        per_km_rate=Decimal(per_km_rate) if per_km_rate is not None else None,
+        minimum_fare=Money(minimum_fare, "USD") if minimum_fare is not None else None,
+        distance_discount_threshold_km=Decimal("500") if per_km_rate is not None else None,
+        distance_discount_pct=10 if per_km_rate is not None else 0,
     )
 
 
@@ -111,6 +124,71 @@ class FarePricingDomainTest(unittest.TestCase):
         )
         self.assertEqual(failed.status, QuoteStatus.FAILED)
         self.assertEqual(failed.failed_reason, "requested currency does not match fare rule set currency")
+
+
+    def test_advance_purchase_peak_and_seat_class_components(self) -> None:
+        quote = calculate_fare_quote(
+            quote_id="quote-dynamic",
+            input_hash="hash-dynamic",
+            traveler_refs=("traveler-1",),
+            channel="web",
+            rule_set=published_rule_set(),
+            requested_currency="USD",
+            quoted_at=NOW,
+            ttl=timedelta(minutes=15),
+            seat_class="FIRST_CLASS",
+            departure_time=NOW + timedelta(days=25),
+        )
+
+        assert quote.breakdown is not None
+        self.assertEqual(quote.breakdown.pricing_components["seatClassMultiplier"]["multiplier"], "1.6")
+        self.assertEqual(quote.breakdown.pricing_components["advancePurchaseTier"]["tierName"], "ADVANCE_PURCHASE_TIER_1")
+        self.assertEqual(quote.breakdown.pricing_components["peakAdjustment"]["totalAdjustmentPct"], -10)
+        self.assertIn("ADVANCE_PURCHASE_TIER_1", {explanation.code for explanation in quote.explanations})
+        self.assertEqual(quote.breakdown.base_fare, Money("100.80", "USD"))
+
+    def test_peak_hour_applies_fifteen_percent_surcharge(self) -> None:
+        quote = calculate_fare_quote(
+            quote_id="quote-peak",
+            input_hash="hash-peak",
+            traveler_refs=("traveler-1",),
+            channel="web",
+            rule_set=published_rule_set(),
+            requested_currency="USD",
+            quoted_at=NOW,
+            ttl=timedelta(minutes=15),
+            seat_class="FIRST_CLASS",
+            departure_time=datetime(2026, 7, 6, 8, 0, tzinfo=UTC),
+        )
+
+        assert quote.breakdown is not None
+        self.assertEqual(quote.breakdown.pricing_components["advancePurchaseTier"]["tierName"], "ADVANCE_PURCHASE_TIER_4")
+        self.assertEqual(quote.breakdown.pricing_components["peakAdjustment"]["hourAdjustment"], 15)
+        self.assertEqual(quote.breakdown.base_fare, Money("184.00", "USD"))
+
+    def test_distance_fare_and_capacity_dynamic_surcharge(self) -> None:
+        rule_set = draft_rule_set(
+            rule("base", RuleKind.BASE_FARE, "100.00", per_km_rate="0.15", minimum_fare="5.00"),
+        ).publish(NOW)
+        quote = calculate_fare_quote(
+            quote_id="quote-capacity",
+            input_hash="hash-capacity",
+            traveler_refs=("traveler-1",),
+            channel="web",
+            rule_set=rule_set,
+            requested_currency="USD",
+            quoted_at=NOW,
+            ttl=timedelta(minutes=15),
+            distance_km=Decimal("600"),
+            departure_time=NOW + timedelta(days=4),
+            capacity_snapshots=(CapacitySnapshot("seg-1", (NOW + timedelta(days=4)).date(), 100, 8, 1),),
+        )
+
+        assert quote.breakdown is not None
+        self.assertIn("baseDistanceFare", quote.breakdown.pricing_components)
+        self.assertEqual(quote.breakdown.pricing_components["dynamicCapacityAdjustment"]["adjustmentPct"], 50)
+        self.assertEqual(quote.breakdown.base_fare, Money("79.65", "USD"))
+        self.assertEqual(quote.breakdown.total, Money("119.48", "USD"))
 
     def test_rule_snapshot_and_quoted_values_are_immutable(self) -> None:
         quote = quoted()


### PR DESCRIPTION
## Summary
- add dynamic fare-pricing domain components for advance purchase, peak/off-peak, seat class, distance, and capacity adjustments
- extend fare quote API/event breakdowns with new optional request fields and pricing components
- cache CapacitySnapshotUpdated events with a new migration and storage/service handlers

## Validation
- cd services/fare-pricing && uv run python -m pytest tests/ -q