### PR TITLE
REQ-344 archive terminal waitlist requests

### DIFF
--- a/services/waitlist/src/app.ts
+++ b/services/waitlist/src/app.ts
@@ -94,6 +94,10 @@ export function createApp(dependencies: AppDependencies = {}): FastifyInstance {
     statusCode: 200,
     body: await runCommand((repository, publisher) => commandService(repository, publisher).accept(param(request, "entryId"), optionalObjectBody(request.body), ctx.correlationId)),
   }));
+  stateChanging(app, idempotencyStore, "POST", "/api/v1/waitlist/archive-sweep", async (_request, _ctx) => ({
+    statusCode: 200,
+    body: { archived: await runCommand((repository, publisher) => commandService(repository, publisher).archiveTerminalRequests()) },
+  }));
   app.get("/api/v1/waitlist/segments/:segmentRef/:departureDate/queue", async (request, reply) => handleRead(reply, request, () => (
     runCommand((repository, publisher) => commandService(repository, publisher).queueInfo(param(request, "segmentRef"), param(request, "departureDate"), query(request).seatClass, query(request).entryId))
   )));

--- a/services/waitlist/src/application.ts
+++ b/services/waitlist/src/application.ts
@@ -105,6 +105,10 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
     return [...this.entries.values()].filter((entry) => entry.status === "MATCHING" && entry.offerExpiresAt !== null && entry.offerExpiresAt <= now);
   }
 
+  async findArchivable(): Promise<readonly WaitlistEntry[]> {
+    return [...this.entries.values()].filter((entry) => isArchivableStatus(entry.status));
+  }
+
   async findByJourneyOrderRef(journeyOrderRef: string): Promise<WaitlistEntry | undefined> {
     return [...this.entries.values()].find((entry) => entry.journeyOrderRef === journeyOrderRef);
   }
@@ -128,7 +132,7 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
   }
 
   private buildQueue(segmentRef: string, departureDate: string, seatClass?: string): WaitlistQueue {
-    const matching = [...this.entries.values()].filter((entry) => entry.segmentRef === segmentRef && entry.departureDate === departureDate && (!seatClass || entry.seatClass === seatClass));
+    const matching = [...this.entries.values()].filter((entry) => entry.status !== "CLOSED" && entry.segmentRef === segmentRef && entry.departureDate === departureDate && (!seatClass || entry.seatClass === seatClass));
     const classForQueue = (seatClass ?? matching[0]?.seatClass ?? "SECOND") as FareClass;
     return new WaitlistQueue(segmentRef, departureDate, classForQueue, matching.filter((entry) => entry.seatClass === classForQueue));
   }
@@ -238,6 +242,16 @@ export class WaitlistApplicationService {
     return this.promotion.expireDueOffers(correlationId);
   }
 
