### PR TITLE
REQ-330 legacy ACL full multi-leg rebook

### DIFF
--- a/deploy/e2e/11-legacy-acl.sh
+++ b/deploy/e2e/11-legacy-acl.sh
@@ -116,4 +116,15 @@ legacy_step CANCEL /api/v1/legacy/cancel "{\"orderId\":\"$ORDER2\"}"
 REFUNDABLE=$(jget "['data']['refundAmount']['minorUnits']")
 [ "$REFUNDABLE" = "8750" ] && ok "legacy cancel refundable amount is 8750" || bad "legacy cancel refundable amount $REFUNDABLE, expected 8750"
 
+ACCT3="acc-$(uuid7)"
+echo "== 6. multi-leg rebook completes all replacement legs"
+legacy_step PRESERVE /api/v1/legacy/preserve "{\"accountId\":\"$ACCT3\",\"contactsId\":\"$TVL\",\"tripId\":\"G1234\",\"seatType\":\"SECOND\",\"date\":\"2026-08-01\",\"from\":\"$P_BJ\",\"to\":\"$P_SH\"}"
+ORDER3=$(jget "['data']['orderId']"); TOTAL3=$(jget "['data']['total']['minorUnits']")
+legacy_step INSIDE_PAYMENT /api/v1/legacy/inside_payment "{\"orderId\":\"$ORDER3\",\"price\":{\"currency\":\"CNY\",\"minorUnits\":${TOTAL3:-10750}}}"
+sleep 8
+legacy_step TICKET_ISSUE /api/v1/legacy/ticket_issue "{\"orderId\":\"$ORDER3\"}"
+legacy_step REBOOK /api/v1/legacy/rebook "{\"orderId\":\"$ORDER3\",\"date\":\"2026-08-02\",\"seatType\":\"FIRST\",\"channelRef\":{\"channel\":\"ALIPAY_SIM\"},\"replacementLegs\":[{\"from\":\"$P_BJ\",\"to\":\"$P_SH\",\"date\":\"2026-08-02\",\"price\":{\"currency\":\"CNY\",\"minorUnits\":${TOTAL3:-10750}}},{\"from\":\"$P_BJ\",\"to\":\"$P_SH\",\"date\":\"2026-08-03\",\"price\":{\"currency\":\"CNY\",\"minorUnits\":${TOTAL3:-10750}}}]}"
+REBOOKED_COUNT=$(echo "$RESP" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["data"].get("rebookedLegs", [])))' 2>/dev/null || echo 0)
+[ "$REBOOKED_COUNT" = "2" ] && ok "legacy rebook completed all replacement legs" || bad "legacy rebook completed $REBOOKED_COUNT replacement legs, expected 2"
+
 summary

--- a/docs/08-contracts/api/legacy-acl.md
+++ b/docs/08-contracts/api/legacy-acl.md
@@ -77,11 +77,22 @@ Maps to: post-sales REFUND case open → evaluate → approve. Returns
 
 **POST** `/api/v1/legacy/rebook`
 
-**Request:** `{ "orderId", "date", "seatType" }`
+**Request:** `{ "orderId", "date", "seatType" }`. For replacement
+selection, callers may additionally provide `replacementLegs[]` (each with
+`itineraryRef` + `segmentRef` or `from`/`to`/`date`, and optional `price`) or
+parallel `itineraryRefs[]` / `replacementSegmentRefs[]`. Payment capture accepts
+optional `channelRef` with `channel` (`ALIPAY_SIM`, `WECHAT_SIM`,
+`UNIONPAY_SIM`), `channelOrderId`, and `faultSeedRef`.
 
 Maps to: post-sales CHANGE case open → evaluate → approve (old ticket
-teardown); rebooking the replacement journey is the caller's follow-up
-`preserve` (phase-1 scope). Returns `data.caseId`, `data.amountDue`.
+teardown) → for every entitled original leg, fare quote → offer → replacement
+journey order → payment intent → payment capture. Each mutating downstream POST
+uses a deterministic idempotency key derived from the legacy request. Returns
+`data.caseId`, `data.amountDue`, and additive `data.rebookedLegs[]` replacement
+refs. If a later replacement leg fails after earlier replacement legs succeeded,
+returns the same legacy envelope with `status: 0`, `data.partial: true`, the
+completed `data.rebookedLegs[]`, and a deterministic failure message; it never
+reports first-leg-only success.
 
 ## Rules
 

