### PR TITLE
REQ-331 disruption recovery downstream touchpoints

### DIFF
--- a/docs/08-contracts/api/disruption-recovery.md
+++ b/docs/08-contracts/api/disruption-recovery.md
@@ -12,20 +12,21 @@ contract is scoped to the ADR-0002 third activation wave and is bounded by
 
 Activation-wave rulings:
 
-- The disruption signal source in this wave is **operations/system reporting** via
-  `POST /api/v1/disruptions`. The request represents Customer Service/Admin
-  manual rows or Transfer Management system reports and MUST carry
+- Disruption signal sources are **operations/system reporting** via
+  `POST /api/v1/disruptions`, plus Provider Integration and Fulfillment
+  `SegmentDelayed` / `SegmentCancelled` events. HTTP requests represent Customer
+  Service/Admin manual rows or Transfer Management system reports and MUST carry
   `disruptionType`, `scheduledServiceRef` and/or `segmentRef`, `serviceDate`,
-  `evidence`, and explicit `affectedOrderIds`. Automatic `segmentRef` to order
-  fan-out is deferred because Journey Order has no by-segment query contract.
-- Service Plan, Provider Integration, and Fulfillment event sources remain
-  deferred. Transfer Management wave 18 opens protected missed-connection
-  recovery through outbound HTTP to this API, not through a new input event.
+  `evidence`, and explicit `affectedOrderIds`. Event ingress resolves affected
+  orders from the local Journey Order `segmentRef` projection; unresolved segment
+  signals are retried through Redis rather than acknowledged.
+- Service Plan event sources remain deferred. Transfer Management wave 18 opens
+  protected missed-connection recovery through outbound HTTP to this API.
 - An `Incident` is opened or merged by the same report. This wave merges by
   `(scheduledServiceRef, serviceDate)` when `scheduledServiceRef` is present;
   otherwise the report opens a distinct incident for its supplied scope.
-- `ServiceAlert` is event-only in this wave. Disruption Recovery publishes
-  `ServiceAlertPublished`; the ServiceAlert read model is deferred.
+- `ServiceAlertPublished` builds the Disruption Recovery ServiceAlert read
+  model exposed by `/api/v1/service-alerts`.
 - The `RecoveryCase` state machine is exactly the 10-state machine from the
   domain document (`OPENED` through `CLOSED`) and follows the transition table
   below. One `RecoveryCase` is opened for each `affectedOrderId` supplied in the
@@ -54,7 +55,7 @@ camelCase and enum values are SCREAMING_SNAKE_CASE.
 
 | Enum | Values |
 |---|---|
-| `disruptionType` | `SERVICE_DELAY`, `SERVICE_CANCELLED`, `SERVICE_SUSPENDED`, `SAILING_SUSPENDED`, `ROAD_CLOSED`, `WEATHER`, `OPERATION_RESTRICTION`, `SUPPLIER_FAILURE`, `DRIVER_CANCELLED`, `DISPATCH_FAILED`, `STOP_CHANGED`, `PORT_CALL_CHANGED`, `BATCH_SYSTEM_EVENT`, `CONNECTION_MISSED`, `MISSED_CONNECTION` |
+| `disruptionType` | `SERVICE_DELAY`, `SERVICE_CANCELLED`, `SERVICE_SUSPENDED`, `SAILING_SUSPENDED`, `ROAD_CLOSED`, `WEATHER`, `OPERATION_RESTRICTION`, `SUPPLIER_FAILURE`, `DRIVER_CANCELLED`, `DISPATCH_FAILED`, `STOP_CHANGED`, `PORT_CALL_CHANGED`, `BATCH_SYSTEM_EVENT`, `CONNECTION_MISSED`, `MISSED_CONNECTION`, `DELAY`, `CANCELLATION`, `PARTIAL`, `FORCE_MAJEURE` |
 | `incidentStatus` | `DETECTED`, `CONFIRMED`, `BATCH_PROCESSING`, `MONITORING`, `RESOLVED`, `CLOSED` |
 | `recoveryCaseStatus` | `OPENED`, `ASSESSING_IMPACT`, `OPTIONS_GENERATED`, `AWAITING_USER_CHOICE`, `EXECUTING_RECOVERY`, `MANUAL_REVIEW`, `RECOVERED`, `DECLINED`, `FAILED`, `CLOSED` |
 | `recoveryOptionType` | `WAIT`, `REFUND`, `COMPENSATION`, `REACCOMMODATION`, `MANUAL` |
@@ -125,7 +126,7 @@ option set:
 | `segmentRef` | string | no | Segment reference from the order/service plan. Required when `scheduledServiceRef` is absent. |
 | `serviceDate` | string | yes | Service operating date in ISO `YYYY-MM-DD`; used with `scheduledServiceRef` for incident merge. |
 | `evidence` | object | yes | Operational evidence object. See `Evidence`. |
-| `affectedOrderIds` | array[string] | yes | Explicit affected journey order IDs (`ord-<uuid>`). Must be non-empty; no automatic segment-to-order fan-out in this wave. |
+| `affectedOrderIds` | array[string] | yes | Explicit affected journey order IDs (`ord-<uuid>`). Must be non-empty for HTTP reports. Provider/Fulfillment segment signals resolve this list from the Journey Order segment projection. |
 | `reportedBy` | object | yes | Reporting actor. See `ActorRef`. |
 | `reportedAt` | RFC3339 UTC | yes | Report timestamp. |
 | `incidentId` | string | yes | Opened or merged incident ID (`inc-<uuid>`). |
@@ -135,7 +136,7 @@ option set:
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `evidenceRef` | string | yes | Reference to the admin/customer-service evidence record or uploaded artifact. |
-| `sourceSystem` | enum | yes | `CUSTOMER_SERVICE`, `ADMIN`, or `TRANSFER_MANAGEMENT`. Other upstream source systems are deferred. |
+| `sourceSystem` | enum | yes | `CUSTOMER_SERVICE`, `ADMIN`, `TRANSFER_MANAGEMENT`, `PROVIDER_INTEGRATION`, or `FULFILLMENT`. |
 | `sourceRecordId` | string | yes | Upstream manual-row identifier. |
 | `summary` | string | yes | Operational summary; MUST NOT include unmasked documents or other sensitive personal data. |
 | `occurredAt` | RFC3339 UTC | no | When the disruption was observed, if known. |
@@ -311,7 +312,7 @@ return the original response. Reusing the same key with a different body returns
 | `scheduledServiceRef` | string | no | Scheduled service reference. Required when `segmentRef` is absent. |
 | `segmentRef` | string | no | Segment reference. Required when `scheduledServiceRef` is absent. |
 | `serviceDate` | string | yes | ISO `YYYY-MM-DD` operating date; used with `scheduledServiceRef` for incident merge. |
-| `evidence` | object | yes | Evidence object with `sourceSystem` of `CUSTOMER_SERVICE`, `ADMIN`, or `TRANSFER_MANAGEMENT`. |
+| `evidence` | object | yes | Evidence object with `sourceSystem` of `CUSTOMER_SERVICE`, `ADMIN`, `TRANSFER_MANAGEMENT`, `PROVIDER_INTEGRATION`, or `FULFILLMENT`. |
 | `affectedOrderIds` | array[string] | yes | Explicit affected `ord-<uuid>` IDs. Must be non-empty. |
 | `reportedBy` | object | yes | Reporting actor; normally `CUSTOMER_SERVICE`, `OPERATIONS`, or `SYSTEM` for Transfer Management missed-connection reports. |
 
