### PR TITLE
REQ-332 topology-weighted transfer MCT

### DIFF
--- a/docs/08-contracts/api/place-network.md
+++ b/docs/08-contracts/api/place-network.md
@@ -56,7 +56,7 @@ Registers a new geographic place.
 | `code` | string | Short code, if set. |
 | `timezone` | string | IANA timezone, if set. |
 | `status` | enum | Current status. |
-| `nodes` | array | List of associated transport nodes. |
+| `nodes` | array | List of associated transport nodes using the TransportNode shape below, including optional access-time weights when configured. |
 
 **Error codes:** `NOT_FOUND`
 
@@ -81,6 +81,8 @@ Registers a new geographic place.
 | `placeId` | string | yes | Parent place ID (`plc-<uuid>`). |
 | `displayName` | string | yes | Display name (e.g. "Platform 3"). |
 | `servingModes` | string[] | yes | Transport modes served (e.g. `["RAIL"]`). |
+| `accessTimeMinutes` | integer | no | Non-negative walking/wayfinding access-time weight in whole minutes for entering/leaving this node. Omitted when unknown. |
+| `walkingEdges` | array | no | Optional directed walking/access edges from this node to adjacent transport nodes. Each item is `{toNodeId, walkingTimeMinutes}` where `toNodeId` is a TransportNode ID (`tnd-<uuid>` or configured node ref) and `walkingTimeMinutes` is a non-negative integer in whole minutes. Omitted or empty when no edge weights are configured. |
 
 **Response (201):**
 
@@ -90,6 +92,8 @@ Registers a new geographic place.
 | `placeId` | string | Parent place. |
 | `displayName` | string | Display name. |
 | `servingModes` | string[] | Transport modes. |
+| `accessTimeMinutes` | integer | Optional; same semantics and minute units as request. Present only when configured. |
+| `walkingEdges` | array | Optional; same `{toNodeId, walkingTimeMinutes}` directed edge shape as request. Present only when one or more edge weights are configured. |
 | `createdAt` | timestamp | Creation time. |
 
 **Error codes:** `VALIDATION_FAILED`, `NOT_FOUND` (placeId), `CONFLICT`

--- a/docs/08-contracts/api/transfer-management.md
+++ b/docs/08-contracts/api/transfer-management.md
@@ -256,7 +256,7 @@ on outbound events/commands use `corr-<uuid-v7>` and `cmd-<uuid-v7>` prefixes.
 | `fromNodeType` | enum | yes | Arrival node type matched by the rule. |
 | `toNodeType` | enum | yes | Departure node type matched by the rule. |
 | `transferCategory` | enum | yes | Transfer category matched by the rule. |
-| `minimumMinutes` | integer | yes | Required minutes; must be positive. |
+| `minimumMinutes` | integer | yes | Required minutes; must be non-negative. |
 | `conditions` | object | yes | Structured non-PII conditions such as baggage/security/accessibility flags. |
 | `validFrom` | RFC3339 UTC | yes | Rule effective start. |
 | `validUntil` | RFC3339 UTC | no | Rule effective end. |
@@ -601,7 +601,7 @@ status depending on previous state.
 | `fromNodeType` | enum | yes | Arrival node type. |
 | `toNodeType` | enum | yes | Departure node type. |
 | `transferCategory` | enum | yes | Transfer category. |
-| `minimumMinutes` | integer | yes | Positive required minutes. |
+| `minimumMinutes` | integer | yes | Non-negative required minutes. |
 | `conditions` | object | yes | Structured condition flags; no PII. |
 | `validFrom` | RFC3339 UTC | yes | Effective start. |
 | `validUntil` | RFC3339 UTC | no | Effective end. |
@@ -626,7 +626,7 @@ immutable; changing a published rule requires creating a new version.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `minimumMinutes` | integer | no | Replacement positive minutes. |
+| `minimumMinutes` | integer | no | Replacement non-negative minutes. |
 | `conditions` | object | no | Replacement non-PII conditions. |
 | `validFrom` | RFC3339 UTC | no | Replacement effective start. |
 | `validUntil` | RFC3339 UTC | no | Replacement effective end. |

--- a/docs/08-contracts/events/place-network.md
+++ b/docs/08-contracts/events/place-network.md
@@ -37,3 +37,5 @@ Last updated: 2026-06-28
 | `placeId` | `PlaceId` | yes | Parent place. |
 | `displayName` | string | yes | Display name. |
 | `servingModes` | string[] | yes | Transport modes served. |
+| `accessTimeMinutes` | integer | no | Non-negative walking/wayfinding access-time weight in whole minutes for entering/leaving this node. Omitted when unknown. |
+| `walkingEdges` | array | no | Optional directed walking/access edges from this node to adjacent transport nodes. Each item is `{toNodeId, walkingTimeMinutes}` where `toNodeId` is a TransportNode ID (`tnd-<uuid>` or configured node ref) and `walkingTimeMinutes` is a non-negative integer in whole minutes. Omitted or empty when no edge weights are configured. |

--- a/docs/08-contracts/events/transfer-management.md
+++ b/docs/08-contracts/events/transfer-management.md
@@ -439,7 +439,7 @@ a normal transition to `RECOVERED`.
 | `fromNodeType` | enum | yes | Arrival node type. |
 | `toNodeType` | enum | yes | Departure node type. |
 | `transferCategory` | enum | yes | Transfer category. |
-| `minimumMinutes` | integer | yes | Positive MCT minutes. |
+| `minimumMinutes` | integer | yes | Non-negative MCT minutes. |
 | `conditions` | object | yes | Non-PII condition flags. |
 | `validFrom` | RFC3339 UTC | yes | Effective start. |
 | `validUntil` | RFC3339 UTC | no | Effective end. |
@@ -464,7 +464,7 @@ a normal transition to `RECOVERED`.
 | `fromNodeType` | enum | yes | Arrival node type. |
 | `toNodeType` | enum | yes | Departure node type. |
 | `transferCategory` | enum | yes | Transfer category. |
-| `minimumMinutes` | integer | yes | Positive MCT minutes. |
+| `minimumMinutes` | integer | yes | Non-negative MCT minutes. |
 | `conditions` | object | yes | Non-PII condition flags. |
 | `validFrom` | RFC3339 UTC | yes | Effective start. |
 | `validUntil` | RFC3339 UTC | no | Effective end. |

--- a/docs/08-contracts/events/transfer-management.md
+++ b/docs/08-contracts/events/transfer-management.md
@@ -17,11 +17,17 @@ Activation-wave rulings:
 - Fulfillment segment delay/arrival/cancelled events are not active today.
   Runtime facts enter through `POST /api/v1/segment-status-reports`; future
   Fulfillment events may be mapped to the same command material.
