### PR TITLE
REQ-343 conform waitlist API errors

### DIFF
--- a/services/waitlist/migrations/001_waitlist.sql
+++ b/services/waitlist/migrations/001_waitlist.sql
@@ -26,6 +26,10 @@ CREATE INDEX IF NOT EXISTS waitlist_offer_expiry_idx
     ON waitlist_entries (offer_expires_at)
     WHERE status = 'MATCHING';
 
+CREATE UNIQUE INDEX IF NOT EXISTS waitlist_active_traveler_intent_idx
+    ON waitlist_entries ((traveler_refs->>0), (data->>'intentFingerprint'))
+    WHERE status IN ('DRAFT', 'QUEUED', 'MATCHING', 'SUSPENDED');
+
 CREATE TABLE IF NOT EXISTS waitlist_offers (
     offer_id text PRIMARY KEY,
     entry_id text NOT NULL REFERENCES waitlist_entries(entry_id),

--- a/services/waitlist/migrations/003_active_traveler_intent_unique_idx.sql
+++ b/services/waitlist/migrations/003_active_traveler_intent_unique_idx.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX IF NOT EXISTS waitlist_active_traveler_intent_idx
+    ON waitlist_entries ((traveler_refs->>0), (data->>'intentFingerprint'))
+    WHERE status IN ('DRAFT', 'QUEUED', 'MATCHING', 'SUSPENDED');

--- a/services/waitlist/src/app.ts
+++ b/services/waitlist/src/app.ts
@@ -1,7 +1,7 @@
 import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from "fastify";
 import { InMemoryEventPublisher, InMemoryIdempotencyStore, errorMessage, handleIdempotency, headerValue, requestContext as kitRequestContext, requestFingerprint, sendError, type EventPublisher, type IdempotencyStore, type RequestContext } from "@trainticket/ts-kit";
 import { DomainError } from "./domain.js";
-import { InMemoryWaitlistRepository, WaitlistApplicationService, type JourneyOrderClient } from "./application.js";
+import { InMemoryWaitlistRepository, WaitlistApplicationService, type JoinWaitlistRequest, type JourneyOrderClient } from "./application.js";
 import type { CapacityAvailabilityClient, FarePricingClient, OfferManagementClient, WaitlistRepository } from "./promotion.js";
 import { serviceProfile } from "./profile.js";
 
@@ -60,16 +60,17 @@ export function createApp(dependencies: AppDependencies = {}): FastifyInstance {
 
   stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist-requests", async (request, ctx) => ({
     statusCode: 201,
-    body: await runCommand((repository, publisher) => commandService(repository, publisher).join(request.body as any, ctx.correlationId)),
+    body: await runCommand((repository, publisher) => commandService(repository, publisher).join(createBody(request.body), ctx.correlationId)),
   }));
   stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist/entries", async (request, ctx) => ({
     statusCode: 201,
-    body: await runCommand((repository, publisher) => commandService(repository, publisher).join(request.body as any, ctx.correlationId)),
+    body: await runCommand((repository, publisher) => commandService(repository, publisher).join(createBody(request.body), ctx.correlationId)),
   }));
   app.get("/api/v1/waitlist-requests", async (request, reply) => handleRead(reply, request, () => {
     const params = query(request);
+    const travelerRef = requiredQueryString(params, "travelerRef");
     return runCommand((repository, publisher) => commandService(repository, publisher).listByTraveler(
-      params.travelerRef ?? "",
+      travelerRef,
       params.status as any,
       parsePageNumber(params.limit, 20, 100),
       parsePageNumber(params.offset, 0, Number.MAX_SAFE_INTEGER),
@@ -83,15 +84,15 @@ export function createApp(dependencies: AppDependencies = {}): FastifyInstance {
   )));
   stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist-requests/:waitlistRequestId/cancel", async (request, ctx) => ({
     statusCode: 200,
-    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "waitlistRequestId"), request.body as any, ctx.correlationId)),
+    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "waitlistRequestId"), cancelBody(request.body), ctx.correlationId)),
   }));
   stateChanging(app, idempotencyStore, "DELETE", "/api/v1/waitlist/entries/:entryId", async (request, ctx) => ({
     statusCode: 200,
-    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "entryId"), request.body as any, ctx.correlationId)),
+    body: await runCommand((repository, publisher) => commandService(repository, publisher).cancel(param(request, "entryId"), cancelBody(request.body), ctx.correlationId)),
   }));
   stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist/entries/:entryId/accept", async (request, ctx) => ({
     statusCode: 200,
