### PR TITLE
REQ-324: Activate identity purchase-limit risk consumer

### DIFF
--- a/services/risk-compliance/migrations/003_identity_purchase_limit_facts.sql
+++ b/services/risk-compliance/migrations/003_identity_purchase_limit_facts.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS risk_purchase_limit_facts (
+  fact_id text PRIMARY KEY,
+  status text NOT NULL CHECK (status IN ('RECORDED', 'CONFIRMED', 'RELEASED', 'MISSED', 'FAILED')),
+  traveler_id text,
+  order_intent_id text,
+  journey_date text,
+  product_code text,
+  segment_refs jsonb NOT NULL DEFAULT '[]'::jsonb,
+  limit_policy_version text,
+  occurred_at timestamptz NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_risk_purchase_limit_facts_traveler_active
+  ON risk_purchase_limit_facts(traveler_id, occurred_at DESC)
+  WHERE status IN ('RECORDED', 'CONFIRMED', 'MISSED', 'FAILED');
+
+CREATE TABLE IF NOT EXISTS risk_processed_purchase_limit_facts (
+  event_id text NOT NULL,
+  fact_id text NOT NULL,
+  event_type text NOT NULL,
+  processed_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (event_id, fact_id),
+  UNIQUE (fact_id, event_type)
+);

--- a/services/risk-compliance/src/risk_compliance/adapters/messaging/redis_streams.py
+++ b/services/risk-compliance/src/risk_compliance/adapters/messaging/redis_streams.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from train_ticket_platform.messaging import RedisEventPublisher, RedisEventSubscriber, default_consumer_name
 
 RISK_COMPLIANCE_PRODUCER = "risk-compliance"
-RISK_COMPLIANCE_SUBSCRIPTIONS: tuple[str, ...] = ("events:journey-order", "events:booking-orchestration")
+RISK_COMPLIANCE_SUBSCRIPTIONS: tuple[str, ...] = ("events:journey-order", "events:booking-orchestration", "events:identity-verification")
 RISK_COMPLIANCE_CONSUMER_GROUP = "risk-compliance"
 
 

--- a/services/risk-compliance/src/risk_compliance/adapters/storage/postgres.py
+++ b/services/risk-compliance/src/risk_compliance/adapters/storage/postgres.py
@@ -14,9 +14,13 @@ from risk_compliance.application import (
     RiskAssessmentResult,
     RiskBlockApplied,
 )
-from risk_compliance.domain import RiskEvaluation, RiskSignal, RiskVerdict, RuleResult
+from risk_compliance.domain import PurchaseLimitFact, PurchaseLimitFactStatus, RiskEvaluation, RiskSignal, RiskVerdict, RuleResult
 from train_ticket_platform.events import EventEnvelope
 from train_ticket_platform.storage import OutboxAppender, ProcessedEventsGuard, SnapshotRepository
+
+
+def _jsonb_payload(value: Any) -> str:
+    return json.dumps(value, separators=(",", ":"))
 
 
 def _json_obj(data: Mapping[str, Any] | str) -> Mapping[str, Any]:
@@ -124,6 +128,34 @@ def _evaluation_to_columns(evaluation: RiskEvaluation) -> tuple[Any, ...]:
     )
 
 
+def _purchase_limit_fact_to_columns(fact: PurchaseLimitFact) -> tuple[Any, ...]:
+    return (
+        fact.fact_id,
+        fact.status.value,
+        fact.traveler_id,
+        fact.order_intent_id,
+        fact.journey_date,
+        fact.product_code,
+        _jsonb_payload(list(fact.segment_refs)),
+        fact.limit_policy_version,
+        _coerce_dt(fact.occurred_at),
+    )
+
+
+def _purchase_limit_fact_from_row(row: Any) -> PurchaseLimitFact:
+    return PurchaseLimitFact(
+        fact_id=str(row[0]),
+        status=PurchaseLimitFactStatus(str(row[1])),
+        traveler_id=None if row[2] is None else str(row[2]),
+        order_intent_id=None if row[3] is None else str(row[3]),
+        journey_date=None if row[4] is None else str(row[4]),
+        product_code=None if row[5] is None else str(row[5]),
+        segment_refs=tuple(str(value) for value in _json_array(row[6])),
+        limit_policy_version=None if row[7] is None else str(row[7]),
+        occurred_at=_coerce_dt(row[8]),
+    )
+
+
 class _TxState:
     def __init__(self, connection: Any) -> None:
         self.connection = connection
