### PR TITLE
REQ-342 waitlist event publishing conformance

### DIFF
--- a/services/waitlist/src/app.ts
+++ b/services/waitlist/src/app.ts
@@ -81,13 +81,13 @@ export function createApp(dependencies: AppDependencies = {}): FastifyInstance {
   app.get("/api/v1/waitlist/entries/:entryId", async (request, reply) => handleRead(reply, request, () => (
     runCommand((repository, publisher) => commandService(repository, publisher).get(param(request, "entryId")))
   )));
-  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist-requests/:waitlistRequestId/cancel", async (request) => ({
+  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist-requests/:waitlistRequestId/cancel", async (request, ctx) => ({
     statusCode: 200,
-    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "waitlistRequestId"))),
+    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "waitlistRequestId"), request.body as any, ctx.correlationId)),
   }));
-  stateChanging(app, idempotencyStore, "DELETE", "/api/v1/waitlist/entries/:entryId", async (request) => ({
+  stateChanging(app, idempotencyStore, "DELETE", "/api/v1/waitlist/entries/:entryId", async (request, ctx) => ({
     statusCode: 200,
-    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "entryId"))),
+    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "entryId"), request.body as any, ctx.correlationId)),
   }));
   stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist/entries/:entryId/accept", async (request, ctx) => ({
     statusCode: 200,

--- a/services/waitlist/src/application.ts
+++ b/services/waitlist/src/application.ts
@@ -1,7 +1,7 @@
 import { type EventPublisher } from "@trainticket/ts-kit";
 import { DomainError, WaitlistEntry, WaitlistQueue, type CreateWaitlistEntry, type FareClass, type PriorityInput, type WaitlistEntrySnapshot } from "./domain.js";
 import { HttpCapacityAvailabilityClient, HttpFarePricingClient, HttpOfferManagementClient, PromotionOrchestrator, type CapacityAvailabilityClient, type FarePricingClient, type OfferManagementClient, type WaitlistCapacityFreed, type WaitlistRepository } from "./promotion.js";
