### PR TITLE
REQ-323 Activate customer-service context consumers

### DIFF
--- a/services/customer-service/migrations/004_case_context.sql
+++ b/services/customer-service/migrations/004_case_context.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS case_context (
+  context_id      text PRIMARY KEY,
+  case_id         text NOT NULL,
+  source_event_id text NOT NULL,
+  source          text NOT NULL,
+  context_type    text NOT NULL,
+  severity        text NOT NULL,
+  occurred_at     timestamptz NOT NULL,
+  data            jsonb NOT NULL,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (case_id, source_event_id)
+);
+
+CREATE INDEX IF NOT EXISTS case_context_case_idx
+  ON case_context (case_id, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS case_context_source_event_idx
+  ON case_context (source_event_id);

--- a/services/customer-service/src/adapters/messaging/stream-config.ts
+++ b/services/customer-service/src/adapters/messaging/stream-config.ts
@@ -1,7 +1,13 @@
 import { dlqForStream as kitDlqForStream, streamForProducer } from "@trainticket/ts-kit";
 
 export const CUSTOMER_SERVICE_CONSUMER_GROUP = "customer-service";
-export const CUSTOMER_SERVICE_SUBSCRIPTIONS = Object.freeze(["events:journey-order", "events:post-sales", "events:admin-audit"]);
+export const CUSTOMER_SERVICE_SUBSCRIPTIONS = Object.freeze([
+  "events:journey-order",
+  "events:post-sales",
+  "events:admin-audit",
+  "events:transfer-management",
+  "events:identity-verification",
+]);
 export const DEFAULT_REDIS_URL = "redis://localhost:6379";
 export const STREAM_MAXLEN = 100_000;
 export const RECOVERY_MIN_IDLE_MS = 60_000;

--- a/services/customer-service/src/adapters/storage/customer-service-repository.ts
+++ b/services/customer-service/src/adapters/storage/customer-service-repository.ts
@@ -13,6 +13,7 @@ import {
   type ManualActionRequestSnapshot,
   type SupportCaseSnapshot,
   type CompensationOfferSnapshot,
+  type CaseContextSnapshot,
 } from "../../domain.js";
 import { type CustomerServiceRepository } from "../../application/ports/customer-service-repository.js";
 
@@ -120,6 +121,40 @@ export class PostgresCustomerServiceRepository implements CustomerServiceReposit
   async saveCompensationOffer(snapshot: CompensationOfferSnapshot, expectedVersion: bigint): Promise<SnapshotRecord<StoredCompensationOfferSnapshot>> {
     return new SnapshotRepository<StoredCompensationOfferSnapshot>(this.client, "compensation_offer_snapshots").save(snapshot.offerId, serializeCompensationOffer(snapshot), expectedVersion);
   }
+
+  async caseContextForCase(caseId: string): Promise<CaseContextSnapshot[]> {
+    const result = await this.client.query(
+      `SELECT data FROM case_context WHERE case_id = $1 ORDER BY occurred_at, created_at`,
+      [caseId],
+    ) as QueryResult<{ data: StoredCaseContextSnapshot }>;
+    return result.rows.map((row) => reviveCaseContext(row.data));
+  }
+
+  async saveCaseContext(snapshot: CaseContextSnapshot): Promise<void> {
+    await this.client.query(
+      `INSERT INTO case_context (context_id, case_id, source_event_id, source, context_type, severity, occurred_at, data)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       ON CONFLICT (case_id, source_event_id) DO NOTHING`,
+      [
+        snapshot.contextId,
+        snapshot.caseId,
+        snapshot.sourceEventId,
+        snapshot.source,
+        snapshot.contextType,
+        snapshot.severity,
+        snapshot.occurredAt,
+        serializeCaseContext(snapshot),
+      ],
+    );
+  }
+
+  async hasCaseContextForEvent(caseId: string, sourceEventId: string): Promise<boolean> {
+    const result = await this.client.query(
+      `SELECT 1 FROM case_context WHERE case_id = $1 AND source_event_id = $2 LIMIT 1`,
+      [caseId, sourceEventId],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
 }
 
 type StoredSupportCaseSnapshot = Omit<SupportCaseSnapshot, "openedAt" | "resolvedAt" | "closedAt" | "resolution" | "escalation" | "escalationHistory" | "slaTracker" | "slaBreaches"> & Readonly<{
@@ -137,6 +172,7 @@ type StoredManualActionRequestSnapshot = Omit<ManualActionRequestSnapshot, "requ
 type StoredCompensationOfferSnapshot = Omit<CompensationOfferSnapshot, "offeredAt" | "acceptedAt" | "issuedAt"> & Readonly<{ offeredAt: string; acceptedAt?: string; issuedAt?: string }>;
 type StoredCaseTimelineSnapshot = Omit<CaseTimelineSnapshot, "entries"> & Readonly<{ entries: readonly StoredTimelineEntrySnapshot[] }>;
 type StoredTimelineEntrySnapshot = Omit<CaseTimelineSnapshot["entries"][number], "occurredAt"> & Readonly<{ occurredAt: string }>;
+type StoredCaseContextSnapshot = Omit<CaseContextSnapshot, "occurredAt" | "createdAt"> & Readonly<{ occurredAt: string; createdAt: string }>;
 
 function serializeSnapshot<T>(snapshot: T): T {
   return JSON.parse(JSON.stringify(snapshot)) as T;
@@ -156,6 +192,10 @@ function serializeManualAction(snapshot: ManualActionRequestSnapshot): StoredMan
 
 function serializeCompensationOffer(snapshot: CompensationOfferSnapshot): StoredCompensationOfferSnapshot {
   return serializeSnapshot(snapshot) as unknown as StoredCompensationOfferSnapshot;
+}
+
+function serializeCaseContext(snapshot: CaseContextSnapshot): StoredCaseContextSnapshot {
+  return serializeSnapshot(snapshot) as unknown as StoredCaseContextSnapshot;
 }
 
 function reviveSupportCase(snapshot: StoredSupportCaseSnapshot): SupportCaseSnapshot {
@@ -194,6 +234,14 @@ function reviveCompensationOffer(snapshot: StoredCompensationOfferSnapshot): Com
     offeredAt: new Date(snapshot.offeredAt),
     acceptedAt: snapshot.acceptedAt ? new Date(snapshot.acceptedAt) : undefined,
     issuedAt: snapshot.issuedAt ? new Date(snapshot.issuedAt) : undefined,
+  };
+}
+
+function reviveCaseContext(snapshot: StoredCaseContextSnapshot): CaseContextSnapshot {
+  return {
+    ...snapshot,
+    occurredAt: new Date(snapshot.occurredAt),
+    createdAt: new Date(snapshot.createdAt),
   };
 }
 

--- a/services/customer-service/src/app.ts
+++ b/services/customer-service/src/app.ts
@@ -612,6 +612,7 @@ function supportCaseResponse(snapshot: {
   slaTracker?: unknown;
   slaBreaches?: readonly unknown[];
   slaMetrics?: unknown;
+  caseContext?: readonly unknown[];
 }) {
   return {
     caseId: snapshot.caseId,
@@ -638,6 +639,7 @@ function supportCaseResponse(snapshot: {
     slaMetrics: snapshot.slaMetrics,
     evidence: snapshot.evidence,
     timeline: snapshot.timeline,
+    caseContext: snapshot.caseContext,
   };
 }
 

--- a/services/customer-service/src/application/customer-service.ts
+++ b/services/customer-service/src/application/customer-service.ts
@@ -23,6 +23,9 @@ import {
   type SupportCaseSnapshot,
   type TimelineEntrySnapshot,
   type CompensationOfferSnapshot,
+  type CaseContextSeverity,
+  type CaseContextSnapshot,
+  type CaseContextType,
 } from "../domain.js";
 import { newCommandId, newCorrelationId, toEventEnvelope, type EventEnvelope, type EventPublisher } from "./messaging.js";
 import { OptimisticConcurrencyConflict, uuidV7 } from "@trainticket/ts-kit";
@@ -33,6 +36,7 @@ export type SupportCaseDetails = SupportCaseSnapshot &
     evidence: readonly ReturnType<EvidenceRef["toSnapshot"]>[];
     timeline: readonly TimelineEntrySnapshot[];
     slaMetrics: Readonly<{ timeToFirstResponseMinutes?: number; timeToResolutionMinutes?: number; compliant: boolean }>;
+    caseContext: readonly CaseContextSnapshot[];
   }>;
 
 export type OpenSupportCaseRequest = Readonly<{
@@ -89,6 +93,7 @@ export class CustomerServiceApplication {
   private readonly timelines = new Map<string, CaseTimeline>();
   private readonly manualActions = new Map<string, ManualActionRequest>();
   private readonly compensationOffers = new Map<string, CompensationOffer>();
+  private readonly caseContextByCase = new Map<string, CaseContextSnapshot[]>();
   private readonly consumedIntegrationEvents = new Map<string, Readonly<{ source: string; eventType: string; consumedAt: Date; payload: Readonly<Record<string, unknown>> }>>();
 
   constructor(
@@ -137,6 +142,7 @@ export class CustomerServiceApplication {
       evidence: Object.freeze((this.evidenceByCase.get(caseId) ?? []).map((evidence) => evidence.toSnapshot())),
       timeline: Object.freeze((this.timelines.get(caseId) ?? CaseTimeline.create(caseId)).entries.map((entry) => ({ ...entry }))),
       slaMetrics: slaMetrics(supportCase.toSnapshot()),
+      caseContext: Object.freeze((this.caseContextByCase.get(caseId) ?? []).map(cloneCaseContext)),
     };
   }
 
@@ -151,6 +157,7 @@ export class CustomerServiceApplication {
       evidence: Object.freeze(await this.repository.evidenceForCase(caseId)),
       timeline: Object.freeze(((await this.findTimeline(caseId)) ?? CaseTimeline.create(caseId)).entries.map((entry) => ({ ...entry }))),
       slaMetrics: slaMetrics(supportCase.toSnapshot()),
+      caseContext: Object.freeze(await this.caseContextForCase(caseId)),
     };
   }
 
@@ -438,6 +445,8 @@ export class CustomerServiceApplication {
 
     if (envelope.producer === "admin-audit" && (envelope.eventType === "ManualActionExecuted" || envelope.eventType === "ManualActionRejected")) {
       await this.recordAdminAuditManualActionOutcome(envelope);
+    } else if (envelope.producer === "transfer-management" || envelope.producer === "identity-verification") {
+      await this.projectCaseContext(envelope);
     } else {
       for (const supportCase of await this.findCasesReferencingEnvelope(envelope)) {
         if (caseReferencesEnvelope(supportCase.toSnapshot(), envelope)) {
@@ -464,6 +473,102 @@ export class CustomerServiceApplication {
 
   consumedIntegrationEventCount(): number {
     return this.consumedIntegrationEvents.size;
+  }
+
+  private async projectCaseContext(envelope: EventEnvelope): Promise<void> {
+    const projection = caseContextProjection(envelope);
+    if (!projection) {
+      return;
+    }
+
+    for (const supportCase of await this.findCasesReferencingCaseContext(envelope)) {
+      if (!caseMatchesContextRefs(supportCase.toSnapshot(), projection.refs)) {
+        continue;
+      }
+      if (await this.hasCaseContextForEvent(supportCase.id, envelope.eventId)) {
+        continue;
+      }
+
+      const context: CaseContextSnapshot = Object.freeze({
+        contextId: newCaseContextId(),
+        caseId: supportCase.id,
+        source: envelope.producer as CaseContextSnapshot["source"],
+        sourceEventId: envelope.eventId,
+        sourceEventType: envelope.eventType,
+        contextType: projection.contextType,
+        severity: projection.severity,
+        occurredAt: new Date(envelope.occurredAt),
+        refs: Object.freeze({ ...projection.refs }),
+        summary: projection.summary,
+        facts: deepFreezeRecord({ ...projection.facts }),
+        createdAt: new Date(),
+      });
+
+      const current = this.caseContextByCase.get(supportCase.id) ?? [];
+      current.push(context);
+      this.caseContextByCase.set(supportCase.id, current);
+      await this.repository?.saveCaseContext(context);
+      await this.appendTimelineEntry(
+        supportCase.id,
+        `CaseContext.${projection.contextType}`,
+        { sourceEventId: envelope.eventId, producer: envelope.producer, contextType: projection.contextType, severity: projection.severity, refs: context.refs, facts: context.facts },
+        "INTERNAL_ONLY",
+        new Date(envelope.occurredAt),
+        envelope.correlationId,
+        envelope.eventId,
+      );
+      if (projection.severity === "CRITICAL") {
+        await this.escalateForCaseContext(supportCase.id, context, envelope);
+      }
+    }
+  }
+
+  private async escalateForCaseContext(caseId: string, context: CaseContextSnapshot, envelope: EventEnvelope): Promise<void> {
+    const { aggregate: current, version } = await this.requireVersionedCase(caseId);
+    if (isTerminalCase(current.toSnapshot())) {
+      return;
+    }
+    const toLevel = escalationLevelForContext(context.contextType, current.escalationLevel);
+    const { case: updated, event } = current.escalate({
+      caseId,
+      targetQueue: queueForCaseContext(context.contextType),
+      reason: context.summary,
+      escalatedBy: "op-system-case-context",
+      toLevel,
+      triggerCondition: "MANUAL",
+      correlationId: envelope.correlationId,
+      causationId: envelope.eventId,
+      escalatedAt: new Date(envelope.occurredAt),
+    });
+    this.cases.set(caseId, updated);
+    if (this.repository) {
+      await this.repository.saveCase(updated.toSnapshot(), version ?? 0n);
+    }
+    await this.publisher.publish(toEventEnvelope(event, envelope.eventId));
+    await this.publisher.publish(toEventEnvelope(toTicketEscalated(event), envelope.eventId));
+  }
+
+  private async findCasesReferencingCaseContext(envelope: EventEnvelope): Promise<SupportCase[]> {
+    const cases = this.repository ? await this.repository.listCases() : [...this.cases.values()];
+    const projection = caseContextProjection(envelope);
+    if (!projection) {
+      return [];
+    }
+    return cases.filter((supportCase) => caseMatchesContextRefs(supportCase.toSnapshot(), projection.refs));
+  }
+
+  private async caseContextForCase(caseId: string): Promise<CaseContextSnapshot[]> {
+    if (this.repository) {
+      return await this.repository.caseContextForCase(caseId);
+    }
+    return (this.caseContextByCase.get(caseId) ?? []).map(cloneCaseContext);
+  }
+
+  private async hasCaseContextForEvent(caseId: string, sourceEventId: string): Promise<boolean> {
+    if (this.repository) {
+      return await this.repository.hasCaseContextForEvent(caseId, sourceEventId);
+    }
+    return (this.caseContextByCase.get(caseId) ?? []).some((context) => context.sourceEventId === sourceEventId);
   }
 
   private async recordAdminAuditManualActionOutcome(envelope: EventEnvelope): Promise<void> {
@@ -638,8 +743,8 @@ function caseReferencesEnvelope(snapshot: SupportCaseSnapshot, envelope: EventEn
     || (references.postSalesCaseId !== undefined && references.postSalesCaseId === postSalesCaseId);
 }
 
-function stringField(payload: Record<string, unknown>, field: string): string | undefined {
-  const value = payload[field];
+function stringField(payload: Record<string, unknown> | undefined, field: string): string | undefined {
+  const value = payload?.[field];
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 }
 
@@ -692,4 +797,276 @@ function slaMetrics(snapshot: SupportCaseSnapshot): SupportCaseDetails["slaMetri
 
 function newTimelineEntryId(): string {
   return `tl-${uuidV7()}`;
+}
+
+function newCaseContextId(): string {
+  return `ctx-${uuidV7()}`;
+}
+
+type CaseContextProjection = Readonly<{
+  contextType: CaseContextType;
+  severity: CaseContextSeverity;
+  refs: Readonly<Record<string, string>>;
+  summary: string;
+  facts: Readonly<Record<string, unknown>>;
+}>;
+
+function caseContextProjection(envelope: EventEnvelope): CaseContextProjection | undefined {
+  if (envelope.producer === "transfer-management") {
+    return transferCaseContextProjection(envelope);
+  }
+  if (envelope.producer === "identity-verification") {
+    return identityCaseContextProjection(envelope);
+  }
+  return undefined;
+}
+
+function transferCaseContextProjection(envelope: EventEnvelope): CaseContextProjection | undefined {
+  const payload = envelope.payload;
+  const connection = objectField(payload, "connection");
+  const refs = compactStringRecord({
+    connectionId: stringField(connection, "connectionId") ?? stringField(payload, "connectionId"),
+    transferPlanId: stringField(connection, "transferPlanId") ?? stringField(payload, "transferPlanId"),
+    journeyOrderId: stringField(connection, "journeyOrderId") ?? stringField(payload, "journeyOrderId"),
+    recoveryCaseId: stringField(payload, "recoveryCaseId") ?? firstString(arrayField(objectField(payload, "recovery"), "caseIds")),
+  });
+  if (Object.keys(refs).length === 0) {
+    return undefined;
+  }
+
+  if (envelope.eventType === "ConnectionMissed") {
+    const missedCause = stringField(payload, "missedCause") ?? "UNKNOWN";
+    return {
+      contextType: "MISSED_CONNECTION",
+      severity: "CRITICAL",
+      refs,
+      summary: `Connection ${refs.connectionId ?? "unknown"} missed (${missedCause})`,
+      facts: compactRecord({
+        previousStatus: stringField(payload, "previousStatus"),
+        status: stringField(payload, "status"),
+        riskLevel: stringField(payload, "riskLevel"),
+        contractType: stringField(payload, "contractType"),
+        missedAt: stringField(payload, "missedAt"),
+        missedCause,
+        recoveryRequired: booleanField(payload, "recoveryRequired"),
+      }),
+    };
+  }
+
+  if (envelope.eventType === "ConnectionRecovered") {
+    const replacementConnectionId = stringField(payload, "replacementConnectionId");
+    return {
+      contextType: "CONNECTION_RECOVERED",
+      severity: "INFO",
+      refs: compactStringRecord({ ...refs, replacementConnectionId }),
+      summary: replacementConnectionId
+        ? `Connection ${refs.connectionId ?? "unknown"} recovered by reaccommodation ${replacementConnectionId}`
+        : `Connection ${refs.connectionId ?? "unknown"} recovered`,
+      facts: compactRecord({
+        previousStatus: stringField(payload, "previousStatus"),
+        status: stringField(payload, "status"),
+        riskLevel: stringField(payload, "riskLevel"),
+        recoveredAt: stringField(payload, "recoveredAt"),
+        recoverySummary: stringField(payload, "recoverySummary"),
+        replacementConnectionId,
+        reaccommodatedAt: stringField(payload, "reaccommodatedAt"),
+        disruptionRecoveryEventId: stringField(payload, "disruptionRecoveryEventId"),
+      }),
+    };
+  }
+
+  if (envelope.eventType === "ConnectionRecoveryFailed") {
+    const reason = stringField(payload, "reason") ?? "UNKNOWN";
+    return {
+      contextType: "CONNECTION_RECOVERY_FAILED",
+      severity: "CRITICAL",
+      refs,
+      summary: `Recovery failed for connection ${refs.connectionId ?? "unknown"}: ${reason}`,
+      facts: compactRecord({
+        status: stringField(payload, "status"),
+        failedAt: stringField(payload, "failedAt"),
+        reason,
+        disruptionRecoveryEventId: stringField(payload, "disruptionRecoveryEventId"),
+      }),
+    };
+  }
+
+  return undefined;
+}
+
+function identityCaseContextProjection(envelope: EventEnvelope): CaseContextProjection | undefined {
+  const payload = envelope.payload;
+  const reason = stringField(payload, "reasonCode") ?? stringField(payload, "reason") ?? stringField(payload, "failureCode");
+  const refs = compactStringRecord({
+    travelerId: stringField(payload, "travelerId"),
+    credentialRecordId: stringField(payload, "credentialRecordId"),
+    verificationCaseId: stringField(payload, "verificationCaseId"),
+    purchaseLimitFactId: stringField(payload, "purchaseLimitFactId"),
+    journeyOrderId: stringField(payload, "journeyOrderId"),
+    orderIntentId: stringField(payload, "orderIntentId"),
+  });
+  if (Object.keys(refs).length === 0) {
+    return undefined;
+  }
+
+  if (envelope.eventType === "VerificationFailed") {
+    const contextType = identityContextType(reason);
+    return {
+      contextType,
+      severity: contextType === "IDENTITY_VERIFICATION_FAILED" ? "WARNING" : "CRITICAL",
+      refs,
+      summary: identitySummary(contextType, refs.travelerId, reason),
+      facts: compactRecord({
+        simOutcome: stringField(payload, "simOutcome"),
+        verificationStatus: stringField(payload, "verificationStatus"),
+        reasonCode: reason,
+        policyVersion: stringField(payload, "policyVersion"),
+        completedAt: stringField(payload, "completedAt") ?? stringField(payload, "rejectedAt"),
+      }),
+    };
+  }
+
+  if (envelope.eventType === "PurchaseLimitFactFailed" || envelope.eventType === "PurchaseLimitFactMissed") {
+    return {
+      contextType: "DUPLICATE_TICKET_SIGNAL",
+      severity: "CRITICAL",
+      refs,
+      summary: `Duplicate-ticket control ${envelope.eventType === "PurchaseLimitFactMissed" ? "missed" : "failed"}`,
+      facts: compactRecord({
+        factStatus: stringField(payload, "factStatus"),
+        limitPolicyVersion: stringField(payload, "limitPolicyVersion"),
+        failedAt: stringField(payload, "failedAt"),
+        missedAt: stringField(payload, "missedAt"),
+        failureCode: stringField(payload, "failureCode"),
+      }),
+    };
+  }
+
+  return undefined;
+}
+
+function identityContextType(reason: string | undefined): CaseContextType {
+  const normalized = reason?.trim().toUpperCase() ?? "";
+  if (normalized.includes("DUPLICATE_TICKET")) {
+    return "DUPLICATE_TICKET_SIGNAL";
+  }
+  if (normalized.includes("BLACKLIST") || normalized.includes("TRAVEL_BAN") || normalized.includes("RESTRICTED")) {
+    return "IDENTITY_BLACKLIST_SIGNAL";
+  }
+  return "IDENTITY_VERIFICATION_FAILED";
+}
+
+function identitySummary(contextType: CaseContextType, travelerId: string | undefined, reason: string | undefined): string {
+  const subject = travelerId ?? "traveler";
+  switch (contextType) {
+    case "IDENTITY_BLACKLIST_SIGNAL": return `Identity blacklist signal for ${subject}`;
+    case "DUPLICATE_TICKET_SIGNAL": return `Duplicate-ticket signal for ${subject}`;
+    default: return `Identity verification failed for ${subject}${reason ? ` (${reason})` : ""}`;
+  }
+}
+
+function caseMatchesContextRefs(snapshot: SupportCaseSnapshot, refs: Readonly<Record<string, string>>): boolean {
+  const businessRefs = snapshot.businessReferences;
+  return matchesOptionalRef(businessRefs.journeyOrderId, refs.journeyOrderId)
+    || matchesOptionalRef(businessRefs.recoveryCaseId, refs.recoveryCaseId)
+    || matchesOptionalRef(businessRefs.accountRef, refs.travelerId)
+    || matchesOptionalRef(snapshot.requesterRef, refs.travelerId)
+    || matchesOptionalRef(businessRefs.journeyOrderId, refs.orderIntentId)
+    || matchesOptionalRef(businessRefField(businessRefs, "connectionId"), refs.connectionId)
+    || matchesOptionalRef(businessRefField(businessRefs, "transferPlanId"), refs.transferPlanId)
+    || matchesOptionalRef(businessRefField(businessRefs, "verificationCaseId"), refs.verificationCaseId)
+    || matchesOptionalRef(businessRefField(businessRefs, "credentialRecordId"), refs.credentialRecordId)
+    || matchesOptionalRef(businessRefField(businessRefs, "purchaseLimitFactId"), refs.purchaseLimitFactId)
+    || matchesOptionalRef(businessRefs.postSalesCaseId, refs.verificationCaseId);
+}
+
+function businessRefField(refs: SupportCaseSnapshot["businessReferences"], field: string): string | undefined {
+  const value = (refs as Readonly<Record<string, unknown>>)[field];
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function matchesOptionalRef(caseRef: string | undefined, contextRef: string | undefined): boolean {
+  return caseRef !== undefined && contextRef !== undefined && caseRef === contextRef;
+}
+
+function escalationLevelForContext(contextType: CaseContextType, currentLevel: EscalationLevel): EscalationLevel {
+  if (currentLevel === "L3_SUPERVISOR") {
+    return "L3_SUPERVISOR";
+  }
+  if (contextType === "IDENTITY_BLACKLIST_SIGNAL" || contextType === "DUPLICATE_TICKET_SIGNAL") {
+    return "L3_SUPERVISOR";
+  }
+  return EscalationPolicy.targetFor("MANUAL", currentLevel);
+}
+
+function queueForCaseContext(contextType: CaseContextType): string {
+  switch (contextType) {
+    case "IDENTITY_BLACKLIST_SIGNAL": return "identity-risk-supervisor";
+    case "DUPLICATE_TICKET_SIGNAL": return "duplicate-ticket-review";
+    case "CONNECTION_RECOVERY_FAILED": return "disruption-recovery-escalation";
+    case "MISSED_CONNECTION": return "missed-connection-support";
+    case "CONNECTION_RECOVERED": return "connection-recovery-support";
+    case "IDENTITY_VERIFICATION_FAILED": return "identity-verification-support";
+  }
+}
+
+function objectField(payload: Record<string, unknown> | undefined, field: string): Record<string, unknown> | undefined {
+  const value = payload?.[field];
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
+}
+
+function arrayField(payload: Record<string, unknown> | undefined, field: string): readonly unknown[] | undefined {
+  const value = payload?.[field];
+  return Array.isArray(value) ? value : undefined;
+}
+
+function booleanField(payload: Record<string, unknown>, field: string): boolean | undefined {
+  const value = payload[field];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function firstString(values: readonly unknown[] | undefined): string | undefined {
+  const value = values?.find((entry) => typeof entry === "string" && entry.trim().length > 0);
+  return typeof value === "string" ? value : undefined;
+}
+
+function compactStringRecord(values: Record<string, string | undefined>): Readonly<Record<string, string>> {
+  const compacted: Record<string, string> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (value !== undefined) {
+      compacted[key] = value;
+    }
+  }
+  return Object.freeze(compacted);
+}
+
+function compactRecord(values: Record<string, unknown>): Readonly<Record<string, unknown>> {
+  const compacted: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (value !== undefined) {
+      compacted[key] = value;
+    }
+  }
+  return Object.freeze(compacted);
+}
+
+function cloneCaseContext(context: CaseContextSnapshot): CaseContextSnapshot {
+  return Object.freeze({
+    ...context,
+    occurredAt: new Date(context.occurredAt),
+    refs: Object.freeze({ ...context.refs }),
+    facts: deepFreezeRecord({ ...context.facts }),
+    createdAt: new Date(context.createdAt),
+  });
+}
+
+function deepFreezeRecord<T extends Record<string, unknown>>(value: T): Readonly<T> {
+  for (const nested of Object.values(value)) {
+    if (Array.isArray(nested)) {
+      Object.freeze(nested);
+    } else if (nested && typeof nested === "object") {
+      deepFreezeRecord(nested as Record<string, unknown>);
+    }
+  }
+  return Object.freeze(value);
 }

--- a/services/customer-service/src/application/ports/customer-service-repository.ts
+++ b/services/customer-service/src/application/ports/customer-service-repository.ts
@@ -8,6 +8,7 @@ import {
   type ManualActionRequestSnapshot,
   type SupportCaseSnapshot,
   type CompensationOfferSnapshot,
+  type CaseContextSnapshot,
 } from "../../domain.js";
 
 export interface CustomerServiceRepository {
@@ -28,4 +29,7 @@ export interface CustomerServiceRepository {
   findCompensationOffer(offerId: string): Promise<Readonly<{ aggregate: CompensationOffer; version: bigint }> | undefined>;
   saveNewCompensationOffer(snapshot: CompensationOfferSnapshot): Promise<{ version: bigint }>;
   saveCompensationOffer(snapshot: CompensationOfferSnapshot, expectedVersion: bigint): Promise<{ version: bigint }>;
+  caseContextForCase(caseId: string): Promise<CaseContextSnapshot[]>;
+  saveCaseContext(snapshot: CaseContextSnapshot): Promise<void>;
+  hasCaseContextForEvent(caseId: string, sourceEventId: string): Promise<boolean>;
 }

--- a/services/customer-service/src/domain.ts
+++ b/services/customer-service/src/domain.ts
@@ -206,6 +206,33 @@ export type SlaBreachRecord = Readonly<{
   breachedAt: Date;
 }>;
 
+export type CaseContextSource = "transfer-management" | "identity-verification";
+
+export type CaseContextType =
+  | "MISSED_CONNECTION"
+  | "CONNECTION_RECOVERED"
+  | "CONNECTION_RECOVERY_FAILED"
+  | "IDENTITY_VERIFICATION_FAILED"
+  | "IDENTITY_BLACKLIST_SIGNAL"
+  | "DUPLICATE_TICKET_SIGNAL";
+
+export type CaseContextSeverity = "INFO" | "WARNING" | "CRITICAL";
+
+export type CaseContextSnapshot = Readonly<{
+  contextId: string;
+  caseId: SupportCaseId;
+  source: CaseContextSource;
+  sourceEventId: EventId;
+  sourceEventType: string;
+  contextType: CaseContextType;
+  severity: CaseContextSeverity;
+  occurredAt: Date;
+  refs: Readonly<Record<string, string>>;
+  summary: string;
+  facts: Readonly<Record<string, unknown>>;
+  createdAt: Date;
+}>;
+
 // ─── Commands ──────────────────────────────────────────────────────────────────
 
 export type OpenSupportCase = Readonly<{

--- a/services/customer-service/src/messaging.test.ts
+++ b/services/customer-service/src/messaging.test.ts
@@ -2,12 +2,17 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import { RedisEventSubscriber } from "./adapters/messaging/subscriber.js";
+import { CUSTOMER_SERVICE_SUBSCRIPTIONS } from "./adapters/messaging/stream-config.js";
 import { CustomerServiceApplication } from "./application/customer-service.js";
 import { EvidenceRef, ManualActionRequest, SupportCase, type CustomerServiceDomainEvent } from "./domain.js";
 import { isPrefixedUuidV7 } from "@trainticket/ts-kit";
 import { ConsumedEventDeduplicator, InMemoryEventPublisher, InMemoryEventSubscriber, toEventEnvelope, type EventEnvelope } from "./application/messaging.js";
 
 describe("customer-service messaging ports", () => {
+  it("subscribes to transfer-management and identity-verification streams", () => {
+    assert.equal(CUSTOMER_SERVICE_SUBSCRIPTIONS.includes("events:transfer-management"), true);
+    assert.equal(CUSTOMER_SERVICE_SUBSCRIPTIONS.includes("events:identity-verification"), true);
+  });
   it("wraps domain events in the contract envelope", () => {
     const { event } = SupportCase.open({
       caseId: "sc-test-envelope",
@@ -145,6 +150,132 @@ describe("customer-service messaging ports", () => {
     assert.deepEqual(timelineEvents.map((e) => e.payload.eventTypeCode), ["PostSalesApplied"]);
     assert.equal(timelineEvents[0].correlationId, "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222");
     assert.equal(timelineEvents[0].causationId, "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c221");
+  });
+
+  it("projects missed connection events into case context and escalates matching cases once", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const application = new CustomerServiceApplication(publisher);
+    const opened = await application.openSupportCase({
+      requesterRef: "tvl-transfer",
+      channel: "APP",
+      priority: "NORMAL",
+      description: "Connection was disrupted",
+      businessReferences: { journeyOrderId: "ord-transfer" },
+    }, "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222");
+    const missed: EventEnvelope = {
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d100",
+      eventType: "ConnectionMissed",
+      occurredAt: "2026-07-05T10:40:00.000Z",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c222",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0d100",
+      producer: "transfer-management",
+      schemaVersion: 1,
+      payload: {
+        connection: {
+          connectionId: "con-transfer",
+          transferPlanId: "tpl-transfer",
+          itineraryRef: "itin-transfer",
+          journeyOrderId: "ord-transfer",
+          previousSegmentRef: "seg-a",
+          nextSegmentRef: "seg-b",
+          travelerRefs: ["tvl-transfer"],
+        },
+        previousStatus: "AT_RISK",
+        status: "MISSED",
+        riskLevel: "MISSED",
+        contractType: "PROTECTED",
+        missedAt: "2026-07-05T10:40:00.000Z",
+        missedCause: "PREVIOUS_SEGMENT_DELAYED",
+        window: { plannedArrivalAt: "2026-07-05T10:20:00.000Z", nextDepartureAt: "2026-07-05T10:35:00.000Z", nextCutoffAt: "2026-07-05T10:30:00.000Z", availableMinutes: -5, mctMinutes: 20, bufferMinutes: -25 },
+        recoveryRequired: true,
+      },
+    };
+
+    await application.handleIntegrationEvent(missed);
+    await application.handleIntegrationEvent(missed);
+
+    const details = application.getSupportCase(opened.caseId);
+    assert.equal(details.caseContext.length, 1);
+    assert.equal(details.caseContext[0].contextType, "MISSED_CONNECTION");
+    assert.equal(details.caseContext[0].sourceEventId, missed.eventId);
+    assert.equal(details.caseContext[0].refs.journeyOrderId, "ord-transfer");
+    assert.equal(details.caseContext[0].facts.missedCause, "PREVIOUS_SEGMENT_DELAYED");
+    assert.equal(details.status, "Escalated");
+    assert.equal(details.escalation?.targetQueue, "missed-connection-support");
+    assert.equal(details.timeline.some((entry) => entry.eventType === "CaseContext.MISSED_CONNECTION"), true);
+    assert.equal(publisher.findByEventType("TicketEscalated").length, 1);
+    assert.equal(application.consumedIntegrationEventCount(), 1);
+  });
+
+  it("projects identity blacklist and duplicate-ticket signals into case context", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const application = new CustomerServiceApplication(publisher);
+    const identityCase = await application.openSupportCase({
+      requesterRef: "tvl-identity",
+      channel: "APP",
+      priority: "NORMAL",
+      description: "Identity verification failed",
+      businessReferences: { accountRef: "tvl-identity" },
+    }, "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c225");
+    const duplicateTicketCase = await application.openSupportCase({
+      requesterRef: "tvl-duplicate",
+      channel: "APP",
+      priority: "NORMAL",
+      description: "Purchase-limit fact needs support follow-up",
+      businessReferences: { purchaseLimitFactId: "plf-identity" },
+    }, "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c226");
+
+    await application.handleIntegrationEvent({
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d200",
+      eventType: "VerificationFailed",
+      occurredAt: "2026-07-05T10:41:00.000Z",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c225",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0d200",
+      producer: "identity-verification",
+      schemaVersion: 1,
+      payload: {
+        verificationCaseId: "ivc-identity",
+        travelerId: "tvl-identity",
+        credentialRecordId: "crd-identity",
+        simOutcome: "REJECTED",
+        simResultRef: "simres-identity",
+        verificationStatus: "FAILED",
+        reasonCode: "BLACKLISTED",
+        policyVersion: "sim-v1",
+        completedAt: "2026-07-05T10:41:00.000Z",
+        aggregateVersion: 2,
+      },
+    });
+    await application.handleIntegrationEvent({
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d201",
+      eventType: "PurchaseLimitFactMissed",
+      occurredAt: "2026-07-05T10:42:00.000Z",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c226",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0d201",
+      producer: "identity-verification",
+      schemaVersion: 1,
+      payload: {
+        purchaseLimitFactId: "plf-identity",
+        ttlBucket: "2026-07-05T10:40Z",
+        monitorRunId: "mon-identity",
+        factStatus: "MISSED",
+        limitPolicyVersion: "limit-v1",
+        missedAt: "2026-07-05T10:42:00.000Z",
+        aggregateVersion: 3,
+      },
+    });
+
+    const identityDetails = application.getSupportCase(identityCase.caseId);
+    const duplicateTicketDetails = application.getSupportCase(duplicateTicketCase.caseId);
+    assert.deepEqual(identityDetails.caseContext.map((context) => context.contextType), ["IDENTITY_BLACKLIST_SIGNAL"]);
+    assert.equal(identityDetails.caseContext[0].facts.reasonCode, "BLACKLISTED");
+    assert.equal(identityDetails.escalationLevel, "L3_SUPERVISOR");
+    assert.equal(identityDetails.escalation?.targetQueue, "identity-risk-supervisor");
+    assert.deepEqual(duplicateTicketDetails.caseContext.map((context) => context.contextType), ["DUPLICATE_TICKET_SIGNAL"]);
+    assert.equal(duplicateTicketDetails.caseContext[0].refs.purchaseLimitFactId, "plf-identity");
+    assert.equal(duplicateTicketDetails.caseContext[0].facts.factStatus, "MISSED");
+    assert.equal(duplicateTicketDetails.escalationLevel, "L3_SUPERVISOR");
+    assert.equal(duplicateTicketDetails.escalation?.targetQueue, "duplicate-ticket-review");
   });
 
   it("records admin-audit manual action outcomes once and preserves event lineage", async () => {


### PR DESCRIPTION
## Summary
- Subscribe customer-service to transfer-management and identity-verification streams.
- Project missed/recovered/failed connection and identity verification/blacklist/duplicate-ticket facts into durable case context.
- Expose caseContext on support case details and drive critical-context escalation/SLA handling.

## Validation
- npm run build (services/customer-service)
- npm test (services/customer-service)