@@ -440,6 +441,26 @@ operations/customer service outside this public API.
 **Error codes:** `NOT_FOUND`, `PRECONDITION_FAILED`, `DOMAIN_RULE_VIOLATION`,
 `IDEMPOTENCY_KEY_REUSED`
 
+### Query Service Alerts
+
+**GET** `/api/v1/service-alerts/{serviceAlertId}` returns a `ServiceAlert`.
+
+**GET** `/api/v1/service-alerts`
+
+Query parameters:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `incidentId` | string | no | Filter alerts by parent incident. |
+| `journeyOrderId` | string | no | Filter alerts whose `affectedOrderIds` contains the order. |
+| `limit` | integer | no | Page size, 1-100; default 20. |
+| `offset` | integer | no | Page offset; default 0. |
+
+Response: `{items,total,limit,offset}` with `items` containing `ServiceAlert`
+resources in reverse `publishedAt` order.
+
+**Error codes:** `NOT_FOUND`
+
 ## Migration note for WAIT auto-through
 
 Before REQ-121, any generated `WAIT` option could be auto-selected and close the
@@ -463,10 +484,15 @@ wave:
   `MISSED_CONNECTION` cases; all other `REACCOMMODATION` generation is deferred.
 - `ApplyRecoveryDecision` / execution convergence — driven internally after
   selection and by consuming `PostSalesApplied` from `events:post-sales`.
-- `PublishServiceAlert` — publishes the event-only `ServiceAlertPublished` fact;
-  the ServiceAlert read model is deferred.
+- `PublishServiceAlert` — publishes `ServiceAlertPublished` and upserts the
+  ServiceAlert read model.
+- `ResolveSegmentAffectedOrders` — consumes `JourneyOrderCreated` from
+  `events:journey-order` into a local `segmentRef -> journeyOrderId` projection;
+  provider/fulfillment segment signals use it to fan out cases without
+  cross-service HTTP. If a segment signal arrives before the projection is ready,
+  the handler returns `HandlerResult.transient_error(...)` so Redis retries/DLQs
+  according to the messaging contract.
 
-Deferred signal sources remain out of this wave: Service Plan, Provider
-Integration, and Fulfillment events do not open incidents or cases until their
-activation waves. Transfer Management opens protected missed-connection recovery
-through this HTTP endpoint, not by publishing a Disruption Recovery input event.
+Provider Integration and Fulfillment segment delay/cancellation events are active
+Disruption Recovery sources. Transfer Management still opens protected
+missed-connection recovery through this HTTP endpoint.

--- a/docs/08-contracts/events/disruption-recovery.md
+++ b/docs/08-contracts/events/disruption-recovery.md
@@ -15,15 +15,16 @@ Activation-wave rulings:
   or Transfer Management system reports and carries a normalized
   `disruptionType`, `scheduledServiceRef` and/or `segmentRef`, `evidence`, and
   explicit `affectedOrderIds`.
-- Automatic `segmentRef` to orders fan-out is deferred because Journey Order has
-  no by-segment query contract. Service Plan, Provider Integration, and
-  Fulfillment signal events remain deferred. Transfer Management wave 18 opens
-  protected missed-connection recovery through HTTP
-  `POST /api/v1/disruptions`, not by a new inbound event.
+- Automatic `segmentRef` to orders fan-out is active through Disruption Recovery's
+  local Journey Order projection, built by consuming `JourneyOrderCreated`
+  `segmentRefs`. No new cross-service HTTP resolver is introduced. Provider
+  Integration and Fulfillment `SegmentDelayed` / `SegmentCancelled` facts open
+  recovery through this projection; unresolved segment signals return transient
+  handler results for Redis retry/DLQ handling.
 - The report opens or merges an `Incident`; merge key is
   `(scheduledServiceRef, serviceDate)` when `scheduledServiceRef` is present.
-  `ServiceAlert` is event-only in this wave: `ServiceAlertPublished` is
-  published, but the ServiceAlert read model is deferred.
+  `ServiceAlertPublished` is published and persisted into the ServiceAlert read
+  model.
 - One `RecoveryCase` is opened per explicit `affectedOrderId`. Event payload
   statuses use the exact 10-state domain machine: `OPENED`, `ASSESSING_IMPACT`,
   `OPTIONS_GENERATED`, `AWAITING_USER_CHOICE`, `EXECUTING_RECOVERY`,
@@ -46,8 +47,9 @@ Activation-wave rulings:
   idempotency key. `MANUAL` moves the case to manual review.
 - Reporting consumption of Disruption Recovery events remains deferred in this
   wave. Notification is active for traveler-facing recovery lifecycle and alert
-  facts. The only active inbound subscription is `events:post-sales`
-  `PostSalesApplied` for REFUND execution convergence.
+  facts. Active inbound subscriptions are `events:post-sales` `PostSalesApplied`,
+  `events:journey-order` `JourneyOrderCreated`, and Provider Integration /
+  Fulfillment segment delay/cancellation facts.
 
 All payload fields are camelCase, all enum values are SCREAMING_SNAKE_CASE, and
 all timestamps are RFC3339 UTC. Envelope fields, including optional trace context
@@ -78,6 +80,22 @@ Downstream HTTP commands use deterministic idempotency keys:
 | `COMPENSATION` | `POST /api/v1/benefits` with `issuanceSource=DISRUPTION_COMP` | `disruption-recovery:compensation:<caseId>:<optionId>` |
 | `REACCOMMODATION` | `POST /api/v1/connections/{connectionId}/reaccommodate` | Fold `disruption-recovery:reaccommodation:<caseId>:<optionId>:<connectionId>` into a UUID-v7 wire key. |
 
+## Normative enums
+
+### disruptionType enum
+
+`disruptionType` values accepted or emitted by Disruption Recovery are:
+`SERVICE_DELAY`, `SERVICE_CANCELLED`, `SERVICE_SUSPENDED`,
+`SAILING_SUSPENDED`, `ROAD_CLOSED`, `WEATHER`, `OPERATION_RESTRICTION`,
+`SUPPLIER_FAILURE`, `DRIVER_CANCELLED`, `DISPATCH_FAILED`, `STOP_CHANGED`,
+`PORT_CALL_CHANGED`, `BATCH_SYSTEM_EVENT`, `CONNECTION_MISSED`,
+`MISSED_CONNECTION`, `DELAY`, `CANCELLATION`, `PARTIAL`, and
+`FORCE_MAJEURE`.
+
+Provider Integration and Fulfillment `SegmentDelayed` ingress maps to `DELAY`;
+`SegmentCancelled` ingress maps to `CANCELLATION`. These emitted/accepted values
+are part of this normative enum.
+
 ## Common payload objects
 
 ### Evidence
@@ -85,7 +103,7 @@ Downstream HTTP commands use deterministic idempotency keys:
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `evidenceRef` | string | yes | Reference to the customer-service/admin evidence record. |
-| `sourceSystem` | enum | yes | `CUSTOMER_SERVICE`, `ADMIN`, or `TRANSFER_MANAGEMENT`; all other sources are deferred. |
+| `sourceSystem` | enum | yes | `CUSTOMER_SERVICE`, `ADMIN`, `TRANSFER_MANAGEMENT`, `PROVIDER_INTEGRATION`, or `FULFILLMENT`. |
 | `sourceRecordId` | string | yes | Upstream manual-row identifier. |
 | `summary` | string | yes | Operational summary; must not include unmasked documents or sensitive personal data. |
 | `occurredAt` | RFC3339 UTC | no | Observation time if known. |
@@ -364,20 +382,21 @@ Downstream HTTP commands use deterministic idempotency keys:
 | Upstream stream | Event type | Purpose |
 |---|---|---|
 | `events:post-sales` | `PostSalesApplied` | Converge a selected `REFUND` option when the downstream Post Sales case reaches `APPLIED`. |