+  async archiveTerminalRequests(): Promise<readonly WaitlistRequestResource[]> {
+    const archived: WaitlistRequestResource[] = [];
+    for (const entry of await this.repository.findArchivable()) {
+      entry.close();
+      const snapshot = await this.repository.save(entry);
+      archived.push(toWaitlistRequestResource(snapshot));
+    }
+    return archived;
+  }
+
   private toCreateCommand(request: JoinWaitlistRequest): CreateWaitlistEntry {
     const travelerRefs = request.travelerRef ? [request.travelerRef] : request.travelerRefs ?? [];
     const seatClass = request.seatClass ?? request.travelClass ?? "SECOND";
@@ -277,6 +291,10 @@ export class WaitlistApplicationService {
 
 function isActiveStatus(status: WaitlistEntrySnapshot["status"]): boolean {
   return status === "DRAFT" || status === "QUEUED" || status === "MATCHING" || status === "SUSPENDED";
+}
+
+function isArchivableStatus(status: WaitlistEntrySnapshot["status"]): boolean {
+  return status === "FULFILLED" || status === "EXPIRED" || status === "CANCELLED";
 }
 
 function toWaitlistRequestResource(snapshot: WaitlistEntrySnapshot): WaitlistRequestResource {

--- a/services/waitlist/src/bootstrap.ts
+++ b/services/waitlist/src/bootstrap.ts
@@ -44,8 +44,16 @@ export async function bootstrap(options: BootstrapOptions = {}) {
     operation.catch((error: unknown) => app.log.error({ err: error }, "waitlist offer expiry scan failed"));
   }, Number.parseInt(process.env.WAITLIST_EXPIRY_SCAN_MS ?? "60000", 10));
   expiryTimer.unref();
+  const archivalTimer = setInterval(() => {
+    const operation = storage
+      ? storage.runCommand((repository, publisher) => new WaitlistApplicationService(repository, publisher).archiveTerminalRequests())
+      : memoryEventService.archiveTerminalRequests();
+    operation.catch((error: unknown) => app.log.error({ err: error }, "waitlist archival sweep failed"));
+  }, Number.parseInt(process.env.WAITLIST_ARCHIVAL_SWEEP_MS ?? "300000", 10));
+  archivalTimer.unref();
   app.addHook("onClose", async () => {
     clearInterval(expiryTimer);
+    clearInterval(archivalTimer);
     abortController.abort();
     messaging.subscriber.stop?.();
     await messaging.close();

--- a/services/waitlist/src/domain.ts
+++ b/services/waitlist/src/domain.ts
@@ -229,6 +229,13 @@ export class WaitlistEntry {
     this._status = "CANCELLED";
   }
 
+  close(): void {
+    if (this._status !== "FULFILLED" && this._status !== "EXPIRED" && this._status !== "CANCELLED") {
+      throw new DomainError("INVALID_TRANSITION", `Cannot close ${this._status} waitlist entry`);
+    }
+    this._status = "CLOSED";
+  }
+
   toSnapshot(queuePosition = 0): WaitlistEntrySnapshot {
     return {
       entryId: this.entryId,

--- a/services/waitlist/src/promotion.ts
+++ b/services/waitlist/src/promotion.ts
@@ -33,6 +33,7 @@ export interface WaitlistRepository {
   findTopQueued(segmentRef: string, departureDate: string, seatClass?: string): Promise<WaitlistEntry | undefined> | WaitlistEntry | undefined;
   findByJourneyOrderRef?(journeyOrderRef: string): Promise<WaitlistEntry | undefined> | WaitlistEntry | undefined;
   findExpiredOffers(now: Date): Promise<readonly WaitlistEntry[]> | readonly WaitlistEntry[];
+  findArchivable(): Promise<readonly WaitlistEntry[]> | readonly WaitlistEntry[];
   queueFor(segmentRef: string, departureDate: string, seatClass?: string): Promise<readonly WaitlistEntrySnapshot[]> | readonly WaitlistEntrySnapshot[];
   listByTraveler(travelerRef: string): Promise<readonly WaitlistEntrySnapshot[]> | readonly WaitlistEntrySnapshot[];
 }

--- a/services/waitlist/src/storage.ts
+++ b/services/waitlist/src/storage.ts
@@ -62,6 +62,11 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
     return result.rows.map(entryFromRow);
   }
 
+  async findArchivable(): Promise<readonly WaitlistEntry[]> {
+    const result = await this.db.query(`SELECT * FROM waitlist_entries WHERE status IN ('FULFILLED', 'EXPIRED', 'CANCELLED') ORDER BY updated_at ASC, entry_id ASC`) as QueryResult<WaitlistRow>;
+    return result.rows.map(entryFromRow);
+  }
+
   async findByJourneyOrderRef(journeyOrderRef: string): Promise<WaitlistEntry | undefined> {
     const result = await this.db.query(`SELECT * FROM waitlist_entries WHERE data->>'journeyOrderRef' = $1 ORDER BY created_at ASC LIMIT 1`, [journeyOrderRef]) as QueryResult<WaitlistRow>;
     return result.rows[0] ? entryFromRow(result.rows[0]) : undefined;
@@ -72,7 +77,7 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
     const seatClause = seatClass ? "AND seat_class = $3" : "";
     if (seatClass) params.push(seatClass);
     const result = await this.db.query(
-      `SELECT * FROM waitlist_entries WHERE segment_ref = $1 AND departure_date = $2 ${seatClause} ORDER BY priority_score DESC, created_at ASC, entry_id ASC`,
+      `SELECT * FROM waitlist_entries WHERE segment_ref = $1 AND departure_date = $2 ${seatClause} AND status <> 'CLOSED' ORDER BY priority_score DESC, created_at ASC, entry_id ASC`,
       params,
     ) as QueryResult<WaitlistRow>;
     const entries = result.rows.map(entryFromRow);

--- a/services/waitlist/tests/app.test.ts
+++ b/services/waitlist/tests/app.test.ts
@@ -210,6 +210,59 @@ test("duplicate active traveler and intent returns conflict", async () => {
   await app.close();
 });
 
+test("on-demand archival sweep closes cancelled request and contract GET still retrieves it", async () => {
+  resetWaitlistStore();
+  const app = createApp();
+  const create = await app.inject({
+    method: "POST",
+    url: "/api/v1/waitlist-requests",
+    headers: { "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c140" },
+    payload: {
+      accountId: "acc-1",
+      travelerRef: "tvl-archive",
+      segmentRef: "seg-archive",
+      travelClass: "SECOND",
+      deadline: "2026-07-20T00:00:00.000Z",
+      paymentGuaranteeRef: "pay-auth-archive",
+      itineraryRef: "itn-archive",
+      intentFingerprint: "intent-archive",
+    },
+  });
+  assert.equal(create.statusCode, 201);
+  const waitlistRequestId = create.json().waitlistRequestId;
+
+  const cancel = await app.inject({ method: "POST", url: `/api/v1/waitlist-requests/${waitlistRequestId}/cancel`, headers: { "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c141" }, payload: { reason: "traveler requested cancellation" } });
+  assert.equal(cancel.statusCode, 200);
+
+  const queueBefore = await app.inject({ method: "GET", url: "/api/v1/waitlist/segments/seg-archive/2026-07-20/queue" });
+  assert.equal(queueBefore.json().totalQueued, 0);
+
+  const sweep = await app.inject({ method: "POST", url: "/api/v1/waitlist/archive-sweep", headers: { "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c142" }, payload: {} });
+  assert.equal(sweep.statusCode, 200);
+  assert.equal(sweep.json().archived[0].waitlistRequestId, waitlistRequestId);
+  assert.equal(sweep.json().archived[0].status, "CLOSED");
+
+  const get = await app.inject({ method: "GET", url: `/api/v1/waitlist-requests/${waitlistRequestId}` });
+  assert.equal(get.statusCode, 200);
+  assert.deepEqual(Object.keys(get.json()).sort(), [
+    "accountId",
+    "deadline",
+    "intentFingerprint",
+    "itineraryRef",
+    "paymentGuaranteeRef",
+    "segmentRef",
+    "status",
+    "travelClass",
+    "travelerRef",
+    "waitlistRequestId",
+  ]);
+  assert.equal(get.json().status, "CLOSED");
+
+  const queueAfter = await app.inject({ method: "GET", url: "/api/v1/waitlist/segments/seg-archive/2026-07-20/queue" });
+  assert.equal(queueAfter.json().totalQueued, 0);
+  await app.close();
+});
+
 test("cancel requires reason and handles null body defensively", async () => {
   const invalidBodies = [{}, { reason: "" }, "null"];
   for (const [index, payload] of invalidBodies.entries()) {

--- a/services/waitlist/tests/domain.test.ts
+++ b/services/waitlist/tests/domain.test.ts
@@ -31,3 +31,36 @@ test("matching entries return to queue instead of cancelling directly", () => {
   assert.equal(entry.offerId, undefined);
   assert.equal(entry.offerExpiresAt, null);
 });
+
+test("close only archives terminal fulfilled expired or cancelled entries", () => {
+  const fulfilled = WaitlistEntry.fromSnapshot({
+    entryId: "wl-fulfilled",
+    accountId: "acc",
+    travelerRefs: ["t1"],
+    segmentRef: "seg",
+    departureDate: "2026-07-20",
+    seatClass: "SECOND",
+    priorityScore: 50,
+    status: "FULFILLED",
+    queuePosition: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    offeredAt: null,
+    offerExpiresAt: null,
+    deadline: "2026-07-20T00:00:00.000Z",
+    paymentGuaranteeRef: "pay-auth-1",
+    intentFingerprint: "intent-1",
+  });
+  const expired = WaitlistEntry.fromSnapshot({ ...fulfilled.toSnapshot(), entryId: "wl-expired", status: "EXPIRED" });
+  const cancelled = WaitlistEntry.fromSnapshot({ ...fulfilled.toSnapshot(), entryId: "wl-cancelled", status: "CANCELLED" });
+  const queued = WaitlistEntry.create({ entryId: "wl-queued", accountId: "acc", travelerRefs: ["t2"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", priority: { groupSize: 1, fareClass: "SECOND" } });
+
+  fulfilled.close();
+  expired.close();
+  cancelled.close();
+
+  assert.equal(fulfilled.status, "CLOSED");
+  assert.equal(expired.status, "CLOSED");
+  assert.equal(cancelled.status, "CLOSED");
+  assert.throws(() => queued.close(), DomainError);
+  assert.throws(() => fulfilled.close(), DomainError);
+});

--- a/services/waitlist/tests/storage.test.ts
+++ b/services/waitlist/tests/storage.test.ts
@@ -58,6 +58,24 @@ test("PostgresWaitlistRepository.save rejects stale loaded version", async () =>
   await assert.rejects(() => repository.save(persistedEntry(2)), OptimisticConcurrencyConflict);
 });
 
+test("PostgresWaitlistRepository finds archivable terminal rows", async () => {
+  const db = new FakeDb();
+  const repository = new PostgresWaitlistRepository(db as never);
+
+  await repository.findArchivable();
+
+  assert.match(db.calls[0].sql, /status IN \('FULFILLED', 'EXPIRED', 'CANCELLED'\)/u);
+});
+
+test("PostgresWaitlistRepository queue queries exclude CLOSED archival rows", async () => {
+  const db = new FakeDb();
+  const repository = new PostgresWaitlistRepository(db as never);
+
+  await repository.queueFor("seg-1", "2026-07-20", "SECOND");
+
+  assert.match(db.calls[0].sql, /status <> 'CLOSED'/u);
+});
+
 test("PostgresWaitlistRepository.add translates unique violation to conflict", async () => {
   const repository = new PostgresWaitlistRepository(new UniqueViolationDb() as never);
   const entry = WaitlistEntry.create({


### PR DESCRIPTION
## Summary
- Add internal waitlist archival sweep from FULFILLED/EXPIRED/CANCELLED to CLOSED with no emitted closed event
- Exclude CLOSED requests from queue working-set queries while preserving contract GET retrieval
- Add on-demand sweep route and periodic runtime sweep plus domain/storage/e2e coverage

## Validation
- npm test (services/waitlist)
- npm run build (services/waitlist)