### PR TITLE
REQ-322 consume transfer-management notifications

### DIFF
--- a/docs/08-contracts/events/transfer-management.md
+++ b/docs/08-contracts/events/transfer-management.md
@@ -31,10 +31,11 @@ Activation-wave rulings:
   replacement fields; when it later consumes the resulting `RecoveryCompleted`
   for the same `caseId`, it idempotently skips because the original connection is
   already `RECOVERED`. `SELF_TRANSFER` misses publish facts only.
-- Downstream Notification, Reporting, Offer Management, Journey Order, and
-  Customer Service consumers are deferred in this wave. The events below are
-  published to the registered stream, but no new downstream consumer is activated
-  except Transfer Management's inbound subscription to Disruption Recovery.
+- Notification now actively consumes traveler-facing connection-state events
+  (`TransferAtRisk`, `ConnectionMissed`, and `ConnectionRecovered`). Reporting,
+  Offer Management, Journey Order, and Customer Service downstream consumers
+  remain deferred except Transfer Management's inbound subscription to Disruption
+  Recovery.
 
 All payload fields are camelCase, all enum values are SCREAMING_SNAKE_CASE, and
 all timestamps are RFC3339 UTC. Envelope fields, including optional trace context
@@ -239,7 +240,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | deferred: notification, customer-service, reporting |
+| **Consumers** | notification; deferred: customer-service, reporting |
 | **Trigger** | A connection transitions to `AT_RISK`. |
 
 **Payload:**
@@ -260,7 +261,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | deferred: notification, customer-service, reporting |
+| **Consumers** | notification; deferred: customer-service, reporting |
 | **Trigger** | A connection transitions to `MISSED`. Protected contracts also start the outbound Disruption Recovery HTTP command. |
 
 **Payload:**
@@ -283,7 +284,7 @@ key. Outbound Disruption Recovery idempotency keys are persisted and reused. Inb
 | Field | Description |
 |---|---|
 | **Producer** | transfer-management |
-| **Consumers** | deferred: notification, customer-service, reporting |
+| **Consumers** | notification; deferred: customer-service, reporting |
 | **Trigger** | Consumed Disruption Recovery `RecoveryCompleted` matches a stored `caseId`, an explicit controlled recovery command restores the connection, or Disruption Recovery calls `POST /api/v1/connections/{connectionId}/reaccommodate`. |
 
 **Payload:**
@@ -517,9 +518,9 @@ remains the active fallback adapter.
 
 ## Deferred downstream touchpoints
 
-| Downstream context | Deferred events | Purpose when activated |
+| Downstream context | Events | Purpose |
 |---|---|---|
-| Notification | `TransferAtRisk`, `ConnectionMissed`, `ConnectionRecovered` | User-facing transfer risk and recovery notifications. |
+| Notification | `TransferAtRisk`, `ConnectionMissed`, `ConnectionRecovered` | Active user-facing transfer risk and recovery notifications. |
 | Reporting | all Transfer Management events | Connection success rate, MCT quality, protected exposure, and supplier quality metrics. |
 | Journey Order | `ConnectionContractConfirmed`, `ConnectionMissed`, `ConnectionRecovered` | Order-detail responsibility and recovery display. |
 | Offer Management | `TransferPlanEvaluated`, `ConnectionContractProposed`, `MctRulePublished` | Quote-time feasibility and contract display. |

--- a/docs/08-contracts/messaging.md
+++ b/docs/08-contracts/messaging.md
@@ -266,7 +266,7 @@ plus notification/finance/reporting fan-in.
 | 31 | `events:post-sales` | `entitlement-ticketing` | PostSalesApproved to void entitlement |
 | 32 | `events:post-sales` | `journey-order` | PostSalesApplied to adjust order |
 | 33 | `events:post-sales` | `notification` | Post-sales events for user notifications |
-| 34 | `events:transfer-management` | *(none — downstream consumers deferred)* | Transfer risk, connection, contract, and MCT facts are produced in wave 18; Notification/Reporting/Journey Order/Customer Service consumption is deferred |
+| 34 | `events:transfer-management` | `notification` | TransferAtRisk, ConnectionMissed, and ConnectionRecovered produce traveler-facing transfer risk/recovery notification intents; Reporting/Journey Order/Customer Service consumption remains deferred |
 | 35 | `events:disruption-recovery` | `notification` | Recovery lifecycle and service-alert facts produce traveler-facing notification intents; Reporting/Journey Order/Customer Service touchpoints remain deferred |
 | 36 | `events:notification` | *(none — notification owns its stream)* | Notification events are not consumed by other business contexts in phase 1 |
 | 37 | `events:traveler-profile` | `offer-management` | Profile changes for eligibility checks |
@@ -331,7 +331,7 @@ analytics, and cross-cutting concerns:
 |---|---|---|
 | `reporting` | All active `events:*` streams except `events:dispatch`, `events:disruption-recovery`, `events:payment-channel`, `events:transfer-management`, and `events:identity-verification` until their deferred-consumer activation waves; includes `events:seat-assignment` and `events:invoicing` in ADR-0003 wave A | Business metrics, funnel analysis, operational dashboards |
 | `finance-settlement` | `events:payment`, `events:payment-channel`, `events:provider-integration`, `events:booking-orchestration`, `events:post-sales`, `events:wallet-promotion`, `events:invoicing` | Revenue recognition, reconciliation, invoice generation, Wallet / Promotion benefit-cost attribution, ADR-0003 SIM channel statement reconciliation, and tax-document lifecycle read models. |