+| `events:journey-order` | `JourneyOrderCreated` | Index `segmentRefs` by `orderId` for automatic segment fan-out. |
+| `events:fulfillment` | `SegmentDelayed`, `SegmentCancelled` | Resolve `segmentRef` to affected orders and open `DELAY` / `CANCELLATION` recovery with `evidence.sourceSystem=FULFILLMENT`. |
+| `events:provider-integration` | `SegmentDelayed`, `SegmentCancelled` | Resolve `segmentRef` to affected orders and open `DELAY` / `CANCELLATION` recovery with `evidence.sourceSystem=PROVIDER_INTEGRATION`. |
 
-No other upstream event subscription is active in this wave. Service Plan,
-Provider Integration, and Fulfillment disruption sources are deferred. Transfer
-Management protected missed-connection reports arrive over HTTP with
-`disruptionType=MISSED_CONNECTION`, `reportedBy.actorType=SYSTEM`, and
-`evidence.sourceSystem=TRANSFER_MANAGEMENT`; the same wave implementation MUST
-update Disruption Recovery code enum/validation allowlists for those values and
-MUST update e2e 17/19 expectations for the `WAIT` plus `REACCOMMODATION`
-`AWAITING_USER_CHOICE` behavior.
+Service Plan disruption sources remain deferred. Transfer Management protected
+missed-connection reports arrive over HTTP with `disruptionType=MISSED_CONNECTION`,
+`reportedBy.actorType=SYSTEM`, and `evidence.sourceSystem=TRANSFER_MANAGEMENT`.
 
-## Deferred downstream touchpoints
+## Downstream touchpoints
 
 | Downstream context | Events | Purpose |
 |---|---|---|
 | Notification | active: `ServiceAlertPublished`, `RecoveryCaseOpened`, `RecoveryOptionsGenerated`, `RecoveryOptionSelected`, `RecoveryExecutionStarted`, `RecoveryCompleted`, `RecoveryFailed` | User-facing alert, option, decision, progress, and completion notifications. `RecoveryExecutionStarted` is progress-only; refund executed / compensation issued notifications are emitted only from `RecoveryCompleted`. |
+| Journey Order | active: `JourneyOrderCreated` projection from `events:journey-order` | Maintains the local `segmentRef -> journeyOrderId` resolver used for automatic segment fan-out. |
+| Fulfillment | active: `SegmentDelayed`, `SegmentCancelled` from `events:fulfillment` | Opens `DELAY` / `CANCELLATION` recovery using affected orders resolved from `segmentRef`; unresolved segment refs return transient handler results. |
+| Provider Integration | active: `SegmentDelayed`, `SegmentCancelled` from `events:provider-integration` | Same segment-signal ingress as Fulfillment with `evidence.sourceSystem=PROVIDER_INTEGRATION`. |
 | Reporting | all Disruption Recovery events | Disruption metrics, waiver/compensation cost attribution, and operational read models. |
 | Journey Order | recovery summary events | Order-detail disruption and recovery display. |

--- a/docs/08-contracts/events/provider-integration.md
+++ b/docs/08-contracts/events/provider-integration.md
@@ -65,3 +65,29 @@ Last updated: 2026-06-28
 |---|---|---|---|
 | `entitlementId` | `EntitlementId` | yes | Platform entitlement ID. |
 | `providerReference` | `ProviderReference` | yes | Provider's ticket reference. |
+
+### SegmentDelayed
+
+| Field | Description |
+|---|---|
+| **Producer** | provider-integration |
+| **Consumers** | disruption-recovery |
+| **Trigger** | External provider reports an operational delay for a booked service segment. |
+
+**Payload:** same shape as Fulfillment `SegmentDelayed`: `segmentRef`,
+`scheduledServiceRef`, `serviceDate`, `estimatedArrivalAt`, `observedAt`, and
+`sourceSystem`. Disruption Recovery maps this event to
+`disruptionType=DELAY` with `evidence.sourceSystem=PROVIDER_INTEGRATION`.
+
+### SegmentCancelled
+
+| Field | Description |
+|---|---|
+| **Producer** | provider-integration |
+| **Consumers** | disruption-recovery |
+| **Trigger** | External provider reports cancellation for a booked service segment. |
+
+**Payload:** same shape as Fulfillment `SegmentCancelled`: `segmentRef`,
+`scheduledServiceRef`, `serviceDate`, `cancelledAt`, `observedAt`, and
+`sourceSystem`. Disruption Recovery maps this event to
+`disruptionType=CANCELLATION` with `evidence.sourceSystem=PROVIDER_INTEGRATION`.

--- a/docs/08-contracts/messaging.md
+++ b/docs/08-contracts/messaging.md
@@ -57,7 +57,7 @@ context.
 | 8 | `booking-orchestration` | `events:booking-orchestration` | BookingSagaStarted, SegmentReservationRequested, SegmentReservationConfirmed, SegmentReservationFailed, SegmentTicketed, SegmentBookingCancelled |
 | 9 | `payment` | `events:payment` | PaymentIntentCreated, PaymentCaptured, PaymentIntentFailed, PaymentExpired, RefundRequested, RefundSettled, RefundFailed |
 | 9a | `payment-channel` | `events:payment-channel` | ChannelOrderCreated, ChannelOrderSubmitted, ChannelOrderAccepted, ChannelOrderSucceeded, ChannelOrderFailed, ChannelOrderMissed, ChannelOrderQueryRecorded, ChannelOrderRecoveryDetected, ChannelRefundCreated, ChannelRefundSubmitted, ChannelRefundSucceeded, ChannelRefundFailed, ChannelRefundMissed, ChannelRefundQueryRecorded, ChannelRefundRecoveryDetected, ChannelStatementGenerated, ChannelStatementFrozen, ChannelStatementLineMatched, ReconciliationDiscrepancyOpened, ReconciliationDiscrepancyLinkedToFinanceCase, ReconciliationDiscrepancyResolved |
-| 10 | `provider-integration` | `events:provider-integration` | ProviderReservationConfirmed, ProviderReservationFailed, ProviderReservationCancelled, ProviderBoardingAccepted |
+| 10 | `provider-integration` | `events:provider-integration` | ProviderReservationConfirmed, ProviderReservationFailed, ProviderReservationCancelled, ProviderBoardingAccepted, SegmentDelayed, SegmentCancelled |
 | 11 | `entitlement-ticketing` | `events:entitlement-ticketing` | EntitlementIssued, EntitlementVoided, EntitlementBoarded, EntitlementSuspended, EntitlementResumed, EntitlementUsed, EntitlementIssueFailed |
 | 12 | `fulfillment` | `events:fulfillment` | BoardingVerified, NoShowRecorded, FulfillmentCompleted, EvidenceDisputeOpened, EvidenceDisputeResolved, SegmentArrived, SegmentDelayed, SegmentCancelled |
 | 13 | `post-sales` | `events:post-sales` | PostSalesCaseOpened, PostSalesRequested, PostSalesEligibilityEvaluated, PostSalesDecisionQuoted, PostSalesApproved, PostSalesRejected, PostSalesApplied, PostSalesFailed |
@@ -260,6 +260,9 @@ plus notification/finance/reporting fan-in.
 | 26 | `events:entitlement-ticketing` | `notification` | Ticketing events for user notifications |
 | 26a | `events:entitlement-ticketing` | `capacity-availability` | RULING (2026-07-07): EntitlementVoided (payload `references.segmentBookingRef`) releases the matching hold promptly. Closes the refund-applied gap: post-sales flips APPLIED on `CapacityReleased`, which previously only arrived via booking-orchestration's lazy fallback (~90s). Row 30 (release on PostSalesApplied) stays as idempotent backstop. |
 | 27 | `events:fulfillment` | `transfer-management` | subscribes only SegmentArrived, SegmentDelayed, SegmentCancelled; all other fulfillment events are explicitly ignored by transfer-management |
