### PR TITLE
REQ-341 waitlist persistence OCC and dedup

### DIFF
--- a/services/waitlist/migrations/002_processed_events_event_id_pk.sql
+++ b/services/waitlist/migrations/002_processed_events_event_id_pk.sql
@@ -1,0 +1,10 @@
+DELETE FROM processed_events duplicate
+USING processed_events keeper
+WHERE duplicate.event_id = keeper.event_id
+  AND (duplicate.processed_at > keeper.processed_at
+    OR (duplicate.processed_at = keeper.processed_at AND duplicate.ctid > keeper.ctid));
+
+ALTER TABLE processed_events DROP CONSTRAINT IF EXISTS processed_events_pkey;
+ALTER TABLE processed_events ALTER COLUMN event_id SET NOT NULL;
+ALTER TABLE processed_events ALTER COLUMN stream DROP NOT NULL;
+ALTER TABLE processed_events ADD PRIMARY KEY (event_id);

--- a/services/waitlist/src/application.ts
+++ b/services/waitlist/src/application.ts
@@ -99,6 +99,10 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
     return [...this.entries.values()].filter((entry) => entry.status === "MATCHING" && entry.offerExpiresAt !== null && entry.offerExpiresAt <= now);
   }
 
+  async findByJourneyOrderRef(journeyOrderRef: string): Promise<WaitlistEntry | undefined> {
+    return [...this.entries.values()].find((entry) => entry.journeyOrderRef === journeyOrderRef);
+  }
+
   async queueFor(segmentRef: string, departureDate: string, seatClass?: string): Promise<readonly WaitlistEntrySnapshot[]> {
     const queue = this.buildQueue(segmentRef, departureDate, seatClass);
     return queue.allEntries().map((entry) => this.snapshot(entry));
@@ -187,6 +191,24 @@ export class WaitlistApplicationService {
 
   async handleCapacityFreed(event: WaitlistCapacityFreed, correlationId?: string) {
     return this.promotion.onCapacityFreed(event, correlationId);
+  }
+
+  async handleJourneyOrderConfirmed(orderId: string, correlationId?: string): Promise<WaitlistRequestResource | undefined> {
+    const entry = await this.repository.findByJourneyOrderRef?.(orderId);
+    if (!entry) return undefined;
+    if (entry.status === "FULFILLED") return toWaitlistRequestResource(await this.snapshot(entry));
+    const now = this.now();
+    entry.accept(now, orderId);
+    const snapshot = await this.repository.save(entry);
+    if (this.publisher) await publishAll(this.publisher, [waitlistEntryAccepted(snapshot, orderId, null, correlationId)]);
+    return toWaitlistRequestResource(snapshot);
+  }
+
+  async handleJourneyOrderCancelled(orderId: string): Promise<WaitlistRequestResource | undefined> {
+    const entry = await this.repository.findByJourneyOrderRef?.(orderId);
+    if (!entry || entry.status !== "MATCHING") return undefined;
+    entry.returnToQueue();
+    return toWaitlistRequestResource(await this.repository.save(entry));
   }
 
   async expireDueOffers(correlationId?: string) {

--- a/services/waitlist/src/bootstrap.ts
+++ b/services/waitlist/src/bootstrap.ts
@@ -1,4 +1,4 @@
-import { createRedisMessagingAdapters } from "@trainticket/ts-kit";
+import { createRedisMessagingAdapters, streamForProducer, type EventEnvelope } from "@trainticket/ts-kit";
 import { createApp } from "./app.js";
 import { WaitlistApplicationService } from "./application.js";
 import { createWaitlistEventHandler, SUBSCRIBED_STREAMS, CONSUMER_GROUP, consumerName } from "./subscriber.js";
@@ -11,6 +11,10 @@ export function runtimeHost(options: Pick<BootstrapOptions, "host"> = {}): strin
 export function runtimePort(options: Pick<BootstrapOptions, "port"> = {}): number { return options.port ?? Number.parseInt(process.env.PORT ?? "8080", 10); }
 export function runtimeRedisUrl(options: Pick<BootstrapOptions, "redisUrl"> = {}): string { return options.redisUrl ?? process.env.REDIS_URL ?? "redis://localhost:6379"; }
 
+function consumedStream(envelope: EventEnvelope): string {
+  return streamForProducer(envelope.producer);
+}
+
 export async function bootstrap(options: BootstrapOptions = {}) {
   const messaging = await createRedisMessagingAdapters(runtimeRedisUrl(options));
   const storage = process.env.DATABASE_URL ? await startWaitlistStorage(runtimeRedisUrl(options)) : undefined;
@@ -18,9 +22,15 @@ export async function bootstrap(options: BootstrapOptions = {}) {
   const abortController = new AbortController();
   const memoryEventService = new WaitlistApplicationService(undefined, messaging.publisher);
   const eventService = {
-    handleCapacityFreed: (event: WaitlistCapacityFreed, correlationId?: string) => storage
-      ? storage.runCommand((repository, publisher) => new WaitlistApplicationService(repository, publisher).handleCapacityFreed(event, correlationId))
+    handleCapacityFreed: (event: WaitlistCapacityFreed, correlationId: string | undefined, envelope: EventEnvelope) => storage
+      ? storage.runConsumedEvent(envelope.eventId, consumedStream(envelope), (repository, publisher) => new WaitlistApplicationService(repository, publisher).handleCapacityFreed(event, correlationId))
       : memoryEventService.handleCapacityFreed(event, correlationId),
+    handleJourneyOrderConfirmed: (orderId: string, correlationId: string | undefined, envelope: EventEnvelope) => storage
+      ? storage.runConsumedEvent(envelope.eventId, consumedStream(envelope), (repository, publisher) => new WaitlistApplicationService(repository, publisher).handleJourneyOrderConfirmed(orderId, correlationId))
+      : memoryEventService.handleJourneyOrderConfirmed(orderId, correlationId),
+    handleJourneyOrderCancelled: (orderId: string, _correlationId: string | undefined, envelope: EventEnvelope) => storage
+      ? storage.runConsumedEvent(envelope.eventId, consumedStream(envelope), (repository, publisher) => new WaitlistApplicationService(repository, publisher).handleJourneyOrderCancelled(orderId))
+      : memoryEventService.handleJourneyOrderCancelled(orderId),
   };
   const subscription = messaging.subscriber.subscribe(SUBSCRIBED_STREAMS, CONSUMER_GROUP, consumerName(options.instanceId ?? process.env.HOSTNAME), createWaitlistEventHandler(eventService), abortController.signal);
   subscription.catch((error: unknown) => {

--- a/services/waitlist/src/domain.ts
+++ b/services/waitlist/src/domain.ts
@@ -94,6 +94,7 @@ export class WaitlistEntry {
     private readonly _capacityReleaseIdempotencyKey: string = uuidV7(),
     private readonly _journeyOrderIdempotencyKey: string = uuidV7(),
     private readonly _capacitySegmentBookingId: string = `sb-${uuidV7()}`,
+    private _loadedVersion = 0,
   ) {}
 
   static create(command: CreateWaitlistEntry): WaitlistEntry {
@@ -172,6 +173,12 @@ export class WaitlistEntry {
   get capacityReleaseIdempotencyKey(): string { return this._capacityReleaseIdempotencyKey; }
   get journeyOrderIdempotencyKey(): string { return this._journeyOrderIdempotencyKey; }
   get capacitySegmentBookingId(): string { return this._capacitySegmentBookingId; }
+  get loadedVersion(): number { return this._loadedVersion; }
+
+  markPersisted(version: number): void {
+    if (!Number.isInteger(version) || version < 1) throw new DomainError("VALIDATION_FAILED", "loadedVersion must be a positive integer");
+    this._loadedVersion = version;
+  }
 
   offer(offerId: string, offerVersion: number, fareQuoteId: string, capacityHoldId: string, now: Date, expiresAt: Date): void {
     this.assertStatus("QUEUED", "Only queued waitlist entries can begin matching");
@@ -188,9 +195,8 @@ export class WaitlistEntry {
 
   accept(now: Date, journeyOrderRef: string): void {
     this.ensureOfferAcceptable(now);
-    assertNonEmpty(journeyOrderRef, "journeyOrderRef");
+    this.recordJourneyOrderRef(journeyOrderRef);
     this._status = "FULFILLED";
-    this._journeyOrderRef = journeyOrderRef;
   }
 
   ensureOfferAcceptable(now: Date): void {
@@ -257,6 +263,11 @@ export class WaitlistEntry {
 
   private assertStatus(expected: WaitlistStatus, message: string): void {
     if (this._status !== expected) throw new DomainError("INVALID_TRANSITION", message);
+  }
+
+  private recordJourneyOrderRef(journeyOrderRef: string): void {
+    assertNonEmpty(journeyOrderRef, "journeyOrderRef");
+    this._journeyOrderRef = journeyOrderRef;
   }
 }
 

--- a/services/waitlist/src/promotion.ts
+++ b/services/waitlist/src/promotion.ts
@@ -30,6 +30,7 @@ export interface WaitlistRepository {
   get(entryId: string): Promise<WaitlistEntry | undefined> | WaitlistEntry | undefined;
   save(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> | WaitlistEntrySnapshot;
   findTopQueued(segmentRef: string, departureDate: string, seatClass?: string): Promise<WaitlistEntry | undefined> | WaitlistEntry | undefined;
+  findByJourneyOrderRef?(journeyOrderRef: string): Promise<WaitlistEntry | undefined> | WaitlistEntry | undefined;
   findExpiredOffers(now: Date): Promise<readonly WaitlistEntry[]> | readonly WaitlistEntry[];
   queueFor(segmentRef: string, departureDate: string, seatClass?: string): Promise<readonly WaitlistEntrySnapshot[]> | readonly WaitlistEntrySnapshot[];
   listByTraveler(travelerRef: string): Promise<readonly WaitlistEntrySnapshot[]> | readonly WaitlistEntrySnapshot[];

--- a/services/waitlist/src/storage.ts
+++ b/services/waitlist/src/storage.ts
@@ -1,7 +1,7 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Redis } from "ioredis";
-import { MigrationRunner, OutboxAppender, OutboxRelay, PostgresIdempotencyStore, checkPostgresReadiness, createPostgresPool, streamForProducer, withTransaction, type EventEnvelope } from "@trainticket/ts-kit";
+import { MigrationRunner, OptimisticConcurrencyConflict, OutboxAppender, OutboxRelay, PostgresIdempotencyStore, checkPostgresReadiness, createPostgresPool, streamForProducer, withTransaction, type EventEnvelope } from "@trainticket/ts-kit";
 import type { Pool, PoolClient, QueryResult } from "pg";
 import { WaitlistEntry, type WaitlistEntrySnapshot } from "./domain.js";
 import type { WaitlistRepository } from "./promotion.js";
@@ -16,6 +16,7 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
       [snapshot.entryId, snapshot.accountId, JSON.stringify(snapshot.travelerRefs), snapshot.segmentRef, snapshot.departureDate, snapshot.seatClass, snapshot.priorityScore, snapshot.status, snapshot.offeredAt, snapshot.offerExpiresAt, snapshot.fareQuoteId ?? null, snapshot.capacityHoldId ?? null, snapshot, snapshot.createdAt],
     );
+    entry.markPersisted(1);
     return this.snapshot(entry);
   }
 
@@ -26,12 +27,16 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
 
   async save(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
     const snapshot = entry.toSnapshot(0);
-    await this.db.query(
+    const loadedVersion = entry.loadedVersion;
+    if (loadedVersion < 1) throw new OptimisticConcurrencyConflict(`Waitlist entry ${entry.entryId} has no loaded version`);
+    const result = await this.db.query(
       `UPDATE waitlist_entries
        SET status=$2, offered_at=$3, offer_expires_at=$4, fare_quote_id=$5, capacity_hold_id=$6, data=$7, version=version+1, updated_at=now()
-       WHERE entry_id=$1`,
-      [snapshot.entryId, snapshot.status, snapshot.offeredAt, snapshot.offerExpiresAt, snapshot.fareQuoteId ?? null, snapshot.capacityHoldId ?? null, snapshot],
+       WHERE entry_id=$1 AND version=$8`,
+      [snapshot.entryId, snapshot.status, snapshot.offeredAt, snapshot.offerExpiresAt, snapshot.fareQuoteId ?? null, snapshot.capacityHoldId ?? null, snapshot, loadedVersion],
     );
+    if (result.rowCount === 0) throw new OptimisticConcurrencyConflict(`Waitlist entry ${entry.entryId} was modified by another writer`);
+    entry.markPersisted(loadedVersion + 1);
     return this.snapshot(entry);
   }
 
@@ -49,6 +54,11 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
   async findExpiredOffers(now: Date): Promise<readonly WaitlistEntry[]> {
     const result = await this.db.query(`SELECT * FROM waitlist_entries WHERE status = 'MATCHING' AND offer_expires_at <= $1 ORDER BY offer_expires_at ASC`, [now.toISOString()]) as QueryResult<WaitlistRow>;
     return result.rows.map(entryFromRow);
+  }
+
+  async findByJourneyOrderRef(journeyOrderRef: string): Promise<WaitlistEntry | undefined> {
+    const result = await this.db.query(`SELECT * FROM waitlist_entries WHERE data->>'journeyOrderRef' = $1 ORDER BY created_at ASC LIMIT 1`, [journeyOrderRef]) as QueryResult<WaitlistRow>;
+    return result.rows[0] ? entryFromRow(result.rows[0]) : undefined;
   }
 
   async queueFor(segmentRef: string, departureDate: string, seatClass?: string): Promise<readonly WaitlistEntrySnapshot[]> {
@@ -78,10 +88,25 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
   }
 }
 
+export class ProcessedEventRepository {
+  constructor(private readonly db: Pool | PoolClient) {}
+
+  async record(eventId: string, stream: string): Promise<boolean> {
+    const result = await this.db.query(
+      `INSERT INTO processed_events (event_id, stream)
+       VALUES ($1, $2)
+       ON CONFLICT (event_id) DO NOTHING`,
+      [eventId, stream],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+}
+
 export type WaitlistStorageRuntime = Readonly<{
   ready: () => Promise<boolean>;
   idempotencyStore: PostgresIdempotencyStore;
   runCommand: <T>(operation: (repository: WaitlistRepository, publisher: TransactionalOutboxPublisher) => Promise<T>) => Promise<T>;
+  runConsumedEvent: <T>(eventId: string, stream: string, operation: (repository: WaitlistRepository, publisher: TransactionalOutboxPublisher) => Promise<T>) => Promise<T | undefined>;
   stop: () => Promise<void>;
 }>;
 
@@ -97,6 +122,10 @@ export async function startWaitlistStorage(redisUrl = process.env.REDIS_URL ?? "
     ready: () => migrations.isReady ? checkPostgresReadiness(pool) : Promise.resolve(false),
     idempotencyStore: new PostgresIdempotencyStore(pool),
     runCommand: (operation) => withTransaction(pool, async (client) => operation(new PostgresWaitlistRepository(client), new TransactionalOutboxPublisher(new OutboxAppender(client)))),
+    runConsumedEvent: (eventId, stream, operation) => withTransaction(pool, async (client) => {
+      if (!await new ProcessedEventRepository(client).record(eventId, stream)) return undefined;
+      return operation(new PostgresWaitlistRepository(client), new TransactionalOutboxPublisher(new OutboxAppender(client)));
+    }),
     stop: async () => { await relay.stop(); await Promise.allSettled([redis.quit(), pool.end()]); },
   };
 }
@@ -110,7 +139,7 @@ export function migrationsDirectory(): string { return process.env.MIGRATIONS_DI
 
 function entryFromRow(row: WaitlistRow): WaitlistEntry {
   const data = row.data ?? {};
-  return WaitlistEntry.fromSnapshot({
+  const entry = WaitlistEntry.fromSnapshot({
     entryId: row.entry_id,
     accountId: row.account_id,
     travelerRefs: Array.isArray(row.traveler_refs) ? row.traveler_refs.map(String) : [],
@@ -139,6 +168,8 @@ function entryFromRow(row: WaitlistRow): WaitlistEntry {
     journeyOrderIdempotencyKey: typeof data.journeyOrderIdempotencyKey === "string" ? data.journeyOrderIdempotencyKey : undefined,
     capacitySegmentBookingId: typeof data.capacitySegmentBookingId === "string" ? data.capacitySegmentBookingId : undefined,
   });
+  entry.markPersisted(Number(row.version));
+  return entry;
 }
 
 function positionIn(entries: readonly WaitlistEntry[], entryId: string): number {
@@ -170,5 +201,6 @@ type WaitlistRow = Readonly<{
   fare_quote_id: string | null;
   capacity_hold_id: string | null;
   data: Record<string, unknown> | null;
+  version: string | number | bigint;
   created_at: Date | string;
 }>;

--- a/services/waitlist/src/subscriber.ts
+++ b/services/waitlist/src/subscriber.ts
@@ -3,18 +3,35 @@ import type { WaitlistApplicationService } from "./application.js";
 import type { WaitlistCapacityFreed } from "./promotion.js";
 
 export const CAPACITY_AVAILABILITY_STREAM = "events:capacity-availability";
-export const SUBSCRIBED_STREAMS: readonly string[] = [CAPACITY_AVAILABILITY_STREAM];
+export const JOURNEY_ORDER_STREAM = "events:journey-order";
+export const SUBSCRIBED_STREAMS: readonly string[] = [CAPACITY_AVAILABILITY_STREAM, JOURNEY_ORDER_STREAM];
 export const CONSUMER_GROUP = "waitlist";
 
 export function consumerName(instanceId?: string): string {
   return `waitlist-${instanceId ?? "default"}`;
 }
 
-export function createWaitlistEventHandler(service: Pick<WaitlistApplicationService, "handleCapacityFreed">) {
+type WaitlistConsumedEventService = Readonly<{
+  handleCapacityFreed(event: WaitlistCapacityFreed, correlationId: string | undefined, envelope: EventEnvelope): Promise<unknown> | unknown;
+  handleJourneyOrderConfirmed(orderId: string, correlationId: string | undefined, envelope: EventEnvelope): Promise<unknown> | unknown;
+  handleJourneyOrderCancelled(orderId: string, correlationId: string | undefined, envelope: EventEnvelope): Promise<unknown> | unknown;
+}>;
+
+export function createWaitlistEventHandler(service: WaitlistConsumedEventService) {
   return async (envelope: EventEnvelope): Promise<EventHandlerResult> => {
     try {
-      if (envelope.eventType !== "WaitlistCapacityFreed") return successfulHandling();
-      await service.handleCapacityFreed(parseCapacityFreed(envelope), envelope.correlationId);
+      if (envelope.eventType === "CapacityReleased" || envelope.eventType === "WaitlistCapacityFreed") {
+        await service.handleCapacityFreed(parseCapacityFreed(envelope), envelope.correlationId, envelope);
+        return successfulHandling();
+      }
+      if (envelope.eventType === "JourneyOrderConfirmed") {
+        await service.handleJourneyOrderConfirmed(parseJourneyOrderId(envelope), envelope.correlationId, envelope);
+        return successfulHandling();
+      }
+      if (envelope.eventType === "JourneyOrderCancelled") {
+        await service.handleJourneyOrderCancelled(parseJourneyOrderId(envelope), envelope.correlationId, envelope);
+        return successfulHandling();
+      }
       return successfulHandling();
     } catch (error) {
       if (error instanceof Error && /failed with status|fetch failed|ECONNREFUSED/u.test(error.message)) return transientHandling(error);
@@ -27,9 +44,13 @@ export function parseCapacityFreed(envelope: EventEnvelope): WaitlistCapacityFre
   const payload = envelope.payload as Record<string, unknown>;
   const segmentRef = string(payload.segmentRef);
   const departureDate = string(payload.departureDate);
-  const freedSlots = number(payload.freedSlots ?? payload.availableSlots ?? 1);
-  const seatClass = typeof payload.seatClass === "string" ? payload.seatClass : undefined;
+  const freedSlots = number(payload.freedSlots ?? payload.availableSlots ?? payload.quantity ?? 1);
+  const seatClass = typeof payload.seatClass === "string" ? payload.seatClass : typeof payload.classRef === "string" ? payload.classRef : undefined;
   return { segmentRef, departureDate, freedSlots, seatClass };
+}
+
+export function parseJourneyOrderId(envelope: EventEnvelope): string {
+  return string((envelope.payload as Record<string, unknown>).orderId);
 }
 
 function string(value: unknown): string {

--- a/services/waitlist/tests/storage.test.ts
+++ b/services/waitlist/tests/storage.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import test from "node:test";
+import { OptimisticConcurrencyConflict } from "@trainticket/ts-kit";
+import { WaitlistEntry } from "../src/domain.js";
+import { PostgresWaitlistRepository, ProcessedEventRepository } from "../src/storage.js";
+
+class FakeDb {
+  public readonly calls: Array<{ sql: string; params: readonly unknown[] }> = [];
+
+  constructor(private readonly rowCounts: readonly number[] = []) {}
+
+  async query(sql: string, params: readonly unknown[] = []) {
+    this.calls.push({ sql, params });
+    return { rows: [], rowCount: this.rowCounts[this.calls.length - 1] ?? 0 };
+  }
+}
+
+function persistedEntry(version: number): WaitlistEntry {
+  const entry = WaitlistEntry.create({
+    accountId: "acc-1",
+    travelerRefs: ["tvl-1"],
+    segmentRef: "seg-1",
+    departureDate: "2026-07-20",
+    seatClass: "SECOND",
+    priority: { groupSize: 1, fareClass: "SECOND" },
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  });
+  entry.markPersisted(version);
+  entry.cancel();
+  return entry;
+}
+
+test("PostgresWaitlistRepository.save uses loaded version in OCC predicate", async () => {
+  const db = new FakeDb([1, 0]);
+  const repository = new PostgresWaitlistRepository(db as never);
+  const entry = persistedEntry(3);
+
+  await repository.save(entry);
+
+  const update = db.calls[0];
+  assert.match(update.sql, /WHERE entry_id=\$1 AND version=\$8/u);
+  assert.equal(update.params[7], 3);
+  assert.equal(entry.loadedVersion, 4);
+});
+
+test("PostgresWaitlistRepository.save rejects stale loaded version", async () => {
+  const db = new FakeDb([0]);
+  const repository = new PostgresWaitlistRepository(db as never);
+
+  await assert.rejects(() => repository.save(persistedEntry(2)), OptimisticConcurrencyConflict);
+});
+
+test("ProcessedEventRepository records by event_id primary key only", async () => {
+  const first = new FakeDb([1]);
+  assert.equal(await new ProcessedEventRepository(first as never).record("evt-1", "events:journey-order"), true);
+  assert.match(first.calls[0].sql, /ON CONFLICT \(event_id\) DO NOTHING/u);
+
+  const replay = new FakeDb([0]);
+  assert.equal(await new ProcessedEventRepository(replay as never).record("evt-1", "events:capacity-availability"), false);
+});
+
+test("processed_events primary key change is applied by a follow-up migration", async () => {
+  const migrationsDir = join(process.cwd(), "migrations");
+  const initialMigration = await readFile(join(migrationsDir, "001_waitlist.sql"), "utf8");
+  assert.match(initialMigration, /PRIMARY KEY \(event_id, stream\)/u);
+
+  const migration = await readFile(join(migrationsDir, "002_processed_events_event_id_pk.sql"), "utf8");
+  assert.match(migration, /DROP CONSTRAINT IF EXISTS processed_events_pkey/u);
+  assert.match(migration, /DROP NOT NULL/u);
+  assert.match(migration, /ADD PRIMARY KEY \(event_id\)/u);
+});


### PR DESCRIPTION
## Summary
- enforce optimistic concurrency in waitlist Postgres saves using the loaded aggregate version
- migrate processed_events to event_id primary key and record consumed event ids transactionally
- route CapacityReleased/WaitlistCapacityFreed plus JourneyOrderConfirmed/Cancelled through durable consumer dedup

## Validation
- cd services/waitlist && npm run build
- cd services/waitlist && npm test