-| `notification` | `events:journey-order`, `events:booking-orchestration`, `events:payment`, `events:entitlement-ticketing`, `events:post-sales`, `events:wallet-promotion`, `events:disruption-recovery`, `events:seat-assignment`, `events:invoicing` | User-facing notification triggers including Wallet / Promotion issued/expired/revoked touchpoints, seat/standing/degradation changes, and invoice/red-flush status touchpoints. |
+| `notification` | `events:journey-order`, `events:booking-orchestration`, `events:payment`, `events:entitlement-ticketing`, `events:post-sales`, `events:wallet-promotion`, `events:disruption-recovery`, `events:transfer-management`, `events:seat-assignment`, `events:invoicing` | User-facing notification triggers including Wallet / Promotion issued/expired/revoked touchpoints, transfer risk/recovery updates, seat/standing/degradation changes, and invoice/red-flush status touchpoints. |
 
 ### Invoicing subscriptions and exclusions
 

--- a/services/notification/src/adapters/messaging/stream-config.ts
+++ b/services/notification/src/adapters/messaging/stream-config.ts
@@ -9,6 +9,7 @@ export const NOTIFICATION_SUBSCRIBED_STREAMS = Object.freeze([
   "events:entitlement-ticketing",
   "events:post-sales",
   "events:disruption-recovery",
+  "events:transfer-management",
   "events:waitlist",
   "events:wallet-promotion",
 ]);

