### PR TITLE
REQ-340 align waitlist state and resource shape

### DIFF
--- a/services/waitlist/migrations/001_waitlist.sql
+++ b/services/waitlist/migrations/001_waitlist.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS waitlist_entries (
     departure_date date NOT NULL,
     seat_class text NOT NULL,
     priority_score integer NOT NULL CHECK (priority_score >= 0 AND priority_score <= 100),
-    status text NOT NULL CHECK (status IN ('QUEUED', 'OFFERED', 'ACCEPTED', 'EXPIRED', 'CANCELLED')),
+    status text NOT NULL CHECK (status IN ('DRAFT', 'QUEUED', 'MATCHING', 'FULFILLED', 'EXPIRED', 'CANCELLED', 'SUSPENDED', 'CLOSED')),
     offered_at timestamptz,
     offer_expires_at timestamptz,
     fare_quote_id text,
@@ -24,7 +24,7 @@ CREATE INDEX IF NOT EXISTS waitlist_queue_order_idx
 
 CREATE INDEX IF NOT EXISTS waitlist_offer_expiry_idx
     ON waitlist_entries (offer_expires_at)
-    WHERE status = 'OFFERED';
+    WHERE status = 'MATCHING';
 
 CREATE TABLE IF NOT EXISTS waitlist_offers (
     offer_id text PRIMARY KEY,

--- a/services/waitlist/src/app.ts
+++ b/services/waitlist/src/app.ts
@@ -58,13 +58,33 @@ export function createApp(dependencies: AppDependencies = {}): FastifyInstance {
   app.get("/readyz", async (_request, reply) => readyBody(reply, dependencies.storage));
   app.get("/metadata", async () => metadata());
 
+  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist-requests", async (request, ctx) => ({
+    statusCode: 201,
+    body: await runCommand((repository, publisher) => commandService(repository, publisher).join(request.body as any, ctx.correlationId)),
+  }));
   stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist/entries", async (request, ctx) => ({
     statusCode: 201,
     body: await runCommand((repository, publisher) => commandService(repository, publisher).join(request.body as any, ctx.correlationId)),
   }));
+  app.get("/api/v1/waitlist-requests", async (request, reply) => handleRead(reply, request, () => {
+    const params = query(request);
+    return runCommand((repository, publisher) => commandService(repository, publisher).listByTraveler(
+      params.travelerRef ?? "",
+      params.status as any,
+      parsePageNumber(params.limit, 20, 100),
+      parsePageNumber(params.offset, 0, Number.MAX_SAFE_INTEGER),
+    ));
+  }));
+  app.get("/api/v1/waitlist-requests/:waitlistRequestId", async (request, reply) => handleRead(reply, request, () => (
+    runCommand((repository, publisher) => commandService(repository, publisher).get(param(request, "waitlistRequestId")))
+  )));
   app.get("/api/v1/waitlist/entries/:entryId", async (request, reply) => handleRead(reply, request, () => (
     runCommand((repository, publisher) => commandService(repository, publisher).get(param(request, "entryId")))
   )));
+  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist-requests/:waitlistRequestId/cancel", async (request) => ({
+    statusCode: 200,
+    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "waitlistRequestId"))),
+  }));
   stateChanging(app, idempotencyStore, "DELETE", "/api/v1/waitlist/entries/:entryId", async (request) => ({
     statusCode: 200,
     body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "entryId"))),
@@ -122,3 +142,8 @@ async function handleRead(reply: FastifyReply, request: FastifyRequest, operatio
 function requestContext(request: FastifyRequest): RequestContext { return kitRequestContext({ headers: request.headers, id: request.id }); }
 function param(request: FastifyRequest, name: string): string { return (request.params as Record<string, string>)[name] ?? ""; }
 function query(request: FastifyRequest): Record<string, string | undefined> { return request.query as Record<string, string | undefined>; }
+function parsePageNumber(value: string | undefined, fallback: number, max: number): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  return Math.min(parsed, max);
+}

--- a/services/waitlist/src/application.ts
+++ b/services/waitlist/src/application.ts
@@ -5,20 +5,45 @@ import { publishAll, waitlistEntryAccepted, waitlistEntryCreated } from "./publi
 
 export type JoinWaitlistRequest = Readonly<{
   accountId: string;
-  travelerRefs: readonly string[];
+  travelerRefs?: readonly string[];
+  travelerRef?: string;
   segmentRef: string;
-  departureDate: string;
-  seatClass: FareClass;
+  departureDate?: string;
+  seatClass?: FareClass;
+  travelClass?: FareClass;
+  deadline?: string;
+  paymentGuaranteeRef?: string;
   loyaltyTier?: PriorityInput["loyaltyTier"];
   tripCount?: number;
   daysBefore?: number;
   specialStatus?: PriorityInput["specialStatus"];
   itineraryRef?: string;
+  intentFingerprint?: string;
 }>;
 
 export type AcceptPromotionRequest = Readonly<{ paymentMethodRef?: string }>;
 export type AcceptPromotionResponse = Readonly<{ orderId: string; seatAssignment: unknown }>;
 export type QueueInfo = Readonly<{ totalQueued: number; myPosition: number | null; estimatedPromotionRate: number }>;