-- Place Network node/place read integration is active for evaluation metadata.
-  Event payloads carry itinerary/node refs, transfer category, and risk
-  evaluations may include `placeGraphVersion` or degradation fields. Place
-  Network walking/access-time weights remain deferred because that contract has no
-  such fields.
+- Place Network node/place read integration is active for evaluation metadata
+  and topology-weighted minimum connection time. Transfer Management consumes the
+  Place Network TransportNode fields `accessTimeMinutes` and
+  `walkingEdges[].{toNodeId,walkingTimeMinutes}` exactly as defined in
+  `docs/08-contracts/api/place-network.md`: all weights are whole minutes and
+  optional. When either endpoint's node has `accessTimeMinutes`, required MCT uses
+  the sum of present endpoint access times (missing endpoint weight contributes
+  `0`). Otherwise, a direct `walkingEdges` item from `fromNodeRef` to `toNodeRef`
+  supplies the required minutes. If those weights are absent or Place Network is
+  unavailable, evaluation remains degraded-not-blocking and falls back to the
+  builtin default policy.
 - Protected missed connections use outbound HTTP to Disruption Recovery. Transfer
   Management stores returned `caseId` mappings and consumes
   `RecoveryCompleted`/`RecoveryFailed` by `caseId` to converge the `Connection`.

--- a/services/place-network/internal/adapters/postgres/snapshots.go
+++ b/services/place-network/internal/adapters/postgres/snapshots.go
@@ -23,12 +23,19 @@ type placeSnapshot struct {
 	CreatedAt     time.Time           `json:"createdAt"`
 }
 