@@ -198,8 +230,8 @@ class PostgresAssessmentRepository:
             self._assessments.save(conn, assessment.assessmentId, _assessment_to_json(assessment), None if snap is None else int(snap[0]))
         self.with_connection(write)
 
-    def try_mark_processed(self, event_id: str) -> bool:
-        return bool(self.with_connection(lambda conn: self._processed.try_mark_processed(conn, event_id, "events:journey-order")))
+    def try_mark_processed(self, event_id: str, stream: str | None = None) -> bool:
+        return bool(self.with_connection(lambda conn: self._processed.try_mark_processed(conn, event_id, stream or "events:journey-order")))
 
     def is_processed(self, event_id: str) -> bool:
         return self.with_connection(lambda conn: conn.execute("SELECT 1 FROM processed_events WHERE event_id = %s", (event_id,)).fetchone() is not None)
@@ -298,6 +330,83 @@ class PostgresRiskEvaluationRepository:
             return fn(state.connection)
         with self.transaction() as conn:
             return fn(conn)
+
+    def try_mark_purchase_limit_fact_processed(self, event_id: str, fact_id: str, event_type: str) -> bool:
+        return bool(
+            self.with_connection(
+                lambda conn: conn.execute(
+                    """
+                    INSERT INTO risk_processed_purchase_limit_facts(event_id, fact_id, event_type)
+                    VALUES (%s, %s, %s) ON CONFLICT DO NOTHING RETURNING event_id
+                    """,
+                    (event_id, fact_id, event_type),
+                ).fetchone()
+            )
+        )
+
+    def record_purchase_limit_fact_processed(self, event_id: str, fact_id: str, event_type: str) -> None:
+        self.with_connection(
+            lambda conn: conn.execute(
+                """
+                INSERT INTO risk_processed_purchase_limit_facts(event_id, fact_id, event_type)
+                VALUES (%s, %s, %s) ON CONFLICT DO NOTHING
+                """,
+                (event_id, fact_id, event_type),
+            )
+        )
+
+    def upsert_purchase_limit_fact(self, fact: PurchaseLimitFact) -> None:
+        def write(conn: Any) -> None:
+            existing = conn.execute(
+                """
+                SELECT fact_id, status, traveler_id, order_intent_id, journey_date, product_code,
+                       segment_refs, limit_policy_version, occurred_at
+                FROM risk_purchase_limit_facts WHERE fact_id = %s
+                """,
+                (fact.fact_id,),
+            ).fetchone()
+            merged = fact if existing is None else _purchase_limit_fact_from_row(existing).merge(fact)
+            conn.execute(
+                """
+                INSERT INTO risk_purchase_limit_facts(
+                  fact_id, status, traveler_id, order_intent_id, journey_date, product_code,
+                  segment_refs, limit_policy_version, occurred_at
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (fact_id) DO UPDATE SET
+                  status = EXCLUDED.status,
+                  traveler_id = COALESCE(EXCLUDED.traveler_id, risk_purchase_limit_facts.traveler_id),
+                  order_intent_id = COALESCE(EXCLUDED.order_intent_id, risk_purchase_limit_facts.order_intent_id),
+                  journey_date = COALESCE(EXCLUDED.journey_date, risk_purchase_limit_facts.journey_date),
+                  product_code = COALESCE(EXCLUDED.product_code, risk_purchase_limit_facts.product_code),
+                  segment_refs = CASE
+                    WHEN jsonb_array_length(EXCLUDED.segment_refs) > 0 THEN EXCLUDED.segment_refs
+                    ELSE risk_purchase_limit_facts.segment_refs
+                  END,
+                  limit_policy_version = COALESCE(EXCLUDED.limit_policy_version, risk_purchase_limit_facts.limit_policy_version),
+                  occurred_at = EXCLUDED.occurred_at,
+                  updated_at = now()
+                """,
+                _purchase_limit_fact_to_columns(merged),
+            )
+        self.with_connection(write)
+
+    def active_purchase_limit_facts(self, traveler_refs: tuple[str, ...]) -> tuple[PurchaseLimitFact, ...]:
+        traveler_set = tuple(sorted({traveler_ref for traveler_ref in traveler_refs if traveler_ref.strip()}))
+        if not traveler_set:
+            return ()
+        def read(conn: Any) -> tuple[PurchaseLimitFact, ...]:
+            rows = conn.execute(
+                """
+                SELECT fact_id, status, traveler_id, order_intent_id, journey_date, product_code,
+                       segment_refs, limit_policy_version, occurred_at
+                FROM risk_purchase_limit_facts
+                WHERE traveler_id = ANY(%s) AND status IN ('RECORDED', 'CONFIRMED', 'MISSED', 'FAILED')
+                ORDER BY occurred_at DESC
+                """,
+                (list(traveler_set),),
+            ).fetchall()
+            return tuple(_purchase_limit_fact_from_row(row) for row in rows)
+        return self.with_connection(read)
 
     def save(self, evaluation: RiskEvaluation) -> None:
         def write(conn: Any) -> None:

--- a/services/risk-compliance/src/risk_compliance/api.py
+++ b/services/risk-compliance/src/risk_compliance/api.py
@@ -435,17 +435,18 @@ def create_app(
         app.state.publisher = postgres_publisher or RedisEventPublisher()
         from .adapters.redis import VelocityRedisCounter
 
-        app.state.risk_service = RiskComplianceService(
-            publisher=app.state.publisher,
-            repository=app.state.assessment_repository,
-            idempotency_store=store,
-        )
-        app.state.subscriber = RedisEventSubscriber()
         app.state.risk_evaluation_service = RiskEvaluationService(
             app.state.publisher,
             repository=evaluation_repository or RiskEvaluationRepository(),
             velocity_counter=VelocityRedisCounter(),
         )
+        app.state.risk_service = RiskComplianceService(
+            publisher=app.state.publisher,
+            repository=app.state.assessment_repository,
+            idempotency_store=store,
+        )
+        app.state.risk_service.purchase_limit_fact_sink = app.state.risk_evaluation_service.repository
+        app.state.subscriber = RedisEventSubscriber()
         subscriber_config = {
             "subscriptions": RISK_COMPLIANCE_SUBSCRIPTIONS,
             "consumer_group": RISK_COMPLIANCE_CONSUMER_GROUP,
@@ -455,6 +456,7 @@ def create_app(
         app.state.risk_service = service
         app.state.publisher = service.publisher
         app.state.risk_evaluation_service = RiskEvaluationService(app.state.publisher)
+        app.state.risk_service.purchase_limit_fact_sink = app.state.risk_evaluation_service.repository
         app.state.risk_service.idempotency_store = store
 
     def handle_risk_event(envelope: Any) -> None:

--- a/services/risk-compliance/src/risk_compliance/application.py
+++ b/services/risk-compliance/src/risk_compliance/application.py
@@ -23,10 +23,32 @@ from train_ticket_platform.messaging import (
     TransientHandlerError,
 )
 
-from .domain import BlockScope, Decision, PolicyVersionRef, RiskAssessment, RiskLevel, allow_subject, assess_risk, block_subject
+from .domain import (
+    BlockScope,
+    Decision,
+    PolicyVersionRef,
+    PurchaseLimitFact,
+    PurchaseLimitFactStatus,
+    RiskAssessment,
+    RiskComplianceError,
+    RiskLevel,
+    allow_subject,
+    assess_risk,
+    block_subject,
+)
 
 PRODUCER = "risk-compliance"
 SCHEMA_VERSION = 1
+IDENTITY_VERIFICATION_STREAM = "events:identity-verification"
+IDENTITY_PURCHASE_LIMIT_EVENT_TYPES = frozenset(
+    {
+        "PurchaseLimitFactRecorded",
+        "PurchaseLimitFactConfirmed",
+        "PurchaseLimitFactReleased",
+        "PurchaseLimitFactMissed",
+        "PurchaseLimitFactFailed",
+    }
+)
 DEFAULT_POLICY_VERSION = PolicyVersionRef(policy_set_id="risk-rules", version="1.0.0")
 FREQUENCY_WINDOW = timedelta(minutes=int(os.environ.get("RISK_FREQUENCY_WINDOW_MINUTES", "5")))
 FREQUENCY_THRESHOLD = int(os.environ.get("RISK_FREQUENCY_THRESHOLD", "2"))
@@ -138,6 +160,7 @@ class InMemoryAssessmentRepository:
         self._assessments: dict[str, RiskAssessmentResult] = {}
         self._blocks: dict[str, RiskBlockApplied] = {}
         self._processed_event_ids: set[str] = set()
+        self._processed_purchase_limit_fact_keys: set[tuple[str, str]] = set()
         self._account_order_times: dict[str, list[datetime]] = {}
         self._account_lifted_at: dict[str, datetime] = {}
         self._ip_order_times: dict[str, list[datetime]] = {}
@@ -162,7 +185,8 @@ class InMemoryAssessmentRepository:
     def save(self, assessment: RiskAssessmentResult) -> None:
         self._assessments[assessment.assessmentId] = assessment
 
-    def try_mark_processed(self, event_id: str) -> bool:
+    def try_mark_processed(self, event_id: str, stream: str | None = None) -> bool:
+        del stream
         if event_id in self._processed_event_ids:
             return False
         self._processed_event_ids.add(event_id)
@@ -173,6 +197,18 @@ class InMemoryAssessmentRepository:
 
     def record_processed(self, event_id: str) -> None:
         self._processed_event_ids.add(event_id)
+
+    def try_mark_purchase_limit_fact_processed(self, event_id: str, fact_id: str, event_type: str) -> bool:
+        del event_id
+        dedup_key = (fact_id, event_type)
+        if dedup_key in self._processed_purchase_limit_fact_keys:
+            return False
+        self._processed_purchase_limit_fact_keys.add(dedup_key)
+        return True
+
+    def record_purchase_limit_fact_processed(self, event_id: str, fact_id: str, event_type: str) -> None:
+        del event_id
+        self._processed_purchase_limit_fact_keys.add((fact_id, event_type))
 
     def save_block(self, block: RiskBlockApplied) -> None:
         self._blocks[block.subjectRef] = block
@@ -231,6 +267,7 @@ class RiskComplianceService:
     publisher: EventPublisher
     repository: InMemoryAssessmentRepository = field(default_factory=InMemoryAssessmentRepository)
     idempotency_store: IdempotencyStore | None = None
+    purchase_limit_fact_sink: Any | None = None
 
     def assess(
         self,
@@ -309,6 +346,9 @@ class RiskComplianceService:
         if envelope.eventType == "RiskAssessmentRequested":
             self._handle_risk_assessment_requested(envelope)
             return
+        if envelope.eventType in IDENTITY_PURCHASE_LIMIT_EVENT_TYPES:
+            self._handle_purchase_limit_fact(envelope)
+            return
         if envelope.eventType != "JourneyOrderCreated":
             return
         transaction = getattr(self.repository, "transaction", None)
@@ -321,10 +361,7 @@ class RiskComplianceService:
 
     def _handle_event_in_transaction(self, envelope: EventEnvelope) -> None:
         try_mark_processed = getattr(self.repository, "try_mark_processed", None)
-        if callable(try_mark_processed):
-            if not try_mark_processed(envelope.eventId):
-                return
-        elif self.repository.is_processed(envelope.eventId):
+        if not _try_mark_processed(self.repository, envelope.eventId, "events:journey-order"):
             return
         result, block = self._assess_journey_order_created(envelope)
         self.repository.save(result)
@@ -352,10 +389,7 @@ class RiskComplianceService:
 
     def _handle_risk_assessment_requested_in_transaction(self, envelope: EventEnvelope) -> None:
         try_mark_processed = getattr(self.repository, "try_mark_processed", None)
-        if callable(try_mark_processed):
-            if not try_mark_processed(envelope.eventId):
-                return
-        elif self.repository.is_processed(envelope.eventId):
+        if not _try_mark_processed(self.repository, envelope.eventId, "events:booking-orchestration"):
             return
         payload = envelope.payload
         saga_id = str(payload.get("sagaId", ""))
@@ -373,6 +407,34 @@ class RiskComplianceService:
         self.publisher.publish(completed_envelope)
         if try_mark_processed is None:
             self.repository.record_processed(envelope.eventId)
+
+    def _handle_purchase_limit_fact(self, envelope: EventEnvelope) -> None:
+        transaction = getattr(self.repository, "transaction", None)
+        context = transaction() if callable(transaction) else None
+        if context is None:
+            self._handle_purchase_limit_fact_in_transaction(envelope)
+            return
+        with context:
+            self._handle_purchase_limit_fact_in_transaction(envelope)
+
+    def _handle_purchase_limit_fact_in_transaction(self, envelope: EventEnvelope) -> None:
+        fact = _purchase_limit_fact_from_envelope(envelope)
+        try_mark_processed = getattr(self.repository, "try_mark_processed", None)
+        if not _try_mark_processed(self.repository, envelope.eventId, IDENTITY_VERIFICATION_STREAM):
+            return
+        fact_store = self.purchase_limit_fact_sink or self.repository
+        try_mark_fact_processed = getattr(fact_store, "try_mark_purchase_limit_fact_processed", None)
+        if callable(try_mark_fact_processed):
+            if not try_mark_fact_processed(envelope.eventId, fact.fact_id, envelope.eventType):
+                return
+        upsert_purchase_limit_fact = getattr(fact_store, "upsert_purchase_limit_fact", None)
+        if callable(upsert_purchase_limit_fact):
+            upsert_purchase_limit_fact(fact)
+        if try_mark_processed is None:
+            self.repository.record_processed(envelope.eventId)
+        record_fact_processed = getattr(fact_store, "record_purchase_limit_fact_processed", None)
+        if try_mark_fact_processed is None and callable(record_fact_processed):
+            record_fact_processed(envelope.eventId, fact.fact_id, envelope.eventType)
 
     def lift_block(self, *, subject_ref: str, scope: str, reason_code: str, correlation_id: str) -> RiskBlockLifted:
         previous = self.repository.active_block(subject_ref)
@@ -434,6 +496,16 @@ class RiskComplianceService:
         result = _to_result(completed)
         block = _block_from_result(result) if completed.decision in BLOCKING_DECISIONS else None
         return result, block
+
+
+def _try_mark_processed(repository: Any, event_id: str, stream: str) -> bool:
+    try_mark_processed = getattr(repository, "try_mark_processed", None)
+    if callable(try_mark_processed):
+        try:
+            return bool(try_mark_processed(event_id, stream))
+        except TypeError:
+            return bool(try_mark_processed(event_id))
+    return not repository.is_processed(event_id)
 
 
 def prefixed_id(prefix: str) -> str:
@@ -619,10 +691,46 @@ def _is_whitelisted_ip(source_ip: str) -> bool:
     return any(address in network for network in _ip_whitelist_ranges())
 
 
-def _required_payload_text(payload: Mapping[str, Any], field_name: str) -> str:
+
+def _purchase_limit_fact_from_envelope(envelope: EventEnvelope) -> PurchaseLimitFact:
+    payload = envelope.payload
+    fact_id = _required_payload_text(payload, "purchaseLimitFactId", event_type=envelope.eventType)
+    raw_status = _required_payload_text(payload, "factStatus", event_type=envelope.eventType)
+    try:
+        status = PurchaseLimitFactStatus(raw_status)
+    except ValueError as exc:
+        raise RiskComplianceError(f"unsupported purchase-limit fact status {raw_status}") from exc
+    occurred_at = _coerce_datetime(envelope.occurredAt)
+    return PurchaseLimitFact(
+        fact_id=fact_id,
+        status=status,
+        traveler_id=_optional_payload_text(payload, "travelerId"),
+        order_intent_id=_optional_payload_text(payload, "orderIntentId"),
+        journey_date=_optional_payload_text(payload, "journeyDate"),
+        product_code=_optional_payload_text(payload, "productCode"),
+        segment_refs=_string_tuple(payload.get("segmentRefs")),
+        limit_policy_version=_optional_payload_text(payload, "limitPolicyVersion"),
+        occurred_at=occurred_at,
+    )
+
+
+def _optional_payload_text(payload: Mapping[str, Any], field_name: str) -> str | None:
+    value = payload.get(field_name)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(item.strip() for item in value if isinstance(item, str) and item.strip())
+
+
+def _required_payload_text(payload: Mapping[str, Any], field_name: str, *, event_type: str = "JourneyOrderCreated") -> str:
     value = payload.get(field_name)
     if not isinstance(value, str) or not value.strip():
-        raise ValueError(f"JourneyOrderCreated payload missing {field_name}")
+        raise ValueError(f"{event_type} payload missing {field_name}")
     return value
 
 

--- a/services/risk-compliance/src/risk_compliance/domain.py
+++ b/services/risk-compliance/src/risk_compliance/domain.py
@@ -108,6 +108,25 @@ class ScalperPattern(str, Enum):
     SAME_ROUTE_BULK = "SAME_ROUTE_BULK"
     RAPID_SEARCH_THEN_BOOK = "RAPID_SEARCH_THEN_BOOK"
     RESALE_REFUND_CYCLE = "RESALE_REFUND_CYCLE"
+    IDENTITY_PURCHASE_LIMIT_DUPLICATE = "IDENTITY_PURCHASE_LIMIT_DUPLICATE"
+
+
+class PurchaseLimitFactStatus(str, Enum):
+    RECORDED = "RECORDED"
+    CONFIRMED = "CONFIRMED"
+    RELEASED = "RELEASED"
+    MISSED = "MISSED"
+    FAILED = "FAILED"
+
+
+ACTIVE_PURCHASE_LIMIT_FACT_STATUSES = frozenset(
+    {
+        PurchaseLimitFactStatus.RECORDED,
+        PurchaseLimitFactStatus.CONFIRMED,
+        PurchaseLimitFactStatus.MISSED,
+        PurchaseLimitFactStatus.FAILED,
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -217,6 +236,62 @@ class DetectedPattern:
     def to_signal(self) -> RiskSignal:
         normalized = 100 if self.score_contribution >= 25 else int(round(self.score_contribution * 100 / 25))
         return RiskSignal("known_scalper_pattern", self.pattern_type.value, min(100, normalized))
+
+
+
+
+@dataclass(frozen=True, slots=True)
+class PurchaseLimitFact:
+    """Identity-verification purchase-limit fact retained for risk scoring.
+
+    The fact ID is a business id from the identity-verification contract and is
+    separate from the transport envelope eventId used for at-least-once dedup.
+    """
+
+    fact_id: str
+    status: PurchaseLimitFactStatus
+    traveler_id: str | None = None
+    order_intent_id: str | None = None
+    journey_date: str | None = None
+    product_code: str | None = None
+    segment_refs: tuple[str, ...] = ()
+    limit_policy_version: str | None = None
+    occurred_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def __post_init__(self) -> None:
+        if not self.fact_id.strip():
+            raise RiskComplianceError("purchase limit fact_id is required")
+        if self.traveler_id is not None and not self.traveler_id.strip():
+            raise RiskComplianceError("traveler_id cannot be blank")
+        if self.order_intent_id is not None and not self.order_intent_id.strip():
+            raise RiskComplianceError("order_intent_id cannot be blank")
+        if self.journey_date is not None and not self.journey_date.strip():
+            raise RiskComplianceError("journey_date cannot be blank")
+        if self.product_code is not None and not self.product_code.strip():
+            raise RiskComplianceError("product_code cannot be blank")
+        if self.limit_policy_version is not None and not self.limit_policy_version.strip():
+            raise RiskComplianceError("limit_policy_version cannot be blank")
+        if any(not segment_ref.strip() for segment_ref in self.segment_refs):
+            raise RiskComplianceError("segment_refs cannot contain blank values")
+
+    @property
+    def is_active_for_scoring(self) -> bool:
+        return self.status in ACTIVE_PURCHASE_LIMIT_FACT_STATUSES
+
+    def merge(self, update: "PurchaseLimitFact") -> "PurchaseLimitFact":
+        if update.fact_id != self.fact_id:
+            raise RiskComplianceError("cannot merge different purchase limit facts")
+        return PurchaseLimitFact(
+            fact_id=self.fact_id,
+            status=update.status,
+            traveler_id=update.traveler_id or self.traveler_id,
+            order_intent_id=update.order_intent_id or self.order_intent_id,
+            journey_date=update.journey_date or self.journey_date,
+            product_code=update.product_code or self.product_code,
+            segment_refs=update.segment_refs or self.segment_refs,
+            limit_policy_version=update.limit_policy_version or self.limit_policy_version,
+            occurred_at=update.occurred_at,
+        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/services/risk-compliance/src/risk_compliance/evaluation.py
+++ b/services/risk-compliance/src/risk_compliance/evaluation.py
@@ -11,6 +11,7 @@ from train_ticket_platform.messaging import EventPublisher
 from .application import prefixed_id
 from .domain import (
     DetectedPattern,
+    PurchaseLimitFact,
     RiskComplianceError,
     RiskEvaluation,
     RiskScoreCalculator,
@@ -66,6 +67,8 @@ class OrderHistoryRecord:
 @dataclass(slots=True)
 class RiskEvaluationRepository:
     _evaluations: dict[str, RiskEvaluation] = field(default_factory=dict)
+    _purchase_limit_facts: dict[str, PurchaseLimitFact] = field(default_factory=dict)
+    _processed_purchase_limit_fact_keys: set[tuple[str, str]] = field(default_factory=set)
     _account_created_at: dict[str, datetime] = field(default_factory=dict)
     _orders: list[OrderHistoryRecord] = field(default_factory=list)
     _payment_attempts: dict[str, list[datetime]] = field(default_factory=lambda: defaultdict(list))
@@ -104,6 +107,32 @@ class RiskEvaluationRepository:
     def record_refund(self, account_id: str, occurred_at: datetime) -> None:
         self._refunds[account_id].append(occurred_at)
 
+    def try_mark_purchase_limit_fact_processed(self, event_id: str, fact_id: str, event_type: str) -> bool:
+        del event_id
+        dedup_key = (fact_id, event_type)
+        if dedup_key in self._processed_purchase_limit_fact_keys:
+            return False
+        self._processed_purchase_limit_fact_keys.add(dedup_key)
+        return True
+
+    def record_purchase_limit_fact_processed(self, event_id: str, fact_id: str, event_type: str) -> None:
+        del event_id
+        self._processed_purchase_limit_fact_keys.add((fact_id, event_type))
+
+    def upsert_purchase_limit_fact(self, fact: PurchaseLimitFact) -> None:
+        existing = self._purchase_limit_facts.get(fact.fact_id)
+        self._purchase_limit_facts[fact.fact_id] = fact if existing is None else existing.merge(fact)
+
+    def active_purchase_limit_facts(self, traveler_refs: tuple[str, ...]) -> tuple[PurchaseLimitFact, ...]:
+        traveler_set = {traveler_ref for traveler_ref in traveler_refs if traveler_ref.strip()}
+        if not traveler_set:
+            return ()
+        return tuple(
+            fact
+            for fact in self._purchase_limit_facts.values()
+            if fact.is_active_for_scoring and fact.traveler_id in traveler_set
+        )
+
     def refunds_since(self, account_id: str, since: datetime) -> tuple[datetime, ...]:
         refunds = [seen_at for seen_at in self._refunds[account_id] if seen_at >= since]
         self._refunds[account_id] = refunds
@@ -130,6 +159,17 @@ class PatternMatcher:
         searches = _int_from_mapping(request.context, "searchCountLast2m")
         if searches > 20:
             detected.append(DetectedPattern(ScalperPattern.RAPID_SEARCH_THEN_BOOK, 2 * 60, 20, 15, f"{searches}/20 searches before booking"))
+        active_limit_facts = self._repository.active_purchase_limit_facts(request.traveler_refs)
+        if active_limit_facts:
+            detected.append(
+                DetectedPattern(
+                    ScalperPattern.IDENTITY_PURCHASE_LIMIT_DUPLICATE,
+                    24 * 60 * 60,
+                    0,
+                    30,
+                    f"{len(active_limit_facts)} active identity purchase-limit facts for traveler",
+                )
+            )
         return tuple(detected)
 
 

--- a/services/risk-compliance/tests/test_api_and_messaging.py
+++ b/services/risk-compliance/tests/test_api_and_messaging.py
@@ -795,3 +795,124 @@ def test_subscription_includes_booking_orchestration_stream() -> None:
 
     assert "events:booking-orchestration" in RISK_COMPLIANCE_SUBSCRIPTIONS
     assert "events:journey-order" in RISK_COMPLIANCE_SUBSCRIPTIONS
+
+
+def purchase_limit_fact_recorded_envelope(event_id: str, fact_id: str, traveler_id: str = "tvl-limit") -> EventEnvelope:
+    return EventEnvelope(
+        eventId=event_id,
+        eventType="PurchaseLimitFactRecorded",
+        occurredAt="2026-07-05T10:20:00.000Z",
+        correlationId=f"corr-{uuid7()}",
+        causationId=f"cmd-{uuid7()}",
+        producer="identity-verification",
+        schemaVersion=1,
+        payload={
+            "purchaseLimitFactId": fact_id,
+            "scopeType": "CREDENTIAL",
+            "scopeRef": "crd-1",
+            "travelerId": traveler_id,
+            "orderIntentId": "oint-1",
+            "journeyDate": "2026-07-20",
+            "productCode": "ADULT_FULL_FARE",
+            "segmentRefs": ["seg-1"],
+            "limitPolicyVersion": "limit-v1",
+            "factStatus": "RECORDED",
+            "recordedAt": "2026-07-05T10:20:00.000Z",
+            "aggregateVersion": 1,
+        },
+    )
+
+
+def purchase_limit_fact_released_envelope(event_id: str, fact_id: str) -> EventEnvelope:
+    return EventEnvelope(
+        eventId=event_id,
+        eventType="PurchaseLimitFactReleased",
+        occurredAt="2026-07-05T10:25:00.000Z",
+        correlationId=f"corr-{uuid7()}",
+        causationId=f"cmd-{uuid7()}",
+        producer="identity-verification",
+        schemaVersion=1,
+        payload={
+            "purchaseLimitFactId": fact_id,
+            "orderIntentId": "oint-1",
+            "releaseReason": "ORDER_INTENT_ABANDONED",
+            "sourceEventId": "evt-source",
+            "factStatus": "RELEASED",
+            "limitPolicyVersion": "limit-v1",
+            "releasedAt": "2026-07-05T10:25:00.000Z",
+            "aggregateVersion": 2,
+        },
+    )
+
+
+def test_subscription_includes_identity_verification_stream() -> None:
+    from risk_compliance.adapters.messaging.redis_streams import RISK_COMPLIANCE_SUBSCRIPTIONS
+
+    assert "events:identity-verification" in RISK_COMPLIANCE_SUBSCRIPTIONS
+
+
+def test_identity_purchase_limit_fact_dedups_by_event_and_fact_id_and_influences_evaluation() -> None:
+    app = fake_app()
+    service = app.state.risk_service
+    publisher = app.state.publisher
+
+    service.handle_event(purchase_limit_fact_recorded_envelope("evt-limit-1", "plf-1"))
+    service.handle_event(purchase_limit_fact_recorded_envelope("evt-limit-1", "plf-2"))
+    service.handle_event(purchase_limit_fact_recorded_envelope("evt-limit-2", "plf-1"))
+
+    response = TestClient(app).post(
+        "/api/v1/risk-evaluations",
+        headers={"Idempotency-Key": str(uuid7()), "X-Correlation-Id": str(uuid7())},
+        json={
+            "orderId": "ord-limit-eval",
+            "accountId": "acct-limit-eval",
+            "travelerRefs": ["tvl-limit"],
+            "totalAmountMinor": 15000,
+            "currency": "CNY",
+            "route": {"origin": "node-shanghai", "destination": "node-beijing"},
+            "departureDate": "2026-07-20",
+            "sourceIp": "203.0.113.45",
+            "channelId": "web",
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["score"] >= 25
+    assert any(
+        signal["signalType"] == "known_scalper_pattern"
+        and "IDENTITY_PURCHASE_LIMIT_DUPLICATE" in signal["rawValue"]
+        for signal in publisher.envelopes[-1].payload["signals"]
+    )
+
+
+def test_identity_purchase_limit_fact_lifecycle_updates_same_fact_id() -> None:
+    app = fake_app()
+    service = app.state.risk_service
+    publisher = app.state.publisher
+
+    service.handle_event(purchase_limit_fact_recorded_envelope("evt-limit-record", "plf-lifecycle"))
+    service.handle_event(purchase_limit_fact_released_envelope("evt-limit-release", "plf-lifecycle"))
+
+    response = TestClient(app).post(
+        "/api/v1/risk-evaluations",
+        headers={"Idempotency-Key": str(uuid7()), "X-Correlation-Id": str(uuid7())},
+        json={
+            "orderId": "ord-limit-released-eval",
+            "accountId": "acct-limit-released-eval",
+            "travelerRefs": ["tvl-limit"],
+            "totalAmountMinor": 15000,
+            "currency": "CNY",
+            "route": {"origin": "node-shanghai", "destination": "node-beijing"},
+            "departureDate": "2026-07-20",
+            "sourceIp": "203.0.113.45",
+            "channelId": "web",
+        },
+    )
+
+    assert response.status_code == 201
+    assert not any(
+        signal["signalType"] == "known_scalper_pattern"
+        and "IDENTITY_PURCHASE_LIMIT_DUPLICATE" in signal["rawValue"]
+        for signal in publisher.envelopes[-1].payload["signals"]
+    )


### PR DESCRIPTION
## Summary
- subscribe risk-compliance to identity-verification purchase-limit events
- deduplicate purchase-limit handling by envelope eventId and purchaseLimitFactId
- persist purchase-limit facts and feed active traveler facts into risk evaluation scalper-pattern scoring

## Validation
- uv run --project services/risk-compliance pytest services/risk-compliance/tests