+| 45 | `events:fulfillment` | `disruption-recovery` | subscribes only SegmentDelayed and SegmentCancelled for recovery case ingress; unresolved segmentRef returns transient HandlerResult for retry/DLQ taxonomy |
+| 46 | `events:provider-integration` | `disruption-recovery` | subscribes only SegmentDelayed and SegmentCancelled for provider-sourced disruption ingress; unresolved segmentRef returns transient HandlerResult for retry/DLQ taxonomy |
+| 47 | `events:journey-order` | `disruption-recovery` | subscribes JourneyOrderCreated to maintain the local segmentRef to journeyOrderId projection |
 | 28 | `events:fulfillment` | `entitlement-ticketing` | BoardingVerified for entitlement lifecycle |
 | 29 | `events:post-sales` | `payment` | PostSalesApproved to trigger refund |
 | 30 | `events:post-sales` | `capacity-availability` | PostSalesApplied to release capacity |

--- a/services/disruption-recovery/migrations/001_disruption_recovery_storage.sql
+++ b/services/disruption-recovery/migrations/001_disruption_recovery_storage.sql
@@ -18,6 +18,24 @@ CREATE INDEX IF NOT EXISTS idx_recovery_case_incident_status
   ON recovery_case_snapshots ((data->>'incidentId'), (data->>'status'), (data->>'openedAt'));
 CREATE INDEX IF NOT EXISTS idx_recovery_case_post_sales_ref
   ON recovery_case_snapshots ((data->'execution'->>'externalRef'));