+type walkingEdgeSnapshot struct {
+	ToNodeID           string `json:"toNodeId"`
+	WalkingTimeMinutes int    `json:"walkingTimeMinutes"`
+}
+
 type nodeSnapshot struct {
-	ID           string                 `json:"id"`
-	PlaceID      string                 `json:"placeId"`
-	DisplayName  string                 `json:"displayName"`
-	ServingModes []domain.TransportMode `json:"servingModes"`
-	CreatedAt    time.Time              `json:"createdAt"`
+	ID                string                 `json:"id"`
+	PlaceID           string                 `json:"placeId"`
+	DisplayName       string                 `json:"displayName"`
+	ServingModes      []domain.TransportMode `json:"servingModes"`
+	AccessTimeMinutes *int                   `json:"accessTimeMinutes,omitempty"`
+	WalkingEdges      []walkingEdgeSnapshot  `json:"walkingEdges,omitempty"`
+	CreatedAt         time.Time              `json:"createdAt"`
 }
 
 func placeSnapshotFromDomain(place domain.Place) placeSnapshot {
@@ -40,7 +47,11 @@ func placeSnapshotFromDomain(place domain.Place) placeSnapshot {
 }
 
 func nodeSnapshotFromDomain(node domain.TransportNode) nodeSnapshot {
-	return nodeSnapshot{ID: string(node.ID), PlaceID: string(node.PlaceID), DisplayName: node.DisplayName, ServingModes: append([]domain.TransportMode(nil), node.ServingModes...), CreatedAt: node.CreatedAt.UTC()}
+	walkingEdges := make([]walkingEdgeSnapshot, len(node.WalkingEdges))
+	for i, edge := range node.WalkingEdges {
+		walkingEdges[i] = walkingEdgeSnapshot{ToNodeID: string(edge.ToNodeID), WalkingTimeMinutes: edge.WalkingTimeMinutes}
+	}
+	return nodeSnapshot{ID: string(node.ID), PlaceID: string(node.PlaceID), DisplayName: node.DisplayName, ServingModes: append([]domain.TransportMode(nil), node.ServingModes...), AccessTimeMinutes: copyInt(node.AccessTimeMinutes), WalkingEdges: walkingEdges, CreatedAt: node.CreatedAt.UTC()}
 }
 
 func decodePlace(raw []byte) (domain.Place, error) {
@@ -70,6 +81,22 @@ func decodeNode(raw []byte) (domain.TransportNode, error) {
 	if err != nil {
 		return domain.TransportNode{}, err
 	}
+	walkingEdges := make([]domain.WalkingEdge, len(snap.WalkingEdges))
+	for i, edge := range snap.WalkingEdges {
+		walkingEdges[i] = domain.WalkingEdge{ToNodeID: domain.TransportNodeID(edge.ToNodeID), WalkingTimeMinutes: edge.WalkingTimeMinutes}
+	}
+	node.SetAccessWeights(snap.AccessTimeMinutes, walkingEdges)
+	if err := node.Validate(); err != nil {
+		return domain.TransportNode{}, err
+	}
 	node.MarkCreatedAt(snap.CreatedAt)
 	return node, nil
+}
+
+func copyInt(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	copied := *value
+	return &copied
 }

--- a/services/place-network/internal/application/service.go
+++ b/services/place-network/internal/application/service.go
@@ -103,10 +103,17 @@ func (s *Service) CreatePlace(ctx context.Context, req CreatePlaceRequest) (*Cre
 	return response, nil
 }
 
+type WalkingEdgeResponse struct {
+	ToNodeID           string `json:"toNodeId"`
+	WalkingTimeMinutes int    `json:"walkingTimeMinutes"`
+}
+
 type NodeSummary struct {
-	NodeID       string   `json:"nodeId"`
-	DisplayName  string   `json:"displayName"`
-	ServingModes []string `json:"servingModes"`
+	NodeID            string                `json:"nodeId"`
+	DisplayName       string                `json:"displayName"`
+	ServingModes      []string              `json:"servingModes"`
+	AccessTimeMinutes *int                  `json:"accessTimeMinutes,omitempty"`
+	WalkingEdges      []WalkingEdgeResponse `json:"walkingEdges,omitempty"`
 }
 
 type GetPlaceResponse struct {
@@ -185,19 +192,28 @@ func (s *Service) ListPlaces(ctx context.Context, req ListPlacesRequest) (*ListP
 	return &ListPlacesResponse{Items: items, Total: page.Total, Limit: limit, Offset: responseOffset}, nil
 }
 
+type WalkingEdgeRequest struct {
+	ToNodeID           string
+	WalkingTimeMinutes int
+}
+
 type CreateTransportNodeRequest struct {
-	PlaceID       string
-	DisplayName   string
-	ServingModes  []string
-	CorrelationID string
+	PlaceID           string
+	DisplayName       string
+	ServingModes      []string
+	AccessTimeMinutes *int
+	WalkingEdges      []WalkingEdgeRequest
+	CorrelationID     string
 }
 
 type CreateTransportNodeResponse struct {
-	NodeID       string   `json:"nodeId"`
-	PlaceID      string   `json:"placeId"`
-	DisplayName  string   `json:"displayName"`
-	ServingModes []string `json:"servingModes"`
-	CreatedAt    string   `json:"createdAt"`
+	NodeID            string                `json:"nodeId"`
+	PlaceID           string                `json:"placeId"`
+	DisplayName       string                `json:"displayName"`
+	ServingModes      []string              `json:"servingModes"`
+	AccessTimeMinutes *int                  `json:"accessTimeMinutes,omitempty"`
+	WalkingEdges      []WalkingEdgeResponse `json:"walkingEdges,omitempty"`
+	CreatedAt         string                `json:"createdAt"`
 }
 
 func (s *Service) CreateTransportNode(ctx context.Context, req CreateTransportNodeRequest) (*CreateTransportNodeResponse, error) {
@@ -215,13 +231,18 @@ func (s *Service) CreateTransportNode(ctx context.Context, req CreateTransportNo
 	if err != nil {
 		return nil, NewDomainError("VALIDATION_FAILED", err.Error())
 	}
+	node.SetAccessWeights(req.AccessTimeMinutes, walkingEdgesFromRequest(req.WalkingEdges))
+	if err := node.Validate(); err != nil {
+		return nil, NewDomainError("VALIDATION_FAILED", err.Error())
+	}
 	node.MarkCreatedAt(now)
 	servingModes := stringModes(node.ServingModes)
+	walkingEdges := walkingEdgesToResponse(node.WalkingEdges)
 	if err := s.unitOfWork(ctx, func(txCtx context.Context) error {
 		if err := s.nodes.Save(txCtx, node); err != nil {
 			return NewDomainError("CONFLICT", err.Error())
 		}
-		event := domain.TransportNodeUpdatedEvent{NodeID: node.ID, PlaceID: node.PlaceID, DisplayName: node.DisplayName, ServingModes: node.ServingModes, UpdatedAt: domain.FormatTimestamp(now)}
+		event := domain.TransportNodeUpdatedEvent{NodeID: node.ID, PlaceID: node.PlaceID, DisplayName: node.DisplayName, ServingModes: node.ServingModes, AccessTimeMinutes: copyInt(node.AccessTimeMinutes), WalkingEdges: walkingEdgesToPayload(node.WalkingEdges), UpdatedAt: domain.FormatTimestamp(now)}
 		if err := s.publisher.Publish(txCtx, domain.NewEventEnvelope("TransportNodeRegistered", now, req.CorrelationID, "", domain.ProducerPlaceNetwork, event)); err != nil {
 			return NewDomainError("UNAVAILABLE", "event publisher unavailable")
 		}
@@ -229,16 +250,18 @@ func (s *Service) CreateTransportNode(ctx context.Context, req CreateTransportNo
 	}); err != nil {
 		return nil, err
 	}
-	response := &CreateTransportNodeResponse{NodeID: string(node.ID), PlaceID: string(node.PlaceID), DisplayName: node.DisplayName, ServingModes: servingModes, CreatedAt: domain.FormatTimestamp(now)}
+	response := &CreateTransportNodeResponse{NodeID: string(node.ID), PlaceID: string(node.PlaceID), DisplayName: node.DisplayName, ServingModes: servingModes, AccessTimeMinutes: copyInt(node.AccessTimeMinutes), WalkingEdges: walkingEdges, CreatedAt: domain.FormatTimestamp(now)}
 	return response, nil
 }
 
 type GetTransportNodeResponse struct {
-	NodeID       string   `json:"nodeId"`
-	PlaceID      string   `json:"placeId"`
-	DisplayName  string   `json:"displayName"`
-	ServingModes []string `json:"servingModes"`
-	CreatedAt    string   `json:"createdAt"`
+	NodeID            string                `json:"nodeId"`
+	PlaceID           string                `json:"placeId"`
+	DisplayName       string                `json:"displayName"`
+	ServingModes      []string              `json:"servingModes"`
+	AccessTimeMinutes *int                  `json:"accessTimeMinutes,omitempty"`
+	WalkingEdges      []WalkingEdgeResponse `json:"walkingEdges,omitempty"`
+	CreatedAt         string                `json:"createdAt"`
 }
 
 func (s *Service) GetTransportNode(ctx context.Context, id domain.TransportNodeID) (*GetTransportNodeResponse, error) {
@@ -246,7 +269,7 @@ func (s *Service) GetTransportNode(ctx context.Context, id domain.TransportNodeI
 	if err != nil || node == nil {
 		return nil, NewDomainError("NOT_FOUND", fmt.Sprintf("transport node not found: %s", id))
 	}
-	return &GetTransportNodeResponse{NodeID: string(node.ID), PlaceID: string(node.PlaceID), DisplayName: node.DisplayName, ServingModes: stringModes(node.ServingModes), CreatedAt: domain.FormatTimestamp(node.CreatedAt)}, nil
+	return &GetTransportNodeResponse{NodeID: string(node.ID), PlaceID: string(node.PlaceID), DisplayName: node.DisplayName, ServingModes: stringModes(node.ServingModes), AccessTimeMinutes: copyInt(node.AccessTimeMinutes), WalkingEdges: walkingEdgesToResponse(node.WalkingEdges), CreatedAt: domain.FormatTimestamp(node.CreatedAt)}, nil
 }
 
 type DomainError struct {
@@ -279,7 +302,45 @@ func stringModes(modes []domain.TransportMode) []string {
 func nodeSummaries(nodes []domain.TransportNode) []NodeSummary {
 	out := make([]NodeSummary, len(nodes))
 	for i, node := range nodes {
-		out[i] = NodeSummary{NodeID: string(node.ID), DisplayName: node.DisplayName, ServingModes: stringModes(node.ServingModes)}
+		out[i] = NodeSummary{NodeID: string(node.ID), DisplayName: node.DisplayName, ServingModes: stringModes(node.ServingModes), AccessTimeMinutes: copyInt(node.AccessTimeMinutes), WalkingEdges: walkingEdgesToResponse(node.WalkingEdges)}
+	}
+	return out
+}
+
+func copyInt(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	copied := *value
+	return &copied
+}
+
+func walkingEdgesFromRequest(edges []WalkingEdgeRequest) []domain.WalkingEdge {
+	out := make([]domain.WalkingEdge, len(edges))
+	for i, edge := range edges {
+		out[i] = domain.WalkingEdge{ToNodeID: domain.TransportNodeID(edge.ToNodeID), WalkingTimeMinutes: edge.WalkingTimeMinutes}
+	}
+	return out
+}
+
+func walkingEdgesToResponse(edges []domain.WalkingEdge) []WalkingEdgeResponse {
+	if len(edges) == 0 {
+		return nil
+	}
+	out := make([]WalkingEdgeResponse, len(edges))
+	for i, edge := range edges {
+		out[i] = WalkingEdgeResponse{ToNodeID: string(edge.ToNodeID), WalkingTimeMinutes: edge.WalkingTimeMinutes}
+	}
+	return out
+}
+
+func walkingEdgesToPayload(edges []domain.WalkingEdge) []domain.WalkingEdgePayload {
+	if len(edges) == 0 {
+		return nil
+	}
+	out := make([]domain.WalkingEdgePayload, len(edges))
+	for i, edge := range edges {
+		out[i] = domain.WalkingEdgePayload{ToNodeID: edge.ToNodeID, WalkingTimeMinutes: edge.WalkingTimeMinutes}
 	}
 	return out
 }

--- a/services/place-network/internal/domain/events.go
+++ b/services/place-network/internal/domain/events.go
@@ -23,12 +23,19 @@ type PlaceUpdatedEvent struct {
 	UpdatedAt     string      `json:"updatedAt"`
 }
 
+type WalkingEdgePayload struct {
+	ToNodeID           TransportNodeID `json:"toNodeId"`
+	WalkingTimeMinutes int             `json:"walkingTimeMinutes"`
+}
+
 type TransportNodeUpdatedEvent struct {
-	NodeID       TransportNodeID `json:"nodeId"`
-	PlaceID      PlaceID         `json:"placeId"`
-	DisplayName  string          `json:"displayName"`
-	ServingModes []TransportMode `json:"servingModes"`
-	UpdatedAt    string          `json:"updatedAt"`
+	NodeID            TransportNodeID      `json:"nodeId"`
+	PlaceID           PlaceID              `json:"placeId"`
+	DisplayName       string               `json:"displayName"`
+	ServingModes      []TransportMode      `json:"servingModes"`
+	AccessTimeMinutes *int                 `json:"accessTimeMinutes,omitempty"`
+	WalkingEdges      []WalkingEdgePayload `json:"walkingEdges,omitempty"`
+	UpdatedAt         string               `json:"updatedAt"`
 }
 
 // EventEnvelope is the shared-primitives event envelope used on the event bus.

--- a/services/place-network/internal/domain/master_data.go
+++ b/services/place-network/internal/domain/master_data.go
@@ -125,14 +125,24 @@ func (p Place) Validate() error {
 	return nil
 }
 
+type WalkingEdge struct {
+	ToNodeID           TransportNodeID
+	WalkingTimeMinutes int
+}
+
 // TransportNode binds a transport-meaningful node to a canonical Place. Service
-// Plan may only publish stops against known, valid nodes.
+// Plan may only publish stops against known, valid nodes. AccessTimeMinutes is
+// an optional walking/wayfinding access-time weight in minutes for transfers
+// that enter or leave this node. WalkingEdges are optional directed edge weights
+// to adjacent transport nodes.
 type TransportNode struct {
-	ID           TransportNodeID
-	PlaceID      PlaceID
-	DisplayName  string
-	ServingModes []TransportMode
-	CreatedAt    time.Time
+	ID                TransportNodeID
+	PlaceID           PlaceID
+	DisplayName       string
+	ServingModes      []TransportMode
+	AccessTimeMinutes *int
+	WalkingEdges      []WalkingEdge
+	CreatedAt         time.Time
 }
 
 func NewTransportNode(id TransportNodeID, placeID PlaceID, displayName string, servingModes []TransportMode) (TransportNode, error) {
@@ -146,6 +156,19 @@ func NewTransportNode(id TransportNodeID, placeID PlaceID, displayName string, s
 		return TransportNode{}, err
 	}
 	return node, nil
+}
+
+func (n *TransportNode) SetAccessWeights(accessTimeMinutes *int, walkingEdges []WalkingEdge) {
+	if accessTimeMinutes == nil {
+		n.AccessTimeMinutes = nil
+	} else {
+		minutes := *accessTimeMinutes
+		n.AccessTimeMinutes = &minutes
+	}
+	n.WalkingEdges = make([]WalkingEdge, len(walkingEdges))
+	for i, edge := range walkingEdges {
+		n.WalkingEdges[i] = WalkingEdge{ToNodeID: TransportNodeID(strings.TrimSpace(string(edge.ToNodeID))), WalkingTimeMinutes: edge.WalkingTimeMinutes}
+	}
 }
 
 func (n *TransportNode) MarkCreatedAt(createdAt time.Time) {
@@ -174,6 +197,23 @@ func (n TransportNode) Validate() error {
 			return fmt.Errorf("duplicate transport mode: %q", mode)
 		}
 		seen[mode] = struct{}{}
+	}
+	if n.AccessTimeMinutes != nil && *n.AccessTimeMinutes < 0 {
+		return fmt.Errorf("accessTimeMinutes must be non-negative")
+	}
+	seenEdges := make(map[TransportNodeID]struct{}, len(n.WalkingEdges))
+	for _, edge := range n.WalkingEdges {
+		toNodeID := TransportNodeID(strings.TrimSpace(string(edge.ToNodeID)))
+		if toNodeID == "" {
+			return fmt.Errorf("walking edge toNodeId is required")
+		}
+		if edge.WalkingTimeMinutes < 0 {
+			return fmt.Errorf("walkingTimeMinutes must be non-negative")
+		}
+		if _, exists := seenEdges[toNodeID]; exists {
+			return fmt.Errorf("duplicate walking edge toNodeId: %q", toNodeID)
+		}
+		seenEdges[toNodeID] = struct{}{}
 	}
 	return nil
 }

--- a/services/place-network/internal/http/handler.go
+++ b/services/place-network/internal/http/handler.go
@@ -88,15 +88,24 @@ func (h *Handler) ListPlaces(ctx *gin.Context) {
 
 func (h *Handler) CreateTransportNode(ctx *gin.Context) {
 	var req struct {
-		PlaceID      string   `json:"placeId" binding:"required"`
-		DisplayName  string   `json:"displayName" binding:"required"`
-		ServingModes []string `json:"servingModes" binding:"required"`
+		PlaceID           string   `json:"placeId" binding:"required"`
+		DisplayName       string   `json:"displayName" binding:"required"`
+		ServingModes      []string `json:"servingModes" binding:"required"`
+		AccessTimeMinutes *int     `json:"accessTimeMinutes"`
+		WalkingEdges      []struct {
+			ToNodeID           string `json:"toNodeId" binding:"required"`
+			WalkingTimeMinutes int    `json:"walkingTimeMinutes"`
+		} `json:"walkingEdges"`
 	}
 	if err := ctx.ShouldBindJSON(&req); err != nil {
 		httpkit.WriteError(ctx, http.StatusBadRequest, httpkit.ValidationFailed, "invalid request body: "+err.Error(), nil)
 		return
 	}
-	resp, err := h.svc.CreateTransportNode(ctx.Request.Context(), application.CreateTransportNodeRequest{PlaceID: req.PlaceID, DisplayName: req.DisplayName, ServingModes: req.ServingModes, CorrelationID: correlationID(ctx)})
+	walkingEdges := make([]application.WalkingEdgeRequest, len(req.WalkingEdges))
+	for i, edge := range req.WalkingEdges {
+		walkingEdges[i] = application.WalkingEdgeRequest{ToNodeID: edge.ToNodeID, WalkingTimeMinutes: edge.WalkingTimeMinutes}
+	}
+	resp, err := h.svc.CreateTransportNode(ctx.Request.Context(), application.CreateTransportNodeRequest{PlaceID: req.PlaceID, DisplayName: req.DisplayName, ServingModes: req.ServingModes, AccessTimeMinutes: req.AccessTimeMinutes, WalkingEdges: walkingEdges, CorrelationID: correlationID(ctx)})
 	if err != nil {
 		h.writeApplicationError(ctx, err)
 		return

--- a/services/place-network/internal/http/handler_test.go
+++ b/services/place-network/internal/http/handler_test.go
@@ -114,7 +114,7 @@ func TestCreateTransportNodeHappyPath(t *testing.T) {
 func TestGetTransportNodeHappyPath(t *testing.T) {
 	router := setupTestRouter(nil)
 	place := createPlace(t, router, "Beijing South", "STATION", "0194f2e0-7b3e-7007-8284-5c26e8b00007")
-	createdRec := performJSON(router, http.MethodPost, "/api/v1/transport-nodes", map[string]any{"placeId": place.PlaceID, "displayName": "Platform 2", "servingModes": []string{"TRAIN"}}, "0194f2e0-7b3e-7008-8284-5c26e8b00008")
+	createdRec := performJSON(router, http.MethodPost, "/api/v1/transport-nodes", map[string]any{"placeId": place.PlaceID, "displayName": "Platform 2", "servingModes": []string{"TRAIN"}, "accessTimeMinutes": 7, "walkingEdges": []map[string]any{{"toNodeId": "tnd-next", "walkingTimeMinutes": 5}}}, "0194f2e0-7b3e-7008-8284-5c26e8b00008")
 	var created application.CreateTransportNodeResponse
 	decode(t, createdRec, &created)
 	rec := perform(router, http.MethodGet, "/api/v1/transport-nodes/"+created.NodeID, nil)
@@ -123,7 +123,7 @@ func TestGetTransportNodeHappyPath(t *testing.T) {
 	}
 	var resp application.GetTransportNodeResponse
 	decode(t, rec, &resp)
-	if resp.NodeID != created.NodeID || resp.PlaceID != place.PlaceID || resp.CreatedAt != "2026-07-05T10:30:00Z" {
+	if resp.NodeID != created.NodeID || resp.PlaceID != place.PlaceID || resp.CreatedAt != "2026-07-05T10:30:00Z" || resp.AccessTimeMinutes == nil || *resp.AccessTimeMinutes != 7 || len(resp.WalkingEdges) != 1 || resp.WalkingEdges[0].ToNodeID != "tnd-next" || resp.WalkingEdges[0].WalkingTimeMinutes != 5 {
 		t.Fatalf("unexpected response: %#v", resp)
 	}
 }

--- a/services/transfer-management/src/transfer_management/application/service.py
+++ b/services/transfer-management/src/transfer_management/application/service.py
@@ -264,8 +264,7 @@ def _can_use_builtin_mct(data: Mapping[str, Any], from_mode: TransferMode, to_mo
 def _topology_weighted_mct_minutes(topology: TopologySnapshot | None) -> int | None:
     if topology is None:
         return None
-    minutes = topology.mctAccessTimeMinutes
-    return minutes if minutes is not None and minutes > 0 else None
+    return topology.mctAccessTimeMinutes
 
 
 def _leg_ref(leg: Mapping[str, Any], index: int) -> str:

--- a/services/transfer-management/src/transfer_management/application/service.py
+++ b/services/transfer-management/src/transfer_management/application/service.py
@@ -52,7 +52,7 @@ from transfer_management.domain import (
     require_text,
 )
 from transfer_management.downstream import DisruptionRecoveryClient, DownstreamError
-from transfer_management.topology import PlaceNetworkClient, PlaceNetworkUnavailable, PlaceNetworkValidationError
+from transfer_management.topology import PlaceNetworkClient, PlaceNetworkUnavailable, PlaceNetworkValidationError, TopologySnapshot
 
 PRODUCER = "transfer-management"
 PROTECTED_TYPES = {ContractType.PROTECTED, ContractType.SUPPLIER_PROTECTED}
@@ -261,6 +261,13 @@ def _can_use_builtin_mct(data: Mapping[str, Any], from_mode: TransferMode, to_mo
     )
 
 
+def _topology_weighted_mct_minutes(topology: TopologySnapshot | None) -> int | None:
+    if topology is None:
+        return None
+    minutes = topology.mctAccessTimeMinutes
+    return minutes if minutes is not None and minutes > 0 else None
+
+
 def _leg_ref(leg: Mapping[str, Any], index: int) -> str:
     return str(leg.get("serviceSegmentRef") or leg.get("segmentRef") or leg.get("servicePlanRef") or f"leg-{index}")
 
@@ -415,12 +422,13 @@ class TransferManagementService:
         cross_mode = _cross_mode_from_data(data, from_mode, to_mode, from_node_ref, to_node_ref)
         override = data.get("mctOverride")
         same_platform = _same_platform(data, category)
-        mct = MinimumConnectionTime.default_for(to_node_ref, from_mode, to_mode, same_platform, int(override) if override is not None else None)
+        topology_minutes = _topology_weighted_mct_minutes(topology)
+        mct = MinimumConnectionTime.default_for(to_node_ref, from_mode, to_mode, same_platform, int(override) if override is not None else topology_minutes)
         rule = self._find_published_rule(from_node_type, to_node_type, category, at)
         if rule is None:
-            if not _can_use_builtin_mct(data, from_mode, to_mode, to_node_ref, same_platform):
+            if topology_minutes is None and not _can_use_builtin_mct(data, from_mode, to_mode, to_node_ref, same_platform):
                 raise DomainError("NO_PUBLISHED_MCT_RULE")
-            rule = self._default_mct_rule(from_node_type, to_node_type, category, mct, at)
+            rule = self._default_mct_rule(from_node_type, to_node_type, category, mct, at, "PLACE_NETWORK_ACCESS_TIME" if topology_minutes is not None else "BUILTIN_STATION_POLICY")
         window_data = dict(data.get("window") or {})
         planned = parse_dt(window_data.get("plannedArrivalAt"), "window.plannedArrivalAt")
         departure = parse_dt(window_data.get("nextDepartureAt"), "window.nextDepartureAt")
@@ -744,8 +752,8 @@ class TransferManagementService:
                 events.append(_envelope(event_type, transfer_id, 1, event_payload, envelope.correlationId, envelope.eventId, at))
         return events
 
-    def _default_mct_rule(self, from_type: NodeType, to_type: NodeType, category: TransferCategory, mct: MinimumConnectionTime, at: datetime) -> MctRule:
-        return MctRule(f"mct-default-{mct.fromMode.value.lower()}-{mct.toMode.value.lower()}-{category.value.lower()}", 1, MctRuleStatus.PUBLISHED, from_type, to_type, category, mct.minutes, {"source": "BUILTIN_STATION_POLICY", "stationRef": mct.stationRef}, at, publishedAt=at)
+    def _default_mct_rule(self, from_type: NodeType, to_type: NodeType, category: TransferCategory, mct: MinimumConnectionTime, at: datetime, source: str = "BUILTIN_STATION_POLICY") -> MctRule:
+        return MctRule(f"mct-default-{mct.fromMode.value.lower()}-{mct.toMode.value.lower()}-{category.value.lower()}", 1, MctRuleStatus.PUBLISHED, from_type, to_type, category, mct.minutes, {"source": source, "stationRef": mct.stationRef}, at, publishedAt=at)
 
     def _carrier_responsible(self, connection: Connection) -> bool:
         return connection.guaranteed or connection.contractType in PROTECTED_TYPES
@@ -818,7 +826,7 @@ class TransferManagementService:
             policy = TransferRiskPolicy("builtin", "builtin-v1", RiskPolicyStatus.ACTIVE, RiskThresholds(10, 0), ActorRef("SYSTEM", "transfer-management"), at, at)
         level, reasons = policy.classify(window.availableMinutes, window.bufferMinutes, tuple(extra_reasons))
         degraded = tuple(dict.fromkeys(degraded_reasons))
-        return RiskEvaluation(evaluation_id, level, rule.mctRuleId, rule.version, window.availableMinutes, rule.minimumMinutes, reasons, at, policy.version, place_graph_version, bool(degraded), degraded)
+        return RiskEvaluation(evaluation_id, level, rule.mctRuleId, rule.version, window.availableMinutes, window.mctMinutes, reasons, at, policy.version, place_graph_version, bool(degraded), degraded)
 
     def _refresh_connection(self, connection: Connection, at: datetime, correlation_id: str, causation_id: str, report: SegmentStatusReport | None) -> tuple[Connection, list[EventEnvelope]]:
         previous_status = connection.status

--- a/services/transfer-management/src/transfer_management/domain.py
+++ b/services/transfer-management/src/transfer_management/domain.py
@@ -202,8 +202,8 @@ class MinimumConnectionTime:
 
     def __post_init__(self) -> None:
         require_text(self.stationRef, "stationRef")
-        if self.minutes <= 0:
-            raise DomainError("minimum connection time must be positive")
+        if self.minutes < 0:
+            raise DomainError("minimum connection time must be non-negative")
 
     @classmethod
     def default_for(cls, station_ref: str, from_mode: TransferMode = TransferMode.TRAIN, to_mode: TransferMode = TransferMode.TRAIN, same_platform: bool = False, override_minutes: int | None = None) -> "MinimumConnectionTime":
@@ -669,8 +669,8 @@ class MctRule:
     retiredAt: datetime | None = None
 
     def __post_init__(self) -> None:
-        if self.minimumMinutes <= 0:
-            raise DomainError("minimumMinutes must be positive")
+        if self.minimumMinutes < 0:
+            raise DomainError("minimumMinutes must be non-negative")
 
     def update(self, data: Mapping[str, Any]) -> "MctRule":
         if self.status is MctRuleStatus.PUBLISHED:
@@ -678,8 +678,8 @@ class MctRule:
         if self.status is MctRuleStatus.RETIRED:
             raise PreconditionFailed("retired MCT rules are immutable")
         minimum = int(data.get("minimumMinutes", self.minimumMinutes))
-        if minimum <= 0:
-            raise DomainError("minimumMinutes must be positive")
+        if minimum < 0:
+            raise DomainError("minimumMinutes must be non-negative")
         return replace(self, minimumMinutes=minimum, conditions=dict(data.get("conditions", self.conditions)), validFrom=optional_dt(data.get("validFrom")) or self.validFrom, validUntil=optional_dt(data.get("validUntil")) if "validUntil" in data else self.validUntil, version=self.version + 1)
 
     def publish(self, at: datetime) -> "MctRule":

--- a/services/transfer-management/src/transfer_management/topology.py
+++ b/services/transfer-management/src/transfer_management/topology.py
@@ -18,11 +18,19 @@ class PlaceNetworkValidationError(ValueError):
 
 
 @dataclass(frozen=True, slots=True)
+class WalkingEdge:
+    toNodeId: str
+    walkingTimeMinutes: int
+
+
+@dataclass(frozen=True, slots=True)
 class TopologyNode:
     nodeId: str
     placeId: str
     placeType: str | None
     createdAt: str | None
+    accessTimeMinutes: int | None = None
+    walkingEdges: tuple[WalkingEdge, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -35,6 +43,19 @@ class TopologySnapshot:
         from_version = self.fromNode.createdAt or "unversioned"
         to_version = self.toNode.createdAt or "unversioned"
         return f"place-network:{self.fromNode.nodeId}@{from_version}:{self.toNode.nodeId}@{to_version}"
+
+    @property
+    def mctAccessTimeMinutes(self) -> int | None:
+        values = [self.fromNode.accessTimeMinutes, self.toNode.accessTimeMinutes]
+        if any(value is not None for value in values):
+            return sum(value or 0 for value in values)
+        edge_minutes = self.walkingTimeMinutes
+        return edge_minutes
+
+    @property
+    def walkingTimeMinutes(self) -> int | None:
+        direct_edges = [edge.walkingTimeMinutes for edge in self.fromNode.walkingEdges if edge.toNodeId == self.toNode.nodeId]
+        return min(direct_edges) if direct_edges else None
 
 
 class PlaceNetworkClient:
@@ -92,7 +113,9 @@ class PlaceNetworkClient:
             raise PlaceNetworkUnavailable("place-network node response missing nodeId or placeId")
         place = self._get_json(f"/api/v1/places/{place_id}")
         place_type = str(place.get("placeType") or "") or None
-        return TopologyNode(node_id, place_id, place_type, str(node.get("createdAt") or "") or None)
+        access_time = _optional_non_negative_int(node.get("accessTimeMinutes"), "accessTimeMinutes")
+        walking_edges = _walking_edges(node.get("walkingEdges"))
+        return TopologyNode(node_id, place_id, place_type, str(node.get("createdAt") or "") or None, access_time, walking_edges)
 
     def _validate_node_type(self, node: TopologyNode, expected: NodeType, field_name: str) -> None:
         if node.placeType is None:
@@ -104,3 +127,34 @@ class PlaceNetworkClient:
         }.get(expected)
         if allowed is not None and node.placeType not in allowed:
             raise PlaceNetworkValidationError(f"{field_name} does not match place-network placeType {node.placeType}")
+
+
+def _optional_non_negative_int(value: Any, field_name: str) -> int | None:
+    if value is None:
+        return None
+    try:
+        minutes = int(value)
+    except (TypeError, ValueError) as exc:
+        raise PlaceNetworkUnavailable(f"place-network node response has invalid {field_name}") from exc
+    if minutes < 0:
+        raise PlaceNetworkUnavailable(f"place-network node response has negative {field_name}")
+    return minutes
+
+
+def _walking_edges(value: Any) -> tuple[WalkingEdge, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise PlaceNetworkUnavailable("place-network node response has invalid walkingEdges")
+    edges: list[WalkingEdge] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            raise PlaceNetworkUnavailable("place-network node response has invalid walkingEdges item")
+        to_node_id = str(item.get("toNodeId") or "").strip()
+        if not to_node_id:
+            raise PlaceNetworkUnavailable("place-network walkingEdges item missing toNodeId")
+        walking_time = _optional_non_negative_int(item.get("walkingTimeMinutes"), "walkingTimeMinutes")
+        if walking_time is None:
+            raise PlaceNetworkUnavailable("place-network walkingEdges item missing walkingTimeMinutes")
+        edges.append(WalkingEdge(to_node_id, walking_time))
+    return tuple(edges)

--- a/services/transfer-management/tests/test_api.py
+++ b/services/transfer-management/tests/test_api.py
@@ -18,11 +18,10 @@ def idem() -> str:
 
 
 class FakeTopology:
-    def __init__(self, place_graph_version: str = "place-network:test-v1", fail: bool = False, missing: bool = False, mct_minutes: int | None = None) -> None:
+    def __init__(self, place_graph_version: str = "place-network:test-v1", fail: bool = False, missing: bool = False) -> None:
         self.place_graph_version = place_graph_version
         self.fail = fail
         self.missing = missing
-        self.mct_minutes = mct_minutes
 
     @property
     def enabled(self):
@@ -35,13 +34,13 @@ class FakeTopology:
         if self.fail:
             from transfer_management.topology import PlaceNetworkUnavailable
             raise PlaceNetworkUnavailable("boom")
-        return type("Snapshot", (), {"placeGraphVersion": self.place_graph_version, "mctAccessTimeMinutes": self.mct_minutes})()
+        return type("Snapshot", (), {"placeGraphVersion": self.place_graph_version, "mctAccessTimeMinutes": None})()
 
     def fetch_snapshot(self, from_node_ref, to_node_ref):
         if self.fail:
             from transfer_management.topology import PlaceNetworkUnavailable
             raise PlaceNetworkUnavailable("boom")
-        return type("Snapshot", (), {"placeGraphVersion": self.place_graph_version, "mctAccessTimeMinutes": self.mct_minutes})()
+        return type("Snapshot", (), {"placeGraphVersion": self.place_graph_version, "mctAccessTimeMinutes": None})()
 
 
 class FakeDownstream:
@@ -163,8 +162,24 @@ def test_no_matching_mct_rule_rejects_connection_registration() -> None:
     assert "NO_PUBLISHED_MCT_RULE" in con.text
 
 
-def test_topology_weighted_mct_allows_ruleless_connection_and_uses_access_time() -> None:
-    client, _, _ = setup_client(topology=FakeTopology(mct_minutes=27))
+def test_topology_weighted_mct_allows_ruleless_connection_and_uses_access_time(monkeypatch) -> None:
+    import httpx
+
+    from transfer_management.topology import PlaceNetworkClient
+
+    original_client = httpx.Client
+
+    def handler(request):
+        bodies = {
+            "/api/v1/transport-nodes/sta-a": {"nodeId": "sta-a", "placeId": "plc-a", "createdAt": "2026-01-01T00:00:00Z", "accessTimeMinutes": 11},
+            "/api/v1/transport-nodes/sta-b": {"nodeId": "sta-b", "placeId": "plc-b", "createdAt": "2026-01-01T00:05:00Z", "accessTimeMinutes": 16},
+            "/api/v1/places/plc-a": {"placeId": "plc-a", "placeType": "STATION"},
+            "/api/v1/places/plc-b": {"placeId": "plc-b", "placeType": "STATION"},
+        }
+        return httpx.Response(200, json=bodies[str(request.url.path)])
+
+    monkeypatch.setattr("transfer_management.topology.httpx.Client", lambda **kwargs: original_client(transport=httpx.MockTransport(handler), **kwargs))
+    client, _, _ = setup_client(topology=PlaceNetworkClient("http://place-network.test"))
     plan = client.post("/api/v1/transfer-plans", headers={"Idempotency-Key": idem()}, json={"itineraryRef": "iti-weighted", "planningSnapshotVersion": 1, "travelerRefs": ["trav-1"], "journeyOrderId": "jo-weighted"})
     assert plan.status_code == 201, plan.text
     now = datetime.now(UTC).replace(microsecond=0)
@@ -173,7 +188,35 @@ def test_topology_weighted_mct_allows_ruleless_connection_and_uses_access_time()
     data = con.json()
     assert data["window"]["mctMinutes"] == 27
     assert data["latestEvaluation"]["requiredMinutes"] == 27
-    assert data["latestEvaluation"]["placeGraphVersion"] == "place-network:test-v1"
+    assert data["latestEvaluation"]["placeGraphVersion"] == "place-network:sta-a@2026-01-01T00:00:00Z:sta-b@2026-01-01T00:05:00Z"
+
+
+def test_topology_weighted_mct_accepts_contracted_zero_access_time(monkeypatch) -> None:
+    import httpx
+
+    from transfer_management.topology import PlaceNetworkClient
+
+    original_client = httpx.Client
+
+    def handler(request):
+        bodies = {
+            "/api/v1/transport-nodes/sta-zero-a": {"nodeId": "sta-zero-a", "placeId": "plc-a", "accessTimeMinutes": 0},
+            "/api/v1/transport-nodes/sta-zero-b": {"nodeId": "sta-zero-b", "placeId": "plc-b", "accessTimeMinutes": 0},
+            "/api/v1/places/plc-a": {"placeId": "plc-a", "placeType": "STATION"},
+            "/api/v1/places/plc-b": {"placeId": "plc-b", "placeType": "STATION"},
+        }
+        return httpx.Response(200, json=bodies[str(request.url.path)])
+
+    monkeypatch.setattr("transfer_management.topology.httpx.Client", lambda **kwargs: original_client(transport=httpx.MockTransport(handler), **kwargs))
+    client, _, _ = setup_client(topology=PlaceNetworkClient("http://place-network.test"))
+    plan = client.post("/api/v1/transfer-plans", headers={"Idempotency-Key": idem()}, json={"itineraryRef": "iti-zero-weighted", "planningSnapshotVersion": 1, "travelerRefs": ["trav-1"], "journeyOrderId": "jo-zero-weighted"})
+    assert plan.status_code == 201, plan.text
+    now = datetime.now(UTC).replace(microsecond=0)
+    con = client.post("/api/v1/connections", headers={"Idempotency-Key": idem()}, json={"transferPlanId": plan.json()["transferPlanId"], "itineraryRef": "iti-zero-weighted", "journeyOrderId": "jo-zero-weighted", "previousSegmentRef": "seg-x", "nextSegmentRef": "seg-y", "travelerRefs": ["trav-1"], "fromNodeRef": "sta-zero-a", "toNodeRef": "sta-zero-b", "fromNodeType": "STATION", "toNodeType": "STATION", "transferCategory": "SAME_STATION", "contractId": "cct-x", "contractType": "PROTECTED", "window": {"plannedArrivalAt": rfc3339_utc(now), "nextDepartureAt": rfc3339_utc(now + timedelta(minutes=1)), "nextCutoffAt": rfc3339_utc(now + timedelta(minutes=1))}})
+    assert con.status_code == 201, con.text
+    data = con.json()
+    assert data["window"]["mctMinutes"] == 0
+    assert data["latestEvaluation"]["requiredMinutes"] == 0
 
 
 def test_evaluate_plan_without_published_rule_marks_unserviceable() -> None:

--- a/services/transfer-management/tests/test_api.py
+++ b/services/transfer-management/tests/test_api.py
@@ -18,10 +18,11 @@ def idem() -> str:
 
 
 class FakeTopology:
-    def __init__(self, place_graph_version: str = "place-network:test-v1", fail: bool = False, missing: bool = False) -> None:
+    def __init__(self, place_graph_version: str = "place-network:test-v1", fail: bool = False, missing: bool = False, mct_minutes: int | None = None) -> None:
         self.place_graph_version = place_graph_version
         self.fail = fail
         self.missing = missing
+        self.mct_minutes = mct_minutes
 
     @property
     def enabled(self):
@@ -34,13 +35,13 @@ class FakeTopology:
         if self.fail:
             from transfer_management.topology import PlaceNetworkUnavailable
             raise PlaceNetworkUnavailable("boom")
-        return type("Snapshot", (), {"placeGraphVersion": self.place_graph_version})()
+        return type("Snapshot", (), {"placeGraphVersion": self.place_graph_version, "mctAccessTimeMinutes": self.mct_minutes})()
 
     def fetch_snapshot(self, from_node_ref, to_node_ref):
         if self.fail:
             from transfer_management.topology import PlaceNetworkUnavailable
             raise PlaceNetworkUnavailable("boom")
-        return type("Snapshot", (), {"placeGraphVersion": self.place_graph_version})()
+        return type("Snapshot", (), {"placeGraphVersion": self.place_graph_version, "mctAccessTimeMinutes": self.mct_minutes})()
 
 
 class FakeDownstream:
@@ -160,6 +161,19 @@ def test_no_matching_mct_rule_rejects_connection_registration() -> None:
     con = client.post("/api/v1/connections", headers={"Idempotency-Key": idem()}, json={"transferPlanId": plan.json()["transferPlanId"], "itineraryRef": "iti-no-rule", "journeyOrderId": "jo-no-rule", "previousSegmentRef": "seg-x", "nextSegmentRef": "seg-y", "travelerRefs": ["trav-1"], "fromNodeRef": "sta", "toNodeRef": "sta", "fromNodeType": "STATION", "toNodeType": "STATION", "transferCategory": "SAME_STATION", "contractId": "cct-x", "contractType": "PROTECTED", "window": {"plannedArrivalAt": rfc3339_utc(now), "nextDepartureAt": rfc3339_utc(now + timedelta(minutes=60)), "nextCutoffAt": rfc3339_utc(now + timedelta(minutes=50))}})
     assert con.status_code == 422, con.text
     assert "NO_PUBLISHED_MCT_RULE" in con.text
+
+
+def test_topology_weighted_mct_allows_ruleless_connection_and_uses_access_time() -> None:
+    client, _, _ = setup_client(topology=FakeTopology(mct_minutes=27))
+    plan = client.post("/api/v1/transfer-plans", headers={"Idempotency-Key": idem()}, json={"itineraryRef": "iti-weighted", "planningSnapshotVersion": 1, "travelerRefs": ["trav-1"], "journeyOrderId": "jo-weighted"})
+    assert plan.status_code == 201, plan.text
+    now = datetime.now(UTC).replace(microsecond=0)
+    con = client.post("/api/v1/connections", headers={"Idempotency-Key": idem()}, json={"transferPlanId": plan.json()["transferPlanId"], "itineraryRef": "iti-weighted", "journeyOrderId": "jo-weighted", "previousSegmentRef": "seg-x", "nextSegmentRef": "seg-y", "travelerRefs": ["trav-1"], "fromNodeRef": "sta-a", "toNodeRef": "sta-b", "fromNodeType": "STATION", "toNodeType": "STATION", "transferCategory": "SAME_STATION", "contractId": "cct-x", "contractType": "PROTECTED", "window": {"plannedArrivalAt": rfc3339_utc(now), "nextDepartureAt": rfc3339_utc(now + timedelta(minutes=60)), "nextCutoffAt": rfc3339_utc(now + timedelta(minutes=60))}})
+    assert con.status_code == 201, con.text
+    data = con.json()
+    assert data["window"]["mctMinutes"] == 27
+    assert data["latestEvaluation"]["requiredMinutes"] == 27
+    assert data["latestEvaluation"]["placeGraphVersion"] == "place-network:test-v1"
 
 
 def test_evaluate_plan_without_published_rule_marks_unserviceable() -> None:


### PR DESCRIPTION
## Summary
- Amend place-network contracts and API/event shapes with optional accessTimeMinutes and walkingEdges topology weights.
- Persist/expose place-network node weights and consume them in transfer-management topology snapshots.
- Use topology-derived MCT when present with builtin fallback when weights are absent/unavailable, plus e2e coverage.

## Validation
- go test ./services/place-network/...
- uv run pytest tests/test_api.py tests/test_domain.py (services/transfer-management)