### PR TITLE
REQ-333 ancillary fee assessment and dynamic pricing

### DIFF
--- a/docs/08-contracts/api/ancillary-service.md
+++ b/docs/08-contracts/api/ancillary-service.md
@@ -17,10 +17,11 @@ Activation-wave rulings:
   `ServiceFulfillmentRecord` is not a separate aggregate on the wire; fulfillment
   records are facts embedded under `AncillaryOrderItem` and published as
   fulfillment-fact events.
-- Pricing is static catalog pricing in this wave. Each catalog item carries a
-  `price` Money value. Fare & Pricing `PriceQuote`, `RuleSnapshot`, and
-  `FeeAssessment` integration remains deferred; future references are carried as
-  optional informational refs only.
+- Pricing consults Fare & Pricing dynamic price rules using the normative
+  fare-pricing input hash and rule snapshot contract. Each catalog item still
+  carries a `price` Money value used as the fallback when Fare & Pricing is
+  unavailable or no applicable rule set is returned. Fee assessments are carried
+  on quoted offers and selected order items.
 - Ancillary order items reference `journeyOrderId`, `travelerRef`, and optional
   `segmentRef`; this contract does not change Journey Order HTTP or event
   contracts. Payment integration is deferred; the resource carries informational
@@ -114,7 +115,7 @@ future `COMPENSATED` closure from the wire contract.
 | `attachmentScope` | enum | yes | Binding scope for the item. |
 | `modalities` | string[] | yes | Applicable transport modes such as `TRAIN`, `AIR`, `BUS`, `FERRY`, or `TRANSFER`. |
 | `supplierRef` | string | no | Normalized supplier capability reference. |
-| `price` | Money | yes | Static catalog price for this wave. |
+| `price` | Money | yes | Catalog fallback price used when Fare & Pricing dynamic rules are unavailable or inapplicable. |
 | `currency` | string | yes | ISO-4217 currency matching `price.currency`; included for search/filter convenience. |
 | `salesWindow` | object | yes | `startAt` and `endAt` RFC3339 UTC timestamps. |
 | `serviceWindow` | object | no | Optional service-validity `startAt` and `endAt` timestamps. |
@@ -145,13 +146,16 @@ future `COMPENSATED` closure from the wire contract.
 | `serviceType` | enum | yes | Service type copied from the catalog snapshot. |
 | `attachmentScope` | enum | yes | Attachment scope copied from the catalog snapshot. |
 | `quantity` | integer | yes | Positive quantity. |
-| `unitPrice` | Money | yes | Static catalog unit price. |
+| `unitPrice` | Money | yes | Quoted unit price from Fare & Pricing dynamic rules, or the catalog fallback price when dynamic pricing is unavailable. |
 | `totalPrice` | Money | yes | `unitPrice * quantity` in minor units. |
 | `eligibility` | object | yes | Minimum eligibility result. See `EligibilityResult`. |
 | `validFrom` | RFC3339 UTC | yes | Quote validity start. |
 | `expiresAt` | RFC3339 UTC | yes | Quote expiry. |
 | `ruleSummary` | string | no | Human-readable rule summary; do not include sensitive personal data. |
-| `futurePricingRefs` | object | no | Optional informational refs reserved for deferred Fare & Pricing integration. |
+| `priceQuoteRef` | object | no | Fare & Pricing quote reference: `{quoteId, inputHash, ruleSnapshot, source}` where `inputHash` and `ruleSnapshot` use `docs/08-contracts/events/fare-pricing.md`; `source` is `FARE_PRICING` or `CATALOG_FALLBACK`. |
+| `assessedFees` | array[object] | no | Fare & Pricing fee components applied to the unit price; component shape is `{ruleId, amount, explanation, refundable}`. |
+| `feeAssessment` | object | no | Fee assessment summary using Fare & Pricing fee-assessment fields: `{assessmentId, purpose, assessedAt, originalQuoteId, fee, currency, succeeded, failedReason}`. |
+| `futurePricingRefs` | object | no | Optional informational refs for backward-compatible clients; normative pricing refs are `priceQuoteRef` and `feeAssessment`. |
 | `createdAt` | RFC3339 UTC | yes | Creation timestamp. |
 | `updatedAt` | RFC3339 UTC | yes | Last update timestamp. |
 
@@ -187,6 +191,9 @@ future `COMPENSATED` closure from the wire contract.
 | `quantity` | integer | yes | Positive quantity. |
 | `payableAmount` | Money | yes | Informational amount due for Payment/Journey Order coordination. |
 | `refundableAmount` | Money | yes | Informational amount currently recommended as refundable. |
+| `assessedFees` | array[object] | yes | Assessed fee components copied from the selected quote and multiplied by quantity; component shape is `{ruleId, amount, explanation, refundable}`. |
+| `feeAssessment` | object | no | Fee assessment summary copied from the selected quote and multiplied by quantity; shape is `{assessmentId, purpose, assessedAt, originalQuoteId, fee, currency, succeeded, failedReason}`. |
+| `priceQuoteRef` | object | no | Fare & Pricing quote reference copied from the selected quote: `{quoteId, inputHash, ruleSnapshot, source}`. |
 | `refundRecommendation` | enum | no | Latest refund suggestion, if evaluated. |
 | `refundReason` | string | no | Stable reason code or summary; no unmasked sensitive personal data. |
 | `status` | enum | yes | Nine-state order-item status. |
@@ -370,8 +377,10 @@ status after minimum eligibility collection.
 
 **POST** `/api/v1/ancillary-offers/{ancillaryOfferId}/quote`
 
-**Idempotency:** REQUIRED (`Idempotency-Key` header). Uses static catalog pricing
-for this wave.
+**Idempotency:** REQUIRED (`Idempotency-Key` header). Pricing consults Fare &
+Pricing dynamic rules with catalog price fallback; the service forwards the same
+client-generated UUID v7 key to Fare & Pricing for safe retry of the quote
+request.
 
 **Request fields:** `expectedVersion` (integer, required), optional
 `validitySeconds` (integer), and optional `clientRequestId` (string).
@@ -566,8 +575,10 @@ The following behaviors have no public HTTP endpoint in this activation wave:
 - Payment contracts are not modified. `payableAmount` and `refundableAmount` are
   information fields for future orchestration and external refund-result
   recording.
-- Fare & Pricing integration is deferred. Static catalog `price` is the only
-  authoritative price source in this wave; `futurePricingRefs` is non-normative.
+- Fare & Pricing integration is active for quoted offers and selected order
+  items. Ancillary Service uses the normative fare-pricing input hash and rule
+  snapshot contract, carries assessed fee facts, and falls back to catalog
+  `price` only when dynamic pricing is unavailable or inapplicable.
 - Additional eligibility dimensions from the domain document remain deferred:
   traveler age/documents, special needs, supplier slot capacity, provider status,
   fare-rule refundability, and bundle split rules.

--- a/docs/08-contracts/events/ancillary-service.md
+++ b/docs/08-contracts/events/ancillary-service.md
@@ -15,9 +15,10 @@ Activation-wave rulings:
   `ServiceFulfillmentRecord` concept is represented as embedded
   `fulfillmentFacts` on `AncillaryOrderItem` and as
   `AncillaryFulfillmentFactRecorded` events.