--- a/services/notification/src/adapters/storage/runtime.ts
+++ b/services/notification/src/adapters/storage/runtime.ts
@@ -200,6 +200,12 @@ function templateCodeFor(envelope: EventEnvelope): string | undefined {
       return recoveryCompletedTemplate(envelope.payload);
     case "RecoveryFailed":
       return "RECOVERY_FAILED";
+    case "TransferAtRisk":
+      return "TRANSFER_AT_RISK";
+    case "ConnectionMissed":
+      return "CONNECTION_MISSED";
+    case "ConnectionRecovered":
+      return stringValue(envelope.payload.replacementConnectionId) ? "CONNECTION_REACCOMMODATED" : "CONNECTION_RECOVERED";
     case "PostSalesEligibilityEvaluated":
       return "post_sales_eligibility";
     case "PostSalesDecisionQuoted":

--- a/services/notification/src/adapters/storage/runtime.ts
+++ b/services/notification/src/adapters/storage/runtime.ts
@@ -134,27 +134,35 @@ export async function isDuplicateBusinessNotification(client: Pick<import("pg").
 }
 
 async function sameBusinessTaskExists(client: Pick<import("pg").PoolClient, "query">, envelope: EventEnvelope): Promise<boolean> {
-  const signature = notificationBusinessSignature(envelope);
-  if (!signature) {
+  const signatures = notificationBusinessSignatures(envelope);
+  if (signatures.length === 0) {
     return false;
   }
-  const result = await client.query(
-    `SELECT 1
-     FROM notification_task_snapshots
-     WHERE data->>'recipientRef' = $1
-       AND data->>'templateCode' = $2
-       AND data->>'triggerBusinessRef' = $3
-     LIMIT 1`,
-    [signature.recipientRef, signature.templateCode, signature.triggerBusinessRef],
-  );
-  return (result.rowCount ?? 0) > 0;
+
+  for (const signature of signatures) {
+    const result = await client.query(
+      `SELECT 1
+       FROM notification_task_snapshots
+       WHERE data->>'recipientRef' = $1
+         AND data->>'templateCode' = $2
+         AND data->>'triggerBusinessRef' = $3
+       LIMIT 1`,
+      [signature.recipientRef, signature.templateCode, signature.triggerBusinessRef],
+    );
+    if ((result.rowCount ?? 0) > 0) {
+      return true;
+    }
+  }
+  return false;
 }
 
-function notificationBusinessSignature(envelope: EventEnvelope): Readonly<{ recipientRef: string; templateCode: string; triggerBusinessRef: string }> | undefined {
+function notificationBusinessSignatures(envelope: EventEnvelope): readonly Readonly<{ recipientRef: string; templateCode: string; triggerBusinessRef: string }>[] {
   const templateCode = templateCodeFor(envelope);
-  const recipientRef = recipientRefFor(envelope.payload);
+  const recipientRefs = recipientRefsFor(envelope.payload);
   const triggerBusinessRef = triggerBusinessRefFor(envelope);
-  return templateCode && recipientRef && triggerBusinessRef ? { recipientRef, templateCode, triggerBusinessRef } : undefined;
+  return templateCode && triggerBusinessRef
+    ? recipientRefs.map((recipientRef) => ({ recipientRef, templateCode, triggerBusinessRef }))
+    : [];
 }
 
 function templateCodeFor(envelope: EventEnvelope): string | undefined {
@@ -229,39 +237,50 @@ function templateCodeFor(envelope: EventEnvelope): string | undefined {
   }
 }
 
-function recipientRefFor(payload: Record<string, unknown>): string | undefined {
-  return stringValue(payload.recipientRef)
+function recipientRefsFor(payload: Record<string, unknown>): readonly string[] {
+  const connection = recordFromUnknown(payload.connection);
+  const direct = stringValue(payload.recipientRef)
     ?? stringValue(payload.travelerId)
     ?? stringValue(payload.accountId)
     ?? stringValue(payload.actorRef)
     ?? stringValue(payload.travelerRef)
     ?? firstString(payload.affectedOrderIds)
     ?? stringValue(payload.journeyOrderId)
-    ?? stringValue(payload.serviceAlertId)
-    ?? recipientFromTravelerRefs(payload.travelerRefs);
+    ?? stringValue(payload.serviceAlertId);
+  if (direct !== undefined) {
+    return [direct];
+  }
+
+  return recipientRefsFromTravelerRefs(connection?.travelerRefs)
+    ?? recipientRefsFromTravelerRefs(payload.travelerRefs)
+    ?? [];
 }
 
-function recipientFromTravelerRefs(value: unknown): string | undefined {
+function recipientRefsFromTravelerRefs(value: unknown): readonly string[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
   }
+
+  const recipientRefs: string[] = [];
   for (const candidate of value) {
     if (typeof candidate === "string" && candidate.trim().length > 0) {
-      return candidate;
+      recipientRefs.push(candidate);
+      continue;
     }
     if (candidate && typeof candidate === "object") {
       const ref = candidate as Record<string, unknown>;
       const recipientRef = stringValue(ref.recipientRef) ?? stringValue(ref.travelerId) ?? stringValue(ref.travelerRef) ?? stringValue(ref.id);
       if (recipientRef) {
-        return recipientRef;
+        recipientRefs.push(recipientRef);
       }
     }
   }
-  return undefined;
+  return recipientRefs.length > 0 ? [...new Set(recipientRefs)] : undefined;
 }
 
 function triggerBusinessRefFor(envelope: EventEnvelope): string | undefined {
   const payload = envelope.payload;
+  const connection = recordFromUnknown(payload.connection);
   const direct = stringValue(payload.orderId)
     ?? stringValue(payload.journeyOrderId)
     ?? stringValue(payload.paymentIntentId)
@@ -275,6 +294,7 @@ function triggerBusinessRefFor(envelope: EventEnvelope): string | undefined {
     ?? stringValue(payload.waitlistRequestId)
     ?? stringValue(payload.journeyOrderRef)
     ?? stringValue(payload.postSalesCaseId)
+    ?? stringValue(connection?.connectionId)
     ?? stringValue(payload.businessRef);
   return direct ? `${envelope.eventType}:${direct}` : undefined;
 }
@@ -302,6 +322,10 @@ function firstString(value: unknown): string | undefined {
     return undefined;
   }
   return value.find((candidate): candidate is string => typeof candidate === "string" && candidate.trim().length > 0);
+}
+
+function recordFromUnknown(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
 }
 
 function stringValue(value: unknown): string | undefined {

--- a/services/notification/src/application/messaging.ts
+++ b/services/notification/src/application/messaging.ts
@@ -114,6 +114,10 @@ function isReq311Template(templateCode: string): boolean {
     "RECOVERY_REACCOMMODATION",
     "RECOVERY_COMPLETED",
     "RECOVERY_FAILED",
+    "TRANSFER_AT_RISK",
+    "CONNECTION_MISSED",
+    "CONNECTION_RECOVERED",
+    "CONNECTION_REACCOMMODATED",
     "DISRUPTION_REBOOK",
   ].includes(templateCode);
 }

--- a/services/notification/src/application/notification-service.ts
+++ b/services/notification/src/application/notification-service.ts
@@ -105,7 +105,7 @@ type TriggerMapping = Readonly<{
   templateType?: NotificationTemplateType | ((payload: Record<string, unknown>) => NotificationTemplateType);
   intent: string | ((payload: Record<string, unknown>) => string);
   channel: ChannelType;
-  recipient: (payload: Record<string, unknown>) => string | undefined;
+  recipient: (payload: Record<string, unknown>) => string | readonly string[] | undefined;
   variables: (payload: Record<string, unknown>) => Record<string, string>;
 }>;
 
@@ -123,8 +123,8 @@ export class NotificationApplicationService {
   ) {}
 
   async handleExternalTrigger(envelope: EventEnvelope): Promise<ExternalTriggerResult> {
-    const command = scheduleCommandFromEnvelope(envelope, this.aggregator);
-    if (command === undefined) {
+    const commands = scheduleCommandsFromEnvelope(envelope, this.aggregator);
+    if (commands === undefined) {
       if (mappingFor(envelope.eventType) === undefined) {
         console.info(`Ignoring unsupported notification trigger ${envelope.eventType} (${envelope.eventId})`);
       }
@@ -133,11 +133,24 @@ export class NotificationApplicationService {
 
     const mapping = mappingFor(envelope.eventType);
     const templateType = mapping ? resolveTemplateType(mapping, envelope.payload) : undefined;
-    if (templateType) {
-      (command.variables as Record<string, string>).renderedPreview = this.renderer.render(templateType, command.channel, command.variables).body;
+    const results: ExternalTriggerResult[] = [];
+    for (const command of commands) {
+      if (templateType) {
+        (command.variables as Record<string, string>).renderedPreview = this.renderer.render(templateType, command.channel, command.variables).body;
+      }
+      results.push(await this.deliverWithFallback(command, templateType));
     }
 
-    return this.deliverWithFallback(command, templateType);
+    if (results.includes("delivered")) {
+      return "delivered";
+    }
+    if (results.includes("failed")) {
+      return "failed";
+    }
+    if (results.includes("cancelled")) {
+      return "cancelled";
+    }
+    return "ignored";
   }
 
   private async deliverWithFallback(command: ScheduleNotification, templateType: NotificationTemplateType | undefined): Promise<ExternalTriggerResult> {
@@ -238,7 +251,7 @@ function resolveIntent(mapping: TriggerMapping, payload: Record<string, unknown>
   return typeof mapping.intent === "function" ? mapping.intent(payload) : mapping.intent;
 }
 
-function scheduleCommandFromEnvelope(envelope: EventEnvelope, aggregator?: NotificationAggregator): ScheduleNotification | undefined {
+function scheduleCommandsFromEnvelope(envelope: EventEnvelope, aggregator?: NotificationAggregator): readonly ScheduleNotification[] | undefined {
   const mapping = mappingFor(envelope.eventType);
   if (mapping === undefined) {
     return undefined;
@@ -247,8 +260,8 @@ function scheduleCommandFromEnvelope(envelope: EventEnvelope, aggregator?: Notif
   validateTriggerContract(envelope);
 
   const payload = envelope.payload;
-  const recipientRef = mapping.recipient(payload);
-  if (recipientRef === undefined) {
+  const recipientRefs = recipientRefsFromMapping(mapping.recipient(payload));
+  if (recipientRefs.length === 0) {
     console.debug(`Skipping notification trigger ${envelope.eventType} (${envelope.eventId}): no resolvable recipientRef`);
     return undefined;
   }
@@ -256,30 +269,40 @@ function scheduleCommandFromEnvelope(envelope: EventEnvelope, aggregator?: Notif
   const businessRef = triggerBusinessRef(envelope);
   const aggregationRef = aggregationBusinessRef(envelope);
   const templateType = resolveTemplateType(mapping, payload);
-  if (aggregator && templateType && aggregationRef && aggregator.shouldSuppress({
-    recipientRef,
-    orderRef: aggregationRef,
-    templateType,
-    occurredAt: dateValue(envelope.occurredAt) ?? new Date(),
-  })) {
-    return undefined;
+  const commands: ScheduleNotification[] = [];
+  for (const recipientRef of recipientRefs) {
+    if (aggregator && templateType && aggregationRef && aggregator.shouldSuppress({
+      recipientRef,
+      orderRef: aggregationRef,
+      templateType,
+      occurredAt: dateValue(envelope.occurredAt) ?? new Date(),
+    })) {
+      continue;
+    }
+
+    commands.push({
+      notificationTaskId: newNotificationTaskId(),
+      triggerEventId: envelope.eventId,
+      triggerEventType: envelope.eventType,
+      correlationId: envelope.correlationId,
+      causationId: envelope.eventId,
+      recipientRef,
+      templateCode: templateType ?? mapping.templateCode,
+      channel: mapping.channel,
+      intent: resolveIntent(mapping, payload),
+      transactionRequired: booleanValue(payload.transactionRequired) ?? true,
+      variables: mapping.variables(payload),
+      scheduledAt: new Date(),
+      triggerBusinessRef: businessRef,
+    });
   }
 
-  return {
-    notificationTaskId: newNotificationTaskId(),
-    triggerEventId: envelope.eventId,
-    triggerEventType: envelope.eventType,
-    correlationId: envelope.correlationId,
-    causationId: envelope.eventId,
-    recipientRef,
-    templateCode: templateType ?? mapping.templateCode,
-    channel: mapping.channel,
-    intent: resolveIntent(mapping, payload),
-    transactionRequired: booleanValue(payload.transactionRequired) ?? true,
-    variables: mapping.variables(payload),
-    scheduledAt: new Date(),
-    triggerBusinessRef: businessRef,
-  };
+  return commands.length > 0 ? commands : undefined;
+}
+
+function recipientRefsFromMapping(value: string | readonly string[] | undefined): readonly string[] {
+  const candidates = Array.isArray(value) ? value : value === undefined ? [] : [value];
+  return [...new Set(candidates.filter((candidate) => candidate.trim().length > 0))];
 }
 
 
@@ -994,10 +1017,10 @@ function baseTransferVariables(payload: Record<string, unknown>): Record<string,
   };
 }
 
-function recipientFromTransferConnection(payload: Record<string, unknown>): string | undefined {
+function recipientFromTransferConnection(payload: Record<string, unknown>): string | readonly string[] | undefined {
   const connection = recordValue(payload.connection);
   return recipientFromDirectFields(payload)
-    ?? recipientFromTravelerRefs(connection?.travelerRefs)
+    ?? recipientRefsFromTravelerRefs(connection?.travelerRefs)
     ?? stringValue(connection?.journeyOrderId);
 }
 
@@ -1116,23 +1139,29 @@ function firstString(value: unknown): string | undefined {
 }
 
 function recipientFromTravelerRefs(value: unknown): string | undefined {
+  return recipientRefsFromTravelerRefs(value)?.[0];
+}
+
+function recipientRefsFromTravelerRefs(value: unknown): readonly string[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
   }
 
+  const recipientRefs: string[] = [];
   for (const candidate of value) {
     if (typeof candidate === "string" && candidate.trim().length > 0) {
-      return candidate;
+      recipientRefs.push(candidate);
+      continue;
     }
     if (candidate && typeof candidate === "object") {
       const ref = candidate as Record<string, unknown>;
       const recipientRef = stringValue(ref.recipientRef) ?? stringValue(ref.travelerId) ?? stringValue(ref.travelerRef) ?? stringValue(ref.id);
       if (recipientRef !== undefined) {
-        return recipientRef;
+        recipientRefs.push(recipientRef);
       }
     }
   }
-  return undefined;
+  return recipientRefs.length > 0 ? [...new Set(recipientRefs)] : undefined;
 }
 
 function pickStringVariables(payload: Record<string, unknown>, keys: readonly string[]): Record<string, string> {

--- a/services/notification/src/application/notification-service.ts
+++ b/services/notification/src/application/notification-service.ts
@@ -103,7 +103,7 @@ class InMemoryRateLimitStore implements RateLimitStore {
 type TriggerMapping = Readonly<{
   templateCode: string;
   templateType?: NotificationTemplateType | ((payload: Record<string, unknown>) => NotificationTemplateType);
-  intent: string;
+  intent: string | ((payload: Record<string, unknown>) => string);
   channel: ChannelType;
   recipient: (payload: Record<string, unknown>) => string | undefined;
   variables: (payload: Record<string, unknown>) => Record<string, string>;
@@ -234,6 +234,10 @@ function resolveTemplateType(mapping: TriggerMapping, payload: Record<string, un
   return typeof mapping.templateType === "function" ? mapping.templateType(payload) : mapping.templateType;
 }
 
+function resolveIntent(mapping: TriggerMapping, payload: Record<string, unknown>): string {
+  return typeof mapping.intent === "function" ? mapping.intent(payload) : mapping.intent;
+}
+
 function scheduleCommandFromEnvelope(envelope: EventEnvelope, aggregator?: NotificationAggregator): ScheduleNotification | undefined {
   const mapping = mappingFor(envelope.eventType);
   if (mapping === undefined) {
@@ -270,7 +274,7 @@ function scheduleCommandFromEnvelope(envelope: EventEnvelope, aggregator?: Notif
     recipientRef,
     templateCode: templateType ?? mapping.templateCode,
     channel: mapping.channel,
-    intent: mapping.intent,
+    intent: resolveIntent(mapping, payload),
     transactionRequired: booleanValue(payload.transactionRequired) ?? true,
     variables: mapping.variables(payload),
     scheduledAt: new Date(),
@@ -291,6 +295,7 @@ function aggregationBusinessRef(envelope: EventEnvelope): string | undefined {
     ?? stringValue(payload.caseId)
     ?? stringValue(payload.serviceAlertId)
     ?? stringValue(payload.incidentId)
+    ?? stringValue(recordValue(payload.connection)?.connectionId)
     ?? stringValue(payload.waitlistRequestId)
     ?? stringValue(payload.journeyOrderRef)
     ?? stringValue(payload.postSalesCaseId);
@@ -311,6 +316,7 @@ function triggerBusinessRef(envelope: EventEnvelope): string | undefined {
     ?? stringValue(payload.waitlistRequestId)
     ?? stringValue(payload.journeyOrderRef)
     ?? stringValue(payload.postSalesCaseId)
+    ?? stringValue(recordValue(payload.connection)?.connectionId)
     ?? stringValue(payload.businessRef);
   return businessRef ? `${envelope.eventType}:${businessRef}` : undefined;
 }
@@ -531,6 +537,34 @@ const CONTRACT_FIELDS_BY_EVENT: Readonly<Record<string, readonly RequiredField[]
     { name: "reason", type: "string" },
     { name: "nextStatus", type: "string" },
   ],
+  TransferAtRisk: [
+    { name: "connection", type: "object" },
+    { name: "previousStatus", type: "string" },
+    { name: "status", type: "string" },
+    { name: "riskLevel", type: "string" },
+    { name: "riskPolicyVersion", type: "string" },
+    { name: "reasons", type: "array" },
+    { name: "window", type: "object" },
+    { name: "detectedAt", type: "string" },
+  ],
+  ConnectionMissed: [
+    { name: "connection", type: "object" },
+    { name: "previousStatus", type: "string" },
+    { name: "status", type: "string" },
+    { name: "riskLevel", type: "string" },
+    { name: "contractType", type: "string" },
+    { name: "missedAt", type: "string" },
+    { name: "missedCause", type: "string" },
+    { name: "window", type: "object" },
+    { name: "recoveryRequired", type: "boolean" },
+  ],
+  ConnectionRecovered: [
+    { name: "connection", type: "object" },
+    { name: "previousStatus", type: "string" },
+    { name: "status", type: "string" },
+    { name: "riskLevel", type: "string" },
+    { name: "recoveredAt", type: "string" },
+  ],
 });
 
 function validateTriggerContract(envelope: EventEnvelope): void {
@@ -666,6 +700,12 @@ function mappingFor(eventType: string): TriggerMapping | undefined {
       return recoveryCompletedMapping();
     case "RecoveryFailed":
       return recoveryFailedMapping();
+    case "TransferAtRisk":
+      return transferAtRiskMapping();
+    case "ConnectionMissed":
+      return connectionMissedMapping();
+    case "ConnectionRecovered":
+      return connectionRecoveredMapping();
     default:
       return undefined;
   }
@@ -875,6 +915,102 @@ function recoveryFailedMapping(): TriggerMapping {
     failedAt: stringValue(payload.failedAt) ?? "--",
     nextStatus: stringValue(payload.nextStatus) ?? "--",
   }));
+}
+
+function transferAtRiskMapping(): TriggerMapping {
+  return transferManagementMapping("TRANSFER_AT_RISK", "TRANSFER_AT_RISK", "TRANSFER_AT_RISK", (payload) => ({
+    ...baseTransferVariables(payload),
+    previousStatus: stringValue(payload.previousStatus) ?? "--",
+    status: stringValue(payload.status) ?? "AT_RISK",
+    riskLevel: stringValue(payload.riskLevel) ?? "AT_RISK",
+    riskPolicyVersion: stringValue(payload.riskPolicyVersion) ?? "--",
+    reasons: stringList(payload.reasons).join(",") || "--",
+    detectedAt: stringValue(payload.detectedAt) ?? "--",
+    availableMinutes: numberLikeString(recordValue(payload.window)?.availableMinutes) ?? "--",
+  }));
+}
+
+function connectionMissedMapping(): TriggerMapping {
+  return transferManagementMapping("CONNECTION_MISSED", "CONNECTION_MISSED", "CONNECTION_MISSED", (payload) => ({
+    ...baseTransferVariables(payload),
+    previousStatus: stringValue(payload.previousStatus) ?? "--",
+    status: stringValue(payload.status) ?? "MISSED",
+    riskLevel: stringValue(payload.riskLevel) ?? "MISSED",
+    contractType: stringValue(payload.contractType) ?? "--",
+    missedAt: stringValue(payload.missedAt) ?? "--",
+    missedCause: stringValue(payload.missedCause) ?? "--",
+    recoveryRequired: booleanValue(payload.recoveryRequired) === true ? "true" : "false",
+    recoveryMessage: booleanValue(payload.recoveryRequired) === true ? "我们正在为您安排恢复方案" : "请查看车站指引或联系客服",
+  }));
+}
+
+function connectionRecoveredMapping(): TriggerMapping {
+  return transferManagementMapping(
+    "CONNECTION_RECOVERED",
+    (payload) => stringValue(payload.replacementConnectionId) ? "CONNECTION_REACCOMMODATED" : "CONNECTION_RECOVERED",
+    (payload) => stringValue(payload.replacementConnectionId) ? "CONNECTION_REACCOMMODATED" : "CONNECTION_RECOVERED",
+    (payload) => ({
+      ...baseTransferVariables(payload),
+      previousStatus: stringValue(payload.previousStatus) ?? "--",
+      status: stringValue(payload.status) ?? "RECOVERED",
+      riskLevel: stringValue(payload.riskLevel) ?? "RECOVERED",
+      recoveryCaseId: stringValue(payload.recoveryCaseId) ?? "--",
+      replacementConnectionId: stringValue(payload.replacementConnectionId) ?? "--",
+      recoveredAt: stringValue(payload.recoveredAt) ?? "--",
+      reaccommodatedAt: stringValue(payload.reaccommodatedAt) ?? "--",
+      recoverySummary: stringValue(payload.recoverySummary) ?? (stringValue(payload.replacementConnectionId) ? "接续已重新安排" : "接续已恢复"),
+      nextDepartureAt: replacementWindowTime(payload, "nextDepartureAt") ?? "--",
+      plannedArrivalAt: replacementWindowTime(payload, "plannedArrivalAt") ?? "--",
+    }),
+  );
+}
+
+function transferManagementMapping(
+  templateCode: string,
+  intent: string | ((payload: Record<string, unknown>) => string),
+  templateType: NotificationTemplateType | ((payload: Record<string, unknown>) => NotificationTemplateType),
+  variables: (payload: Record<string, unknown>) => Record<string, string>,
+): TriggerMapping {
+  return {
+    templateCode,
+    templateType,
+    intent,
+    channel: "PUSH",
+    recipient: recipientFromTransferConnection,
+    variables,
+  };
+}
+
+function baseTransferVariables(payload: Record<string, unknown>): Record<string, string> {
+  const connection = recordValue(payload.connection);
+  return {
+    ...pickStringVariables(payload, ["recoveryCaseId", "replacementConnectionId"]),
+    connectionId: stringValue(connection?.connectionId) ?? stringValue(payload.connectionId) ?? "--",
+    transferPlanId: stringValue(connection?.transferPlanId) ?? stringValue(payload.transferPlanId) ?? "--",
+    itineraryRef: stringValue(connection?.itineraryRef) ?? "--",
+    journeyOrderId: stringValue(connection?.journeyOrderId) ?? stringValue(payload.journeyOrderId) ?? "--",
+    previousSegmentRef: stringValue(connection?.previousSegmentRef) ?? "--",
+    nextSegmentRef: stringValue(connection?.nextSegmentRef) ?? "--",
+  };
+}
+
+function recipientFromTransferConnection(payload: Record<string, unknown>): string | undefined {
+  const connection = recordValue(payload.connection);
+  return recipientFromDirectFields(payload)
+    ?? recipientFromTravelerRefs(connection?.travelerRefs)
+    ?? stringValue(connection?.journeyOrderId);
+}
+
+function replacementWindowTime(payload: Record<string, unknown>, field: string): string | undefined {
+  return stringValue(recordValue(payload.replacementWindow)?.[field]);
+}
+
+function stringList(value: unknown): string[] {
+  return Array.isArray(value) ? value.flatMap((candidate) => stringValue(candidate) ?? []) : [];
+}
+
+function numberLikeString(value: unknown): string | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? String(value) : stringValue(value);
 }
 
 function disruptionRecoveryMapping(

--- a/services/notification/src/domain.ts
+++ b/services/notification/src/domain.ts
@@ -85,6 +85,10 @@ export type NotificationTemplateType =
   | "RECOVERY_REACCOMMODATION"
   | "RECOVERY_COMPLETED"
   | "RECOVERY_FAILED"
+  | "TRANSFER_AT_RISK"
+  | "CONNECTION_MISSED"
+  | "CONNECTION_RECOVERED"
+  | "CONNECTION_REACCOMMODATED"
   | "DISRUPTION_REBOOK";
 
 // ─── Value Objects ─────────────────────────────────────────────────────────────
@@ -890,6 +894,10 @@ export function builtInNotificationTemplates(): readonly NotificationTemplate[] 
     templateSet("RECOVERY_REACCOMMODATION", "接续改签更新", "订单 {journeyOrderId} 的接续改签恢复有更新：{reaccommodationSummary}。", "接续改签更新", "接续改签更新"),
     templateSet("RECOVERY_COMPLETED", "恢复处理已完成", "订单 {journeyOrderId} 的异常恢复处理已完成。", "恢复处理完成", "恢复处理已完成"),
     templateSet("RECOVERY_FAILED", "恢复处理需人工跟进", "订单 {journeyOrderId} 的异常恢复处理暂未完成，将继续为您跟进。", "恢复需跟进", "恢复需跟进"),
+    templateSet("TRANSFER_AT_RISK", "接续风险提醒", "您的接续 {connectionId} 可能受影响，请关注下一段 {nextSegmentRef}，当前可用换乘时间 {availableMinutes} 分钟。", "接续{connectionId}有风险", "接续风险提醒"),
+    templateSet("CONNECTION_MISSED", "接续已错过", "您的接续 {connectionId} 已错过，原因：{missedCause}。{recoveryMessage}", "接续已错过：{missedCause}", "接续已错过"),
+    templateSet("CONNECTION_RECOVERED", "接续恢复完成", "您的接续 {connectionId} 已恢复，{recoverySummary}。", "接续已恢复", "接续恢复完成"),
+    templateSet("CONNECTION_REACCOMMODATED", "接续已重新安排", "您的接续已重新安排至 {replacementConnectionId}，下一段出发时间 {nextDepartureAt}。", "接续已重新安排", "接续已重新安排"),
     templateSet("DISRUPTION_REBOOK", "列车取消改签", "由于列车取消，已为您改签至 {newTrainNumber} {newDepartureTime}", "已改签至{newTrainNumber}", "已为您改签"),
   ].flat());
 }
@@ -908,7 +916,7 @@ function renderTemplate(template: string, variables: Readonly<Record<string, str
 }
 
 function isAggregatableTemplate(type: NotificationTemplateType): boolean {
-  return !type.startsWith("RECOVERY_") && type !== "DISRUPTION_ALERT";
+  return !type.startsWith("RECOVERY_") && !type.startsWith("CONNECTION_") && type !== "TRANSFER_AT_RISK" && type !== "DISRUPTION_ALERT";
 }
 
 function aggregationPriority(type: NotificationTemplateType): number {
@@ -935,6 +943,10 @@ function aggregationPriority(type: NotificationTemplateType): number {
     case "RECOVERY_REACCOMMODATION":
     case "RECOVERY_COMPLETED":
     case "RECOVERY_FAILED":
+    case "TRANSFER_AT_RISK":
+    case "CONNECTION_MISSED":
+    case "CONNECTION_RECOVERED":
+    case "CONNECTION_REACCOMMODATED":
       return 6;
   }
 }

--- a/services/notification/src/messaging.test.ts
+++ b/services/notification/src/messaging.test.ts
@@ -706,7 +706,7 @@ describe("notification messaging integration surface", () => {
       journeyOrderId: "ord-401",
       previousSegmentRef: "seg-prev-401",
       nextSegmentRef: "seg-next-401",
-      travelerRefs: ["tvl-401"],
+      travelerRefs: ["tvl-401", "tvl-402"],
     };
     const window = {
       plannedArrivalAt: "2026-07-05T10:00:00.000Z",
@@ -764,19 +764,21 @@ describe("notification messaging integration surface", () => {
       },
     }), "delivered");
 
-    assert.deepEqual(sentChannels, ["PUSH", "PUSH"]);
+    assert.deepEqual(sentChannels, ["PUSH", "PUSH", "PUSH", "PUSH"]);
+    const scheduled = publisher.envelopes.filter((envelope) => envelope.eventType === "NotificationScheduled");
     assert.deepEqual(
-      publisher.envelopes
-        .filter((envelope) => envelope.eventType === "NotificationScheduled")
-        .map((envelope) => [envelope.payload.templateType, envelope.payload.intent, envelope.payload.recipientRef, envelope.payload.channel]),
+      scheduled.map((envelope) => [envelope.payload.templateType, envelope.payload.intent, envelope.payload.recipientRef, envelope.payload.channel]),
       [
         ["CONNECTION_MISSED", "CONNECTION_MISSED", "tvl-401", "PUSH"],
+        ["CONNECTION_MISSED", "CONNECTION_MISSED", "tvl-402", "PUSH"],
         ["CONNECTION_REACCOMMODATED", "CONNECTION_REACCOMMODATED", "tvl-401", "PUSH"],
+        ["CONNECTION_REACCOMMODATED", "CONNECTION_REACCOMMODATED", "tvl-402", "PUSH"],
       ],
     );
-    const scheduled = publisher.envelopes.filter((envelope) => envelope.eventType === "NotificationScheduled");
-    assert.equal(scheduled[0].payload.templateCode, "CONNECTION_MISSED");
-    assert.equal(scheduled[1].payload.templateCode, "CONNECTION_REACCOMMODATED");
+    assert.deepEqual(
+      scheduled.map((envelope) => envelope.payload.templateCode),
+      ["CONNECTION_MISSED", "CONNECTION_MISSED", "CONNECTION_REACCOMMODATED", "CONNECTION_REACCOMMODATED"],
+    );
   });
 
   it("rate-limits transfer-management traveler notifications", async () => {

--- a/services/notification/src/messaging.test.ts
+++ b/services/notification/src/messaging.test.ts
@@ -683,4 +683,150 @@ describe("notification messaging integration surface", () => {
     assert.equal(publisher.envelopes.filter((envelope) => envelope.eventType === "NotificationScheduled").length, 1);
   });
 
+
+  it("consumes transfer-management missed-connection and reaccommodation facts for affected travelers", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const sentChannels: string[] = [];
+    const service = new NotificationApplicationService(
+      publisher,
+      undefined,
+      { send: (task) => { sentChannels.push(task.channel); return { ok: true }; } },
+    );
+    const base = {
+      schemaVersion: 1,
+      producer: "transfer-management",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c401",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c401",
+      occurredAt: "2026-07-05T10:00:00.000Z",
+    } as const;
+    const connection = {
+      connectionId: "con-0194f2e0-7b3e-7610-8284-5c26e8b0c401",
+      transferPlanId: "tpl-0194f2e0-7b3e-7610-8284-5c26e8b0c401",
+      itineraryRef: "iti-401",
+      journeyOrderId: "ord-401",
+      previousSegmentRef: "seg-prev-401",
+      nextSegmentRef: "seg-next-401",
+      travelerRefs: ["tvl-401"],
+    };
+    const window = {
+      plannedArrivalAt: "2026-07-05T10:00:00.000Z",
+      actualArrivalAt: "2026-07-05T10:25:00.000Z",
+      nextDepartureAt: "2026-07-05T10:30:00.000Z",
+      nextCutoffAt: "2026-07-05T10:20:00.000Z",
+      availableMinutes: -5,
+      mctMinutes: 20,
+      bufferMinutes: -25,
+    };
+
+    assert.equal(await service.handleExternalTrigger({
+      ...base,
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b04010",
+      eventType: "ConnectionMissed",
+      payload: {
+        connection,
+        previousStatus: "AT_RISK",
+        status: "MISSED",
+        riskLevel: "MISSED",
+        contractType: "PROTECTED",
+        missedAt: "2026-07-05T10:21:00.000Z",
+        missedCause: "CUTOFF_EXPIRED",
+        window,
+        recoveryRequired: true,
+        recovery: {
+          caseIds: ["rcv-401"],
+          outboundIdempotencyKey: "idem-401",
+          recoveryTriggerStatus: "OPENED",
+        },
+      },
+    }), "delivered");
+
+    assert.equal(await service.handleExternalTrigger({
+      ...base,
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b04011",
+      eventType: "ConnectionRecovered",
+      occurredAt: "2026-07-05T10:35:00.000Z",
+      payload: {
+        connection,
+        previousStatus: "MISSED",
+        status: "RECOVERED",
+        riskLevel: "RECOVERED",
+        recoveryCaseId: "rcv-401",
+        replacementConnectionId: "con-0194f2e0-7b3e-7610-8284-5c26e8b0c402",
+        replacementWindow: {
+          plannedArrivalAt: "2026-07-05T11:10:00.000Z",
+          nextDepartureAt: "2026-07-05T11:40:00.000Z",
+          nextCutoffAt: "2026-07-05T11:35:00.000Z",
+          source: "SYSTEM",
+        },
+        reaccommodatedAt: "2026-07-05T10:35:00.000Z",
+        recoveredAt: "2026-07-05T10:35:00.000Z",
+        recoverySummary: "Connection reaccommodated",
+      },
+    }), "delivered");
+
+    assert.deepEqual(sentChannels, ["PUSH", "PUSH"]);
+    assert.deepEqual(
+      publisher.envelopes
+        .filter((envelope) => envelope.eventType === "NotificationScheduled")
+        .map((envelope) => [envelope.payload.templateType, envelope.payload.intent, envelope.payload.recipientRef, envelope.payload.channel]),
+      [
+        ["CONNECTION_MISSED", "CONNECTION_MISSED", "tvl-401", "PUSH"],
+        ["CONNECTION_REACCOMMODATED", "CONNECTION_REACCOMMODATED", "tvl-401", "PUSH"],
+      ],
+    );
+    const scheduled = publisher.envelopes.filter((envelope) => envelope.eventType === "NotificationScheduled");
+    assert.equal(scheduled[0].payload.templateCode, "CONNECTION_MISSED");
+    assert.equal(scheduled[1].payload.templateCode, "CONNECTION_REACCOMMODATED");
+  });
+
+  it("rate-limits transfer-management traveler notifications", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const service = new NotificationApplicationService(
+      publisher,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { checkAndRecord: () => ({ allowed: false, retryAfter: new Date("2026-07-05T11:00:00.000Z") }) },
+    );
+
+    await assert.rejects(
+      () => service.handleExternalTrigger({
+        eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b04012",
+        eventType: "TransferAtRisk",
+        schemaVersion: 1,
+        producer: "transfer-management",
+        correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c401",
+        causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c401",
+        occurredAt: "2026-07-05T10:00:00.000Z",
+        payload: {
+          connection: {
+            connectionId: "con-401",
+            transferPlanId: "tpl-401",
+            itineraryRef: "iti-401",
+            journeyOrderId: "ord-401",
+            previousSegmentRef: "seg-prev-401",
+            nextSegmentRef: "seg-next-401",
+            travelerRefs: ["tvl-401"],
+          },
+          previousStatus: "TIGHT",
+          status: "AT_RISK",
+          riskLevel: "AT_RISK",
+          riskPolicyVersion: "builtin-v1",
+          reasons: ["BUFFER_BELOW_THRESHOLD"],
+          window: {
+            plannedArrivalAt: "2026-07-05T10:00:00.000Z",
+            nextDepartureAt: "2026-07-05T10:30:00.000Z",
+            nextCutoffAt: "2026-07-05T10:20:00.000Z",
+            availableMinutes: 10,
+            mctMinutes: 20,
+            bufferMinutes: -10,
+          },
+          detectedAt: "2026-07-05T09:55:00.000Z",
+        },
+      }),
+      (error: Error) => error.name === "RateLimitExceeded",
+    );
+  });
+
 });

--- a/services/notification/src/storage.test.ts
+++ b/services/notification/src/storage.test.ts
@@ -139,6 +139,52 @@ describe("notification PostgreSQL pilot seams", () => {
     assert.equal(await isDuplicateBusinessNotification(client as never, duplicate), true);
   });
 
+  it("detects transfer-management business duplicates using nested connection travelers", async () => {
+    const client = new FakeDuplicateNotificationClient();
+    const event: EventEnvelope = {
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b04010",
+      eventType: "ConnectionMissed",
+      schemaVersion: 1,
+      producer: "transfer-management",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c401",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c401",
+      occurredAt: "2026-07-05T10:00:00.000Z",
+      payload: {
+        connection: {
+          connectionId: "con-401",
+          transferPlanId: "tpl-401",
+          itineraryRef: "iti-401",
+          journeyOrderId: "ord-401",
+          previousSegmentRef: "seg-prev-401",
+          nextSegmentRef: "seg-next-401",
+          travelerRefs: ["tvl-401", "tvl-402"],
+        },
+        previousStatus: "AT_RISK",
+        status: "MISSED",
+        riskLevel: "MISSED",
+        contractType: "PROTECTED",
+        missedAt: "2026-07-05T10:21:00.000Z",
+        missedCause: "CUTOFF_EXPIRED",
+        window: {
+          plannedArrivalAt: "2026-07-05T10:00:00.000Z",
+          nextDepartureAt: "2026-07-05T10:30:00.000Z",
+          nextCutoffAt: "2026-07-05T10:20:00.000Z",
+          availableMinutes: -5,
+          mctMinutes: 20,
+          bufferMinutes: -25,
+        },
+        recoveryRequired: true,
+      },
+    };
+    client.snapshot = {
+      recipientRef: "tvl-402",
+      templateCode: "CONNECTION_MISSED",
+      triggerBusinessRef: "ConnectionMissed:con-401",
+    };
+
+    assert.equal(await isDuplicateBusinessNotification(client as never, event), true);
+  });
+
   it("marks readiness unavailable while configured storage is not ready", async () => {
     const app = createApp({}, { ready: () => Promise.resolve(false) });
 


### PR DESCRIPTION
## Summary
- activate notification subscription to `events:transfer-management`
- map `TransferAtRisk`, `ConnectionMissed`, and `ConnectionRecovered` (including reaccommodation) to traveler notification intents/templates
- add transfer-management contract validation, durable dedup business signatures, and e2e-style notification assertions for missed/reaccommodation flow

## Validation
- `cd services/notification && npm run build`
- `cd services/notification && npm test`