-    body: await runCommand((repository, publisher) => commandService(repository, publisher).accept(param(request, "entryId"), request.body as any, ctx.correlationId)),
+    body: await runCommand((repository, publisher) => commandService(repository, publisher).accept(param(request, "entryId"), optionalObjectBody(request.body), ctx.correlationId)),
   }));
   app.get("/api/v1/waitlist/segments/:segmentRef/:departureDate/queue", async (request, reply) => handleRead(reply, request, () => (
     runCommand((repository, publisher) => commandService(repository, publisher).queueInfo(param(request, "segmentRef"), param(request, "departureDate"), query(request).seatClass, query(request).entryId))
@@ -101,8 +102,11 @@ export function createApp(dependencies: AppDependencies = {}): FastifyInstance {
   app.setErrorHandler((error, request, reply) => {
     const ctx = requestContext(request);
     if (error instanceof DomainError) {
-      const status = error.code === "NOT_FOUND" ? 404 : error.code === "PRECONDITION_FAILED" || error.code === "INVALID_TRANSITION" ? 409 : 400;
-      sendError(reply, status, error.code, error.message, ctx, { domainCode: error.code });
+      sendError(reply, statusForDomainError(error), error.code, error.message, ctx, { domainCode: error.code });
+      return;
+    }
+    if (isJsonBodyParseError(error, request)) {
+      sendError(reply, 400, "VALIDATION_FAILED", errorMessage(error), ctx, { domainCode: "VALIDATION_FAILED" });
       return;
     }
     sendError(reply, 500, "INTERNAL_ERROR", errorMessage(error), ctx);
@@ -133,7 +137,7 @@ async function handleRead(reply: FastifyReply, request: FastifyRequest, operatio
   try { return reply.status(200).send(await operation()); }
   catch (error) {
     const ctx = requestContext(request);
-    if (error instanceof DomainError) sendError(reply, error.code === "NOT_FOUND" ? 404 : 409, error.code, error.message, ctx, { domainCode: error.code });
+    if (error instanceof DomainError) sendError(reply, statusForDomainError(error), error.code, error.message, ctx, { domainCode: error.code });
     else throw error;
     return reply;
   }
@@ -142,6 +146,45 @@ async function handleRead(reply: FastifyReply, request: FastifyRequest, operatio
 function requestContext(request: FastifyRequest): RequestContext { return kitRequestContext({ headers: request.headers, id: request.id }); }
 function param(request: FastifyRequest, name: string): string { return (request.params as Record<string, string>)[name] ?? ""; }
 function query(request: FastifyRequest): Record<string, string | undefined> { return request.query as Record<string, string | undefined>; }
+function statusForDomainError(error: DomainError): number {
+  if (error.code === "NOT_FOUND") return 404;
+  if (error.code === "CONFLICT" || error.code === "PRECONDITION_FAILED" || error.code === "INVALID_TRANSITION") return 409;
+  return 400;
+}
+function createBody(body: unknown): JoinWaitlistRequest {
+  const parsed = objectBody(body);
+  for (const field of ["accountId", "travelerRef", "segmentRef", "deadline", "paymentGuaranteeRef", "itineraryRef", "intentFingerprint"]) requiredString(parsed, field);
+  return parsed as unknown as JoinWaitlistRequest;
+}
+function cancelBody(body: unknown): Record<string, unknown> {
+  const parsed = objectBody(body);
+  requiredString(parsed, "reason");
+  return parsed;
+}
+function objectBody(body: unknown): Record<string, unknown> {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) throw new DomainError("VALIDATION_FAILED", "Request body must be a JSON object");
+  return body as Record<string, unknown>;
+}
+function optionalObjectBody(body: unknown): Record<string, unknown> {
+  if (body === undefined) return {};
+  return objectBody(body);
+}
+function requiredString(body: Record<string, unknown>, field: string): string {
+  const value = body[field];
+  if (typeof value !== "string" || value.trim().length === 0) throw new DomainError("VALIDATION_FAILED", `${field} is required`);
+  return value;
+}
+function requiredQueryString(params: Record<string, string | undefined>, field: string): string {
+  const value = params[field];
+  if (typeof value !== "string" || value.trim().length === 0) throw new DomainError("VALIDATION_FAILED", `${field} is required`);
+  return value;
+}
+function isJsonBodyParseError(error: unknown, request: FastifyRequest): boolean {
+  if (request.method !== "POST" && request.method !== "DELETE") return false;
+  if (typeof error !== "object" || error === null) return false;
+  const candidate = error as { code?: unknown; statusCode?: unknown };
+  return candidate.statusCode === 400 || candidate.code === "FST_ERR_CTP_EMPTY_JSON_BODY" || candidate.code === "FST_ERR_CTP_INVALID_JSON_BODY";
+}
 function parsePageNumber(value: string | undefined, fallback: number, max: number): number {
   const parsed = Number.parseInt(value ?? "", 10);
   if (!Number.isFinite(parsed) || parsed < 0) return fallback;

--- a/services/waitlist/src/application.ts
+++ b/services/waitlist/src/application.ts
@@ -80,6 +80,9 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
   private readonly entries = new Map<string, WaitlistEntry>();
 
   async add(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
+    if (this.hasActiveDuplicate(entry.travelerRefs[0] ?? "", entry.intentFingerprint)) {
+      throw new DomainError("CONFLICT", "An active waitlist request already exists for this traveler and intent");
+    }
     this.entries.set(entry.entryId, entry);
     entry.markPersisted(1);
     return this.snapshot(entry);
@@ -119,6 +122,10 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
   }
 
   clear(): void { this.entries.clear(); }
+
+  private hasActiveDuplicate(travelerRef: string, intentFingerprint: string): boolean {
+    return [...this.entries.values()].some((entry) => isActiveStatus(entry.status) && entry.travelerRefs[0] === travelerRef && entry.intentFingerprint === intentFingerprint);
+  }
 
   private buildQueue(segmentRef: string, departureDate: string, seatClass?: string): WaitlistQueue {
     const matching = [...this.entries.values()].filter((entry) => entry.segmentRef === segmentRef && entry.departureDate === departureDate && (!seatClass || entry.seatClass === seatClass));
@@ -176,11 +183,13 @@ export class WaitlistApplicationService {
   }
 
   async cancel(entryId: string, request: CancelWaitlistRequest = {}, correlationId?: string): Promise<{ waitlistRequestId: string; status: "CANCELLED"; cancelledAt: string }> {
+    const body = objectBody(request);
+    const reason = requiredString(body, "reason");
     const entry = await this.requireEntry(entryId);
     const cancelledAt = this.now().toISOString();
     entry.cancel();
     const snapshot = await this.repository.save(entry);
-    if (this.publisher) await publishAll(this.publisher, [waitlistCancelled(snapshot, entry.loadedVersion, request.reason ?? "", correlationId, cancelledAt)]);
+    if (this.publisher) await publishAll(this.publisher, [waitlistCancelled(snapshot, entry.loadedVersion, reason, correlationId, cancelledAt)]);
     return { waitlistRequestId: snapshot.entryId, status: "CANCELLED", cancelledAt };
   }
 
@@ -230,7 +239,7 @@ export class WaitlistApplicationService {
   }
 
   private toCreateCommand(request: JoinWaitlistRequest): CreateWaitlistEntry {
-    const travelerRefs = request.travelerRefs ?? (request.travelerRef ? [request.travelerRef] : []);
+    const travelerRefs = request.travelerRef ? [request.travelerRef] : request.travelerRefs ?? [];
     const seatClass = request.seatClass ?? request.travelClass ?? "SECOND";
     const departureDate = request.departureDate ?? dateFromDeadline(request.deadline);
     return {
@@ -266,6 +275,10 @@ export class WaitlistApplicationService {
   }
 }
 
+function isActiveStatus(status: WaitlistEntrySnapshot["status"]): boolean {
+  return status === "DRAFT" || status === "QUEUED" || status === "MATCHING" || status === "SUSPENDED";
+}
+
 function toWaitlistRequestResource(snapshot: WaitlistEntrySnapshot): WaitlistRequestResource {
   return {
     waitlistRequestId: snapshot.entryId,
@@ -280,6 +293,19 @@ function toWaitlistRequestResource(snapshot: WaitlistEntrySnapshot): WaitlistReq
     status: snapshot.status,
     journeyOrderRef: snapshot.journeyOrderRef,
   };
+}
+
+function objectBody(value: unknown): CancelWaitlistRequest {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new DomainError("VALIDATION_FAILED", "Request body must be a JSON object");
+  }
+  return value as CancelWaitlistRequest;
+}
+
+function requiredString(body: CancelWaitlistRequest, field: "reason"): string {
+  const value = body[field];
+  if (typeof value !== "string" || value.trim().length === 0) throw new DomainError("VALIDATION_FAILED", `${field} is required`);
+  return value;
 }
 
 function daysBefore(departureDate: string): number {

--- a/services/waitlist/src/domain.ts
+++ b/services/waitlist/src/domain.ts
@@ -60,7 +60,7 @@ export type CreateWaitlistEntry = Readonly<{
 }>;
 
 export class DomainError extends Error {
-  constructor(public readonly code: "VALIDATION_FAILED" | "INVALID_TRANSITION" | "NOT_FOUND" | "PRECONDITION_FAILED", message: string) {
+  constructor(public readonly code: "VALIDATION_FAILED" | "INVALID_TRANSITION" | "NOT_FOUND" | "PRECONDITION_FAILED" | "CONFLICT", message: string) {
     super(message);
     this.name = "DomainError";
   }

--- a/services/waitlist/src/storage.ts
+++ b/services/waitlist/src/storage.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { Redis } from "ioredis";
 import { MigrationRunner, OptimisticConcurrencyConflict, OutboxAppender, OutboxRelay, PostgresIdempotencyStore, checkPostgresReadiness, createPostgresPool, streamForProducer, withTransaction, type EventEnvelope } from "@trainticket/ts-kit";
 import type { Pool, PoolClient, QueryResult } from "pg";
-import { WaitlistEntry, type WaitlistEntrySnapshot } from "./domain.js";
+import { DomainError, WaitlistEntry, type WaitlistEntrySnapshot } from "./domain.js";
 import type { WaitlistRepository } from "./promotion.js";
 
 export class PostgresWaitlistRepository implements WaitlistRepository {
@@ -11,11 +11,16 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
 
   async add(entry: WaitlistEntry): Promise<WaitlistEntrySnapshot> {
     const snapshot = entry.toSnapshot(0);
-    await this.db.query(
-      `INSERT INTO waitlist_entries (entry_id, account_id, traveler_refs, segment_ref, departure_date, seat_class, priority_score, status, offered_at, offer_expires_at, fare_quote_id, capacity_hold_id, data, created_at)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
-      [snapshot.entryId, snapshot.accountId, JSON.stringify(snapshot.travelerRefs), snapshot.segmentRef, snapshot.departureDate, snapshot.seatClass, snapshot.priorityScore, snapshot.status, snapshot.offeredAt, snapshot.offerExpiresAt, snapshot.fareQuoteId ?? null, snapshot.capacityHoldId ?? null, snapshot, snapshot.createdAt],
-    );
+    try {
+      await this.db.query(
+        `INSERT INTO waitlist_entries (entry_id, account_id, traveler_refs, segment_ref, departure_date, seat_class, priority_score, status, offered_at, offer_expires_at, fare_quote_id, capacity_hold_id, data, created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+        [snapshot.entryId, snapshot.accountId, JSON.stringify(snapshot.travelerRefs), snapshot.segmentRef, snapshot.departureDate, snapshot.seatClass, snapshot.priorityScore, snapshot.status, snapshot.offeredAt, snapshot.offerExpiresAt, snapshot.fareQuoteId ?? null, snapshot.capacityHoldId ?? null, snapshot, snapshot.createdAt],
+      );
+    } catch (error) {
+      if (isUniqueViolation(error)) throw new DomainError("CONFLICT", "An active waitlist request already exists for this traveler and intent");
+      throw error;
+    }
     entry.markPersisted(1);
     return this.snapshot(entry);
   }
@@ -185,6 +190,11 @@ function deadlineFromDepartureDate(departureDate: string): string { return `${de
 function defaultIntentFingerprint(travelerRefs: unknown, segmentRef: string, departureDate: string, seatClass: string): string {
   const travelerRef = Array.isArray(travelerRefs) ? String(travelerRefs[0] ?? "unknown") : "unknown";
   return `${travelerRef}:${segmentRef}:${departureDate}:${seatClass}`;
+}
+function isUniqueViolation(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const pgError = error as { code?: unknown; constraint?: unknown };
+  return pgError.code === "23505" && (pgError.constraint === undefined || pgError.constraint === "waitlist_active_traveler_intent_idx");
 }
 function sanitizedErrorForLog(error: unknown): Readonly<{ name: string; message: string }> { return error instanceof Error ? { name: error.name || "Error", message: error.message || "Storage failed" } : { name: typeof error, message: "Storage failed" }; }
 

--- a/services/waitlist/tests/app.test.ts
+++ b/services/waitlist/tests/app.test.ts
@@ -55,3 +55,195 @@ test("waitlist request endpoints return contract resource shape", async () => {
 
   await app.close();
 });
+
+test("create rejects missing travelerRef even when legacy travelerRefs is supplied", async () => {
+  resetWaitlistStore();
+  const app = createApp();
+  const response = await app.inject({
+    method: "POST",
+    url: "/api/v1/waitlist-requests",
+    headers: { "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c124" },
+    payload: {
+      accountId: "acc-1",
+      travelerRefs: ["tvl-legacy"],
+      segmentRef: "seg-1",
+      deadline: "2026-07-20T00:00:00.000Z",
+      paymentGuaranteeRef: "pay-auth-1",
+      itineraryRef: "itn-1",
+      intentFingerprint: "intent-1",
+    },
+  });
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.json().code, "VALIDATION_FAILED");
+  assert.equal(response.json().details.domainCode, "VALIDATION_FAILED");
+  assert.match(response.json().message, /travelerRef is required/u);
+  await app.close();
+});
+
+test("create rejects all contract-required fields that were previously defaulted", async () => {
+  const fields = ["accountId", "segmentRef", "deadline", "paymentGuaranteeRef", "itineraryRef", "intentFingerprint"];
+  for (const [index, field] of fields.entries()) {
+    resetWaitlistStore();
+    const app = createApp();
+    const payload: Record<string, unknown> = {
+      accountId: "acc-1",
+      travelerRef: "tvl-1",
+      segmentRef: "seg-1",
+      deadline: "2026-07-20T00:00:00.000Z",
+      paymentGuaranteeRef: "pay-auth-1",
+      itineraryRef: "itn-1",
+      intentFingerprint: "intent-1",
+    };
+    delete payload[field];
+
+    const idempotencyKey = [
+      "0194f2e0-7b3e-7610-8284-5c26e8b0c125",
+      "0194f2e0-7b3e-7610-8284-5c26e8b0c126",
+      "0194f2e0-7b3e-7610-8284-5c26e8b0c127",
+      "0194f2e0-7b3e-7610-8284-5c26e8b0c128",
+      "0194f2e0-7b3e-7610-8284-5c26e8b0c129",
+      "0194f2e0-7b3e-7610-8284-5c26e8b0c130",
+    ][index] ?? "0194f2e0-7b3e-7610-8284-5c26e8b0c125";
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/waitlist-requests",
+      headers: { "Idempotency-Key": idempotencyKey },
+      payload,
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.json().code, "VALIDATION_FAILED");
+    assert.match(response.json().message, new RegExp(`${field} is required`, "u"));
+    await app.close();
+  }
+});
+
+test("create rejects malformed bodies with validation error", async () => {
+  const cases = [
+    { payload: "null", message: /Request body must be a JSON object/u },
+    { payload: "", message: /Body cannot be empty|Request body must be a JSON object/u },
+    { payload: "{", message: /Body is not valid JSON|Unexpected end/u },
+  ];
+
+  for (const [index, testCase] of cases.entries()) {
+    resetWaitlistStore();
+    const app = createApp();
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/waitlist-requests",
+      headers: { "Idempotency-Key": [
+        "0194f2e0-7b3e-7610-8284-5c26e8b0c129",
+        "0194f2e0-7b3e-7610-8284-5c26e8b0c136",
+        "0194f2e0-7b3e-7610-8284-5c26e8b0c137",
+      ][index] ?? "0194f2e0-7b3e-7610-8284-5c26e8b0c129", "content-type": "application/json" },
+      payload: testCase.payload,
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.json().code, "VALIDATION_FAILED");
+    assert.match(response.json().message, testCase.message);
+    await app.close();
+  }
+});
+
+test("create uses documented travelerRef when legacy travelerRefs is also present", async () => {
+  resetWaitlistStore();
+  const app = createApp();
+  const payload = {
+    accountId: "acc-1",
+    travelerRef: "tvl-contract",
+    travelerRefs: ["tvl-legacy"],
+    segmentRef: "seg-1",
+    travelClass: "SECOND",
+    deadline: "2026-07-20T00:00:00.000Z",
+    paymentGuaranteeRef: "pay-auth-1",
+    itineraryRef: "itn-1",
+    intentFingerprint: "intent-contract-canonical",
+  };
+
+  const first = await app.inject({ method: "POST", url: "/api/v1/waitlist-requests", headers: { "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c138" }, payload });
+  const duplicate = await app.inject({ method: "POST", url: "/api/v1/waitlist-requests", headers: { "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c139" }, payload: { ...payload, travelerRefs: ["tvl-other-legacy"] } });
+
+  assert.equal(first.statusCode, 201);
+  assert.equal(first.json().travelerRef, "tvl-contract");
+  assert.equal(duplicate.statusCode, 409);
+  assert.equal(duplicate.json().code, "CONFLICT");
+  await app.close();
+});
+
+test("list requires travelerRef query parameter", async () => {
+  resetWaitlistStore();
+  const app = createApp();
+
+  for (const url of ["/api/v1/waitlist-requests", "/api/v1/waitlist-requests?travelerRef="]) {
+    const response = await app.inject({ method: "GET", url });
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.json().code, "VALIDATION_FAILED");
+    assert.match(response.json().message, /travelerRef is required/u);
+  }
+
+  await app.close();
+});
+
+test("duplicate active traveler and intent returns conflict", async () => {
+  resetWaitlistStore();
+  const app = createApp();
+  const payload = {
+    accountId: "acc-1",
+    travelerRef: "tvl-1",
+    segmentRef: "seg-1",
+    travelClass: "SECOND",
+    deadline: "2026-07-20T00:00:00.000Z",
+    paymentGuaranteeRef: "pay-auth-1",
+    itineraryRef: "itn-1",
+    intentFingerprint: "intent-duplicate",
+  };
+
+  const first = await app.inject({ method: "POST", url: "/api/v1/waitlist-requests", headers: { "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c130" }, payload });
+  const duplicate = await app.inject({ method: "POST", url: "/api/v1/waitlist-requests", headers: { "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c131" }, payload: { ...payload, segmentRef: "seg-2" } });
+
+  assert.equal(first.statusCode, 201);
+  assert.equal(duplicate.statusCode, 409);
+  assert.equal(duplicate.json().code, "CONFLICT");
+  assert.equal(duplicate.json().details.domainCode, "CONFLICT");
+  await app.close();
+});
+
+test("cancel requires reason and handles null body defensively", async () => {
+  const invalidBodies = [{}, { reason: "" }, "null"];
+  for (const [index, payload] of invalidBodies.entries()) {
+    resetWaitlistStore();
+    const app = createApp();
+    const create = await app.inject({
+      method: "POST",
+      url: "/api/v1/waitlist-requests",
+      headers: { "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c132" },
+      payload: {
+        accountId: "acc-1",
+        travelerRef: "tvl-1",
+        segmentRef: "seg-1",
+        travelClass: "SECOND",
+        deadline: "2026-07-20T00:00:00.000Z",
+        paymentGuaranteeRef: "pay-auth-1",
+        itineraryRef: "itn-1",
+        intentFingerprint: "intent-cancel",
+      },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/v1/waitlist-requests/${create.json().waitlistRequestId}/cancel`,
+      headers: { "Idempotency-Key": [
+        "0194f2e0-7b3e-7610-8284-5c26e8b0c133",
+        "0194f2e0-7b3e-7610-8284-5c26e8b0c134",
+        "0194f2e0-7b3e-7610-8284-5c26e8b0c135",
+      ][index] ?? "0194f2e0-7b3e-7610-8284-5c26e8b0c133", "content-type": "application/json" },
+      payload,
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.json().code, "VALIDATION_FAILED");
+    await app.close();
+  }
+});

--- a/services/waitlist/tests/storage.test.ts
+++ b/services/waitlist/tests/storage.test.ts
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import test from "node:test";
 import { OptimisticConcurrencyConflict } from "@trainticket/ts-kit";
-import { WaitlistEntry } from "../src/domain.js";
+import { DomainError, WaitlistEntry } from "../src/domain.js";
 import { PostgresWaitlistRepository, ProcessedEventRepository } from "../src/storage.js";
 
 class FakeDb {
@@ -14,6 +14,12 @@ class FakeDb {
   async query(sql: string, params: readonly unknown[] = []) {
     this.calls.push({ sql, params });
     return { rows: [], rowCount: this.rowCounts[this.calls.length - 1] ?? 0 };
+  }
+}
+
+class UniqueViolationDb {
+  async query(): Promise<never> {
+    throw Object.assign(new Error("duplicate key value violates unique constraint"), { code: "23505" });
   }
 }
 
@@ -50,6 +56,26 @@ test("PostgresWaitlistRepository.save rejects stale loaded version", async () =>
   const repository = new PostgresWaitlistRepository(db as never);
 
   await assert.rejects(() => repository.save(persistedEntry(2)), OptimisticConcurrencyConflict);
+});
+
+test("PostgresWaitlistRepository.add translates unique violation to conflict", async () => {
+  const repository = new PostgresWaitlistRepository(new UniqueViolationDb() as never);
+  const entry = WaitlistEntry.create({
+    accountId: "acc-1",
+    travelerRefs: ["tvl-1"],
+    segmentRef: "seg-1",
+    departureDate: "2026-07-20",
+    seatClass: "SECOND",
+    priority: { groupSize: 1, fareClass: "SECOND" },
+    paymentGuaranteeRef: "pay-auth-1",
+    itineraryRef: "itn-1",
+    intentFingerprint: "intent-1",
+  });
+
+  await assert.rejects(
+    () => repository.add(entry),
+    (error) => error instanceof DomainError && error.code === "CONFLICT",
+  );
 });
 
 test("ProcessedEventRepository records by event_id primary key only", async () => {


### PR DESCRIPTION
## Summary
- enforce waitlist HTTP create/cancel required-field validation with defensive null/non-object handling
- translate duplicate active traveler/intent unique violations to CONFLICT and enforce the active duplicate invariant in memory/Postgres
- add focused API/storage regression tests for validation and conflict behavior

## Validation
- npm run build --prefix services/waitlist
- npm test --prefix services/waitlist