-- Catalog pricing is authoritative for this wave. Event payloads use `Money`
-  fields copied from the catalog/offer/order snapshots. Fare & Pricing quote,
-  fee assessment, and dynamic price-rule integrations are deferred.
+- Fare & Pricing dynamic price rules are authoritative when available. Event
+  payloads carry `Money` fields copied from the quoted offer/order snapshots,
+  the Fare & Pricing `RuleSnapshot`/`inputHash` references, and assessed fees.
+  Catalog price remains the fallback price when Fare & Pricing is unavailable.
 - Ancillary Service does not modify Journey Order, Payment, Fare & Pricing, or
   Entitlement contracts. Cross-context references are carried as strings such as
   `journeyOrderId`, `travelerRef`, `segmentRef`, `entitlementRef`, and optional
@@ -88,7 +89,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | `serviceType` | enum | yes | `INSURANCE`, `MEAL`, `BAGGAGE`, `CONSIGN`, `SEAT_SELECTION`, `TRANSFER_PICKUP`, `LOUNGE`, `FAST_TRACK`, or `BUNDLE`. |
 | `attachmentScope` | enum | yes | `JOURNEY`, `SEGMENT`, `TRAVELER`, `ENTITLEMENT`, `PLACE`, or `TRANSFER`. |
 | `displayName` | string | yes | Display name captured at quote/order time. |
-| `unitPrice` | Money | yes | Static catalog unit price. |
+| `unitPrice` | Money | yes | Catalog fallback unit price captured at quote/order time. |
 | `purchaseCutoffHoursBeforeDeparture` | integer | yes | Minimum cutoff used by eligibility. |
 | `eligibilityRuleVersion` | string | yes | Eligibility rule snapshot version. |
 | `fulfillmentMethod` | enum | yes | `VOUCHER`, `PROVIDER_CONFIRMATION`, `MANUAL_OPS`, or `NONE`. |
@@ -135,7 +136,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | `attachmentScope` | enum | yes | Binding scope. |
 | `modalities` | string[] | yes | Applicable transport modalities. |
 | `supplierRef` | string | no | Normalized supplier capability reference. |
-| `price` | Money | yes | Static catalog price. |
+| `price` | Money | yes | Catalog fallback price. |
 | `salesWindow` | object | yes | Sale `startAt` and `endAt` timestamps. |
 | `serviceWindow` | object | no | Service `startAt` and `endAt` timestamps when applicable. |
 | `purchaseCutoffHoursBeforeDeparture` | integer | yes | Purchase cutoff. |
@@ -196,7 +197,7 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 |---|---|
 | **Producer** | ancillary-service |
 | **Consumers** | deferred: offer-management, journey-order, notification, reporting |
-| **Trigger** | `QuoteAncillaryOffer` command succeeds after minimum eligibility and static catalog pricing. |
+| **Trigger** | `QuoteAncillaryOffer` command succeeds after minimum eligibility and Fare & Pricing dynamic-rule pricing or catalog fallback pricing. |
 
 **Payload:**
 
@@ -211,8 +212,11 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | `entitlementRef` | string | no | Entitlement proof or lookup reference. |
 | `catalogSnapshot` | object | yes | Catalog snapshot used for the quote. |
 | `quantity` | integer | yes | Positive quantity. |
-| `unitPrice` | Money | yes | Static catalog unit price. |
+| `unitPrice` | Money | yes | Dynamic-rule unit price when Fare & Pricing quoted successfully; otherwise catalog fallback unit price. |
 | `totalPrice` | Money | yes | Quoted total. |
+| `assessedFees` | array[object] | no | Unit-level assessed fee components `{ruleId, amount, explanation, refundable}`. |
+| `feeAssessment` | object | no | Fee assessment summary `{assessmentId, purpose, assessedAt, originalQuoteId, fee, currency, succeeded, failedReason}`. |
+| `priceQuoteRef` | object | no | Fare & Pricing quote reference `{quoteId, inputHash, ruleSnapshot, source}`. |
 | `eligibility` | object | yes | Minimum eligibility result. |
 | `validFrom` | RFC3339 UTC | yes | Quote validity start. |
 | `expiresAt` | RFC3339 UTC | yes | Quote expiry. |
@@ -266,6 +270,9 @@ All monetary values use the shared `Money` shape: `currency` plus integer
 | `quantity` | integer | yes | Positive quantity. |
 | `payableAmount` | Money | yes | Informational amount payable outside this domain. |
 | `refundableAmount` | Money | yes | Initial refundable amount, normally zero or the payable amount by policy. |
+| `assessedFees` | array[object] | yes | Assessed fee components copied from the selected quote and multiplied by quantity. |
+| `feeAssessment` | object | no | Fee assessment summary copied from the selected quote and multiplied by quantity. |
+| `priceQuoteRef` | object | no | Fare & Pricing quote reference copied from the selected quote. |
 | `status` | enum | yes | `SELECTED`. |
 | `selectedAt` | RFC3339 UTC | yes | Selection timestamp. |
 | `aggregateVersion` | integer | yes | Aggregate version after selection. |

--- a/services/ancillary-service/src/adapters/storage/runtime.ts
+++ b/services/ancillary-service/src/adapters/storage/runtime.ts
@@ -4,6 +4,7 @@ import { Redis } from "ioredis";
 import { MigrationRunner, OutboxAppender, OutboxRelay, PostgresIdempotencyStore, ProcessedEventsGuard, checkPostgresReadiness, createPostgresPool, streamForProducer, withTransaction, type EventEnvelope } from "@trainticket/ts-kit";
 import { type Pool } from "pg";
 import { AncillaryApplicationService } from "../../application.js";
+import { HttpFarePricingGateway, type AncillaryPricingGateway } from "../../pricing.js";
 import { PostgresAncillaryRepository } from "./repository.js";
 
 export type AncillaryStorageRuntime = Readonly<{ ready: () => Promise<boolean>; idempotencyStore: PostgresIdempotencyStore; runCommand: <T>(operation: (application: AncillaryApplicationService) => Promise<T>) => Promise<T>; handleUpstreamEvent: (envelope: EventEnvelope, stream?: string) => Promise<"ack" | "retry" | "dlq">; stop: () => Promise<void> }>;
@@ -14,22 +15,24 @@ export async function startAncillaryStorage(redisUrl = process.env.REDIS_URL ?? 
   const redis = new Redis(redisUrl, { lazyConnect: true });
   await redis.connect();
   const relay = new OutboxRelay(pool, redis, { pollIntervalMs: 250, onFailure: (error) => console.error(sanitizedErrorForLog(error)) });
+  const pricingGateway = farePricingGatewayFromEnv();
   relay.start();
   return {
     ready: () => migrations.isReady ? checkPostgresReadiness(pool) : Promise.resolve(false),
     idempotencyStore: new PostgresIdempotencyStore(pool),
-    runCommand: (operation) => withAncillaryTransaction(pool, operation),
+    runCommand: (operation) => withAncillaryTransaction(pool, operation, pricingGateway),
     handleUpstreamEvent: (envelope, stream) => withAncillaryTransaction(pool, async (application, client) => {
       const guard = new ProcessedEventsGuard(client);
       if (!await guard.tryStart(envelope.eventId, stream)) return "ack";
       return application.handleJourneyOrderCancelled(envelope);
-    }),
+    }, pricingGateway),
     stop: async () => { await relay.stop(); await Promise.allSettled([redis.quit(), pool.end()]); },
   };
 }