-import { publishAll, waitlistEntryAccepted, waitlistEntryCreated } from "./publisher.js";
+import { publishAll, waitlistCancelled, waitlistFulfilled, waitlistPaymentAuthorizationRequested, waitlistQueued, waitlistRequestCreated } from "./publisher.js";
 
 export type JoinWaitlistRequest = Readonly<{
   accountId: string;
@@ -22,6 +22,7 @@ export type JoinWaitlistRequest = Readonly<{
 }>;
 
 export type AcceptPromotionRequest = Readonly<{ paymentMethodRef?: string }>;
+export type CancelWaitlistRequest = Readonly<{ reason?: string }>;
 export type AcceptPromotionResponse = Readonly<{ orderId: string; seatAssignment: unknown }>;
 export type QueueInfo = Readonly<{ totalQueued: number; myPosition: number | null; estimatedPromotionRate: number }>;
 export type WaitlistRequestList = Readonly<{
@@ -80,6 +81,7 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
 
   async add(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
     this.entries.set(entry.entryId, entry);
+    entry.markPersisted(1);
     return this.snapshot(entry);
   }
 
@@ -87,6 +89,7 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
 
   async save(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
     this.entries.set(entry.entryId, entry);
+    entry.markPersisted(entry.loadedVersion + 1);
     return this.snapshot(entry);
   }
 
@@ -150,7 +153,14 @@ export class WaitlistApplicationService {
   async join(request: JoinWaitlistRequest, correlationId?: string): Promise<WaitlistRequestResource> {
     const entry = WaitlistEntry.create(this.toCreateCommand(request));
     const snapshot = await this.repository.add(entry);
-    if (this.publisher) await publishAll(this.publisher, [waitlistEntryCreated(snapshot, correlationId)]);
+    const aggregateVersion = entry.loadedVersion;
+    if (this.publisher) {
+      await publishAll(this.publisher, [
+        waitlistRequestCreated(snapshot, aggregateVersion, correlationId),
+        waitlistPaymentAuthorizationRequested(snapshot, aggregateVersion, correlationId),
+        waitlistQueued(snapshot, aggregateVersion, correlationId, snapshot.createdAt),
+      ]);
+    }
     return toWaitlistRequestResource(snapshot);
   }
 
@@ -165,11 +175,13 @@ export class WaitlistApplicationService {
     return { items: page.map(toWaitlistRequestResource), total: snapshots.length, limit, offset };
   }
 
-  async cancel(entryId: string): Promise<{ waitlistRequestId: string; status: "CANCELLED"; cancelledAt: string }> {
+  async cancel(entryId: string, request: CancelWaitlistRequest = {}, correlationId?: string): Promise<{ waitlistRequestId: string; status: "CANCELLED"; cancelledAt: string }> {
     const entry = await this.requireEntry(entryId);
+    const cancelledAt = this.now().toISOString();
     entry.cancel();
     const snapshot = await this.repository.save(entry);
-    return { waitlistRequestId: snapshot.entryId, status: "CANCELLED", cancelledAt: this.now().toISOString() };
+    if (this.publisher) await publishAll(this.publisher, [waitlistCancelled(snapshot, entry.loadedVersion, request.reason ?? "", correlationId, cancelledAt)]);
+    return { waitlistRequestId: snapshot.entryId, status: "CANCELLED", cancelledAt };
   }
 
   async accept(entryId: string, request: AcceptPromotionRequest = {}, correlationId?: string): Promise<AcceptPromotionResponse> {
@@ -177,9 +189,8 @@ export class WaitlistApplicationService {
     const now = this.now();
     entry.ensureOfferAcceptable(now);
     const order = await this.journeyOrder.createOrder(entry, request.paymentMethodRef);
-    entry.accept(now, order.orderId);
-    const snapshot = await this.repository.save(entry);
-    if (this.publisher) await publishAll(this.publisher, [waitlistEntryAccepted(snapshot, order.orderId, order.seatAssignment, correlationId)]);
+    entry.attachJourneyOrder(order.orderId);
+    await this.repository.save(entry);
     return order;
   }
 
@@ -200,15 +211,18 @@ export class WaitlistApplicationService {
     const now = this.now();
     entry.accept(now, orderId);
     const snapshot = await this.repository.save(entry);
-    if (this.publisher) await publishAll(this.publisher, [waitlistEntryAccepted(snapshot, orderId, null, correlationId)]);
+    if (this.publisher) await publishAll(this.publisher, [waitlistFulfilled(snapshot, entry.loadedVersion, orderId, correlationId, now.toISOString())]);
     return toWaitlistRequestResource(snapshot);
   }
 
-  async handleJourneyOrderCancelled(orderId: string): Promise<WaitlistRequestResource | undefined> {
+  async handleJourneyOrderCancelled(orderId: string, correlationId?: string): Promise<WaitlistRequestResource | undefined> {
     const entry = await this.repository.findByJourneyOrderRef?.(orderId);
     if (!entry || entry.status !== "MATCHING") return undefined;
+    const queuedAt = this.now().toISOString();
     entry.returnToQueue();
-    return toWaitlistRequestResource(await this.repository.save(entry));
+    const snapshot = await this.repository.save(entry);
+    if (this.publisher) await publishAll(this.publisher, [waitlistQueued(snapshot, entry.loadedVersion, correlationId, queuedAt, { journeyOrderRef: orderId })]);
+    return toWaitlistRequestResource(snapshot);
   }
 
   async expireDueOffers(correlationId?: string) {

--- a/services/waitlist/src/domain.ts
+++ b/services/waitlist/src/domain.ts
@@ -207,7 +207,7 @@ export class WaitlistEntry {
   }
 
   expire(): void {
-    this.assertStatus("QUEUED", `Cannot expire ${this._status} waitlist entry`);
+    if (this._status !== "QUEUED" && this._status !== "MATCHING") throw new DomainError("INVALID_TRANSITION", `Cannot expire ${this._status} waitlist entry`);
     this._status = "EXPIRED";
   }
 
@@ -263,6 +263,11 @@ export class WaitlistEntry {
 
   private assertStatus(expected: WaitlistStatus, message: string): void {
     if (this._status !== expected) throw new DomainError("INVALID_TRANSITION", message);
+  }
+
+  attachJourneyOrder(journeyOrderRef: string): void {
+    this.assertStatus("MATCHING", "Only matching waitlist entries can be attached to a journey order");
+    this.recordJourneyOrderRef(journeyOrderRef);
   }
 
   private recordJourneyOrderRef(journeyOrderRef: string): void {

--- a/services/waitlist/src/promotion.ts
+++ b/services/waitlist/src/promotion.ts
@@ -1,4 +1,4 @@
-import { type EventPublisher } from "@trainticket/ts-kit";
+import { isPrefixedUuidV7, type EventPublisher } from "@trainticket/ts-kit";
 import { DomainError, type WaitlistEntry, type WaitlistEntrySnapshot } from "./domain.js";
 import { publishAll, waitlistExpired, waitlistHoldAuthorized, waitlistMatchStarted } from "./publisher.js";
 
@@ -7,7 +7,7 @@ export type WaitlistCapacityFreed = Readonly<{
   departureDate: string;
   seatClass?: string;
   freedSlots: number;
-  capacityReleaseRef?: string;
+  capacityReleaseRef: string;
 }>;
 
 export type WaitlistOffer = Readonly<{
@@ -150,6 +150,7 @@ export class PromotionOrchestrator {
     for (let index = 0; index < slots; index++) {
       const entry = await this.repository.findTopQueued(event.segmentRef, event.departureDate, event.seatClass);
       if (!entry) break;
+      assertCapacityReleaseRef(event.capacityReleaseRef);
       const quote = await this.farePricing.quote(entry);
       const commercialOffer = await this.offerManagement.createOffer(entry, quote.fareQuoteId);
       const hold = await this.capacityAvailability.hold(entry, quote.fareQuoteId);
@@ -162,7 +163,7 @@ export class PromotionOrchestrator {
       offers.push(offer);
       await publishAll(this.publisher, [
         waitlistHoldAuthorized(snapshot, entry.loadedVersion, correlationId, now.toISOString()),
-        waitlistMatchStarted(snapshot, entry.loadedVersion, event.capacityReleaseRef ?? "unknown", correlationId, now.toISOString()),
+        waitlistMatchStarted(snapshot, entry.loadedVersion, event.capacityReleaseRef, correlationId, now.toISOString()),
       ]);
     }
     return { promoted, offers };
@@ -178,7 +179,6 @@ export class PromotionOrchestrator {
       const snapshot = await this.repository.save(entry);
       expired.push(snapshot);
       await publishAll(this.publisher, [waitlistExpired(snapshot, entry.loadedVersion, correlationId, now.toISOString())]);
-      await this.onCapacityFreed({ segmentRef: entry.segmentRef, departureDate: entry.departureDate, seatClass: entry.seatClass, freedSlots: 1 }, correlationId);
     }
     return expired;
   }
@@ -189,6 +189,12 @@ export function offerFromEntry(entry: WaitlistEntry): WaitlistOffer {
     throw new DomainError("PRECONDITION_FAILED", "Waitlist entry does not have an active offer");
   }
   return { offerId: entry.offerId, offerVersion: entry.offerVersion, entryId: entry.entryId, fareQuoteId: entry.fareQuoteId, capacityHoldId: entry.capacityHoldId, expiresAt: entry.offerExpiresAt.toISOString() };
+}
+
+function assertCapacityReleaseRef(capacityReleaseRef: string): void {
+  if (!isPrefixedUuidV7(capacityReleaseRef, ["evt"])) {
+    throw new DomainError("VALIDATION_FAILED", "capacityReleaseRef must be the consumed CapacityReleased eventId");
+  }
 }
 
 function trimRight(value: string): string { return value.replace(/\/+$/u, ""); }

--- a/services/waitlist/src/promotion.ts
+++ b/services/waitlist/src/promotion.ts
@@ -1,12 +1,13 @@
 import { type EventPublisher } from "@trainticket/ts-kit";
 import { DomainError, type WaitlistEntry, type WaitlistEntrySnapshot } from "./domain.js";
-import { publishAll, waitlistEntryPromoted, waitlistOfferExpired } from "./publisher.js";
+import { publishAll, waitlistExpired, waitlistHoldAuthorized, waitlistMatchStarted } from "./publisher.js";
 
 export type WaitlistCapacityFreed = Readonly<{
   segmentRef: string;
   departureDate: string;
   seatClass?: string;
   freedSlots: number;
+  capacityReleaseRef?: string;
 }>;
 
 export type WaitlistOffer = Readonly<{
@@ -159,7 +160,10 @@ export class PromotionOrchestrator {
       const snapshot = await this.repository.save(entry);
       promoted.push({ ...snapshot, waitlistRequestId: snapshot.entryId });
       offers.push(offer);
-      await publishAll(this.publisher, [waitlistEntryPromoted(snapshot, offer, correlationId)]);
+      await publishAll(this.publisher, [
+        waitlistHoldAuthorized(snapshot, entry.loadedVersion, correlationId, now.toISOString()),
+        waitlistMatchStarted(snapshot, entry.loadedVersion, event.capacityReleaseRef ?? "unknown", correlationId, now.toISOString()),
+      ]);
     }
     return { promoted, offers };
   }
@@ -168,13 +172,12 @@ export class PromotionOrchestrator {
     const now = this.now();
     const expired: WaitlistEntrySnapshot[] = [];
     for (const entry of await this.repository.findExpiredOffers(now)) {
-      const offer = offerFromEntry(entry);
       const capacityHoldId = entry.capacityHoldId;
-      entry.returnToQueue();
+      entry.expire();
       if (capacityHoldId) await this.capacityAvailability.releaseHold(entry, capacityHoldId);
       const snapshot = await this.repository.save(entry);
       expired.push(snapshot);
-      await publishAll(this.publisher, [waitlistOfferExpired(snapshot, offer, correlationId)]);
+      await publishAll(this.publisher, [waitlistExpired(snapshot, entry.loadedVersion, correlationId, now.toISOString())]);
       await this.onCapacityFreed({ segmentRef: entry.segmentRef, departureDate: entry.departureDate, seatClass: entry.seatClass, freedSlots: 1 }, correlationId);
     }
     return expired;

--- a/services/waitlist/src/publisher.ts
+++ b/services/waitlist/src/publisher.ts
@@ -1,31 +1,161 @@
+import { createHash } from "node:crypto";
 import { createEventEnvelope, type EventEnvelope, type EventPublisher } from "@trainticket/ts-kit";
 import type { WaitlistEntrySnapshot } from "./domain.js";
-import type { WaitlistOffer } from "./promotion.js";
 
 export const WAITLIST_PRODUCER = "waitlist";
 
+export type WaitlistEventType =
+  | "WaitlistRequestCreated"
+  | "WaitlistPaymentAuthorizationRequested"
+  | "WaitlistQueued"
+  | "WaitlistMatchStarted"
+  | "WaitlistHoldAuthorized"
+  | "WaitlistFulfilled"
+  | "WaitlistCancelled"
+  | "WaitlistExpired";
+
 export type WaitlistEventPayload = Record<string, unknown>;
 
-export function waitlistEntryCreated(entry: WaitlistEntrySnapshot, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistEntryCreated", { entry }, correlationId);
+export function deterministicEventId(seed: string): string {
+  const bytes = createHash("sha256").update(seed, "utf8").digest().subarray(0, 16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x70;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = [...bytes].map((value) => value.toString(16).padStart(2, "0")).join("");
+  return `evt-${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
-export function waitlistEntryPromoted(entry: WaitlistEntrySnapshot, offer: WaitlistOffer, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistEntryPromoted", { entry, offer }, correlationId);
+export function waitlistEventIdSeed(eventType: WaitlistEventType, waitlistRequestId: string, aggregateVersion: number): string {
+  return `waitlist:${eventType}:${waitlistRequestId}:${aggregateVersion}`;
 }
 
-export function waitlistOfferExpired(entry: WaitlistEntrySnapshot, offer: WaitlistOffer, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistOfferExpired", { entry, offer }, correlationId);
+export function waitlistRequestCreated(entry: WaitlistEntrySnapshot, aggregateVersion: number, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistRequestCreated", entry, aggregateVersion, {
+    ...basePayload(entry),
+    deadline: entry.deadline,
+    paymentGuaranteeRef: entry.paymentGuaranteeRef,
+    itineraryRef: itineraryRef(entry),
+    intentFingerprint: entry.intentFingerprint,
+    status: "DRAFT",
+    createdAt: entry.createdAt,
+  }, correlationId, entry.createdAt);
 }
 
-export function waitlistEntryAccepted(entry: WaitlistEntrySnapshot, orderId: string, seatAssignment: unknown, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return waitlistEnvelope("WaitlistEntryAccepted", { entry, orderId, seatAssignment }, correlationId);
+export function waitlistPaymentAuthorizationRequested(entry: WaitlistEntrySnapshot, aggregateVersion: number, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistPaymentAuthorizationRequested", entry, aggregateVersion, {
+    waitlistRequestId: entry.entryId,
+    accountId: entry.accountId,
+    travelerRef: travelerRef(entry),
+    paymentGuaranteeRef: entry.paymentGuaranteeRef,
+    requestedAt: entry.createdAt,
+    status: "DRAFT",
+  }, correlationId, entry.createdAt);
+}
+
+export function waitlistQueued(
+  entry: WaitlistEntrySnapshot,
+  aggregateVersion: number,
+  correlationId: string | undefined,
+  queuedAt: string,
+  options: Readonly<{ journeyOrderRef?: string; requeueReason?: string }> = {},
+): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistQueued", entry, aggregateVersion, {
+    ...basePayload(entry),
+    itineraryRef: itineraryRef(entry),
+    intentFingerprint: entry.intentFingerprint,
+    queuedAt,
+    status: "QUEUED",
+    journeyOrderRef: options.journeyOrderRef ?? entry.journeyOrderRef,
+    requeueReason: options.requeueReason,
+  }, correlationId, queuedAt);
+}
+
+export function waitlistMatchStarted(
+  entry: WaitlistEntrySnapshot,
+  aggregateVersion: number,
+  matchedCapacityReleaseRef: string,
+  correlationId: string | undefined,
+  startedAt: string,
+): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistMatchStarted", entry, aggregateVersion, {
+    ...basePayload(entry),
+    matchedCapacityReleaseRef,
+    journeyOrderIdempotencyKey: entry.journeyOrderIdempotencyKey,
+    startedAt,
+    status: "MATCHING",
+  }, correlationId, startedAt);
+}
+
+export function waitlistHoldAuthorized(entry: WaitlistEntrySnapshot, aggregateVersion: number, correlationId: string | undefined, authorizedAt: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistHoldAuthorized", entry, aggregateVersion, {
+    ...basePayload(entry),
+    authorizedAt,
+    status: "MATCHING",
+  }, correlationId, authorizedAt);
+}
+
+export function waitlistFulfilled(entry: WaitlistEntrySnapshot, aggregateVersion: number, journeyOrderRef: string, correlationId: string | undefined, fulfilledAt: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistFulfilled", entry, aggregateVersion, {
+    ...basePayload(entry),
+    journeyOrderRef,
+    fulfilledAt,
+    status: entry.status,
+  }, correlationId, fulfilledAt);
+}
+
+export function waitlistCancelled(entry: WaitlistEntrySnapshot, aggregateVersion: number, reason: string, correlationId: string | undefined, cancelledAt: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistCancelled", entry, aggregateVersion, {
+    ...basePayload(entry),
+    cancelledAt,
+    reason,
+    status: "CANCELLED",
+  }, correlationId, cancelledAt);
+}
+
+export function waitlistExpired(entry: WaitlistEntrySnapshot, aggregateVersion: number, correlationId: string | undefined, expiredAt: string): EventEnvelope<WaitlistEventPayload> {
+  return waitlistEnvelope("WaitlistExpired", entry, aggregateVersion, {
+    ...basePayload(entry),
+    deadline: entry.deadline,
+    expiredAt,
+    status: "EXPIRED",
+  }, correlationId, expiredAt);
 }
 
 export async function publishAll(publisher: EventPublisher, envelopes: readonly EventEnvelope[]): Promise<void> {
   for (const envelope of envelopes) await publisher.publish(envelope);
 }
 
-function waitlistEnvelope(eventType: string, payload: WaitlistEventPayload, correlationId?: string): EventEnvelope<WaitlistEventPayload> {
-  return createEventEnvelope({ eventType, producer: WAITLIST_PRODUCER, payload, correlationId });
+function waitlistEnvelope(
+  eventType: WaitlistEventType,
+  entry: WaitlistEntrySnapshot,
+  aggregateVersion: number,
+  payload: WaitlistEventPayload,
+  correlationId?: string,
+  occurredAt?: string,
+): EventEnvelope<WaitlistEventPayload> {
+  return createEventEnvelope({
+    eventType,
+    producer: WAITLIST_PRODUCER,
+    payload,
+    correlationId,
+    occurredAt,
+    eventId: deterministicEventId(waitlistEventIdSeed(eventType, entry.entryId, aggregateVersion)),
+  });
+}
+
+function basePayload(entry: WaitlistEntrySnapshot): WaitlistEventPayload {
+  return {
+    waitlistRequestId: entry.entryId,
+    accountId: entry.accountId,
+    travelerRef: travelerRef(entry),
+    segmentRef: entry.segmentRef,
+    travelClass: entry.seatClass,
+  };
+}
+
+function travelerRef(entry: WaitlistEntrySnapshot): string {
+  return entry.travelerRefs[0] ?? "";
+}
+
+function itineraryRef(entry: WaitlistEntrySnapshot): string {
+  return entry.itineraryRef ?? entry.segmentRef;
 }

--- a/services/waitlist/src/storage.ts
+++ b/services/waitlist/src/storage.ts
@@ -32,11 +32,12 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
     const result = await this.db.query(
       `UPDATE waitlist_entries
        SET status=$2, offered_at=$3, offer_expires_at=$4, fare_quote_id=$5, capacity_hold_id=$6, data=$7, version=version+1, updated_at=now()
-       WHERE entry_id=$1 AND version=$8`,
+       WHERE entry_id=$1 AND version=$8
+       RETURNING version`,
       [snapshot.entryId, snapshot.status, snapshot.offeredAt, snapshot.offerExpiresAt, snapshot.fareQuoteId ?? null, snapshot.capacityHoldId ?? null, snapshot, loadedVersion],
     );
     if (result.rowCount === 0) throw new OptimisticConcurrencyConflict(`Waitlist entry ${entry.entryId} was modified by another writer`);
-    entry.markPersisted(loadedVersion + 1);
+    entry.markPersisted(Number((result as QueryResult<{ version: string | number | bigint }>).rows[0]?.version ?? loadedVersion + 1));
     return this.snapshot(entry);
   }
 

--- a/services/waitlist/src/subscriber.ts
+++ b/services/waitlist/src/subscriber.ts
@@ -46,7 +46,7 @@ export function parseCapacityFreed(envelope: EventEnvelope): WaitlistCapacityFre
   const departureDate = string(payload.departureDate);
   const freedSlots = number(payload.freedSlots ?? payload.availableSlots ?? payload.quantity ?? 1);
   const seatClass = typeof payload.seatClass === "string" ? payload.seatClass : typeof payload.classRef === "string" ? payload.classRef : undefined;
-  return { segmentRef, departureDate, freedSlots, seatClass };
+  return { segmentRef, departureDate, freedSlots, seatClass, capacityReleaseRef: envelope.eventId };
 }
 
 export function parseJourneyOrderId(envelope: EventEnvelope): string {

--- a/services/waitlist/tests/domain.test.ts
+++ b/services/waitlist/tests/domain.test.ts
@@ -19,11 +19,10 @@ test("queue orders by priority descending then createdAt ascending", () => {
   assert.equal(queue.positionOf("wl-old"), 2);
 });
 
-test("matching entries return to queue instead of expiring or cancelling directly", () => {
+test("matching entries return to queue instead of cancelling directly", () => {
   const entry = WaitlistEntry.create({ entryId: "wl-match", accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", priority: { loyaltyTier: "GOLD", tripCount: 10, daysBefore: 10 }, createdAt: new Date("2026-01-01T00:00:00.000Z") });
   entry.offer("offer-1", 1, "fare-1", "hold-1", new Date("2026-01-01T00:00:00.000Z"), new Date("2026-01-01T00:15:00.000Z"));
 
-  assert.throws(() => entry.expire(), DomainError);
   assert.throws(() => entry.cancel(), DomainError);
 
   entry.returnToQueue();

--- a/services/waitlist/tests/promotion.test.ts
+++ b/services/waitlist/tests/promotion.test.ts
@@ -5,6 +5,8 @@ import { InMemoryWaitlistRepository, WaitlistApplicationService, type JourneyOrd
 import type { CapacityAvailabilityClient, FarePricingClient, OfferManagementClient } from "../src/promotion.js";
 import type { WaitlistEntry } from "../src/domain.js";
 
+const CAPACITY_RELEASE_REF = "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c123";
+
 class StubFarePricing implements FarePricingClient {
   public calls: string[] = [];
   async quote(entry: WaitlistEntry) { this.calls.push(entry.entryId); return { fareQuoteId: `fq-${entry.entryId}` }; }
@@ -34,23 +36,25 @@ test("WaitlistCapacityFreed promotes highest-priority queued entry", async () =>
   const regular = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "NONE", tripCount: 0, daysBefore: 20 });
   const platinum = await service.join({ accountId: "acc", travelerRefs: ["t2"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
 
-  const result = await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
+  const result = await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: CAPACITY_RELEASE_REF });
 
   assert.equal(result.promoted[0]?.waitlistRequestId, platinum.waitlistRequestId);
   assert.equal((await service.get(platinum.waitlistRequestId)).status, "MATCHING");
   assert.equal((await service.get(regular.waitlistRequestId)).status, "QUEUED");
+  const matchStarted = publisher.findByEventType("WaitlistMatchStarted")[0];
+  assert.equal(matchStarted?.payload.matchedCapacityReleaseRef, CAPACITY_RELEASE_REF);
   assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 1);
   assert.equal(publisher.findByEventType("WaitlistHoldAuthorized").length, 1);
 });
 
-test("expired matching attempt expires, releases hold, and frees capacity", async () => {
+test("expired matching attempt expires and waits for CapacityReleased before promoting another entry", async () => {
   let current = new Date("2026-01-01T00:00:00.000Z");
   const repository = new InMemoryWaitlistRepository();
   const publisher = new InMemoryEventPublisher();
   const capacity = new StubCapacity();
   const service = new WaitlistApplicationService(repository, publisher, new StubFarePricing(), capacity, new StubJourneyOrder(), () => current, new StubOfferManagement());
   const first = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
-  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
+  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: CAPACITY_RELEASE_REF });
 
   current = new Date("2026-01-01T00:16:00.000Z");
   await service.expireDueOffers();
@@ -59,13 +63,27 @@ test("expired matching attempt expires, releases hold, and frees capacity", asyn
   assert.deepEqual(capacity.released, [`hold-${first.waitlistRequestId}`]);
   assert.equal(publisher.findByEventType("WaitlistExpired").length, 1);
   assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 1);
+  assert.equal(publisher.findByEventType("WaitlistMatchStarted").at(-1)?.payload.matchedCapacityReleaseRef, CAPACITY_RELEASE_REF);
+});
+
+test("capacity freed without a CapacityReleased eventId is rejected before publishing a match fact", async () => {
+  const publisher = new InMemoryEventPublisher();
+  const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
+  await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
+
+  await assert.rejects(
+    () => service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: "" }),
+    /capacityReleaseRef must be the consumed CapacityReleased eventId/u,
+  );
+
+  assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 0);
 });
 
 test("accept promotion creates journey order and records order ref", async () => {
   const publisher = new InMemoryEventPublisher();
   const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
   const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
-  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
+  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: CAPACITY_RELEASE_REF });
   const order = await service.accept(entry.waitlistRequestId, { paymentMethodRef: "pm-1" });
   assert.equal(order.orderId, `ord-${entry.waitlistRequestId}`);
   assert.equal((await service.get(entry.waitlistRequestId)).journeyOrderRef, `ord-${entry.waitlistRequestId}`);
@@ -78,7 +96,7 @@ test("accept does not mutate entry when journey order creation fails", async () 
   }
   const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), new InMemoryEventPublisher(), new StubFarePricing(), new StubCapacity(), new FailingJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
   const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
-  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
+  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: CAPACITY_RELEASE_REF });
 
   await assert.rejects(() => service.accept(entry.waitlistRequestId), /downstream unavailable/);
 

--- a/services/waitlist/tests/promotion.test.ts
+++ b/services/waitlist/tests/promotion.test.ts
@@ -39,10 +39,11 @@ test("WaitlistCapacityFreed promotes highest-priority queued entry", async () =>
   assert.equal(result.promoted[0]?.waitlistRequestId, platinum.waitlistRequestId);
   assert.equal((await service.get(platinum.waitlistRequestId)).status, "MATCHING");
   assert.equal((await service.get(regular.waitlistRequestId)).status, "QUEUED");
-  assert.equal(publisher.findByEventType("WaitlistEntryPromoted").length, 1);
+  assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 1);
+  assert.equal(publisher.findByEventType("WaitlistHoldAuthorized").length, 1);
 });
 
-test("expired matching attempt returns to queue, releases hold, and frees capacity", async () => {
+test("expired matching attempt expires, releases hold, and frees capacity", async () => {
   let current = new Date("2026-01-01T00:00:00.000Z");
   const repository = new InMemoryWaitlistRepository();
   const publisher = new InMemoryEventPublisher();
@@ -54,19 +55,21 @@ test("expired matching attempt returns to queue, releases hold, and frees capaci
   current = new Date("2026-01-01T00:16:00.000Z");
   await service.expireDueOffers();
 
-  assert.equal((await service.get(first.waitlistRequestId)).status, "MATCHING");
+  assert.equal((await service.get(first.waitlistRequestId)).status, "EXPIRED");
   assert.deepEqual(capacity.released, [`hold-${first.waitlistRequestId}`]);
-  assert.equal(publisher.findByEventType("WaitlistOfferExpired").length, 1);
-  assert.equal(publisher.findByEventType("WaitlistEntryPromoted").length, 2);
+  assert.equal(publisher.findByEventType("WaitlistExpired").length, 1);
+  assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 1);
 });
 
-test("accept promotion creates journey order and publishes accepted event", async () => {
-  const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), new InMemoryEventPublisher(), new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
+test("accept promotion creates journey order and records order ref", async () => {
+  const publisher = new InMemoryEventPublisher();
+  const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
   const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
   await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1 });
   const order = await service.accept(entry.waitlistRequestId, { paymentMethodRef: "pm-1" });
   assert.equal(order.orderId, `ord-${entry.waitlistRequestId}`);
-  assert.equal((await service.get(entry.waitlistRequestId)).status, "FULFILLED");
+  assert.equal((await service.get(entry.waitlistRequestId)).journeyOrderRef, `ord-${entry.waitlistRequestId}`);
+  assert.equal(publisher.findByEventType("WaitlistFulfilled").length, 0);
 });
 
 test("accept does not mutate entry when journey order creation fails", async () => {

--- a/services/waitlist/tests/publisher.test.ts
+++ b/services/waitlist/tests/publisher.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { InMemoryEventPublisher, isUuidV7 } from "@trainticket/ts-kit";
+import { InMemoryWaitlistRepository, WaitlistApplicationService, type JourneyOrderClient } from "../src/application.js";
+import type { CapacityAvailabilityClient, FarePricingClient, OfferManagementClient } from "../src/promotion.js";
+import type { WaitlistEntry } from "../src/domain.js";
+import { deterministicEventId } from "../src/publisher.js";
+
+class StubFarePricing implements FarePricingClient {
+  async quote(entry: WaitlistEntry) { return { fareQuoteId: `fq-${entry.entryId}` }; }
+}
+
+class StubOfferManagement implements OfferManagementClient {
+  async createOffer(entry: WaitlistEntry) { return { offerId: `off-${entry.entryId}`, offerVersion: 1 }; }
+}
+
+class StubCapacity implements CapacityAvailabilityClient {
+  async hold(entry: WaitlistEntry) { return { capacityHoldId: `hold-${entry.entryId}` }; }
+  async releaseHold() {}
+}
+
+class StubJourneyOrder implements JourneyOrderClient {
+  async createOrder(entry: WaitlistEntry) { return { orderId: `ord-${entry.entryId}`, seatAssignment: null }; }
+}
+
+test("deterministic event ids are stable UUIDv7-shaped event ids", () => {
+  const seed = "waitlist:WaitlistQueued:wlr-123:2";
+  const eventId = deterministicEventId(seed);
+
+  assert.equal(eventId, deterministicEventId(seed));
+  assert.match(eventId, /^evt-/u);
+  assert.equal(isUuidV7(eventId.slice("evt-".length)), true);
+  assert.notEqual(eventId, seed);
+});
+
+test("join publishes waitlist contract facts with deterministic ids and fields", async () => {
+  const publisher = new InMemoryEventPublisher();
+  const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, undefined, undefined, undefined, () => new Date("2026-01-01T00:00:00.000Z"));
+
+  const resource = await service.join({
+    accountId: "acc-1",
+    travelerRef: "tvl-1",
+    segmentRef: "seg-1",
+    travelClass: "SECOND",
+    deadline: "2026-07-20T00:00:00.000Z",
+    paymentGuaranteeRef: "pay-auth-1",
+    itineraryRef: "itn-1",
+    intentFingerprint: "intent-1",
+  }, "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c123");
+
+  assert.deepEqual(publisher.envelopes.map((event) => event.eventType), ["WaitlistRequestCreated", "WaitlistPaymentAuthorizationRequested", "WaitlistQueued"]);
+  assert.deepEqual(publisher.envelopes.map((event) => event.eventId), [
+    deterministicEventId(`waitlist:WaitlistRequestCreated:${resource.waitlistRequestId}:1`),
+    deterministicEventId(`waitlist:WaitlistPaymentAuthorizationRequested:${resource.waitlistRequestId}:1`),
+    deterministicEventId(`waitlist:WaitlistQueued:${resource.waitlistRequestId}:1`),
+  ]);
+  assert.equal(publisher.envelopes.every((event) => isUuidV7(event.eventId.slice("evt-".length))), true);
+
+  const created = publisher.envelopes[0]?.payload as Record<string, unknown>;
+  assert.equal(created.waitlistRequestId, resource.waitlistRequestId);
+  assert.equal(created.accountId, "acc-1");
+  assert.equal(created.travelerRef, "tvl-1");
+  assert.equal(created.segmentRef, "seg-1");
+  assert.equal(created.travelClass, "SECOND");
+  assert.equal(created.deadline, "2026-07-20T00:00:00.000Z");
+  assert.equal(created.paymentGuaranteeRef, "pay-auth-1");
+  assert.equal(created.itineraryRef, "itn-1");
+  assert.equal(created.intentFingerprint, "intent-1");
+  assert.equal(created.status, "DRAFT");
+  assert.equal(typeof created.createdAt, "string");
+
+  const payment = publisher.envelopes[1]?.payload as Record<string, unknown>;
+  assert.equal(payment.paymentGuaranteeRef, "pay-auth-1");
+  assert.equal(payment.requestedAt, created.createdAt);
+  assert.equal(payment.status, "DRAFT");
+
+  const queued = publisher.envelopes[2]?.payload as Record<string, unknown>;
+  assert.equal(queued.status, "QUEUED");
+  assert.equal(queued.itineraryRef, "itn-1");
+  assert.equal(queued.intentFingerprint, "intent-1");
+  assert.equal(queued.queuedAt, created.createdAt);
+});
+
+test("cancel publishes WaitlistCancelled with supplied reason without defaulting API input", async () => {
+  const publisher = new InMemoryEventPublisher();
+  const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, undefined, undefined, undefined, () => new Date("2026-01-01T00:00:00.000Z"));
+  const resource = await service.join({ accountId: "acc", travelerRef: "tvl", segmentRef: "seg", departureDate: "2026-07-20", travelClass: "SECOND", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itn", intentFingerprint: "intent" });
+
+  await service.cancel(resource.waitlistRequestId, { reason: "USER_REQUESTED" });
+
+  const event = publisher.findByEventType("WaitlistCancelled")[0];
+  assert.equal(event?.eventId, deterministicEventId(`waitlist:WaitlistCancelled:${resource.waitlistRequestId}:2`));
+  assert.equal(event?.payload.reason, "USER_REQUESTED");
+  assert.equal(event?.payload.status, "CANCELLED");
+});
+
+test("journey order cancellation requeue publishes WaitlistQueued with journeyOrderRef", async () => {
+  const publisher = new InMemoryEventPublisher();
+  const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
+  const entry = await service.join({ accountId: "acc", travelerRef: "tvl", segmentRef: "seg", departureDate: "2026-07-20", travelClass: "SECOND", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itn", intentFingerprint: "intent" });
+  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c123" });
+  await service.accept(entry.waitlistRequestId);
+  const matching = await service.get(entry.waitlistRequestId);
+
+  const requeued = await service.handleJourneyOrderCancelled(`ord-${entry.waitlistRequestId}`);
+
+  assert.equal(matching.status, "MATCHING");
+  assert.equal(requeued?.status, "QUEUED");
+  const queued = publisher.findByEventType("WaitlistQueued").at(-1);
+  assert.equal(queued?.eventId, deterministicEventId(`waitlist:WaitlistQueued:${entry.waitlistRequestId}:4`));
+  assert.equal(queued?.payload.journeyOrderRef, `ord-${entry.waitlistRequestId}`);
+});


### PR DESCRIPTION
## Summary
- add waitlist-local deterministic UUIDv7-shaped event id derivation from contract seeds
- publish contract waitlist facts/payload fields for create, queue/requeue, match, hold, fulfill, cancel, and expire paths
- decouple hold fact from journey-order creation and preserve journeyOrderRef on order-cancel requeue

## Validation
- cd services/waitlist && npm test
- cd services/waitlist && npm run build