+CREATE TABLE IF NOT EXISTS segment_order_index (
+  segment_ref text NOT NULL,
+  journey_order_id text NOT NULL,
+  indexed_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (segment_ref, journey_order_id)
+);
+CREATE INDEX IF NOT EXISTS idx_segment_order_index_order
+  ON segment_order_index (journey_order_id);
+CREATE TABLE IF NOT EXISTS service_alert_snapshots (
+  id text PRIMARY KEY,
+  version bigint NOT NULL,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_service_alert_snapshots_incident
+  ON service_alert_snapshots ((data->>'incidentId'), (data->>'publishedAt'));
+CREATE INDEX IF NOT EXISTS idx_service_alert_snapshots_order_ids
+  ON service_alert_snapshots USING gin ((data->'affectedOrderIds'));
 CREATE TABLE IF NOT EXISTS outbox (
   seq bigserial PRIMARY KEY,
   event_id text NOT NULL UNIQUE,

--- a/services/disruption-recovery/src/disruption_recovery/adapters/messaging/__init__.py
+++ b/services/disruption-recovery/src/disruption_recovery/adapters/messaging/__init__.py
@@ -1,5 +1,16 @@
 from __future__ import annotations
 
+JOURNEY_ORDER_STREAM = "events:journey-order"
 POST_SALES_STREAM = "events:post-sales"
+FULFILLMENT_STREAM = "events:fulfillment"
+PROVIDER_INTEGRATION_STREAM = "events:provider-integration"
 
-__all__ = ["POST_SALES_STREAM"]
+INBOUND_STREAMS = (POST_SALES_STREAM, JOURNEY_ORDER_STREAM, FULFILLMENT_STREAM, PROVIDER_INTEGRATION_STREAM)
+
+__all__ = [
+    "FULFILLMENT_STREAM",
+    "INBOUND_STREAMS",
+    "JOURNEY_ORDER_STREAM",
+    "POST_SALES_STREAM",
+    "PROVIDER_INTEGRATION_STREAM",
+]

--- a/services/disruption-recovery/src/disruption_recovery/adapters/storage/postgres.py
+++ b/services/disruption-recovery/src/disruption_recovery/adapters/storage/postgres.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from train_ticket_platform.storage import OutboxAppender, ProcessedEventsGuard, SnapshotRepository
 
-from disruption_recovery.application.service import InMemoryStore, NotFoundError
+from disruption_recovery.application.service import InMemoryStore, NotFoundError, ServiceAlert
 from disruption_recovery.domain import Incident, RecoveryCase, RecoveryCaseStatus, RecoveryExecution, RecoveryOption, RecoveryOptionSet, RecoveryOptionType, ExecutionTarget
 
 
@@ -74,6 +74,15 @@ def case_from_json(data: Mapping[str, Any] | str, version: int = 0) -> RecoveryC
     return RecoveryCase(str(data["caseId"]), str(data["incidentId"]), str(data["journeyOrderId"]), dict(data["affectedScope"]), RecoveryCaseStatus(str(data["status"])), _parse_dt(str(data["openedAt"])) or datetime.now(UTC), _parse_dt(str(data["updatedAt"])) or datetime.now(UTC), _option_set_from_json(data.get("optionSet")), data.get("selectedOptionId"), _execution_from_json(data.get("execution")), version)
 
 
+def alert_to_json(alert: ServiceAlert) -> dict[str, Any]:
+    return alert.to_json()
+
+
+def alert_from_json(data: Mapping[str, Any] | str, version: int = 0) -> ServiceAlert:
+    del version
+    return ServiceAlert.from_payload(_json_obj(data))
+
+
 @dataclass
 class _UnitOfWorkState:
     connection: Any | None = None
@@ -93,6 +102,7 @@ class PostgresDisruptionRecoveryStore(InMemoryStore):
         self._outbox = outbox or OutboxAppender()
         self._incidents = SnapshotRepository("incident_snapshots")
         self._cases = SnapshotRepository("recovery_case_snapshots")
+        self._alerts = SnapshotRepository("service_alert_snapshots")
         self._processed = ProcessedEventsGuard()
 
     @contextmanager
@@ -196,6 +206,57 @@ class PostgresDisruptionRecoveryStore(InMemoryStore):
             row = conn.execute("SELECT id, version, data FROM recovery_case_snapshots WHERE data->'execution'->>'externalRef' = %s ORDER BY id LIMIT 1", (post_sales_case_id,)).fetchone()
             if not row: return None
             self._remember("case", str(row[0]), int(row[1])); return case_from_json(row[2], int(row[1]))
+        return self._with_conn(read)
+
+    def index_journey_order(self, order_id: str, segment_refs: tuple[str, ...]) -> None:
+        clean_order_id = str(order_id).strip()
+        if not clean_order_id:
+            return
+        unique_segment_refs = tuple(dict.fromkeys(str(item).strip() for item in segment_refs if str(item).strip()))
+        if not unique_segment_refs:
+            return
+        def write(conn: Any) -> None:
+            for segment_ref in unique_segment_refs:
+                conn.execute("INSERT INTO segment_order_index(segment_ref, journey_order_id) VALUES (%s, %s) ON CONFLICT DO NOTHING", (segment_ref, clean_order_id))
+        self._with_conn(write)
+
+    def find_orders_by_segment(self, segment_ref: str) -> tuple[str, ...]:
+        def read(conn: Any) -> tuple[str, ...]:
+            rows = conn.execute("SELECT journey_order_id FROM segment_order_index WHERE segment_ref = %s ORDER BY journey_order_id", (segment_ref,)).fetchall()
+            return tuple(str(row[0]) for row in rows)
+        return self._with_conn(read)
+
+    def save_service_alert(self, alert: ServiceAlert) -> None:
+        def write(conn: Any) -> None:
+            expected = self._take("service_alert", alert.serviceAlertId)
+            if expected is None and self._alerts.get(conn, alert.serviceAlertId) is not None:
+                return
+            self._alerts.save(conn, alert.serviceAlertId, alert_to_json(alert), expected)
+        self._with_conn(write)
+
+    def get_service_alert(self, service_alert_id: str) -> ServiceAlert:
+        def read(conn: Any) -> ServiceAlert:
+            snap = self._alerts.get(conn, service_alert_id)
+            if snap is None:
+                raise NotFoundError(f"service alert not found: {service_alert_id}")
+            version, data = snap; self._remember("service_alert", service_alert_id, version); return alert_from_json(data, version)
+        return self._with_conn(read)
+
+    def list_service_alerts(self, incident_id: str | None, journey_order_id: str | None, limit: int, offset: int) -> tuple[tuple[ServiceAlert, ...], int]:
+        def read(conn: Any) -> tuple[tuple[ServiceAlert, ...], int]:
+            params: list[Any] = []
+            clauses: list[str] = []
+            if incident_id:
+                clauses.append("data->>'incidentId' = %s"); params.append(incident_id)
+            if journey_order_id:
+                clauses.append("data->'affectedOrderIds' ? %s"); params.append(journey_order_id)
+            where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+            total = int(conn.execute(f"SELECT count(*) FROM service_alert_snapshots{where}", tuple(params)).fetchone()[0])
+            rows = conn.execute(f"SELECT id, version, data FROM service_alert_snapshots{where} ORDER BY data->>'publishedAt' DESC LIMIT %s OFFSET %s", tuple(params + [limit, offset])).fetchall()
+            items = []
+            for aggregate_id, version, data in rows:
+                self._remember("service_alert", str(aggregate_id), int(version)); items.append(alert_from_json(data, int(version)))
+            return tuple(items), total
         return self._with_conn(read)
 
     def append_outbox(self, envelopes: Iterable[Any]) -> None:

--- a/services/disruption-recovery/src/disruption_recovery/api.py
+++ b/services/disruption-recovery/src/disruption_recovery/api.py
@@ -14,7 +14,7 @@ from train_ticket_platform.observability import init_opentelemetry
 from train_ticket_platform.storage import DatabaseConfig, DatabasePool, OutboxRelay, PostgresIdempotencyStore, ReadinessGate, run_migrations
 from train_ticket_platform.ids import new_uuid7
 
-from .adapters.messaging import POST_SALES_STREAM
+from .adapters.messaging import INBOUND_STREAMS
 from .adapters.storage.postgres import PostgresDisruptionRecoveryStore
 from .application.service import DisruptionRecoveryService, InMemoryStore
 from .downstream import DownstreamHttpClient
@@ -156,9 +156,9 @@ def _postgres_store_from_env(app: FastAPI) -> tuple[Any, IdempotencyStore | None
     relay.start()
     subscriber = RedisEventSubscriber()
     service_holder: dict[str, Any] = {}
-    def handle(envelope: Any) -> None:
-        service_holder["service"].handle_post_sales_applied(envelope, POST_SALES_STREAM)
-    thread = subscriber.start_in_background((POST_SALES_STREAM,), "disruption-recovery", handle)
+    def handle(envelope: Any) -> Any:
+        return service_holder["service"].handle_inbound_event(envelope)
+    thread = subscriber.start_in_background(INBOUND_STREAMS, "disruption-recovery", handle)
     app.state.outbox_relay = relay
     app.state.event_subscriber = subscriber
     app.state.event_subscriber_thread = thread

--- a/services/disruption-recovery/src/disruption_recovery/application/service.py
+++ b/services/disruption-recovery/src/disruption_recovery/application/service.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from typing import Any, Mapping
 
 from train_ticket_platform.events import EventEnvelope, rfc3339_utc
+from train_ticket_platform.messaging import HandlerResult
 
 from disruption_recovery.domain import (
     ActorRef,
@@ -79,13 +80,61 @@ class DisruptionReport:
         return data
 
 
+@dataclass(frozen=True, slots=True)
+class ServiceAlert:
+    serviceAlertId: str
+    incidentId: str
+    disruptionType: str
+    serviceDate: str
+    audience: str
+    messageSummary: str
+    publishedAt: datetime
+    scheduledServiceRef: str | None = None
+    segmentRef: str | None = None
+    affectedOrderIds: tuple[str, ...] = ()
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "ServiceAlert":
+        return cls(
+            serviceAlertId=require_text(str(payload.get("serviceAlertId") or ""), "serviceAlertId"),
+            incidentId=require_text(str(payload.get("incidentId") or ""), "incidentId"),
+            disruptionType=require_text(str(payload.get("disruptionType") or ""), "disruptionType"),
+            serviceDate=require_text(str(payload.get("serviceDate") or ""), "serviceDate"),
+            audience=require_text(str(payload.get("audience") or ""), "audience"),
+            messageSummary=require_text(str(payload.get("messageSummary") or ""), "messageSummary"),
+            publishedAt=_parse_datetime(payload.get("publishedAt")) or now_utc(),
+            scheduledServiceRef=str(payload.get("scheduledServiceRef") or "").strip() or None,
+            segmentRef=str(payload.get("segmentRef") or "").strip() or None,
+            affectedOrderIds=tuple(dict.fromkeys(str(item).strip() for item in payload.get("affectedOrderIds") or [] if str(item).strip())),
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "serviceAlertId": self.serviceAlertId,
+            "incidentId": self.incidentId,
+            "disruptionType": self.disruptionType,
+            "serviceDate": self.serviceDate,
+            "audience": self.audience,
+            "affectedOrderIds": list(self.affectedOrderIds),
+            "messageSummary": self.messageSummary,
+            "publishedAt": rfc3339_utc(self.publishedAt),
+        }
+        if self.scheduledServiceRef:
+            data["scheduledServiceRef"] = self.scheduledServiceRef
+        if self.segmentRef:
+            data["segmentRef"] = self.segmentRef
+        return data
+
+
 class InMemoryStore:
     def __init__(self) -> None:
         self.incidents: dict[str, Incident] = {}
         self.incident_merge_index: dict[str, str] = {}
         self.cases: dict[str, RecoveryCase] = {}
         self.case_index: dict[tuple[str, str], str] = {}
+        self.segment_order_index: dict[str, set[str]] = {}
         self.refund_execution_index: dict[str, str] = {}
+        self.service_alerts: dict[str, ServiceAlert] = {}
         self._outbox: list[EventEnvelope] = []
         self.processed_events: set[str] = set()
 
@@ -150,6 +199,34 @@ class InMemoryStore:
             if case.execution and case.execution.externalRef == post_sales_case_id:
                 return case
         return None
+
+    def index_journey_order(self, order_id: str, segment_refs: tuple[str, ...]) -> None:
+        clean_order_id = str(order_id).strip()
+        if not clean_order_id:
+            return
+        for segment_ref in dict.fromkeys(str(item).strip() for item in segment_refs if str(item).strip()):
+            self.segment_order_index.setdefault(segment_ref, set()).add(clean_order_id)
+
+    def find_orders_by_segment(self, segment_ref: str) -> tuple[str, ...]:
+        return tuple(sorted(self.segment_order_index.get(str(segment_ref).strip(), ())))
+
+    def save_service_alert(self, alert: ServiceAlert) -> None:
+        self.service_alerts[alert.serviceAlertId] = alert
+
+    def get_service_alert(self, service_alert_id: str) -> ServiceAlert:
+        try:
+            return self.service_alerts[service_alert_id]
+        except KeyError as exc:
+            raise NotFoundError(f"service alert not found: {service_alert_id}") from exc
+
+    def list_service_alerts(self, incident_id: str | None, journey_order_id: str | None, limit: int, offset: int) -> tuple[tuple[ServiceAlert, ...], int]:
+        items = list(self.service_alerts.values())
+        if incident_id:
+            items = [alert for alert in items if alert.incidentId == incident_id]
+        if journey_order_id:
+            items = [alert for alert in items if journey_order_id in alert.affectedOrderIds]
+        items.sort(key=lambda alert: alert.publishedAt, reverse=True)
+        return tuple(items[offset: offset + limit]), len(items)
 
 
 class DownstreamPort:
@@ -236,6 +313,32 @@ class DisruptionRecoveryService:
         if callable(append):
             append(tuple(events))
 
+    def _save_service_alert(self, payload: Mapping[str, Any]) -> ServiceAlert:
+        alert = ServiceAlert.from_payload(payload)
+        save = getattr(self.store, "save_service_alert", None)
+        if callable(save):
+            save(alert)
+        return alert
+
+    def _append_service_alert_event(self, events: list[EventEnvelope], incident: Incident, disruption_type: str, service_date: str, evidence: Evidence, affected: tuple[str, ...], scheduled: str | None, segment: str | None, correlation_id: str, causation_id: str, at: datetime) -> ServiceAlert:
+        payload = {
+            "serviceAlertId": prefixed_uuid7("sal"),
+            "incidentId": incident.incidentId,
+            "disruptionType": disruption_type,
+            "serviceDate": service_date,
+            "audience": "AFFECTED_ORDERS",
+            "affectedOrderIds": list(affected),
+            "messageSummary": evidence.summary,
+            "publishedAt": rfc3339_utc(at),
+        }
+        if scheduled:
+            payload["scheduledServiceRef"] = scheduled
+        if segment:
+            payload["segmentRef"] = segment
+        alert = self._save_service_alert(payload)
+        events.append(_envelope("ServiceAlertPublished", incident.incidentId, incident.version + 2, payload, correlation_id, causation_id, at))
+        return alert
+
     def _append_declared_event(self, events: list[EventEnvelope], report: DisruptionReport, data: Mapping[str, Any], correlation_id: str, causation_id: str, at: datetime) -> Disruption:
         normalized_type = normalize_disruption_type(report.disruptionType)
         delay_minutes = _int_or_none(data.get("delayMinutes"))
@@ -307,9 +410,9 @@ class DisruptionRecoveryService:
             cases.append(case)
         mass_recovery = self._process_mass_disruption(disruption, data, affected, correlation_id, causation_id, at)
         events.extend(mass_recovery["events"])
-        events.append(_envelope("ServiceAlertPublished", incident.incidentId, incident.version + 2, {"serviceAlertId": prefixed_uuid7("sal"), "incidentId": incident.incidentId, "disruptionType": disruption_type, "serviceDate": service_date, "audience": "AFFECTED_ORDERS", "affectedOrderIds": list(affected), "messageSummary": evidence.summary, "publishedAt": rfc3339_utc(at)} | ({"scheduledServiceRef": scheduled} if scheduled else {}) | ({"segmentRef": segment} if segment else {}), correlation_id, causation_id, at))
+        alert = self._append_service_alert_event(events, incident, disruption_type, service_date, evidence, affected, scheduled, segment, correlation_id, causation_id, at)
         self._append(events)
-        response = {"disruption": report.to_json() | {"classification": disruption.to_json()}, "incident": incident.to_json(), "recoveryCases": [case.to_json() for case in cases]}
+        response = {"disruption": report.to_json() | {"classification": disruption.to_json()}, "incident": incident.to_json(), "recoveryCases": [case.to_json() for case in cases], "serviceAlert": alert.to_json()}
         if mass_recovery["summary"] is not None:
             response["massRecovery"] = mass_recovery["summary"]
         return response
@@ -365,31 +468,140 @@ class DisruptionRecoveryService:
         self._append([_envelope("RecoveryCaseClosed", case.caseId, case.version + 1, {"caseId": case.caseId, "incidentId": case.incidentId, "journeyOrderId": case.journeyOrderId, "previousStatus": previous.value, "closedBy": closed_by.to_json(), "closeReason": reason, "closedAt": rfc3339_utc(at), "status": "CLOSED"}, correlation_id, causation_id, at)])
         return case.to_json()
 
-    def handle_post_sales_applied(self, envelope: EventEnvelope, stream: str | None = None) -> bool:
+    def handle_post_sales_applied(self, envelope: EventEnvelope, stream: str | None = None) -> HandlerResult:
         if envelope.eventType != "PostSalesApplied":
-            return False
+            return HandlerResult.success()
         # The dedup claim must commit atomically with the case mutation and
         # the outbox append: a crash after a standalone claim would ack-skip
         # the upstream event forever and lose refund convergence.
         transaction = getattr(self.store, "transaction", None)
         context = transaction() if callable(transaction) else nullcontext()
-        with context:
-            mark = getattr(self.store, "mark_processed", None)
-            if callable(mark) and not mark(envelope.eventId, stream):
-                return True
-            payload = dict(envelope.payload)
-            post_sales_case_id = str(payload.get("caseId") or "")
-            case = self.store.find_case_by_post_sales_case(post_sales_case_id)
-            if case is None or case.status in TERMINAL_STATUSES:
-                return True
-            option = case.selected_option()
-            if option is None:
-                return True
-            at = now_utc()
-            case = case.complete(option, post_sales_case_id, at)
-            self.store.save_case(case)
-            self._append([self._completed_event(case, option, envelope.correlationId, envelope.eventId, at)])
-            return True
+        try:
+            with context:
+                mark = getattr(self.store, "mark_processed", None)
+                if callable(mark) and not mark(envelope.eventId, stream):
+                    return HandlerResult.success()
+                payload = dict(envelope.payload)
+                post_sales_case_id = str(payload.get("caseId") or "")
+                case = self.store.find_case_by_post_sales_case(post_sales_case_id)
+                if case is None or case.status in TERMINAL_STATUSES:
+                    return HandlerResult.success()
+                option = case.selected_option()
+                if option is None:
+                    return HandlerResult.success()
+                at = now_utc()
+                case = case.complete(option, post_sales_case_id, at)
+                self.store.save_case(case)
+                self._append([self._completed_event(case, option, envelope.correlationId, envelope.eventId, at)])
+                return HandlerResult.success()
+        except Exception as exc:
+            return HandlerResult.transient_error(str(exc))
+
+    def handle_inbound_event(self, envelope: EventEnvelope, stream: str | None = None) -> HandlerResult:
+        if envelope.eventType == "PostSalesApplied":
+            return self.handle_post_sales_applied(envelope, stream)
+        if envelope.eventType == "JourneyOrderCreated":
+            return self.handle_journey_order_created(envelope, stream)
+        if envelope.eventType in {"SegmentDelayed", "SegmentCancelled"}:
+            return self.handle_segment_signal(envelope, stream)
+        if envelope.eventType == "ServiceAlertPublished" and envelope.producer == PRODUCER:
+            return self.handle_service_alert_published(envelope, stream)
+        return HandlerResult.success()
+
+    def handle_journey_order_created(self, envelope: EventEnvelope, stream: str | None = None) -> HandlerResult:
+        if envelope.eventType != "JourneyOrderCreated":
+            return HandlerResult.success()
+        transaction = getattr(self.store, "transaction", None)
+        context = transaction() if callable(transaction) else nullcontext()
+        try:
+            with context:
+                mark = getattr(self.store, "mark_processed", None)
+                if callable(mark) and not mark(envelope.eventId, stream):
+                    return HandlerResult.success()
+                payload = dict(envelope.payload)
+                order_id = str(payload.get("orderId") or "").strip()
+                segment_refs = tuple(str(item).strip() for item in payload.get("segmentRefs") or [] if str(item).strip())
+                if not order_id or not segment_refs:
+                    return HandlerResult.fatal_error("JourneyOrderCreated requires orderId and segmentRefs")
+                index = getattr(self.store, "index_journey_order", None)
+                if not callable(index):
+                    return HandlerResult.transient_error("segment order index is unavailable")
+                index(order_id, segment_refs)
+                return HandlerResult.success()
+        except Exception as exc:
+            return HandlerResult.transient_error(str(exc))
+
+    def handle_segment_signal(self, envelope: EventEnvelope, stream: str | None = None) -> HandlerResult:
+        if envelope.eventType not in {"SegmentDelayed", "SegmentCancelled"}:
+            return HandlerResult.success()
+        payload = dict(envelope.payload)
+        segment_ref = str(payload.get("segmentRef") or "").strip()
+        service_date = str(payload.get("serviceDate") or "").strip()
+        scheduled = str(payload.get("scheduledServiceRef") or "").strip() or None
+        if not segment_ref or not service_date:
+            return HandlerResult.fatal_error(f"{envelope.eventType} requires segmentRef and serviceDate")
+        finder = getattr(self.store, "find_orders_by_segment", None)
+        if not callable(finder):
+            return HandlerResult.transient_error("segment order resolver is unavailable")
+        affected = tuple(finder(segment_ref))
+        if not affected:
+            return HandlerResult.transient_error(f"no affected orders resolved for segmentRef {segment_ref}")
+        disruption_type = "DELAY" if envelope.eventType == "SegmentDelayed" else "CANCELLATION"
+        observed_at = str(payload.get("observedAt") or payload.get("estimatedArrivalAt") or payload.get("cancelledAt") or "").strip() or None
+        report = {
+            "disruptionType": disruption_type,
+            "scheduledServiceRef": scheduled,
+            "segmentRef": segment_ref,
+            "serviceDate": service_date,
+            "evidence": {
+                "evidenceRef": envelope.eventId,
+                "sourceSystem": "PROVIDER_INTEGRATION" if envelope.producer == "provider-integration" else "FULFILLMENT",
+                "sourceRecordId": envelope.eventId,
+                "summary": _segment_signal_summary(envelope.eventType, payload),
+            },
+            "affectedOrderIds": list(affected),
+            "reportedBy": {"actorType": "SYSTEM", "actorId": envelope.producer or "segment-signal"},
+        }
+        if observed_at:
+            report["evidence"]["occurredAt"] = observed_at
+        if envelope.eventType == "SegmentDelayed":
+            delay_minutes = _delay_minutes(payload)
+            if delay_minutes is not None:
+                report["delayMinutes"] = delay_minutes
+                report["estimatedResolution"] = str(payload.get("estimatedArrivalAt"))
+        return self._handle_report_from_event(report, envelope, stream)
+
+    def handle_service_alert_published(self, envelope: EventEnvelope, stream: str | None = None) -> HandlerResult:
+        if envelope.eventType != "ServiceAlertPublished":
+            return HandlerResult.success()
+        transaction = getattr(self.store, "transaction", None)
+        context = transaction() if callable(transaction) else nullcontext()
+        try:
+            with context:
+                mark = getattr(self.store, "mark_processed", None)
+                if callable(mark) and not mark(envelope.eventId, stream):
+                    return HandlerResult.success()
+                self._save_service_alert(dict(envelope.payload))
+                return HandlerResult.success()
+        except DomainError as exc:
+            return HandlerResult.fatal_error(str(exc))
+        except Exception as exc:
+            return HandlerResult.transient_error(str(exc))
+
+    def _handle_report_from_event(self, report: Mapping[str, Any], envelope: EventEnvelope, stream: str | None) -> HandlerResult:
+        transaction = getattr(self.store, "transaction", None)
+        context = transaction() if callable(transaction) else nullcontext()
+        try:
+            with context:
+                mark = getattr(self.store, "mark_processed", None)
+                if callable(mark) and not mark(envelope.eventId, stream):
+                    return HandlerResult.success()
+                self.report_disruption(report, envelope.correlationId, envelope.eventId)
+                return HandlerResult.success()
+        except DomainError as exc:
+            return HandlerResult.fatal_error(str(exc))
+        except Exception as exc:
+            return HandlerResult.transient_error(str(exc))
 
     def _process_mass_disruption(self, disruption: Disruption, data: Mapping[str, Any], affected_order_ids: tuple[str, ...], correlation_id: str, causation_id: str, at: datetime) -> dict[str, Any]:
         batch_requested = _bool_flag(data.get("processBatches")) or len(affected_order_ids) > MassDisruptionProcessor.BATCH_SIZE
@@ -558,6 +770,25 @@ class DisruptionRecoveryService:
         response = self.downstream.reaccommodate_connection(connection_id, body, case.execution.idempotencyKey, correlation_id)
         replacement = dict(response.get("replacementConnection") or {})
         return str(replacement.get("connectionId") or response.get("replacementConnectionId") or connection_id)
+
+
+def _segment_signal_summary(event_type: str, payload: Mapping[str, Any]) -> str:
+    segment_ref = str(payload.get("segmentRef") or "segment").strip() or "segment"
+    if event_type == "SegmentDelayed":
+        eta = str(payload.get("estimatedArrivalAt") or "").strip()
+        return f"Segment {segment_ref} delayed" + (f"; estimated arrival {eta}" if eta else "")
+    return f"Segment {segment_ref} cancelled"
+
+
+def _delay_minutes(payload: Mapping[str, Any]) -> int | None:
+    raw = payload.get("delayMinutes")
+    if raw is not None and str(raw).strip():
+        return max(0, int(raw))
+    scheduled_arrival = _parse_datetime(payload.get("scheduledArrivalAt"))
+    estimated_arrival = _parse_datetime(payload.get("estimatedArrivalAt"))
+    if scheduled_arrival is None or estimated_arrival is None:
+        return None
+    return max(0, int((estimated_arrival - scheduled_arrival).total_seconds() // 60))
 
 
 def _parse_datetime(value: Any) -> datetime | None:

--- a/services/disruption-recovery/src/disruption_recovery/domain.py
+++ b/services/disruption-recovery/src/disruption_recovery/domain.py
@@ -192,7 +192,7 @@ class Evidence:
 
     def __post_init__(self) -> None:
         require_text(self.evidenceRef, "evidenceRef")
-        if self.sourceSystem not in {"CUSTOMER_SERVICE", "ADMIN", "TRANSFER_MANAGEMENT"}:
+        if self.sourceSystem not in {"CUSTOMER_SERVICE", "ADMIN", "TRANSFER_MANAGEMENT", "PROVIDER_INTEGRATION", "FULFILLMENT"}:
             raise DomainError("evidence.sourceSystem is invalid")
         require_text(self.sourceRecordId, "sourceRecordId")
         require_text(self.summary, "summary")

--- a/services/disruption-recovery/src/disruption_recovery/web/handlers.py
+++ b/services/disruption-recovery/src/disruption_recovery/web/handlers.py
@@ -95,3 +95,16 @@ def resolve_manual(case_id: str, body: ManualResolveRequest, request: Request) -
 @router.post("/recovery-cases/{case_id}/close")
 def close_case(case_id: str, body: CloseCaseRequest, request: Request) -> dict[str, Any]:
     return _service(request).close_case(case_id, body.model_dump(exclude_none=True), _corr(request), _cause(request))
+
+
+@router.get("/service-alerts/{service_alert_id}")
+def get_service_alert(service_alert_id: str, request: Request) -> dict[str, Any]:
+    return _service(request).store.get_service_alert(service_alert_id).to_json()
+
+
+@router.get("/service-alerts")
+def list_service_alerts(request: Request, incidentId: str | None = None, journeyOrderId: str | None = None, limit: int = 20, offset: int = 0) -> dict[str, Any]:
+    safe_limit = max(1, min(limit, 100))
+    safe_offset = max(0, offset)
+    items, total = _service(request).store.list_service_alerts(incidentId, journeyOrderId, safe_limit, safe_offset)
+    return {"items": [item.to_json() for item in items], "total": total, "limit": safe_limit, "offset": safe_offset}

--- a/services/disruption-recovery/tests/test_api.py
+++ b/services/disruption-recovery/tests/test_api.py
@@ -205,3 +205,22 @@ def test_reaccommodation_selection_posts_downstream_and_replay_keeps_key() -> No
     started = event_payloads(store, "RecoveryExecutionStarted")[0]
     assert started["downstreamRequest"]["connectionId"] == downstream.calls[0][0]
     assert started["downstreamRequest"]["idempotencyKey"] == first_key
+
+
+
+def test_service_alert_read_model_is_queryable() -> None:
+    store = InMemoryStore()
+    app = create_app(store=store)
+    client = TestClient(app)
+    response = client.post("/api/v1/disruptions", json=report_body(), headers={"Idempotency-Key": "0194f2e0-7b3e-7610-8000-000000000118"})
+    assert response.status_code == 202
+    service_alert = response.json()["serviceAlert"]
+
+    fetched = client.get(f"/api/v1/service-alerts/{service_alert['serviceAlertId']}")
+    assert fetched.status_code == 200
+    assert fetched.json()["incidentId"] == response.json()["incident"]["incidentId"]
+
+    listed = client.get("/api/v1/service-alerts", params={"incidentId": response.json()["incident"]["incidentId"]})
+    assert listed.status_code == 200
+    assert listed.json()["total"] == 1
+    assert listed.json()["items"][0]["serviceAlertId"] == service_alert["serviceAlertId"]

--- a/services/disruption-recovery/tests/test_messaging.py
+++ b/services/disruption-recovery/tests/test_messaging.py
@@ -1,0 +1,92 @@
+from datetime import UTC, datetime
+
+from train_ticket_platform.events import EventEnvelope
+from train_ticket_platform.messaging import HandlerStatus
+
+from disruption_recovery.application.service import DisruptionRecoveryService, InMemoryStore
+
+
+def envelope(event_id: str, event_type: str, producer: str, payload: dict) -> EventEnvelope:
+    return EventEnvelope(
+        eventId=event_id,
+        eventType=event_type,
+        occurredAt=datetime(2026, 8, 2, 9, tzinfo=UTC),
+        correlationId="corr-0194f2e0-7b3e-7610-8000-000000000900",
+        causationId="cmd-0194f2e0-7b3e-7610-8000-000000000901",
+        producer=producer,
+        schemaVersion=1,
+        payload=payload,
+    )
+
+
+def test_fulfillment_segment_signal_fans_out_to_indexed_orders_and_alert_model() -> None:
+    store = InMemoryStore()
+    service = DisruptionRecoveryService(store)
+    created = envelope(
+        "evt-0194f2e0-7b3e-7610-8000-000000000902",
+        "JourneyOrderCreated",
+        "journey-order",
+        {"orderId": "ord-0194f2e0-7b3e-7610-8000-000000000903", "segmentRefs": ["seg-0194f2e0-7b3e-7610-8000-000000000904"]},
+    )
+    assert service.handle_inbound_event(created, "events:journey-order").status is HandlerStatus.SUCCESS
+
+    delayed = envelope(
+        "evt-0194f2e0-7b3e-7610-8000-000000000905",
+        "SegmentDelayed",
+        "fulfillment",
+        {
+            "segmentRef": "seg-0194f2e0-7b3e-7610-8000-000000000904",
+            "scheduledServiceRef": "ssch-0194f2e0-7b3e-7610-8000-000000000906",
+            "serviceDate": "2026-08-02",
+            "estimatedArrivalAt": "2026-08-02T10:45:00Z",
+            "observedAt": "2026-08-02T09:30:00Z",
+            "sourceSystem": "OPS",
+        },
+    )
+    result = service.handle_inbound_event(delayed, "events:fulfillment")
+    assert result.status is HandlerStatus.SUCCESS
+    assert len(store.cases) == 1
+    case = next(iter(store.cases.values()))
+    assert case.journeyOrderId == "ord-0194f2e0-7b3e-7610-8000-000000000903"
+    assert case.affectedScope["disruptionType"] == "DELAY"
+    assert next(iter(store.service_alerts.values())).affectedOrderIds == (case.journeyOrderId,)
+
+
+def test_provider_segment_cancellation_opens_case_with_provider_source() -> None:
+    store = InMemoryStore()
+    service = DisruptionRecoveryService(store)
+    store.index_journey_order("ord-0194f2e0-7b3e-7610-8000-000000000907", ("seg-0194f2e0-7b3e-7610-8000-000000000908",))
+    cancelled = envelope(
+        "evt-0194f2e0-7b3e-7610-8000-000000000909",
+        "SegmentCancelled",
+        "provider-integration",
+        {
+            "segmentRef": "seg-0194f2e0-7b3e-7610-8000-000000000908",
+            "scheduledServiceRef": "ssch-0194f2e0-7b3e-7610-8000-000000000910",
+            "serviceDate": "2026-08-02",
+            "cancelledAt": "2026-08-02T08:00:00Z",
+            "observedAt": "2026-08-02T08:00:00Z",
+        },
+    )
+
+    result = service.handle_inbound_event(cancelled, "events:provider-integration")
+
+    assert result.status is HandlerStatus.SUCCESS
+    event_payloads = [event.payload for event in store.take_outbox() if event.eventType == "DisruptionReported"]
+    assert event_payloads[0]["disruptionType"] == "CANCELLATION"
+    assert event_payloads[0]["evidence"]["sourceSystem"] == "PROVIDER_INTEGRATION"
+    assert next(iter(store.cases.values())).affectedScope["disruptionType"] == "CANCELLATION"
+
+
+def test_unresolved_segment_signal_returns_transient_for_redis_retry() -> None:
+    service = DisruptionRecoveryService(InMemoryStore())
+    delayed = envelope(
+        "evt-0194f2e0-7b3e-7610-8000-000000000911",
+        "SegmentDelayed",
+        "fulfillment",
+        {"segmentRef": "seg-missing", "scheduledServiceRef": "ssch-1", "serviceDate": "2026-08-02", "observedAt": "2026-08-02T09:00:00Z"},
+    )
+
+    result = service.handle_inbound_event(delayed, "events:fulfillment")
+
+    assert result.status is HandlerStatus.TRANSIENT_ERROR


### PR DESCRIPTION
## Summary
- Add JourneyOrderCreated segment projection and provider/fulfillment SegmentDelayed/SegmentCancelled ingress with HandlerResult propagation for Redis retry/DLQ behavior.
- Persist and expose the ServiceAlert read model via /api/v1/service-alerts.
- Update disruption recovery contracts/enums for DELAY/CANCELLATION and PROVIDER_INTEGRATION/FULFILLMENT sources.

## Validation
- uv run --project services/disruption-recovery pytest services/disruption-recovery/tests
- python3 -m compileall services/disruption-recovery/src/disruption_recovery
- git diff --check