-async function withAncillaryTransaction<T>(pool: Pool, operation: (application: AncillaryApplicationService, client: any) => Promise<T>): Promise<T> {
-  return withTransaction(pool, async (client) => operation(new AncillaryApplicationService(new PostgresAncillaryRepository(client), new TransactionalOutboxPublisher(new OutboxAppender(client))), client));
+async function withAncillaryTransaction<T>(pool: Pool, operation: (application: AncillaryApplicationService, client: any) => Promise<T>, pricingGateway?: AncillaryPricingGateway): Promise<T> {
+  return withTransaction(pool, async (client) => operation(new AncillaryApplicationService(new PostgresAncillaryRepository(client), new TransactionalOutboxPublisher(new OutboxAppender(client)), pricingGateway), client));
 }
 class TransactionalOutboxPublisher { constructor(private readonly appender: OutboxAppender) {} async publish(envelope: EventEnvelope): Promise<void> { await this.appender.append(envelope, streamForProducer(envelope.producer)); } }
 export function migrationsDirectory(): string { return join(dirname(fileURLToPath(import.meta.url)), "../../../migrations"); }
+function farePricingGatewayFromEnv(): AncillaryPricingGateway | undefined { const baseUrl = process.env.FARE_PRICING_URL?.trim(); return baseUrl ? new HttpFarePricingGateway(baseUrl) : undefined; }
 function sanitizedErrorForLog(error: unknown): Readonly<{ name: string; message: string }> { return error instanceof Error ? { name: error.name || "Error", message: error.message || "Storage failed" } : { name: typeof error, message: "Storage failed" }; }

--- a/services/ancillary-service/src/ancillary-lifecycle.test.ts
+++ b/services/ancillary-service/src/ancillary-lifecycle.test.ts
@@ -8,8 +8,12 @@ import { AncillaryCatalogItem, AncillaryOffer, AncillaryOrderItem, type CatalogI
 
 const CORR = "corr-018f0000-0000-7000-8000-000000000118";
 
+function futureDeparture(hoursAhead = 24): string {
+  return new Date(Date.now() + hoursAhead * 3_600_000).toISOString();
+}
+
 function catalogInput(overrides: Partial<CatalogInput> = {}): CatalogInput {
-  const now = new Date("2026-07-09T10:00:00.000Z");
+  const now = new Date();
   return {
     serviceType: "MEAL",
     displayName: "Hot meal",
@@ -38,7 +42,7 @@ async function serviceWithPublishedCatalog(overrides: Partial<CatalogInput> = {}
 
 async function selectedOrderItem(overrides: Partial<CatalogInput> = {}) {
   const { service, publisher, catalog } = await serviceWithPublishedCatalog(overrides);
-  const draft = await service.draftOffer({ catalogItemId: catalog.catalogItemId, journeyOrderId: "ord-1", travelerRef: "trav-1", segmentRef: catalog.requiresSegmentRef ? "seg-1" : undefined, entitlementRef: "ent-1", departureAt: "2026-07-10T10:00:00.000Z", quantity: 2 });
+  const draft = await service.draftOffer({ catalogItemId: catalog.catalogItemId, journeyOrderId: "ord-1", travelerRef: "trav-1", segmentRef: catalog.requiresSegmentRef ? "seg-1" : undefined, entitlementRef: "ent-1", departureAt: futureDeparture(), quantity: 2 });
   const quoted = await service.quoteOffer(draft.ancillaryOfferId, { expectedVersion: draft.offerVersion }, CORR);
   const item = await service.selectOffer(quoted.ancillaryOfferId, { journeyOrderId: "ord-1", expectedVersion: quoted.offerVersion }, CORR);
   return { service, publisher, catalog, quoted, item };
@@ -71,11 +75,11 @@ describe("ancillary domain state machines", () => {
 
   it("enforces offer state rules and expiry scan", async () => {
     const { service, catalog } = await serviceWithPublishedCatalog({ attachmentScope: "JOURNEY", requiresEntitlementRef: true, requiresSegmentRef: false });
-    const ineligible = await service.draftOffer({ catalogItemId: catalog.catalogItemId, travelerRef: "trav", departureAt: "2026-07-09T10:30:00.000Z", quantity: 1 });
+    const ineligible = await service.draftOffer({ catalogItemId: catalog.catalogItemId, travelerRef: "trav", departureAt: new Date(Date.now() + 30 * 60_000).toISOString(), quantity: 1 });
     assert.equal(ineligible.status, "INELIGIBLE");
     assert.equal((await service.quoteOffer(ineligible.ancillaryOfferId, { expectedVersion: ineligible.offerVersion }, CORR)).status, "INELIGIBLE");
 
-    const draft = await service.draftOffer({ catalogItemId: catalog.catalogItemId, travelerRef: "trav", entitlementRef: "ent", departureAt: "2026-07-10T10:00:00.000Z", quantity: 1 });
+    const draft = await service.draftOffer({ catalogItemId: catalog.catalogItemId, travelerRef: "trav", entitlementRef: "ent", departureAt: futureDeparture(), quantity: 1 });
     const quoted = await service.quoteOffer(draft.ancillaryOfferId, { expectedVersion: draft.offerVersion, validitySeconds: 1 }, CORR);
     assert.equal(quoted.status, "QUOTED");
     assert.equal(await service.expireOffers(new Date(Date.parse(quoted.expiresAt) + 1), CORR), 1);
@@ -130,7 +134,7 @@ describe("ancillary integration-event regressions", () => {
     assertLastEventId(publisher, "AncillaryCatalogItemSuperseded", catalog.catalogItemId, superseded.version);
 
     const active = await serviceWithPublishedCatalog({ attachmentScope: "JOURNEY", requiresSegmentRef: false });
-    const draft = await active.service.draftOffer({ catalogItemId: active.catalog.catalogItemId, travelerRef: "trav", entitlementRef: "ent", departureAt: "2026-07-10T10:00:00.000Z", quantity: 1 });
+    const draft = await active.service.draftOffer({ catalogItemId: active.catalog.catalogItemId, travelerRef: "trav", entitlementRef: "ent", departureAt: futureDeparture(), quantity: 1 });
     const quoted = await active.service.quoteOffer(draft.ancillaryOfferId, { expectedVersion: draft.offerVersion, validitySeconds: 1 }, CORR);
     assertLastEventId(active.publisher, "AncillaryOfferQuoted", quoted.ancillaryOfferId, quoted.offerVersion);
     await active.service.expireOffers(new Date(Date.parse(quoted.expiresAt) + 1), CORR);
@@ -164,7 +168,7 @@ describe("ancillary integration-event regressions", () => {
 
   it("freezes catalog snapshots from the selected offer with unitPrice for quantity greater than one", async () => {
     const { service, publisher, catalog } = await serviceWithPublishedCatalog();
-    const draft = await service.draftOffer({ catalogItemId: catalog.catalogItemId, travelerRef: "trav", segmentRef: "seg-1", entitlementRef: "ent", departureAt: "2026-07-10T10:00:00.000Z", quantity: 3 });
+    const draft = await service.draftOffer({ catalogItemId: catalog.catalogItemId, travelerRef: "trav", segmentRef: "seg-1", entitlementRef: "ent", departureAt: futureDeparture(), quantity: 3 });
     const quoted = await service.quoteOffer(draft.ancillaryOfferId, { expectedVersion: draft.offerVersion }, CORR);
     await service.selectOffer(quoted.ancillaryOfferId, { journeyOrderId: "ord-quantity", expectedVersion: quoted.offerVersion }, CORR);
     const selected = publisher.findByEventType("AncillaryOrderItemSelected").at(-1)?.payload as any;

--- a/services/ancillary-service/src/ancillary.test.ts
+++ b/services/ancillary-service/src/ancillary.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { describe, it, mock } from "node:test";
 import { InMemoryEventPublisher, createEventEnvelope } from "@trainticket/ts-kit";
-import { AncillaryApplicationService, InMemoryAncillaryRepository, createApp, resetAncillaryStore } from "./index.js";
+import { AncillaryApplicationService, HttpFarePricingGateway, InMemoryAncillaryRepository, createApp, resetAncillaryStore, type AncillaryPricingGateway } from "./index.js";
 
 function uuid7(): string { return "018f0000-0000-7000-8000-" + Math.random().toString(16).slice(2).padEnd(12, "0").slice(0, 12); }
 function catalogBody(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -10,11 +10,23 @@ function catalogBody(overrides: Record<string, unknown> = {}): Record<string, un
 }
 async function post(app: ReturnType<typeof createApp>, url: string, body: unknown) { return await app.inject({ method: "POST", url, headers: { "idempotency-key": uuid7() }, payload: body as Record<string, unknown> }); }
 
+const dynamicPricingGateway: AncillaryPricingGateway = {
+  async quoteAncillaryPrice() {
+    return {
+      quoteId: "fq-dynamic-1",
+      inputHash: "dynamic-hash",
+      unitPrice: { currency: "CNY", minorUnits: 3200 },
+      ruleSnapshot: { ruleSetId: "frs-ancillary", ruleSetVersion: "v1", capturedAt: new Date().toISOString(), ruleIds: ["base-meal", "service-fee"], explanationCodes: ["DYNAMIC_MEAL", "SERVICE_FEE"], digest: "digest" },
+      fees: [{ ruleId: "service-fee", amount: { currency: "CNY", minorUnits: 150 }, explanation: { code: "SERVICE_FEE", parameters: {} }, refundable: false }],
+    };
+  },
+};
+
 describe("ancillary-service contract flows", () => {
-  it("creates catalog, quotes/selects offer, confirms and records fulfillment", async () => {
+  it("creates catalog, prices via dynamic rules, assesses fees, and fulfills", async () => {
     resetAncillaryStore();
     const publisher = new InMemoryEventPublisher();
-    const app = createApp({}, { publisher });
+    const app = createApp({}, { publisher, pricingGateway: dynamicPricingGateway });
     const created = await post(app, "/api/v1/ancillary-catalog-items", catalogBody());
     assert.equal(created.statusCode, 201);
     const catalog = created.json();
@@ -26,10 +38,17 @@ describe("ancillary-service contract flows", () => {
     assert.equal(draft.statusCode, 201);
     const quote = await post(app, `/api/v1/ancillary-offers/${draft.json().ancillaryOfferId}/quote`, { expectedVersion: draft.json().offerVersion, validitySeconds: 300 });
     assert.equal(quote.statusCode, 200);
-    assert.equal(quote.json().totalPrice.minorUnits, 5000);
+    assert.equal(quote.json().unitPrice.minorUnits, 3200);
+    assert.equal(quote.json().totalPrice.minorUnits, 6400);
+    assert.equal(quote.json().priceQuoteRef.source, "FARE_PRICING");
+    assert.equal(quote.json().priceQuoteRef.quoteId, "fq-dynamic-1");
+    assert.equal(quote.json().feeAssessment.fee.minorUnits, 150);
     const selected = await post(app, `/api/v1/ancillary-offers/${quote.json().ancillaryOfferId}/select`, { journeyOrderId: "ord-1", expectedVersion: quote.json().offerVersion });
     assert.equal(selected.statusCode, 201);
     assert.equal(selected.json().status, "SELECTED");
+    assert.equal(selected.json().payableAmount.minorUnits, 6400);
+    assert.equal(selected.json().feeAssessment.fee.minorUnits, 300);
+    assert.equal(selected.json().assessedFees[0].amount.minorUnits, 300);
 
     const pending = await post(app, `/api/v1/ancillary-order-items/${selected.json().ancillaryOrderItemId}/confirm`, { reasonCode: "SUPPLIER_PENDING" });
     assert.equal(pending.statusCode, 200);
@@ -40,8 +59,42 @@ describe("ancillary-service contract flows", () => {
     assert.equal(ready.json().status, "FULFILLMENT_READY");
     const fulfilled = await post(app, `/api/v1/ancillary-order-items/${selected.json().ancillaryOrderItemId}/fulfillment-facts`, { factType: "MEAL_ISSUED", occurredAt: new Date().toISOString(), performedBy: "PROVIDER", idempotencyRef: "meal-1" });
     assert.equal(fulfilled.json().status, "FULFILLED");
-    assert.deepEqual(publisher.findByEventType("AncillaryOfferQuoted")[0].payload.totalPrice, { currency: "CNY", minorUnits: 5000 });
+    assert.deepEqual(publisher.findByEventType("AncillaryOfferQuoted")[0].payload.totalPrice, { currency: "CNY", minorUnits: 6400 });
+    assert.equal((publisher.findByEventType("AncillaryOfferQuoted")[0].payload.priceQuoteRef as any).source, "FARE_PRICING");
+    assert.equal((publisher.findByEventType("AncillaryOrderItemSelected")[0].payload.feeAssessment as any).fee.minorUnits, 300);
     assert.equal(publisher.findByEventType("AncillaryOrderItemFulfilled").length, 1);
+  });
+
+  it("uses the client UUID v7 idempotency key for outbound fare-pricing quote retries", async () => {
+    const key = "018f0000-0000-7000-8000-000000000123";
+    const fetchMock = mock.fn<typeof fetch>(async (_url, init) => {
+      assert.equal((init?.headers as Record<string, string>)["idempotency-key"], key);
+      return new Response(JSON.stringify({
+        quoteId: "fq-http-1",
+        status: "QUOTED",
+        validFrom: new Date().toISOString(),
+        validUntil: new Date(Date.now() + 300000).toISOString(),
+        breakdown: { total: { currency: "CNY", minorUnits: 3100 }, fees: [] },
+      }), { status: 201, headers: { "content-type": "application/json" } });
+    });
+    const gateway = new HttpFarePricingGateway("https://fare-pricing.example", fetchMock);
+
+    const result = await gateway.quoteAncillaryPrice({
+      ancillaryOfferId: "aof-1",
+      offerVersion: 2,
+      catalogItemId: "aci-1",
+      travelerRef: "tvl-1",
+      segmentRef: "seg-1",
+      departureAt: new Date().toISOString(),
+      quantity: 1,
+      catalogUnitPrice: { currency: "CNY", minorUnits: 2500 },
+      context: {},
+      correlationId: "corr-018f0000-0000-7000-8000-000000000111",
+      idempotencyKey: key,
+    });
+
+    assert.equal(fetchMock.mock.callCount(), 1);
+    assert.equal(result?.quoteId, "fq-http-1");
   });
 
   it("rejects ineligible time windows and expires quoted offers", async () => {

--- a/services/ancillary-service/src/app.ts
+++ b/services/ancillary-service/src/app.ts
@@ -2,6 +2,7 @@ import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest }
 
 import { AncillaryApplicationService, InMemoryAncillaryRepository, isDomainError, type AncillaryRepository } from "./application.js";
 import { serviceProfile } from "./profile.js";
+import { HttpFarePricingGateway, type AncillaryPricingGateway } from "./pricing.js";
 import { InMemoryIdempotencyStore, errorMessage, handleIdempotency, headerValue, requestContext as kitRequestContext, requestFingerprint, sendError as kitSendError, type ErrorEnvelope, type EventPublisher, type IdempotencyStore, type RequestContext } from "@trainticket/ts-kit";
 
 export type HealthStatus = Readonly<{ status: "ok"; service: typeof serviceProfile }>;
@@ -18,7 +19,7 @@ type OTelSpan = Readonly<{ setAttribute?: (key: string, value: string | number) 
 type OTelTracer = Readonly<{ startSpan: (name: string, options?: Record<string, unknown>) => OTelSpan }>;
 
 type AppStorage = Readonly<{ ready: () => boolean | Promise<boolean>; runCommand?: <T>(operation: (service: AncillaryApplicationService) => Promise<T>) => Promise<T> }>;
-type AppDependencies = Readonly<{ repository?: AncillaryRepository; publisher?: EventPublisher; idempotencyStore?: IdempotencyStore; storage?: AppStorage }>;
+type AppDependencies = Readonly<{ repository?: AncillaryRepository; publisher?: EventPublisher; pricingGateway?: AncillaryPricingGateway; idempotencyStore?: IdempotencyStore; storage?: AppStorage }>;
 
 const defaultRepository = new InMemoryAncillaryRepository();
 const defaultIdempotencyStore = new InMemoryIdempotencyStore();
@@ -41,7 +42,8 @@ export function metadata(): ServiceMetadata { return { service: serviceProfile, 
 
 export function createApp(instrumentation: InstrumentationHooks = {}, dependencies: AppDependencies = {}): FastifyInstance {
   const app = Fastify({ logger: false });
-  const service = new AncillaryApplicationService(dependencies.repository ?? defaultRepository, dependencies.publisher);
+  const pricingGateway = dependencies.pricingGateway ?? farePricingGatewayFromEnv();
+  const service = new AncillaryApplicationService(dependencies.repository ?? defaultRepository, dependencies.publisher, pricingGateway);
   const idempotencyStore = dependencies.idempotencyStore ?? defaultIdempotencyStore;
   const runCommand = dependencies.storage?.runCommand ?? (<T>(operation: (svc: AncillaryApplicationService) => Promise<T>) => operation(service));
   const spans = new WeakMap<FastifyRequest, TraceSpan>();
@@ -80,7 +82,7 @@ export function createApp(instrumentation: InstrumentationHooks = {}, dependenci
   app.get("/api/v1/ancillary-catalog-items", async (request, reply) => handleRead(reply, request, () => runCommand((svc) => svc.listCatalogItems({ ...query(request), limit: limit(request), offset: offset(request) }))));
 
   stateChanging(app, idempotencyStore, "POST", "/api/v1/ancillary-offers", async (request) => ({ statusCode: 201, body: await runCommand((svc) => svc.draftOffer(request.body as any)) }), replyNoop);
-  stateChanging(app, idempotencyStore, "POST", "/api/v1/ancillary-offers/:ancillaryOfferId/quote", async (request, ctx) => ({ statusCode: 200, body: await runCommand((svc) => svc.quoteOffer(param(request, "ancillaryOfferId"), request.body as any, ctx.correlationId)) }), replyNoop);
+  stateChanging(app, idempotencyStore, "POST", "/api/v1/ancillary-offers/:ancillaryOfferId/quote", async (request, ctx) => ({ statusCode: 200, body: await runCommand((svc) => svc.quoteOffer(param(request, "ancillaryOfferId"), quoteInput(request), ctx.correlationId)) }), replyNoop);
   stateChanging(app, idempotencyStore, "POST", "/api/v1/ancillary-offers/:ancillaryOfferId/select", async (request, ctx) => ({ statusCode: 201, body: await runCommand((svc) => svc.selectOffer(param(request, "ancillaryOfferId"), request.body as any, ctx.correlationId)) }), replyNoop);
   app.get("/api/v1/ancillary-offers/:ancillaryOfferId", async (request, reply) => handleRead(reply, request, () => runCommand((svc) => svc.getOffer(param(request, "ancillaryOfferId")))));
   stateChanging(app, idempotencyStore, "POST", "/api/v1/ancillary-order-items/:ancillaryOrderItemId/confirm", async (request, ctx) => ({ statusCode: 200, body: await runCommand((svc) => svc.confirmOrderItem(param(request, "ancillaryOrderItemId"), request.body as any, ctx.correlationId)) }), replyNoop);
@@ -125,8 +127,13 @@ async function handleRead(reply: FastifyReply, request: FastifyRequest, operatio
   }
 }
 
+function farePricingGatewayFromEnv(): AncillaryPricingGateway | undefined {
+  const baseUrl = process.env.FARE_PRICING_URL?.trim();
+  return baseUrl ? new HttpFarePricingGateway(baseUrl) : undefined;
+}
 function requestContext(request: AppRequest): RequestContext { return kitRequestContext({ headers: request.headers, id: request.id }); }
 function traceContext(request: AppRequest, context: RequestContext = requestContext(request)): RequestTraceContext { return { ...context, method: request.method, url: request.url }; }
+function quoteInput(request: FastifyRequest): { expectedVersion: number; validitySeconds?: number; pricing?: Parameters<AncillaryApplicationService["quoteOffer"]>[1]["pricing"]; priceQuoteIdempotencyKey?: string } { return { ...(request.body as { expectedVersion: number; validitySeconds?: number; pricing?: Parameters<AncillaryApplicationService["quoteOffer"]>[1]["pricing"] }), priceQuoteIdempotencyKey: headerValue(request.headers["idempotency-key"]) }; }
 type AppRequest = FastifyRequest;
 function healthBody(): HealthStatus { return { status: health(), service: serviceProfile }; }
 function probeBody(probe: ProbeStatus["probe"]): ProbeStatus { return { status: health(), probe }; }

--- a/services/ancillary-service/src/application.ts
+++ b/services/ancillary-service/src/application.ts
@@ -23,6 +23,12 @@ import {
   type PerformedBy,
   type RefundRecommendation,
 } from "./domain.js";
+import {
+  ancillarySegmentRefs,
+  farePricingInputHash,
+  type AncillaryPricingGateway,
+  type PricingContext,
+} from "./pricing.js";
 
 export interface AncillaryRepository {
   saveCatalog(snapshot: AncillaryCatalogItemSnapshot): Promise<void>;
@@ -165,6 +171,7 @@ export class AncillaryApplicationService {
   constructor(
     private readonly repository: AncillaryRepository,
     private readonly publisher?: EventPublisher,
+    private readonly pricingGateway?: AncillaryPricingGateway,
   ) {}
 
   async createCatalogItem(
@@ -346,23 +353,45 @@ export class AncillaryApplicationService {
     primaryTicketStatus?: any;
     departureAt: string;
     quantity: number;
+    pricing?: PricingContext;
   }): Promise<AncillaryOfferSnapshot> {
     const catalog = await this.requireCatalog(input.catalogItemId);
     const offer = AncillaryOffer.draft(catalog, input);
     const snapshot = offer.toSnapshot();
-    await this.repository.saveOffer(snapshot);
-    return snapshot;
+    const snapshotWithPricingContext = input.pricing
+      ? { ...snapshot, futurePricingRefs: { pricingContext: input.pricing } }
+      : snapshot;
+    await this.repository.saveOffer(snapshotWithPricingContext);
+    return snapshotWithPricingContext;
   }
 
   async quoteOffer(
     ancillaryOfferId: string,
-    input: { expectedVersion: number; validitySeconds?: number },
+    input: {
+      expectedVersion: number;
+      validitySeconds?: number;
+      pricing?: PricingContext;
+      priceQuoteIdempotencyKey?: string;
+    },
     correlationId: string,
   ): Promise<AncillaryOfferSnapshot> {
     const offer = AncillaryOffer.fromSnapshot(
       await this.requireOffer(ancillaryOfferId),
     );
-    offer.quote(input.expectedVersion, input.validitySeconds);
+    const offerSnapshot = offer.toSnapshot();
+    const pricingContext =
+      input.pricing ??
+      ((offerSnapshot.futurePricingRefs?.pricingContext as
+        | PricingContext
+        | undefined) ??
+        {});
+    const pricing = await this.dynamicPricingOrFallback(
+      offerSnapshot,
+      pricingContext,
+      correlationId,
+      input.priceQuoteIdempotencyKey,
+    );
+    offer.quote(input.expectedVersion, input.validitySeconds, new Date(), pricing);
     const snapshot = offer.toSnapshot();
     await this.repository.saveOffer(snapshot);
     if (snapshot.status === "QUOTED") {
@@ -765,6 +794,40 @@ export class AncillaryApplicationService {
     return "ack";
   }
 
+  private async dynamicPricingOrFallback(
+    snapshot: AncillaryOfferSnapshot,
+    context: PricingContext,
+    correlationId: string,
+    idempotencyKey?: string,
+  ): Promise<Parameters<AncillaryOffer["quote"]>[3]> {
+    const result = await this.pricingGateway?.quoteAncillaryPrice({
+      ancillaryOfferId: snapshot.ancillaryOfferId,
+      offerVersion: snapshot.offerVersion,
+      catalogItemId: snapshot.catalogItemId,
+      travelerRef: snapshot.travelerRef,
+      segmentRef: snapshot.segmentRef,
+      departureAt: snapshot.eligibility.departureAt,
+      quantity: snapshot.quantity,
+      catalogUnitPrice: snapshot.catalogSnapshot.unitPrice,
+      context,
+      correlationId,
+      idempotencyKey,
+    });
+    if (result) return { ...result, source: "FARE_PRICING" };
+    const channel = context.channel ?? "DIRECT";
+    const segmentRefs = ancillarySegmentRefs(snapshot);
+    const inputHash = farePricingInputHash(segmentRefs, channel, [
+      snapshot.travelerRef,
+    ]);
+    return {
+      unitPrice: snapshot.catalogSnapshot.unitPrice,
+      quoteId: `catalog-${snapshot.ancillaryOfferId}`,
+      inputHash,
+      fees: [],
+      source: "CATALOG_FALLBACK",
+    };
+  }
+
   private async requireCatalog(
     catalogItemId: string,
   ): Promise<AncillaryCatalogItemSnapshot> {
@@ -864,6 +927,9 @@ function offerEventBase(
     quantity: snapshot.quantity,
     unitPrice: snapshot.unitPrice,
     totalPrice: snapshot.totalPrice,
+    assessedFees: snapshot.assessedFees,
+    feeAssessment: snapshot.feeAssessment,
+    priceQuoteRef: snapshot.priceQuoteRef,
     eligibility: snapshot.eligibility,
     validFrom: snapshot.validFrom,
     expiresAt: snapshot.expiresAt,
@@ -884,6 +950,9 @@ function orderEventBase(
     quantity: snapshot.quantity,
     payableAmount: snapshot.payableAmount,
     refundableAmount: snapshot.refundableAmount,
+    assessedFees: snapshot.assessedFees,
+    feeAssessment: snapshot.feeAssessment,
+    priceQuoteRef: snapshot.priceQuoteRef,
   };
 }
 function cancelEventBase(
@@ -898,6 +967,9 @@ function cancelEventBase(
     serviceType: snapshot.serviceType,
     payableAmount: snapshot.payableAmount,
     refundableAmount: snapshot.refundableAmount,
+    assessedFees: snapshot.assessedFees,
+    feeAssessment: snapshot.feeAssessment,
+    priceQuoteRef: snapshot.priceQuoteRef,
   };
 }
 function deterministicEventId(

--- a/services/ancillary-service/src/bootstrap.ts
+++ b/services/ancillary-service/src/bootstrap.ts
@@ -3,17 +3,20 @@ import { CONSUMER_GROUP, SUBSCRIBED_STREAMS, consumerName } from "./adapters/mes
 import { startAncillaryStorage } from "./adapters/storage/runtime.js";
 import { AncillaryApplicationService, InMemoryAncillaryRepository } from "./application.js";
 import { createApp, opentelemetryInstrumentationFromEnv, type InstrumentationHooks } from "./app.js";
+import { HttpFarePricingGateway } from "./pricing.js";
 
 export type BootstrapOptions = Readonly<{ host?: string; port?: number; instrumentation?: InstrumentationHooks; redisUrl?: string; instanceId?: string }>;
 export function runtimeHost(options: Pick<BootstrapOptions, "host"> = {}): string { return options.host ?? process.env.HOST ?? "0.0.0.0"; }
 export function runtimePort(options: Pick<BootstrapOptions, "port"> = {}): number { if (options.port !== undefined) return options.port; const configured = Number.parseInt(process.env.PORT ?? "", 10); return Number.isFinite(configured) ? configured : 8080; }
 export function runtimeRedisUrl(options: Pick<BootstrapOptions, "redisUrl"> = {}): string { return options.redisUrl ?? process.env.REDIS_URL ?? "redis://localhost:6379"; }
+function farePricingGatewayFromEnv(): HttpFarePricingGateway | undefined { const baseUrl = process.env.FARE_PRICING_URL?.trim(); return baseUrl ? new HttpFarePricingGateway(baseUrl) : undefined; }
 export async function bootstrap(options: BootstrapOptions = {}) {
   const messaging = await createRedisMessagingAdapters(runtimeRedisUrl(options));
   const storage = process.env.DATABASE_URL ? await startAncillaryStorage(runtimeRedisUrl(options)) : undefined;
   const repository = new InMemoryAncillaryRepository();
-  const application = new AncillaryApplicationService(repository, messaging.publisher);
-  const app = createApp(options.instrumentation ?? opentelemetryInstrumentationFromEnv(), { repository, publisher: messaging.publisher, idempotencyStore: storage?.idempotencyStore, storage });
+  const pricingGateway = farePricingGatewayFromEnv();
+  const application = new AncillaryApplicationService(repository, messaging.publisher, pricingGateway);
+  const app = createApp(options.instrumentation ?? opentelemetryInstrumentationFromEnv(), { repository, publisher: messaging.publisher, pricingGateway, idempotencyStore: storage?.idempotencyStore, storage });
   const abortController = new AbortController();
   const expiryTimer = setInterval(() => {
     void (storage ? storage.runCommand((svc) => svc.expireOffers()) : application.expireOffers()).catch((error: unknown) => app.log.warn({ err: error }, "ancillary offer expiry scan failed"));

--- a/services/ancillary-service/src/domain.ts
+++ b/services/ancillary-service/src/domain.ts
@@ -1,5 +1,12 @@
 import { uuidV7 } from "@trainticket/ts-kit";
 
+import {
+  multiplyPriceComponent,
+  type PriceComponent,
+  type PriceQuoteRef,
+  type RuleSnapshot,
+} from "./pricing.js";
+
 export class DomainError extends Error {
   constructor(
     public readonly code: string,
@@ -110,6 +117,17 @@ export type FulfillmentFact = Readonly<{
   notes?: string;
 }>;
 
+export type FeeAssessment = Readonly<{
+  assessmentId: string;
+  purpose: "ANCILLARY_PURCHASE";
+  assessedAt: string;
+  originalQuoteId: string;
+  fee: Money;
+  currency: string;
+  succeeded: boolean;
+  failedReason?: string;
+}>;
+
 export type CatalogSnapshot = Readonly<{
   catalogItemId: string;
   catalogItemVersion: number;
@@ -174,6 +192,9 @@ export type AncillaryOfferSnapshot = Readonly<{
   validFrom: string;
   expiresAt: string;
   ruleSummary?: string;
+  priceQuoteRef?: PriceQuoteRef;
+  assessedFees?: readonly PriceComponent[];
+  feeAssessment?: FeeAssessment;
   futurePricingRefs?: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;
@@ -197,6 +218,9 @@ export type AncillaryOrderItemSnapshot = Readonly<{
   quantity: number;
   payableAmount: Money;
   refundableAmount: Money;
+  assessedFees: readonly PriceComponent[];
+  feeAssessment?: FeeAssessment;
+  priceQuoteRef?: PriceQuoteRef;
   refundRecommendation?: RefundRecommendation;
   refundReason?: string;
   status: OrderItemStatus;
@@ -392,6 +416,16 @@ export class AncillaryOffer {
     expectedVersion: number,
     validitySeconds = 900,
     now = new Date(),
+    pricing?: {
+      unitPrice: Money;
+      quoteId: string;
+      inputHash: string;
+      validFrom?: string;
+      validUntil?: string;
+      ruleSnapshot?: RuleSnapshot;
+      fees?: readonly PriceComponent[];
+      source: PriceQuoteRef["source"];
+    },
   ): void {
     this.expectVersion(expectedVersion);
     if (
@@ -404,12 +438,38 @@ export class AncillaryOffer {
         "INVALID_OFFER_TRANSITION",
         "Only DRAFTING offers may be quoted",
       );
+    const priced = pricing ?? {
+      unitPrice: this.snapshot.catalogSnapshot.unitPrice,
+      quoteId: `catalog-${this.snapshot.ancillaryOfferId}`,
+      inputHash: "",
+      source: "CATALOG_FALLBACK" as const,
+      fees: [],
+    };
+    const unitPrice = priced.unitPrice;
+    const feeAssessment = assessFees(
+      priced.quoteId,
+      priced.fees ?? [],
+      unitPrice.currency,
+      now,
+    );
     this.snapshot = {
       ...this.snapshot,
       status: "QUOTED",
       offerVersion: this.snapshot.offerVersion + 1,
-      validFrom: iso(now),
-      expiresAt: iso(new Date(now.getTime() + validitySeconds * 1000)),
+      unitPrice,
+      totalPrice: multiplyMoney(unitPrice, this.snapshot.quantity),
+      priceQuoteRef: {
+        quoteId: priced.quoteId,
+        inputHash: priced.inputHash,
+        ruleSnapshot: priced.ruleSnapshot,
+        source: priced.source,
+      },
+      assessedFees: priced.fees ?? [],
+      feeAssessment,
+      futurePricingRefs: undefined,
+      validFrom: priced.validFrom ?? iso(now),
+      expiresAt:
+        priced.validUntil ?? iso(new Date(now.getTime() + validitySeconds * 1000)),
       updatedAt: iso(now),
     };
   }
@@ -496,6 +556,15 @@ export class AncillaryOrderItem {
       quantity: offer.quantity,
       payableAmount: offer.totalPrice,
       refundableAmount: zeroMoney(offer.totalPrice.currency),
+      assessedFees: offer.assessedFees
+        ? offer.assessedFees.map((fee) =>
+            multiplyPriceComponent(fee, offer.quantity),
+          )
+        : [],
+      feeAssessment: offer.feeAssessment
+        ? multiplyFeeAssessment(offer.feeAssessment, offer.quantity)
+        : undefined,
+      priceQuoteRef: offer.priceQuoteRef,
       status: "SELECTED",
       fulfillmentFacts: [],
       selectedAt: at,
@@ -756,6 +825,44 @@ export function multiplyMoney(money: Money, quantity: number): Money {
 }
 export function zeroMoney(currency: string): Money {
   return { currency, minorUnits: 0 };
+}
+export function addMoney(first: Money, second: Money): Money {
+  if (first.currency !== second.currency)
+    throw new DomainError(
+      "CURRENCY_MISMATCH",
+      "Money values must share currency",
+    );
+  return {
+    currency: first.currency,
+    minorUnits: first.minorUnits + second.minorUnits,
+  };
+}
+export function assessFees(
+  originalQuoteId: string,
+  fees: readonly PriceComponent[],
+  currency: string,
+  now = new Date(),
+): FeeAssessment {
+  const totalFee = fees.reduce(
+    (total, fee) => addMoney(total, fee.amount),
+    zeroMoney(currency),
+  );
+  return {
+    assessmentId: `fas-${uuidV7(now)}`,
+    purpose: "ANCILLARY_PURCHASE",
+    assessedAt: iso(now),
+    originalQuoteId,
+    fee: totalFee,
+    currency: totalFee.currency,
+    succeeded: true,
+  };
+}
+export function multiplyFeeAssessment(
+  assessment: FeeAssessment,
+  quantity: number,
+): FeeAssessment {
+  const fee = multiplyMoney(assessment.fee, quantity);
+  return { ...assessment, fee, currency: fee.currency };
 }
 export function iso(date: Date): string {
   return date.toISOString();

--- a/services/ancillary-service/src/index.ts
+++ b/services/ancillary-service/src/index.ts
@@ -17,4 +17,5 @@ export {
 export { bootstrap, runtimeHost, runtimePort, runtimeRedisUrl, type BootstrapOptions } from "./bootstrap.js";
 export * from "./domain.js";
 export * from "./application.js";
+export * from "./pricing.js";
 export { serviceProfile, type ServiceProfile } from "./profile.js";

--- a/services/ancillary-service/src/pricing.ts
+++ b/services/ancillary-service/src/pricing.ts
@@ -1,0 +1,174 @@
+import { createHash } from "node:crypto";
+
+import { uuidV7 } from "@trainticket/ts-kit";
+
+import type { Money } from "./domain.js";
+
+export type PriceExplanation = Readonly<{
+  code: string;
+  parameters: Readonly<Record<string, string>>;
+}>;
+
+export type PriceComponent = Readonly<{
+  ruleId: string;
+  amount: Money;
+  explanation: PriceExplanation;
+  refundable: boolean;
+}>;
+
+export type RuleSnapshot = Readonly<{
+  ruleSetId: string;
+  ruleSetVersion: string;
+  capturedAt: string;
+  ruleIds: readonly string[];
+  explanationCodes: readonly string[];
+  digest: string;
+}>;
+
+export type PriceQuoteRef = Readonly<{
+  quoteId: string;
+  inputHash: string;
+  ruleSnapshot?: RuleSnapshot;
+  source: "FARE_PRICING" | "CATALOG_FALLBACK";
+}>;
+
+export type PricingContext = Readonly<{
+  channel?: string;
+  productCode?: string;
+  fareRuleRefs?: readonly string[];
+  seatClass?: string;
+  distanceKm?: number;
+  departureTime?: string;
+}>;
+
+export type AncillaryPricingInput = Readonly<{
+  ancillaryOfferId: string;
+  offerVersion: number;
+  catalogItemId: string;
+  travelerRef: string;
+  segmentRef?: string;
+  departureAt: string;
+  quantity: number;
+  catalogUnitPrice: Money;
+  context: PricingContext;
+  correlationId: string;
+  idempotencyKey?: string;
+}>;
+
+export type AncillaryPricingResult = Readonly<{
+  quoteId: string;
+  inputHash: string;
+  unitPrice: Money;
+  validFrom?: string;
+  validUntil?: string;
+  ruleSnapshot?: RuleSnapshot;
+  fees: readonly PriceComponent[];
+}>;
+
+export interface AncillaryPricingGateway {
+  quoteAncillaryPrice(
+    input: AncillaryPricingInput,
+  ): Promise<AncillaryPricingResult | undefined>;
+}
+
+export function farePricingInputHash(
+  segmentRefs: readonly string[],
+  channel: string,
+  travelerRefs: readonly string[],
+): string {
+  const material = `${[...segmentRefs].sort().join(",")}|${channel}|${[
+    ...travelerRefs,
+  ]
+    .sort()
+    .join(",")}`;
+  return createHash("sha256").update(material, "utf8").digest("hex");
+}
+
+export function ancillarySegmentRefs(
+  input: Pick<AncillaryPricingInput, "segmentRef" | "catalogItemId">,
+): readonly string[] {
+  return [input.segmentRef ?? input.catalogItemId];
+}
+
+export function multiplyPriceComponent(
+  component: PriceComponent,
+  quantity: number,
+): PriceComponent {
+  return {
+    ...component,
+    amount: {
+      currency: component.amount.currency,
+      minorUnits: component.amount.minorUnits * quantity,
+    },
+  };
+}
+
+export class HttpFarePricingGateway implements AncillaryPricingGateway {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {}
+
+  async quoteAncillaryPrice(
+    input: AncillaryPricingInput,
+  ): Promise<AncillaryPricingResult | undefined> {
+    const channel = input.context.channel ?? "DIRECT";
+    const segmentRefs = ancillarySegmentRefs(input);
+    const travelerRefs = [input.travelerRef];
+    const requestBody: Record<string, unknown> = {
+      travelerRefs,
+      channel,
+      segmentRefs,
+      productCode: input.context.productCode ?? input.catalogItemId,
+      fareRuleRefs: input.context.fareRuleRefs,
+      seatClass: input.context.seatClass,
+      distanceKm: input.context.distanceKm,
+      departureTime: input.context.departureTime ?? input.departureAt,
+    };
+    for (const key of Object.keys(requestBody))
+      if (requestBody[key] === undefined) delete requestBody[key];
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(
+        `${this.baseUrl.replace(/\/$/, "")}/api/v1/fare-quotes`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "idempotency-key": input.idempotencyKey ?? uuidV7(),
+            "x-correlation-id": input.correlationId,
+          },
+          body: JSON.stringify(requestBody),
+        },
+      );
+    } catch {
+      return undefined;
+    }
+    if (!response.ok) return undefined;
+    const payload = (await response.json()) as FareQuoteResponse;
+    if (payload.status !== "QUOTED" || !payload.breakdown?.total)
+      return undefined;
+    return {
+      quoteId: payload.quoteId,
+      inputHash: farePricingInputHash(segmentRefs, channel, travelerRefs),
+      unitPrice: payload.breakdown.total,
+      validFrom: payload.validFrom,
+      validUntil: payload.validUntil,
+      ruleSnapshot: payload.ruleSnapshot,
+      fees: payload.breakdown.fees ?? [],
+    };
+  }
+}
+
+type FareQuoteResponse = Readonly<{
+  quoteId: string;
+  status: "QUOTED" | "FAILED";
+  validFrom: string;
+  validUntil: string;
+  breakdown?: Readonly<{
+    total: Money;
+    fees?: readonly PriceComponent[];
+  }>;
+  ruleSnapshot?: RuleSnapshot;
+}>;


### PR DESCRIPTION
## Summary
- integrate ancillary offer quoting with Fare & Pricing dynamic rules using the normative inputHash and rule snapshot contract, with catalog fallback
- carry assessed fees, feeAssessment, and priceQuoteRef from offers into order items and lifecycle events
- add e2e assertion for dynamic-rule pricing plus fee assessment and refresh ancillary contract docs

## Validation
- npm --prefix services/ancillary-service run build
- npm --prefix services/ancillary-service test