### PR TITLE
REQ-320 reporting consumes phase-three contexts

### DIFF
--- a/deploy/e2e/14-waitlist.sh
+++ b/deploy/e2e/14-waitlist.sh
@@ -309,6 +309,25 @@ last_events events:waitlist 8
 [ "$(stream_mentions events:waitlist WaitlistFulfilled "$WLR_F")" = yes ] && ok "WaitlistFulfilled event exists" || bad "missing WaitlistFulfilled event"
 [ "$(stream_mentions events:waitlist WaitlistExpired "$WLR_E")" = yes ] && ok "WaitlistExpired event exists" || bad "missing WaitlistExpired event"
 
+ROLLUP=""
+for attempt in $(seq 1 20); do
+  req GET reporting /api/v1/metrics/operational
+  if [ "$LAST_CODE" = 200 ]; then
+    ROLLUP=$(RESP_JSON="$RESP" python3 - <<'PY' 2>/dev/null
+import json, os
+body = json.loads(os.environ["RESP_JSON"])
+for rollup in body.get("contextRollups", []):
+    if rollup.get("sourceContext") == "waitlist" and rollup.get("eventType") == "WaitlistQueued" and int(rollup.get("count") or 0) > 0:
+        print("yes")
+        break
+PY
+)
+    [ "$ROLLUP" = yes ] && break
+  fi
+  sleep 3
+done
+[ "$ROLLUP" = yes ] && ok "reporting consumed waitlist read model" || bad "reporting waitlist rollup missing"
+
 resume_loadgen
 trap - EXIT
 [ -n "$LG_REPLICAS" ] && [ "$LG_REPLICAS" != "0" ] && ok "loadgen resumed (replicas=$LG_REPLICAS)"

--- a/services/reporting/src/reporting/__init__.py
+++ b/services/reporting/src/reporting/__init__.py
@@ -2,6 +2,7 @@ from .api import create_app, create_production_app
 from .domain import (
     ConsumedEventLog,
     ConsumedEventRecord,
+    ContextEventRollup,
     AnomalyDetected,
     AnomalyDetector,
     AnomalyRule,
@@ -41,6 +42,7 @@ from .runtime import SERVICE_PROFILE, ServiceProfile, health, profile
 __all__ = [
     'ConsumedEventLog',
     'ConsumedEventRecord',
+    'ContextEventRollup',
     'AnomalyDetected',
     'AnomalyDetector',
     'AnomalyRule',

--- a/services/reporting/src/reporting/adapters/messaging/stream_config.py
+++ b/services/reporting/src/reporting/adapters/messaging/stream_config.py
@@ -32,6 +32,21 @@ SUBSCRIBED_CONTEXTS = (
     "finance-settlement",
     "reporting",
     "supplier-catalog",
+    "disruption-recovery",
+    "transfer-management",
+    "waitlist",
+    "wallet-promotion",
+    "dispatch",
+    "ancillary-service",
+    "loyalty-membership",
+    "corporate-travel",
+    "travel-insurance",
+    "identity-verification",
+    "payment-channel",
+    "group-booking",
+    "marketing-campaign",
+    "invoicing",
+    "seat-assignment",
 )
 
 

--- a/services/reporting/src/reporting/adapters/storage/postgres.py
+++ b/services/reporting/src/reporting/adapters/storage/postgres.py
@@ -185,6 +185,8 @@ def _flags_from_event(event: OperationalEvent) -> dict[str, Any]:
         "distanceKm": None if event.distance_km is None else str(event.distance_km),
         "ancillaryAttached": event.ancillary_attached,
         "insuranceAttached": event.insurance_attached,
+        "sourceContext": event.source_context,
+        "anomalySignal": event.anomaly_signal,
     }
 
 
@@ -235,6 +237,8 @@ def _event_from_row(row: Sequence[Any]) -> OperationalEvent:
         distance_km=_decimal_flag(flags, "distanceKm"),
         ancillary_attached=_bool_flag(flags, "ancillaryAttached"),
         insurance_attached=_bool_flag(flags, "insuranceAttached"),
+        source_context=None if flags.get("sourceContext") is None else str(flags.get("sourceContext")),
+        anomaly_signal=_bool_flag(flags, "anomalySignal"),
     )
 
 