--- a/services/legacy-acl/src/legacy_acl/application.py
+++ b/services/legacy-acl/src/legacy_acl/application.py
@@ -53,6 +53,7 @@ _PROJECTION_LAG_CODES = frozenset({
     "MISSING_TRAVELER_SNAPSHOT",
 })
 _PROJECTION_RETRY_DELAYS_SECONDS = (0.2, 0.4, 0.8, 1.6, 3.2)
+_DEFAULT_PAYMENT_CHANNEL = "ALIPAY_SIM"
 
 
 class LegacyAclService:
@@ -159,12 +160,7 @@ class LegacyAclService:
             )
             commands.append("CreatePaymentIntent")
             payment_intent_id = _required_text(intent, "paymentIntentId")
-            self.client.post(
-                "payment",
-                f"/api/v1/payment-intents/{quote(payment_intent_id)}/capture",
-                {},
-                _headers(ctx, "capture"),
-            )
+            self._capture_payment(payment_intent_id, payload, ctx, "capture")
             commands.append("CapturePayment")
             return self._finish(
                 LegacyOperation.INSIDE_PAYMENT,
@@ -251,7 +247,48 @@ class LegacyAclService:
         return self._post_sales(payload, ctx, LegacyOperation.CANCEL, "REFUND", "CUSTOMER_REQUEST", "refundableAmount", "refundAmount")
 
     def rebook(self, payload: Mapping[str, Any], ctx: LegacyContext) -> LegacyResult:
-        return self._post_sales(payload, ctx, LegacyOperation.REBOOK, "CHANGE", "CUSTOMER_CHANGE", "amountDue", "amountDue")
+        commands: list[str] = []
+        result_refs: dict[str, Any] = {"rebookedLegs": []}
+        try:
+            order_id = _required_text(payload, "orderId")
+            order = self._get_order(order_id)
+            entitlements = _ordered_entitlements(order, self._entitlements_for_order(order_id, ctx))
+            scope = _post_sales_scope(entitlements)
+            opened = self.client.post(
+                "post-sales",
+                "/api/v1/post-sales-cases",
+                {
+                    "journeyOrderId": order_id,
+                    "caseType": "CHANGE",
+                    "scope": scope,
+                    "reasonCode": "CUSTOMER_CHANGE",
+                    "actorRef": _required_text(order, "accountId"),
+                },
+                _headers(ctx, "rebook-case"),
+            )
+            commands.append("OpenPostSalesCase")
+            case_id = _required_text(opened, "caseId")
+            evaluated = self.client.post("post-sales", f"/api/v1/post-sales-cases/{quote(case_id)}/evaluate", {}, _headers(ctx, "rebook-evaluate"))
+            commands.append("EvaluatePostSalesEligibility")
+            self.client.post("post-sales", f"/api/v1/post-sales-cases/{quote(case_id)}/approve", {}, _headers(ctx, "rebook-approve"))
+            commands.append("ApprovePostSalesCase")
+            amount_due = _required_mapping(evaluated, "amountDue")
+            result_refs = {"caseId": case_id, "amountDue": amount_due, "rebookedLegs": []}
+
+            for index in range(_replacement_count(payload, len(entitlements))):
+                entitlement = entitlements[index] if index < len(entitlements) else entitlements[-1]
+                leg_result = self._rebook_leg(payload, order, entitlement, index, ctx, commands)
+                result_refs["rebookedLegs"].append(leg_result)
+
+            return self._finish(LegacyOperation.REBOOK, Outcome.SUCCEEDED, ctx, commands, result_refs, None)
+        except Exception as exc:
+            if result_refs.get("caseId") and result_refs.get("rebookedLegs"):
+                completed = len(result_refs["rebookedLegs"]) if isinstance(result_refs.get("rebookedLegs"), list) else 0
+                message = f"rebook failed after {completed} replacement leg(s): {str(exc) or exc.__class__.__name__}"
+                partial_refs = {**result_refs, "partial": True, "failureMessage": message}
+                self._publish(LegacyOperation.REBOOK, Outcome.FAILED, ctx, commands, partial_refs, message)
+                return LegacyResult(0, message, partial_refs)
+            return self._failure(LegacyOperation.REBOOK, ctx, commands, exc)
 
     def _post_sales(
         self,
@@ -302,6 +339,156 @@ class LegacyAclService:
             )
         except Exception as exc:
             return self._failure(operation, ctx, commands, exc)
+
+    def _rebook_leg(
+        self,
+        payload: Mapping[str, Any],
+        order: Mapping[str, Any],
+        entitlement: Mapping[str, Any],
+        index: int,
+        ctx: LegacyContext,
+        commands: list[str],
+    ) -> dict[str, Any]:
+        account_id = _required_text(order, "accountId")
+        traveler_ref = _required_text(entitlement, "travelerRef")
+        replacement = _replacement_leg(payload, index)
+        itinerary_ref, segment_ref = self._replacement_refs(payload, replacement, order, entitlement, index, traveler_ref, ctx, commands)
+
+        suffix = f"rebook-{index + 1}"
+        fare_quote = self.client.post(
+            "fare-pricing",
+            "/api/v1/fare-quotes",
+            {"travelerRefs": [traveler_ref], "channel": "WEB", "segmentRefs": [segment_ref]},
+            _headers(ctx, f"{suffix}-fare-quote"),
+        )
+        commands.append("CreateFareQuote")
+        offer = self._post_awaiting_projections(
+            "offer-management",
+            "/api/v1/offers",
+            {
+                "accountId": account_id,
+                "channelId": "WEB",
+                "itineraryRef": itinerary_ref,
+                "travelerRefs": [traveler_ref],
+                "quoteRequestId": str(fare_quote.get("quoteId", ctx.source_ref)),
+            },
+            _headers(ctx, f"{suffix}-offer"),
+        )
+        commands.append("CreateOffer")
+        offer_id = _required_text(offer, "offerId")
+        offer_version = _required_int(offer, "offerVersion")
+        replacement_order = self.client.post(
+            "journey-order",
+            "/api/v1/journey-orders",
+            {
+                "accountId": account_id,
+                "offerId": offer_id,
+                "offerVersion": offer_version,
+                "travelerRefs": [traveler_ref],
+                "segmentRefs": [segment_ref],
+            },
+            _headers(ctx, f"{suffix}-order"),
+        )
+        commands.append("CreateJourneyOrder")
+        replacement_order_id = _required_text(replacement_order, "orderId")
+        intent = self.client.post(
+            "payment",
+            "/api/v1/payment-intents",
+            {
+                "businessRef": replacement_order_id,
+                "purpose": "rebook",
+                "amount": _payment_amount(offer, fare_quote, replacement),
+                "payerRef": account_id,
+            },
+            _headers(ctx, f"{suffix}-payment-intent"),
+        )
+        commands.append("CreatePaymentIntent")
+        payment_intent_id = _required_text(intent, "paymentIntentId")
+        self._capture_payment(payment_intent_id, payload, ctx, f"{suffix}-capture")
+        commands.append("CapturePayment")
+        return {
+            "originalSegmentRef": _required_text(entitlement, "segmentRef"),
+            "replacementSegmentRef": segment_ref,
+            "replacementOrderId": replacement_order_id,
+            "offerId": offer_id,
+            "paymentIntentId": payment_intent_id,
+        }
+
+    def _replacement_refs(
+        self,
+        payload: Mapping[str, Any],
+        replacement: Mapping[str, Any],
+        order: Mapping[str, Any],
+        entitlement: Mapping[str, Any],
+        index: int,
+        traveler_ref: str,
+        ctx: LegacyContext,
+        commands: list[str],
+    ) -> tuple[str, str]:
+        itinerary_ref = (
+            _optional_text(replacement, "itineraryRef")
+            or _optional_indexed_text(payload, "itineraryRefs", index)
+            or _optional_text(payload, "itineraryRef")
+        )
+        segment_ref = (
+            _optional_text(replacement, "segmentRef")
+            or _optional_text(replacement, "replacementSegmentRef")
+            or _optional_indexed_text(payload, "replacementSegmentRefs", index)
+            or _optional_indexed_text(payload, "segmentRefs", index)
+        )
+        if itinerary_ref and segment_ref:
+            return itinerary_ref, segment_ref
+
+        origin = (
+            _optional_text(replacement, "from")
+            or _optional_text(replacement, "originRef")
+            or _optional_text(payload, "from")
+            or _optional_text(payload, "originRef")
+        )
+        destination = (
+            _optional_text(replacement, "to")
+            or _optional_text(replacement, "destinationRef")
+            or _optional_text(payload, "to")
+            or _optional_text(payload, "destinationRef")
+        )
+        departure_date = _optional_text(replacement, "date") or _optional_text(payload, "date")
+        if origin and destination and departure_date:
+            search = self.client.post(
+                "trip-planning",
+                "/api/v1/itineraries/search",
+                {
+                    "originRef": origin,
+                    "destinationRef": destination,
+                    "departureDate": departure_date,
+                    "travelerRefs": [traveler_ref],
+                    "channel": "WEB",
+                },
+                _headers(ctx, f"rebook-{index + 1}-search"),
+            )
+            commands.append("SearchItineraries")
+            itinerary = _first_mapping(search, "itineraries", "no replacement itinerary found")
+            leg = _indexed_mapping(itinerary, "legs", index) or _first_mapping(itinerary, "legs", "replacement itinerary contains no legs")
+            return _required_text(itinerary, "itineraryRef"), _required_text(leg, "serviceSegmentRef")
+
+        # Compatibility fallback for legacy callers that only supplied orderId/date/seatType.
+        # Reuse the original offer itinerary snapshot, so the normal quote -> offer ->
+        # order -> payment chain still has a projected itinerary to resolve against.
+        original_segment = _required_text(entitlement, "segmentRef")
+        original_offer_id = _optional_text(order, "offerId")
+        if original_offer_id:
+            original_offer = self.client.get("offer-management", f"/api/v1/offers/{quote(original_offer_id)}", _headers(ctx, f"rebook-{index + 1}-original-offer"))
+            original_itinerary_ref = _optional_text(original_offer, "itineraryRef")
+            if original_itinerary_ref:
+                return original_itinerary_ref, original_segment
+        return f"legacy-rebook:{original_segment}", original_segment
+
+    def _capture_payment(self, payment_intent_id: str, payload: Mapping[str, Any], ctx: LegacyContext, suffix: str) -> None:
+        self.client.post(
+            "payment",
+            f"/api/v1/payment-intents/{quote(payment_intent_id)}/capture",
+            {"channelRef": _channel_ref(payload)},
+            _headers(ctx, suffix),
+        )
 
     def _finish(
         self,
@@ -459,9 +646,98 @@ class LegacyAclService:
         return segment_refs[0], traveler_refs[0]
 
     def _first_entitlement(self, order_id: str) -> Mapping[str, Any]:
-        page = self.client.get("entitlement-ticketing", f"/api/v1/entitlements?journeyOrderId={quote(order_id)}&limit=20&offset=0")
-        item = _first_mapping(page, "items", "no entitlement found for order")
-        return item
+        return self._entitlements_for_order(order_id, None)[0]
+
+    def _entitlements_for_order(self, order_id: str, ctx: LegacyContext | None) -> list[Mapping[str, Any]]:
+        headers = _headers(ctx, "list-entitlements") if ctx else None
+        page = self.client.get("entitlement-ticketing", f"/api/v1/entitlements?journeyOrderId={quote(order_id)}&limit=100&offset=0", headers)
+        items = page.get("items")
+        if isinstance(items, list):
+            entitlements = [item for item in items if isinstance(item, Mapping)]
+            if entitlements:
+                return entitlements
+        raise DownstreamError("no entitlement found for order")
+
+
+def _ordered_entitlements(order: Mapping[str, Any], entitlements: list[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
+    segment_order = {segment_ref: index for index, segment_ref in enumerate(_required_string_list(order, "segmentRefs"))}
+    return sorted(entitlements, key=lambda entitlement: segment_order.get(str(entitlement.get("segmentRef", "")), len(segment_order)))
+
+
+def _post_sales_scope(entitlements: list[Mapping[str, Any]]) -> dict[str, list[str]]:
+    return {
+        "orderItemRefs": [_required_text(entitlement, "segmentBookingId") for entitlement in entitlements],
+        "segmentRefs": [_required_text(entitlement, "segmentRef") for entitlement in entitlements],
+        "travelerRefs": [_required_text(entitlement, "travelerRef") for entitlement in entitlements],
+        "entitlementRefs": [_required_text(entitlement, "entitlementId") for entitlement in entitlements],
+    }
+
+
+def _replacement_leg(payload: Mapping[str, Any], index: int) -> Mapping[str, Any]:
+    for field in ("replacementLegs", "rebookLegs", "legs", "replacementItineraries"):
+        value = payload.get(field)
+        if isinstance(value, list) and index < len(value) and isinstance(value[index], Mapping):
+            return value[index]
+    return {}
+
+
+def _replacement_count(payload: Mapping[str, Any], entitlement_count: int) -> int:
+    count = entitlement_count
+    for field in ("replacementLegs", "rebookLegs", "legs", "replacementItineraries", "itineraryRefs", "replacementSegmentRefs", "segmentRefs"):
+        value = payload.get(field)
+        if isinstance(value, list):
+            count = max(count, len(value))
+    return count
+
+
+def _payment_amount(offer: Mapping[str, Any], fare_quote: Mapping[str, Any], replacement: Mapping[str, Any]) -> Mapping[str, Any]:
+    for candidate in (replacement.get("price"), replacement.get("amount"), offer.get("total"), _nested(fare_quote, "breakdown", "total")):
+        if isinstance(candidate, Mapping) and _positive_minor_units(candidate):
+            return candidate
+    raise ValueError("replacement payment amount is required")
+
+
+def _positive_minor_units(amount: Mapping[str, Any]) -> bool:
+    value = amount.get("minorUnits")
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0 and isinstance(amount.get("currency"), str) and bool(amount.get("currency"))
+
+
+def _channel_ref(payload: Mapping[str, Any]) -> Mapping[str, str]:
+    supplied = payload.get("channelRef")
+    channel_ref: dict[str, str] = {}
+    if isinstance(supplied, Mapping):
+        for field in ("channel", "channelOrderId", "faultSeedRef"):
+            value = supplied.get(field)
+            if isinstance(value, str) and value.strip():
+                channel_ref[field] = value.strip()
+    channel = channel_ref.get("channel", _DEFAULT_PAYMENT_CHANNEL)
+    if channel not in {"ALIPAY_SIM", "WECHAT_SIM", "UNIONPAY_SIM"}:
+        raise ValueError("channelRef.channel is unsupported")
+    channel_ref["channel"] = channel
+    return channel_ref
+
+
+def _optional_text(payload: Mapping[str, Any], field: str) -> str | None:
+    value = payload.get(field)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _optional_indexed_text(payload: Mapping[str, Any], field: str, index: int) -> str | None:
+    value = payload.get(field)
+    if isinstance(value, list) and index < len(value):
+        item = value[index]
+        if isinstance(item, str) and item.strip():
+            return item.strip()
+    return None
+
+
+def _indexed_mapping(payload: Mapping[str, Any], field: str, index: int) -> Mapping[str, Any] | None:
+    value = payload.get(field)
+    if isinstance(value, list) and index < len(value) and isinstance(value[index], Mapping):
+        return value[index]
+    return None
 
 
 def _headers(ctx: LegacyContext, suffix: str) -> dict[str, str]:

--- a/services/legacy-acl/tests/test_api.py
+++ b/services/legacy-acl/tests/test_api.py
@@ -130,6 +130,10 @@ def test_inside_payment_ticket_issue_execute_cancel_and_rebook_mapping() -> None
         assert result_field in body["data"]
         if operation == "CANCEL":
             assert body["data"]["refundAmount"] == {"currency": "CNY", "minorUnits": 8750}
+        if operation == "INSIDE_PAYMENT":
+            capture = next(call for call in fake.calls if call[1] == "payment" and call[2].endswith("/capture"))
+            assert capture[3] == {"channelRef": {"channel": "ALIPAY_SIM"}}
+            assert capture[4].get("Idempotency-Key")
         assert publisher.envelopes[-1].payload["legacyOperation"] == operation
         assert publisher.envelopes[-1].payload["outcome"] == "SUCCEEDED"
 
@@ -151,6 +155,155 @@ def test_downstream_post_idempotency_keys_are_distinct_uuid7_and_stable_on_repla
     assert len(first_post_keys) == len(set(first_post_keys))
     assert all(is_uuid7(key) for key in first_post_keys)
     assert HEADERS["Idempotency-Key"] not in first_post_keys
+
+
+def test_rebook_rebooks_every_entitled_leg_with_payment_channel_refs() -> None:
+    class MultiLegFake(FakeDownstream):
+        def __init__(self) -> None:
+            super().__init__()
+            self.order_count = 0
+            self.intent_count = 0
+
+        def post(self, service: str, path: str, body: Mapping[str, Any], headers: Mapping[str, str] | None = None) -> dict[str, Any]:
+            self.calls.append(("POST", service, path, dict(body), dict(headers or {})))
+            if service == "post-sales" and path == "/api/v1/post-sales-cases":
+                assert body["scope"]["segmentRefs"] == ["seg-old-1", "seg-old-2"]
+                assert body["scope"]["entitlementRefs"] == ["ent-1", "ent-2"]
+                return {"caseId": "psc-multi"}
+            if service == "post-sales" and path.endswith("/evaluate"):
+                return {"caseId": "psc-multi", "amountDue": {"currency": "CNY", "minorUnits": 9000}}
+            if service == "post-sales" and path.endswith("/approve"):
+                return {"caseId": "psc-multi", "status": "APPROVED"}
+            if service == "fare-pricing" and path == "/api/v1/fare-quotes":
+                return {"quoteId": f"fq-{body['segmentRefs'][0]}", "breakdown": {"total": {"currency": "CNY", "minorUnits": 4500}}}
+            if service == "offer-management":
+                return {"offerId": f"off-{body['itineraryRef']}", "offerVersion": 1, "total": {"currency": "CNY", "minorUnits": 4500}}
+            if service == "journey-order" and path == "/api/v1/journey-orders":
+                self.order_count += 1
+                return {"orderId": f"ord-new-{self.order_count}", "accountId": "acc-1", "travelerRefs": body["travelerRefs"], "segmentRefs": body["segmentRefs"]}
+            if service == "payment" and path == "/api/v1/payment-intents":
+                self.intent_count += 1
+                return {"paymentIntentId": f"pi-new-{self.intent_count}"}
+            if service == "payment" and path.endswith("/capture"):
+                assert body == {"channelRef": {"channel": "WECHAT_SIM", "faultSeedRef": "seed-1"}}
+                assert headers and headers.get("Idempotency-Key")
+                return {"paymentIntentId": path.split("/")[-2], "status": "CAPTURED"}
+            raise AssertionError((service, path, body))
+
+        def get(self, service: str, path: str, headers: Mapping[str, str] | None = None) -> dict[str, Any]:
+            self.calls.append(("GET", service, path, {}, dict(headers or {})))
+            if service == "journey-order":
+                return {"orderId": "ord-multi", "accountId": "acc-1", "travelerRefs": ["tvl-1"], "segmentRefs": ["seg-old-1", "seg-old-2"]}
+            if service == "entitlement-ticketing":
+                return {
+                    "items": [
+                        {"entitlementId": "ent-1", "segmentBookingId": "sb-1", "journeyOrderId": "ord-multi", "travelerRef": "tvl-1", "segmentRef": "seg-old-1"},
+                        {"entitlementId": "ent-2", "segmentBookingId": "sb-2", "journeyOrderId": "ord-multi", "travelerRef": "tvl-1", "segmentRef": "seg-old-2"},
+                    ],
+                    "total": 2,
+                    "limit": 100,
+                    "offset": 0,
+                }
+            raise AssertionError((service, path))
+
+    fake = MultiLegFake()
+    publisher = InMemoryEventPublisher()
+    response = client(fake, publisher).post(
+        "/api/v1/legacy/rebook",
+        headers=HEADERS,
+        json={
+            "orderId": "ord-multi",
+            "date": "2026-08-02",
+            "seatType": "FIRST",
+            "channelRef": {"channel": "WECHAT_SIM", "faultSeedRef": "seed-1"},
+            "replacementLegs": [
+                {"itineraryRef": "itin-new-1", "segmentRef": "seg-new-1", "price": {"currency": "CNY", "minorUnits": 4500}},
+                {"itineraryRef": "itin-new-2", "segmentRef": "seg-new-2", "price": {"currency": "CNY", "minorUnits": 4500}},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == 1
+    assert body["data"]["caseId"] == "psc-multi"
+    assert [leg["replacementSegmentRef"] for leg in body["data"]["rebookedLegs"]] == ["seg-new-1", "seg-new-2"]
+    capture_calls = [call for call in fake.calls if call[1] == "payment" and call[2].endswith("/capture")]
+    assert len(capture_calls) == 2
+    capture_keys = [call[4]["Idempotency-Key"] for call in capture_calls]
+    assert len(capture_keys) == len(set(capture_keys))
+    assert all(is_uuid7(key) for key in capture_keys)
+    assert publisher.envelopes[-1].payload["outcome"] == "SUCCEEDED"
+    assert len(publisher.envelopes[-1].payload["resultRefs"]["rebookedLegs"]) == 2
+
+
+def test_rebook_later_leg_failure_returns_deterministic_partial_result() -> None:
+    class LaterLegFailFake(FakeDownstream):
+        def __init__(self) -> None:
+            super().__init__()
+            self.order_count = 0
+
+        def post(self, service: str, path: str, body: Mapping[str, Any], headers: Mapping[str, str] | None = None) -> dict[str, Any]:
+            self.calls.append(("POST", service, path, dict(body), dict(headers or {})))
+            if service == "post-sales" and path == "/api/v1/post-sales-cases":
+                return {"caseId": "psc-partial"}
+            if service == "post-sales" and path.endswith("/evaluate"):
+                return {"amountDue": {"currency": "CNY", "minorUnits": 9000}}
+            if service == "post-sales" and path.endswith("/approve"):
+                return {"status": "APPROVED"}
+            if service == "fare-pricing":
+                if body["segmentRefs"] == ["seg-new-2"]:
+                    raise DownstreamError("fare unavailable")
+                return {"quoteId": "fq-ok", "breakdown": {"total": {"currency": "CNY", "minorUnits": 4500}}}
+            if service == "offer-management":
+                return {"offerId": "off-ok", "offerVersion": 1, "total": {"currency": "CNY", "minorUnits": 4500}}
+            if service == "journey-order" and path == "/api/v1/journey-orders":
+                self.order_count += 1
+                return {"orderId": f"ord-new-{self.order_count}"}
+            if service == "payment" and path == "/api/v1/payment-intents":
+                return {"paymentIntentId": "pi-ok"}
+            if service == "payment" and path.endswith("/capture"):
+                return {"paymentIntentId": "pi-ok", "status": "CAPTURED"}
+            raise AssertionError((service, path, body))
+
+        def get(self, service: str, path: str, headers: Mapping[str, str] | None = None) -> dict[str, Any]:
+            self.calls.append(("GET", service, path, {}, dict(headers or {})))
+            if service == "journey-order":
+                return {"orderId": "ord-multi", "accountId": "acc-1", "travelerRefs": ["tvl-1"], "segmentRefs": ["seg-old-1", "seg-old-2"]}
+            if service == "entitlement-ticketing":
+                return {
+                    "items": [
+                        {"entitlementId": "ent-1", "segmentBookingId": "sb-1", "journeyOrderId": "ord-multi", "travelerRef": "tvl-1", "segmentRef": "seg-old-1"},
+                        {"entitlementId": "ent-2", "segmentBookingId": "sb-2", "journeyOrderId": "ord-multi", "travelerRef": "tvl-1", "segmentRef": "seg-old-2"},
+                    ],
+                    "total": 2,
+                    "limit": 100,
+                    "offset": 0,
+                }
+            raise AssertionError((service, path))
+
+    fake = LaterLegFailFake()
+    publisher = InMemoryEventPublisher()
+    response = client(fake, publisher).post(
+        "/api/v1/legacy/rebook",
+        headers=HEADERS,
+        json={
+            "orderId": "ord-multi",
+            "replacementLegs": [
+                {"itineraryRef": "itin-new-1", "segmentRef": "seg-new-1"},
+                {"itineraryRef": "itin-new-2", "segmentRef": "seg-new-2"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == 0
+    assert body["data"]["partial"] is True
+    assert len(body["data"]["rebookedLegs"]) == 1
+    assert body["msg"] == "rebook failed after 1 replacement leg(s): fare unavailable"
+    assert publisher.envelopes[-1].payload["outcome"] == "FAILED"
+    assert publisher.envelopes[-1].payload["resultRefs"]["partial"] is True
 
 
 def test_operator_header_is_required() -> None:


### PR DESCRIPTION
## Summary
- Drives legacy rebook through post-sales then quote/offer/order/payment capture for every replacement leg.
- Reuses the shared capture path so every payment capture carries channelRef and Idempotency-Key.
- Documents deterministic partial rebook failure response and adds multi-leg coverage.

## Validation
- uv run pytest -q (services/legacy-acl)
- bash -n deploy/e2e/11-legacy-acl.sh
- git diff --check