+export type WaitlistRequestList = Readonly<{
+  items: readonly WaitlistRequestResource[];
+  total: number;
+  limit: number;
+  offset: number;
+}>;
+
+export type WaitlistRequestResource = Readonly<{
+  waitlistRequestId: string;
+  accountId: string;
+  travelerRef: string;
+  segmentRef: string;
+  travelClass?: string;
+  deadline: string;
+  paymentGuaranteeRef: string;
+  itineraryRef: string;
+  intentFingerprint: string;
+  status: WaitlistEntrySnapshot["status"];
+  journeyOrderRef?: string;
+}>;
 
 export interface JourneyOrderClient {
   createOrder(entry: WaitlistEntry, paymentMethodRef?: string): Promise<AcceptPromotionResponse>;
@@ -71,12 +96,19 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
   }
 
   async findExpiredOffers(now: Date): Promise<readonly WaitlistEntry[]> {
-    return [...this.entries.values()].filter((entry) => entry.status === "OFFERED" && entry.offerExpiresAt !== null && entry.offerExpiresAt <= now);
+    return [...this.entries.values()].filter((entry) => entry.status === "MATCHING" && entry.offerExpiresAt !== null && entry.offerExpiresAt <= now);
   }
 
   async queueFor(segmentRef: string, departureDate: string, seatClass?: string): Promise<readonly WaitlistEntrySnapshot[]> {
     const queue = this.buildQueue(segmentRef, departureDate, seatClass);
     return queue.allEntries().map((entry) => this.snapshot(entry));
+  }
+
+  async listByTraveler(travelerRef: string): Promise<readonly WaitlistEntrySnapshot[]> {
+    return [...this.entries.values()]
+      .filter((entry) => entry.travelerRefs.includes(travelerRef))
+      .sort((left, right) => left.createdAt.getTime() - right.createdAt.getTime())
+      .map((entry) => this.snapshot(entry));
   }
 
   clear(): void { this.entries.clear(); }
@@ -111,23 +143,29 @@ export class WaitlistApplicationService {
     this.promotion = new PromotionOrchestrator(repository, farePricing, capacityAvailability, publisher ?? { publish: async () => undefined }, offerManagement, now);
   }
 