--- a/services/reporting/src/reporting/api.py
+++ b/services/reporting/src/reporting/api.py
@@ -132,6 +132,17 @@ def operational_snapshot_to_json(snapshot: MetricSnapshot) -> dict[str, object]:
         "refund_rate": snapshot.refund_rate,
         "scalper_block_rate": snapshot.scalper_block_rate,
         "routeMetrics": [route_metrics_to_json(route) for route in snapshot.route_metrics],
+        "contextRollups": [
+            {
+                "sourceContext": rollup.source_context,
+                "eventType": rollup.event_type,
+                "count": rollup.count,
+                "lastOccurredAt": rfc3339_utc(rollup.last_occurred_at),
+                "anomalyCount": rollup.anomaly_count,
+                "anomalyRate": rollup.anomaly_rate,
+            }
+            for rollup in snapshot.context_rollups
+        ],
     }
 
 

--- a/services/reporting/src/reporting/application/service.py
+++ b/services/reporting/src/reporting/application/service.py
@@ -181,27 +181,57 @@ def _parse_decimal(value: Any) -> Decimal | None:
         return None
 
 
+def _parse_bool(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y"}
+    return bool(value)
+
+
+_FAILURE_EVENT_WORDS = (
+    "Failed",
+    "Rejected",
+    "Missed",
+    "Expired",
+    "Cancelled",
+    "Revoked",
+    "Blocked",
+    "Discrepancy",
+    "NoShow",
+    "Degradation",
+)
+
+
+def _is_anomaly_signal(event_type: str, payload: Mapping[str, Any]) -> bool:
+    if any(word in event_type for word in _FAILURE_EVENT_WORDS):
+        return True
+    status = str(_payload_value(payload, "status", "finalStatus", "result", "outcome") or "").upper()
+    return status in {"FAILED", "REJECTED", "MISSED", "EXPIRED", "CANCELLED", "REVOKED", "BLOCKED"}
+
+
 def operational_event_from_envelope(envelope: EventEnvelope) -> OperationalEvent:
     payload = envelope.payload or {}
+    anomaly_signal = _is_anomaly_signal(envelope.eventType, payload)
     return OperationalEvent(
         event_id=envelope.eventId,
         event_type=envelope.eventType,
         occurred_at=_parse_occurred_at(envelope.occurredAt),
-        route_id=_payload_value(payload, "routeId", "route_id", "route"),
-        service_date=_parse_date(_payload_value(payload, "serviceDate", "travelDate", "departureDate")),
-        seat_class=_payload_value(payload, "seatClass", "seat_class", "class"),
+        route_id=_payload_value(payload, "routeId", "route_id", "route", "segmentRef", "serviceSegmentRef"),
+        service_date=_parse_date(_payload_value(payload, "serviceDate", "travelDate", "departureDate", "requestedAt", "validFrom")),
+        seat_class=_payload_value(payload, "seatClass", "seat_class", "class", "berthType"),
         amount=_parse_money(payload),
-        channel=_payload_value(payload, "channel", "salesChannel"),
-        passenger_type=_payload_value(payload, "passengerType", "passenger_type"),
-        capacity=_parse_int(_payload_value(payload, "capacity", "totalCapacity", "seatsAvailable")),
-        confirmed=_parse_int(_payload_value(payload, "confirmed", "confirmedSeats", "bookedSeats")),
-        booking_latency_ms=_parse_int(_payload_value(payload, "bookingLatencyMs", "latencyMs")),
-        payment_failed=bool(_payload_value(payload, "paymentFailed", "failed", "declined") or envelope.eventType in {"PaymentFailed", "PaymentDeclined", "PaymentCaptureFailed"}),
-        refunded=bool(_payload_value(payload, "refunded") or envelope.eventType in {"RefundSettled", "RefundCompleted", "RefundIssued"}),
-        scalper_blocked=bool(_payload_value(payload, "scalperBlocked", "blockedByRisk") or envelope.eventType in {"ScalperBlocked", "RiskBookingBlocked"}),
+        channel=_payload_value(payload, "channel", "salesChannel", "channelId", "sourceChannel"),
+        passenger_type=_payload_value(payload, "passengerType", "passenger_type", "travelerType"),
+        capacity=_parse_int(_payload_value(payload, "capacity", "totalCapacity", "seatsAvailable", "availableSeats", "availableUnits")),
+        confirmed=_parse_int(_payload_value(payload, "confirmed", "confirmedSeats", "bookedSeats", "usedSeats", "allocatedSeats")),
+        booking_latency_ms=_parse_int(_payload_value(payload, "bookingLatencyMs", "latencyMs", "elapsedMs")),
+        payment_failed=_parse_bool(_payload_value(payload, "paymentFailed", "failed", "declined") or envelope.eventType in {"PaymentFailed", "PaymentDeclined", "PaymentCaptureFailed", "ChannelOrderFailed", "ChannelRefundFailed"}),
+        refunded=_parse_bool(_payload_value(payload, "refunded") or envelope.eventType in {"RefundSettled", "RefundCompleted", "RefundIssued", "ChannelRefundSucceeded", "AncillaryOrderItemRefunded"}),
+        scalper_blocked=_parse_bool(_payload_value(payload, "scalperBlocked", "blockedByRisk") or envelope.eventType in {"ScalperBlocked", "RiskBookingBlocked", "RiskBlockApplied"}),
         distance_km=_parse_decimal(_payload_value(payload, "distanceKm", "distance_km")),
-        ancillary_attached=bool(_payload_value(payload, "ancillaryAttached", "ancillary_attach")),
-        insurance_attached=bool(_payload_value(payload, "insuranceAttached", "insurance_attach")),
+        ancillary_attached=_parse_bool(_payload_value(payload, "ancillaryAttached", "ancillary_attach") or envelope.eventType.startswith("Ancillary")),
+        insurance_attached=_parse_bool(_payload_value(payload, "insuranceAttached", "insurance_attach") or envelope.eventType.startswith("Insurance")),
+        source_context=envelope.producer,
+        anomaly_signal=anomaly_signal,
     )
 
 

--- a/services/reporting/src/reporting/domain.py
+++ b/services/reporting/src/reporting/domain.py
@@ -517,6 +517,8 @@ class OperationalEvent:
     distance_km: Decimal | None = None
     ancillary_attached: bool = False
     insurance_attached: bool = False
+    source_context: str | None = None
+    anomaly_signal: bool = False
 
     def __post_init__(self) -> None:
         if not self.event_id.strip():
@@ -594,6 +596,29 @@ class RouteMetrics:
 
 
 @dataclass(frozen=True, slots=True)
+class ContextEventRollup:
+    source_context: str
+    event_type: str
+    count: int
+    last_occurred_at: datetime
+    anomaly_count: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.source_context.strip():
+            raise ReportingError("context rollup source_context is required")
+        if not self.event_type.strip():
+            raise ReportingError("context rollup event_type is required")
+        if self.count < 1:
+            raise ReportingError("context rollup count must be positive")
+        if self.anomaly_count < 0 or self.anomaly_count > self.count:
+            raise ReportingError("context rollup anomaly_count must be between zero and count")
+
+    @property
+    def anomaly_rate(self) -> float:
+        return self.anomaly_count / self.count
+
+
+@dataclass(frozen=True, slots=True)
 class MetricSnapshot:
     generated_at: datetime
     orders_per_second: int
@@ -603,6 +628,7 @@ class MetricSnapshot:
     refund_rate: float
     scalper_block_rate: float
     route_metrics: tuple[RouteMetrics, ...] = ()
+    context_rollups: tuple[ContextEventRollup, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -695,6 +721,7 @@ class MetricAggregator:
             refund_rate=self._rate(len(refund_events), len(order_events_24h)),
             scalper_block_rate=self._rate(len(blocked_1h), len(risk_events_1h)),
             route_metrics=routes,
+            context_rollups=self.context_rollups(),
         )
 
     def route_metrics(self, at: datetime | None = None) -> tuple[RouteMetrics, ...]:
@@ -729,6 +756,24 @@ class MetricAggregator:
         metrics.sort(key=lambda item: (item.service_date, item.route_id))
         return tuple(metrics)
 
+    def context_rollups(self) -> tuple[ContextEventRollup, ...]:
+        grouped: dict[tuple[str, str], dict[str, Any]] = {}
+        for event in self.events:
+            context = event.source_context or "unknown"
+            bucket = grouped.setdefault(
+                (context, event.event_type),
+                {"count": 0, "last_occurred_at": event.occurred_at, "anomaly_count": 0},
+            )
+            bucket["count"] += 1
+            if event.occurred_at > bucket["last_occurred_at"]:
+                bucket["last_occurred_at"] = event.occurred_at
+            if event.anomaly_signal:
+                bucket["anomaly_count"] += 1
+        return tuple(
+            ContextEventRollup(context, event_type, bucket["count"], bucket["last_occurred_at"], bucket["anomaly_count"])
+            for (context, event_type), bucket in sorted(grouped.items())
+        )
+
     def revenue_report(self, group_by: str = "route", limit: int = 20, at: datetime | None = None) -> RevenueReport:
         if limit < 1:
             raise ReportingError("revenue report limit must be positive")
@@ -739,12 +784,14 @@ class MetricAggregator:
             "channel": lambda event: event.channel,
             "passenger_type": lambda event: event.passenger_type,
             "time_period": lambda event: event.occurred_at.astimezone(UTC).strftime("%Y-%m-%dT%H:00:00Z"),
+            "source_context": lambda event: event.source_context,
+            "event_type": lambda event: event.event_type,
         }
         if group_by not in dimensions:
             raise ReportingError("unsupported revenue report dimension")
         grouped: dict[str, list[OperationalEvent]] = {}
         for event in self.events:
-            if not event.is_payment_captured or event.amount is None:
+            if group_by not in {"source_context", "event_type"} and (not event.is_payment_captured or event.amount is None):
                 continue
             value = dimensions[group_by](event) or "unknown"
             grouped.setdefault(value, []).append(event)
@@ -808,13 +855,14 @@ class MetricAggregator:
 
     def _revenue_item(self, dimension: str, value: str, events: list[OperationalEvent]) -> RevenueItem:
         revenue = sum((event.amount.amount for event in events if event.amount is not None), Decimal("0.00"))
+        count = len(events) if dimension in {"source_context", "event_type"} else sum(1 for event in events if event.amount is not None)
         distance = sum((event.distance_km or Decimal("0")) for event in events)
         yield_per_km = Decimal("0.00") if distance == 0 else (revenue / distance).quantize(Decimal("0.01"))
         return RevenueItem(
             dimension=dimension,
             value=value,
             revenue=Money(revenue, self.currency),
-            count=len(events),
+            count=count,
             yield_per_km=yield_per_km,
             ancillary_attach_rate=self._rate(sum(1 for event in events if event.ancillary_attached), len(events)),
             insurance_attach_rate=self._rate(sum(1 for event in events if event.insurance_attached), len(events)),

--- a/services/reporting/tests/test_api_and_messaging.py
+++ b/services/reporting/tests/test_api_and_messaging.py
@@ -14,6 +14,7 @@ from reporting.api import configure_error_handlers, configure_runtime_endpoints
 from reporting.application.ports import EventEnvelope, EventHandler, EventPublisher, EventSubscriber, HandlerResult
 from reporting.application.service import ReportingApplicationService
 from reporting.adapters.messaging.publisher import RedisEventPublisher
+from reporting.adapters.messaging.stream_config import SUBSCRIBED_CONTEXTS, reporting_subscription_streams
 from reporting.adapters.messaging.subscriber import RedisEventSubscriber
 from reporting.domain import ReportingError
 
@@ -190,8 +191,70 @@ class EndpointTest(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["items"][0]["value"], "B")
 
+    def test_new_context_events_increment_context_rollup_and_anomaly_signal(self) -> None:
+        service = ReportingApplicationService()
+        service.handle_event(EventEnvelope(
+            eventId="evt-waitlist-queued",
+            eventType="WaitlistQueued",
+            occurredAt="2026-07-05T10:30:00.000Z",
+            correlationId="corr-1",
+            producer="waitlist",
+            schemaVersion=1,
+            payload={"waitlistRequestId": "wlr-1", "segmentRef": "seg-1"},
+            causationId="evt-source",
+        ))
+        service.handle_event(EventEnvelope(
+            eventId="evt-waitlist-expired",
+            eventType="WaitlistExpired",
+            occurredAt="2026-07-05T10:31:00.000Z",
+            correlationId="corr-1",
+            producer="waitlist",
+            schemaVersion=1,
+            payload={"waitlistRequestId": "wlr-2", "segmentRef": "seg-1"},
+            causationId="evt-source",
+        ))
+
+        response = TestClient(create_app(service=service)).get("/api/v1/metrics/operational")
+
+        self.assertEqual(response.status_code, 200)
+        rollups = {(item["sourceContext"], item["eventType"]): item for item in response.json()["contextRollups"]}
+        self.assertEqual(rollups[("waitlist", "WaitlistQueued")]["count"], 1)
+        self.assertEqual(rollups[("waitlist", "WaitlistExpired")]["anomalyCount"], 1)
+
+    def test_context_rollup_is_queryable_via_revenue_report_shape(self) -> None:
+        service = ReportingApplicationService()
+        service.handle_event(EventEnvelope(eventId="evt-dispatch-failed", eventType="DispatchFailed", occurredAt="2026-07-05T10:30:00.000Z", correlationId="corr-1", producer="dispatch", schemaVersion=1, payload={"dispatchId": "disp-1"}, causationId="evt-source"))
+        service.handle_event(EventEnvelope(eventId="evt-dispatch-requested", eventType="DispatchRequested", occurredAt="2026-07-05T10:30:01.000Z", correlationId="corr-1", producer="dispatch", schemaVersion=1, payload={"dispatchId": "disp-2"}, causationId="evt-source"))
+
+        response = TestClient(create_app(service=service)).get("/api/v1/metrics/revenue?groupBy=source_context")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["items"][0]["value"], "dispatch")
+        self.assertEqual(response.json()["items"][0]["count"], 2)
+
 
 class MessagingTest(unittest.TestCase):