-  async join(request: JoinWaitlistRequest, correlationId?: string): Promise<WaitlistEntrySnapshot & { estimatedWaitMinutes: number }> {
+  async join(request: JoinWaitlistRequest, correlationId?: string): Promise<WaitlistRequestResource> {
     const entry = WaitlistEntry.create(this.toCreateCommand(request));
     const snapshot = await this.repository.add(entry);
     if (this.publisher) await publishAll(this.publisher, [waitlistEntryCreated(snapshot, correlationId)]);
-    return { ...snapshot, estimatedWaitMinutes: Math.max(5, snapshot.queuePosition * 15) };
+    return toWaitlistRequestResource(snapshot);
   }
 
-  async get(entryId: string): Promise<WaitlistEntrySnapshot> {
+  async get(entryId: string): Promise<WaitlistRequestResource> {
     const entry = await this.requireEntry(entryId);
-    return this.snapshot(entry);
+    return toWaitlistRequestResource(await this.snapshot(entry));
   }
 
-  async cancel(entryId: string): Promise<{ cancelled: true }> {
+  async listByTraveler(travelerRef: string, status?: WaitlistEntrySnapshot["status"], limit = 20, offset = 0): Promise<WaitlistRequestList> {
+    const snapshots = (await this.repository.listByTraveler(travelerRef)).filter((entry) => !status || entry.status === status);
+    const page = snapshots.slice(offset, offset + limit);
+    return { items: page.map(toWaitlistRequestResource), total: snapshots.length, limit, offset };
+  }
+
+  async cancel(entryId: string): Promise<{ waitlistRequestId: string; status: "CANCELLED"; cancelledAt: string }> {
     const entry = await this.requireEntry(entryId);
     entry.cancel();
-    await this.repository.save(entry);
-    return { cancelled: true };
+    const snapshot = await this.repository.save(entry);
+    return { waitlistRequestId: snapshot.entryId, status: "CANCELLED", cancelledAt: this.now().toISOString() };
   }
 
   async accept(entryId: string, request: AcceptPromotionRequest = {}, correlationId?: string): Promise<AcceptPromotionResponse> {
@@ -135,7 +173,7 @@ export class WaitlistApplicationService {
     const now = this.now();
     entry.ensureOfferAcceptable(now);
     const order = await this.journeyOrder.createOrder(entry, request.paymentMethodRef);
-    entry.accept(now);
+    entry.accept(now, order.orderId);
     const snapshot = await this.repository.save(entry);
     if (this.publisher) await publishAll(this.publisher, [waitlistEntryAccepted(snapshot, order.orderId, order.seatAssignment, correlationId)]);
     return order;
@@ -156,19 +194,25 @@ export class WaitlistApplicationService {
   }
 
   private toCreateCommand(request: JoinWaitlistRequest): CreateWaitlistEntry {
+    const travelerRefs = request.travelerRefs ?? (request.travelerRef ? [request.travelerRef] : []);
+    const seatClass = request.seatClass ?? request.travelClass ?? "SECOND";
+    const departureDate = request.departureDate ?? dateFromDeadline(request.deadline);
     return {
       accountId: request.accountId,
-      travelerRefs: request.travelerRefs,
+      travelerRefs,
       segmentRef: request.segmentRef,
-      departureDate: request.departureDate,
-      seatClass: request.seatClass,
+      departureDate,
+      seatClass,
       itineraryRef: request.itineraryRef ?? request.segmentRef,
+      deadline: request.deadline,
+      paymentGuaranteeRef: request.paymentGuaranteeRef,
+      intentFingerprint: request.intentFingerprint,
       priority: {
         loyaltyTier: request.loyaltyTier ?? "NONE",
         tripCount: request.tripCount ?? 0,
-        daysBefore: request.daysBefore ?? daysBefore(request.departureDate),
-        groupSize: request.travelerRefs.length,
-        fareClass: request.seatClass,
+        daysBefore: request.daysBefore ?? daysBefore(departureDate),
+        groupSize: travelerRefs.length,
+        fareClass: seatClass,
         specialStatus: request.specialStatus ?? "NONE",
       },
     };
@@ -186,8 +230,29 @@ export class WaitlistApplicationService {
   }
 }
 
+function toWaitlistRequestResource(snapshot: WaitlistEntrySnapshot): WaitlistRequestResource {
+  return {
+    waitlistRequestId: snapshot.entryId,
+    accountId: snapshot.accountId,
+    travelerRef: snapshot.travelerRefs[0] ?? "",
+    segmentRef: snapshot.segmentRef,
+    travelClass: snapshot.seatClass,
+    deadline: snapshot.deadline,
+    paymentGuaranteeRef: snapshot.paymentGuaranteeRef,
+    itineraryRef: snapshot.itineraryRef ?? snapshot.segmentRef,
+    intentFingerprint: snapshot.intentFingerprint,
+    status: snapshot.status,
+    journeyOrderRef: snapshot.journeyOrderRef,
+  };
+}
+
 function daysBefore(departureDate: string): number {
   const departure = new Date(`${departureDate}T00:00:00.000Z`).getTime();
   if (!Number.isFinite(departure)) return 0;
   return Math.max(0, Math.ceil((departure - Date.now()) / (24 * 60 * 60 * 1000)));
+}
+
+function dateFromDeadline(deadline?: string): string {
+  if (!deadline) return new Date().toISOString().slice(0, 10);
+  return deadline.slice(0, 10);
 }

--- a/services/waitlist/src/domain.ts
+++ b/services/waitlist/src/domain.ts
@@ -1,6 +1,6 @@
 import { uuidV7 } from "@trainticket/ts-kit";
 
-export type WaitlistStatus = "QUEUED" | "OFFERED" | "ACCEPTED" | "EXPIRED" | "CANCELLED";
+export type WaitlistStatus = "DRAFT" | "QUEUED" | "MATCHING" | "FULFILLED" | "EXPIRED" | "CANCELLED" | "SUSPENDED" | "CLOSED";
 export type LoyaltyTier = "PLATINUM" | "GOLD" | "SILVER" | "NONE";
 export type FareClass = "BUSINESS" | "FIRST" | "SECOND" | "SECOND_CLASS" | "STANDING";
 export type SpecialStatus = "MILITARY" | "DISABLED" | "STUDENT" | "NONE";
@@ -27,11 +27,15 @@ export type WaitlistEntrySnapshot = Readonly<{
   createdAt: string;
   offeredAt: string | null;
   offerExpiresAt: string | null;
+  deadline: string;
+  paymentGuaranteeRef: string;
+  intentFingerprint: string;
   fareQuoteId?: string;
   capacityHoldId?: string;
   offerId?: string;
   offerVersion?: number;
   itineraryRef?: string;
+  journeyOrderRef?: string;
   fareQuoteIdempotencyKey?: string;
   offerIdempotencyKey?: string;
   capacityHoldIdempotencyKey?: string;
@@ -49,6 +53,9 @@ export type CreateWaitlistEntry = Readonly<{
   seatClass: FareClass;
   priority: Omit<PriorityInput, "groupSize" | "fareClass"> & Partial<Pick<PriorityInput, "groupSize" | "fareClass">>;
   itineraryRef?: string;
+  deadline?: string;
+  paymentGuaranteeRef?: string;
+  intentFingerprint?: string;
   createdAt?: Date;
 }>;
 
@@ -77,6 +84,10 @@ export class WaitlistEntry {
     private _offerId?: string,
     private _offerVersion?: number,
     public readonly itineraryRef?: string,
+    public readonly deadline: string = deadlineFromDepartureDate(departureDate),
+    public readonly paymentGuaranteeRef: string = `pay-auth-${uuidV7()}`,
+    public readonly intentFingerprint: string = defaultIntentFingerprint(travelerRefs[0] ?? "unknown", segmentRef, departureDate, seatClass),
+    private _journeyOrderRef?: string,
     private readonly _fareQuoteIdempotencyKey: string = uuidV7(),
     private readonly _offerIdempotencyKey: string = uuidV7(),
     private readonly _capacityHoldIdempotencyKey: string = uuidV7(),
@@ -94,7 +105,7 @@ export class WaitlistEntry {
     const fareClass = command.priority.fareClass ?? command.seatClass;
     const priorityScore = PriorityCalculator.calculate({ ...command.priority, groupSize, fareClass });
     return new WaitlistEntry(
-      command.entryId ?? `wl-${uuidV7()}`,
+      command.entryId ?? `wlr-${uuidV7()}`,
       command.accountId,
       [...command.travelerRefs],
       command.segmentRef,
@@ -109,7 +120,10 @@ export class WaitlistEntry {
       undefined,
       undefined,
       undefined,
-      command.itineraryRef,
+      command.itineraryRef ?? command.segmentRef,
+      command.deadline ?? deadlineFromDepartureDate(command.departureDate),
+      command.paymentGuaranteeRef ?? `pay-auth-${uuidV7()}`,
+      command.intentFingerprint ?? defaultIntentFingerprint(command.travelerRefs[0] ?? "unknown", command.segmentRef, command.departureDate, command.seatClass),
     );
   }
 
@@ -131,6 +145,10 @@ export class WaitlistEntry {
       snapshot.offerId,
       snapshot.offerVersion,
       snapshot.itineraryRef,
+      snapshot.deadline,
+      snapshot.paymentGuaranteeRef,
+      snapshot.intentFingerprint,
+      snapshot.journeyOrderRef,
       snapshot.fareQuoteIdempotencyKey,
       snapshot.offerIdempotencyKey,
       snapshot.capacityHoldIdempotencyKey,
@@ -147,6 +165,7 @@ export class WaitlistEntry {
   get capacityHoldId(): string | undefined { return this._capacityHoldId; }
   get offerId(): string | undefined { return this._offerId; }
   get offerVersion(): number | undefined { return this._offerVersion; }
+  get journeyOrderRef(): string | undefined { return this._journeyOrderRef; }
   get fareQuoteIdempotencyKey(): string { return this._fareQuoteIdempotencyKey; }
   get offerIdempotencyKey(): string { return this._offerIdempotencyKey; }
   get capacityHoldIdempotencyKey(): string { return this._capacityHoldIdempotencyKey; }
@@ -155,9 +174,9 @@ export class WaitlistEntry {
   get capacitySegmentBookingId(): string { return this._capacitySegmentBookingId; }
 
   offer(offerId: string, offerVersion: number, fareQuoteId: string, capacityHoldId: string, now: Date, expiresAt: Date): void {
-    this.assertStatus("QUEUED", "Only queued waitlist entries can be offered");
+    this.assertStatus("QUEUED", "Only queued waitlist entries can begin matching");
     if (expiresAt <= now) throw new DomainError("VALIDATION_FAILED", "Offer expiry must be in the future");
-    this._status = "OFFERED";
+    this._status = "MATCHING";
     this._offeredAt = now;
     this._offerExpiresAt = expiresAt;
     if (!Number.isInteger(offerVersion) || offerVersion < 1) throw new DomainError("VALIDATION_FAILED", "offerVersion must be positive");
@@ -167,30 +186,38 @@ export class WaitlistEntry {
     this._offerVersion = offerVersion;
   }
 
-  accept(now: Date): void {
+  accept(now: Date, journeyOrderRef: string): void {
     this.ensureOfferAcceptable(now);
-    this._status = "ACCEPTED";
+    assertNonEmpty(journeyOrderRef, "journeyOrderRef");
+    this._status = "FULFILLED";
+    this._journeyOrderRef = journeyOrderRef;
   }
 
   ensureOfferAcceptable(now: Date): void {
-    this.assertStatus("OFFERED", "Only offered waitlist entries can be accepted");
+    this.assertStatus("MATCHING", "Only matching waitlist entries can be fulfilled");
     if (this._offerExpiresAt && now > this._offerExpiresAt) {
-      throw new DomainError("PRECONDITION_FAILED", "Waitlist offer has expired");
+      throw new DomainError("PRECONDITION_FAILED", "Waitlist match has expired");
     }
   }
 
-  expire(now: Date): void {
-    if (this._status !== "OFFERED" && this._status !== "QUEUED") {
-      throw new DomainError("INVALID_TRANSITION", `Cannot expire ${this._status} waitlist entry`);
-    }
-    if (this._status === "OFFERED" && this._offerExpiresAt && now < this._offerExpiresAt) {
-      throw new DomainError("PRECONDITION_FAILED", "Waitlist offer has not reached its expiry time");
-    }
+  expire(): void {
+    this.assertStatus("QUEUED", `Cannot expire ${this._status} waitlist entry`);
     this._status = "EXPIRED";
   }
 
+  returnToQueue(): void {
+    this.assertStatus("MATCHING", "Only matching waitlist entries can return to the queue");
+    this._status = "QUEUED";
+    this._offeredAt = null;
+    this._offerExpiresAt = null;
+    this._fareQuoteId = undefined;
+    this._capacityHoldId = undefined;
+    this._offerId = undefined;
+    this._offerVersion = undefined;
+  }
+
   cancel(): void {
-    if (this._status === "ACCEPTED" || this._status === "EXPIRED") {
+    if (this._status !== "DRAFT" && this._status !== "QUEUED" && this._status !== "SUSPENDED") {
       throw new DomainError("INVALID_TRANSITION", `Cannot cancel ${this._status} waitlist entry`);
     }
     this._status = "CANCELLED";
@@ -210,11 +237,15 @@ export class WaitlistEntry {
       createdAt: this.createdAt.toISOString(),
       offeredAt: this._offeredAt?.toISOString() ?? null,
       offerExpiresAt: this._offerExpiresAt?.toISOString() ?? null,
+      deadline: this.deadline,
+      paymentGuaranteeRef: this.paymentGuaranteeRef,
+      intentFingerprint: this.intentFingerprint,
       fareQuoteId: this._fareQuoteId,
       capacityHoldId: this._capacityHoldId,
       offerId: this._offerId,
       offerVersion: this._offerVersion,
       itineraryRef: this.itineraryRef,
+      journeyOrderRef: this._journeyOrderRef,
       fareQuoteIdempotencyKey: this._fareQuoteIdempotencyKey,
       offerIdempotencyKey: this._offerIdempotencyKey,
       capacityHoldIdempotencyKey: this._capacityHoldIdempotencyKey,
@@ -324,4 +355,12 @@ function specialPoints(status: SpecialStatus | readonly SpecialStatus[] = "NONE"
 
 function assertNonEmpty(value: string, field: string): void {
   if (value.trim().length === 0) throw new DomainError("VALIDATION_FAILED", `${field} is required`);
+}
+
+function deadlineFromDepartureDate(departureDate: string): string {
+  return `${departureDate}T00:00:00.000Z`;
+}
+
+function defaultIntentFingerprint(travelerRef: string, segmentRef: string, departureDate: string, seatClass: FareClass): string {
+  return `${travelerRef}:${segmentRef}:${departureDate}:${seatClass}`;
 }

--- a/services/waitlist/src/promotion.ts
+++ b/services/waitlist/src/promotion.ts
@@ -18,8 +18,10 @@ export type WaitlistOffer = Readonly<{
   expiresAt: string;
 }>;
 
+export type PromotedWaitlistRequest = WaitlistEntrySnapshot & Readonly<{ waitlistRequestId: string }>;
+
 export type PromotionResult = Readonly<{
-  promoted: readonly WaitlistEntrySnapshot[];
+  promoted: readonly PromotedWaitlistRequest[];
   offers: readonly WaitlistOffer[];
 }>;
 
@@ -30,6 +32,7 @@ export interface WaitlistRepository {
   findTopQueued(segmentRef: string, departureDate: string, seatClass?: string): Promise<WaitlistEntry | undefined> | WaitlistEntry | undefined;
   findExpiredOffers(now: Date): Promise<readonly WaitlistEntry[]> | readonly WaitlistEntry[];
   queueFor(segmentRef: string, departureDate: string, seatClass?: string): Promise<readonly WaitlistEntrySnapshot[]> | readonly WaitlistEntrySnapshot[];
+  listByTraveler(travelerRef: string): Promise<readonly WaitlistEntrySnapshot[]> | readonly WaitlistEntrySnapshot[];
 }
 
 export interface FarePricingClient {
@@ -139,7 +142,7 @@ export class PromotionOrchestrator {
   ) {}
 
   async onCapacityFreed(event: WaitlistCapacityFreed, correlationId?: string): Promise<PromotionResult> {
-    const promoted: WaitlistEntrySnapshot[] = [];
+    const promoted: PromotedWaitlistRequest[] = [];
     const offers: WaitlistOffer[] = [];
     const slots = Math.max(0, Math.floor(event.freedSlots));
     for (let index = 0; index < slots; index++) {
@@ -153,7 +156,7 @@ export class PromotionOrchestrator {
       const offer = { offerId: commercialOffer.offerId, offerVersion: commercialOffer.offerVersion, entryId: entry.entryId, fareQuoteId: quote.fareQuoteId, capacityHoldId: hold.capacityHoldId, expiresAt: expiresAt.toISOString() };
       entry.offer(offer.offerId, offer.offerVersion, quote.fareQuoteId, hold.capacityHoldId, now, expiresAt);
       const snapshot = await this.repository.save(entry);
-      promoted.push(snapshot);
+      promoted.push({ ...snapshot, waitlistRequestId: snapshot.entryId });
       offers.push(offer);
       await publishAll(this.publisher, [waitlistEntryPromoted(snapshot, offer, correlationId)]);
     }
@@ -166,7 +169,7 @@ export class PromotionOrchestrator {
     for (const entry of await this.repository.findExpiredOffers(now)) {
       const offer = offerFromEntry(entry);
       const capacityHoldId = entry.capacityHoldId;
-      entry.expire(now);
+      entry.returnToQueue();
       if (capacityHoldId) await this.capacityAvailability.releaseHold(entry, capacityHoldId);
       const snapshot = await this.repository.save(entry);
       expired.push(snapshot);

--- a/services/waitlist/src/storage.ts
+++ b/services/waitlist/src/storage.ts
@@ -47,7 +47,7 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
   }
 
   async findExpiredOffers(now: Date): Promise<readonly WaitlistEntry[]> {
-    const result = await this.db.query(`SELECT * FROM waitlist_entries WHERE status = 'OFFERED' AND offer_expires_at <= $1 ORDER BY offer_expires_at ASC`, [now.toISOString()]) as QueryResult<WaitlistRow>;
+    const result = await this.db.query(`SELECT * FROM waitlist_entries WHERE status = 'MATCHING' AND offer_expires_at <= $1 ORDER BY offer_expires_at ASC`, [now.toISOString()]) as QueryResult<WaitlistRow>;
     return result.rows.map(entryFromRow);
   }
 
@@ -58,6 +58,15 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
     const result = await this.db.query(
       `SELECT * FROM waitlist_entries WHERE segment_ref = $1 AND departure_date = $2 ${seatClause} ORDER BY priority_score DESC, created_at ASC, entry_id ASC`,
       params,
+    ) as QueryResult<WaitlistRow>;
+    const entries = result.rows.map(entryFromRow);
+    return entries.map((entry) => entry.toSnapshot(positionIn(entries, entry.entryId)));
+  }
+
+  async listByTraveler(travelerRef: string): Promise<readonly WaitlistEntrySnapshot[]> {
+    const result = await this.db.query(
+      `SELECT * FROM waitlist_entries WHERE traveler_refs ? $1 ORDER BY created_at ASC, entry_id ASC`,
+      [travelerRef],
     ) as QueryResult<WaitlistRow>;
     const entries = result.rows.map(entryFromRow);
     return entries.map((entry) => entry.toSnapshot(positionIn(entries, entry.entryId)));
@@ -119,6 +128,10 @@ function entryFromRow(row: WaitlistRow): WaitlistEntry {
     offerId: typeof data.offerId === "string" ? data.offerId : undefined,
     offerVersion: typeof data.offerVersion === "number" ? data.offerVersion : undefined,
     itineraryRef: typeof data.itineraryRef === "string" ? data.itineraryRef : undefined,
+    deadline: typeof data.deadline === "string" ? data.deadline : deadlineFromDepartureDate(dateString(row.departure_date)),
+    paymentGuaranteeRef: typeof data.paymentGuaranteeRef === "string" ? data.paymentGuaranteeRef : `pay-auth-${row.entry_id}`,
+    intentFingerprint: typeof data.intentFingerprint === "string" ? data.intentFingerprint : defaultIntentFingerprint(row.traveler_refs, row.segment_ref, dateString(row.departure_date), row.seat_class),
+    journeyOrderRef: typeof data.journeyOrderRef === "string" ? data.journeyOrderRef : undefined,
     fareQuoteIdempotencyKey: typeof data.fareQuoteIdempotencyKey === "string" ? data.fareQuoteIdempotencyKey : undefined,
     offerIdempotencyKey: typeof data.offerIdempotencyKey === "string" ? data.offerIdempotencyKey : undefined,
     capacityHoldIdempotencyKey: typeof data.capacityHoldIdempotencyKey === "string" ? data.capacityHoldIdempotencyKey : undefined,
@@ -136,6 +149,11 @@ function positionIn(entries: readonly WaitlistEntry[], entryId: string): number 
 
 function dateString(value: Date | string): string { return value instanceof Date ? value.toISOString().slice(0, 10) : String(value).slice(0, 10); }
 function instantString(value: Date | string): string { return value instanceof Date ? value.toISOString() : new Date(value).toISOString(); }
+function deadlineFromDepartureDate(departureDate: string): string { return `${departureDate}T00:00:00.000Z`; }
+function defaultIntentFingerprint(travelerRefs: unknown, segmentRef: string, departureDate: string, seatClass: string): string {
+  const travelerRef = Array.isArray(travelerRefs) ? String(travelerRefs[0] ?? "unknown") : "unknown";
+  return `${travelerRef}:${segmentRef}:${departureDate}:${seatClass}`;
+}
 function sanitizedErrorForLog(error: unknown): Readonly<{ name: string; message: string }> { return error instanceof Error ? { name: error.name || "Error", message: error.message || "Storage failed" } : { name: typeof error, message: "Storage failed" }; }
 
 type WaitlistRow = Readonly<{

--- a/services/waitlist/tests/app.test.ts
+++ b/services/waitlist/tests/app.test.ts
@@ -1,11 +1,57 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { createApp } from "../src/app.js";
+import { createApp, resetWaitlistStore } from "../src/app.js";
 
 test("health endpoint returns 200", async () => {
   const app = createApp();
   const response = await app.inject({ method: "GET", url: "/health" });
   assert.equal(response.statusCode, 200);
   assert.equal(response.json().status, "ok");
+  await app.close();
+});
+
+test("waitlist request endpoints return contract resource shape", async () => {
+  resetWaitlistStore();
+  const app = createApp();
+  const create = await app.inject({
+    method: "POST",
+    url: "/api/v1/waitlist-requests",
+    headers: { "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c123" },
+    payload: {
+      accountId: "acc-1",
+      travelerRef: "tvl-1",
+      segmentRef: "seg-1",
+      travelClass: "SECOND",
+      deadline: "2026-07-20T00:00:00.000Z",
+      paymentGuaranteeRef: "pay-auth-1",
+      itineraryRef: "itn-1",
+      intentFingerprint: "intent-1",
+    },
+  });
+  const resource = create.json();
+  assert.equal(create.statusCode, 201);
+  assert.deepEqual(Object.keys(resource).sort(), [
+    "accountId",
+    "deadline",
+    "intentFingerprint",
+    "itineraryRef",
+    "paymentGuaranteeRef",
+    "segmentRef",
+    "status",
+    "travelClass",
+    "travelerRef",
+    "waitlistRequestId",
+  ]);
+  assert.equal(resource.status, "QUEUED");
+  assert.equal(resource.waitlistRequestId.startsWith("wlr-"), true);
+
+  const get = await app.inject({ method: "GET", url: `/api/v1/waitlist-requests/${resource.waitlistRequestId}` });
+  assert.equal(get.statusCode, 200);
+  assert.deepEqual(get.json(), resource);
+
+  const list = await app.inject({ method: "GET", url: "/api/v1/waitlist-requests?travelerRef=tvl-1" });
+  assert.equal(list.statusCode, 200);
+  assert.equal(list.json().items[0].waitlistRequestId, resource.waitlistRequestId);
+
   await app.close();
 });

--- a/services/waitlist/tests/domain.test.ts
+++ b/services/waitlist/tests/domain.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { PriorityCalculator, WaitlistEntry, WaitlistQueue } from "../src/domain.js";
+import { DomainError, PriorityCalculator, WaitlistEntry, WaitlistQueue } from "../src/domain.js";
 
 test("platinum member scores higher than non-member", () => {
   const platinum = PriorityCalculator.calculate({ loyaltyTier: "PLATINUM", tripCount: 2, daysBefore: 3, groupSize: 1, fareClass: "SECOND", specialStatus: "NONE" });
@@ -17,4 +17,18 @@ test("queue orders by priority descending then createdAt ascending", () => {
   const queue = new WaitlistQueue("seg", "2026-07-20", "SECOND", [newer, older, platinum]);
   assert.deepEqual(queue.queuedEntries().map((entry) => entry.entryId), ["wl-vip", "wl-old", "wl-new"]);
   assert.equal(queue.positionOf("wl-old"), 2);
+});
+
+test("matching entries return to queue instead of expiring or cancelling directly", () => {
+  const entry = WaitlistEntry.create({ entryId: "wl-match", accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "GOLD", tripCount: 10, daysBefore: 10 }, createdAt: new Date("2026-01-01T00:00:00.000Z") });
+  entry.offer("offer-1", 1, "fare-1", "hold-1", new Date("2026-01-01T00:00:00.000Z"), new Date("2026-01-01T00:15:00.000Z"));
+
+  assert.throws(() => entry.expire(), DomainError);
+  assert.throws(() => entry.cancel(), DomainError);
+
+  entry.returnToQueue();
+
+  assert.equal(entry.status, "QUEUED");
+  assert.equal(entry.offerId, undefined);
+  assert.equal(entry.offerExpiresAt, null);
 });

--- a/services/waitlist/tests/promotion.test.ts
+++ b/services/waitlist/tests/promotion.test.ts
@@ -36,28 +36,26 @@ test("WaitlistCapacityFreed promotes highest-priority queued entry", async () =>
 
   const result = await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
 
-  assert.equal(result.promoted[0]?.entryId, platinum.entryId);
-  assert.equal((await service.get(platinum.entryId)).status, "OFFERED");
-  assert.equal((await service.get(regular.entryId)).status, "QUEUED");
+  assert.equal(result.promoted[0]?.waitlistRequestId, platinum.waitlistRequestId);
+  assert.equal((await service.get(platinum.waitlistRequestId)).status, "MATCHING");
+  assert.equal((await service.get(regular.waitlistRequestId)).status, "QUEUED");
   assert.equal(publisher.findByEventType("WaitlistEntryPromoted").length, 1);
 });
 
-test("expired offer releases hold and promotes next queued entry", async () => {
+test("expired matching attempt returns to queue, releases hold, and frees capacity", async () => {
   let current = new Date("2026-01-01T00:00:00.000Z");
   const repository = new InMemoryWaitlistRepository();
   const publisher = new InMemoryEventPublisher();
   const capacity = new StubCapacity();
   const service = new WaitlistApplicationService(repository, publisher, new StubFarePricing(), capacity, new StubJourneyOrder(), () => current, new StubOfferManagement());
   const first = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
-  const second = await service.join({ accountId: "acc", travelerRefs: ["t2"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "GOLD", tripCount: 0, daysBefore: 20 });
   await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
 
   current = new Date("2026-01-01T00:16:00.000Z");
   await service.expireDueOffers();
 
-  assert.equal((await service.get(first.entryId)).status, "EXPIRED");
-  assert.equal((await service.get(second.entryId)).status, "OFFERED");
-  assert.deepEqual(capacity.released, [`hold-${first.entryId}`]);
+  assert.equal((await service.get(first.waitlistRequestId)).status, "MATCHING");
+  assert.deepEqual(capacity.released, [`hold-${first.waitlistRequestId}`]);
   assert.equal(publisher.findByEventType("WaitlistOfferExpired").length, 1);
   assert.equal(publisher.findByEventType("WaitlistEntryPromoted").length, 2);
 });
@@ -66,9 +64,9 @@ test("accept promotion creates journey order and publishes accepted event", asyn
   const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), new InMemoryEventPublisher(), new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
   const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
   await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
-  const order = await service.accept(entry.entryId, { paymentMethodRef: "pm-1" });
-  assert.equal(order.orderId, `ord-${entry.entryId}`);
-  assert.equal((await service.get(entry.entryId)).status, "ACCEPTED");
+  const order = await service.accept(entry.waitlistRequestId, { paymentMethodRef: "pm-1" });
+  assert.equal(order.orderId, `ord-${entry.waitlistRequestId}`);
+  assert.equal((await service.get(entry.waitlistRequestId)).status, "FULFILLED");
 });
 
 test("accept does not mutate entry when journey order creation fails", async () => {
@@ -79,7 +77,7 @@ test("accept does not mutate entry when journey order creation fails", async () 
   const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
   await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
 
-  await assert.rejects(() => service.accept(entry.entryId), /downstream unavailable/);
+  await assert.rejects(() => service.accept(entry.waitlistRequestId), /downstream unavailable/);
 
-  assert.equal((await service.get(entry.entryId)).status, "OFFERED");
+  assert.equal((await service.get(entry.waitlistRequestId)).status, "MATCHING");
 });


### PR DESCRIPTION
## Summary
- replace legacy waitlist statuses with the contract 8-state enum and mapped transitions
- add WaitlistRequest resource projection for create/get/list responses
- update waitlist migration status check/index and tests for contract shape

## Validation
- cd services/waitlist && npm run build
- cd services/waitlist && npm test
- grep -R "ACCEPTED\|OFFERED" -n services/waitlist/src services/waitlist/tests services/waitlist/migrations