+    def test_reporting_subscribes_to_all_phase_three_context_streams(self) -> None:
+        missing_contexts = {
+            "disruption-recovery",
+            "transfer-management",
+            "waitlist",
+            "wallet-promotion",
+            "dispatch",
+            "ancillary-service",
+            "loyalty-membership",
+            "corporate-travel",
+            "travel-insurance",
+            "identity-verification",
+            "payment-channel",
+            "group-booking",
+            "marketing-campaign",
+            "invoicing",
+            "seat-assignment",
+        }
+        self.assertTrue(missing_contexts.issubset(set(SUBSCRIBED_CONTEXTS)))
+        self.assertTrue({f"events:{context}" for context in missing_contexts}.issubset(set(reporting_subscription_streams())))
+
     def test_application_publisher_wraps_event_in_correct_envelope(self) -> None:
         publisher = FakePublisher()
         service = ReportingApplicationService(publisher=publisher)

--- a/services/reporting/tests/test_domain.py
+++ b/services/reporting/tests/test_domain.py
@@ -17,6 +17,7 @@ from reporting import (
     FunnelStep,
     FunnelStepCount,
     FunnelView,
+    ContextEventRollup,
     MetricCategory,
     MetricDefinition,
     MetricGranularity,
@@ -460,6 +461,23 @@ class RealTimeMetricsEnrichmentTest(unittest.TestCase):
 
         self.assertEqual(anomalies[0].rule_id, "ERROR_RATE_SPIKE")
         self.assertEqual(anomalies[0].severity, AnomalySeverity.CRITICAL)
+
+    def test_context_rollups_count_source_contexts_and_anomaly_signals(self) -> None:
+        aggregator = MetricAggregator(currency="USD")
+        aggregator.record(OperationalEvent("waitlist-1", "WaitlistQueued", NOW, source_context="waitlist"))
+        aggregator.record(OperationalEvent("waitlist-2", "WaitlistExpired", NOW + timedelta(minutes=1), source_context="waitlist", anomaly_signal=True))
+
+        snapshot = aggregator.snapshot(NOW + timedelta(minutes=2))
+        rollups = {(item.source_context, item.event_type): item for item in snapshot.context_rollups}
+
+        self.assertEqual(rollups[("waitlist", "WaitlistQueued")].count, 1)
+        self.assertEqual(rollups[("waitlist", "WaitlistExpired")].anomaly_rate, 1.0)
+
+    def test_context_rollup_rejects_invalid_counts(self) -> None:
+        with self.assertRaisesRegex(ReportingError, "count must be positive"):
+            ContextEventRollup("waitlist", "WaitlistQueued", 0, NOW)
+        with self.assertRaisesRegex(ReportingError, "anomaly_count"):
+            ContextEventRollup("waitlist", "WaitlistQueued", 1, NOW, anomaly_count=2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- subscribe reporting to the missing Phase-3/deferred producer streams
- add source-context/event-type rollups and anomaly counts to reporting read models/API projections
- extend waitlist e2e to assert reporting consumes a newly-fed context

## Validation
- uv run pytest tests/test_domain.py tests/test_api_and_messaging.py
- bash -n deploy/e2e/14-waitlist.sh