### PR TITLE
REQ-353 share waitlist archival service

### DIFF
--- a/services/waitlist/src/app.ts
+++ b/services/waitlist/src/app.ts
@@ -20,6 +20,7 @@ export type AppDependencies = Readonly<{
   offerManagement?: OfferManagementClient;
   now?: () => Date;
   storage?: AppStorage;
+  applicationService?: WaitlistApplicationService;
 }>;
 
 const defaultRepository = new InMemoryWaitlistRepository();
@@ -33,15 +34,18 @@ export function resetWaitlistStore(): void { defaultRepository.clear(); defaultP
 export function createApp(dependencies: AppDependencies = {}): FastifyInstance {
   const app = Fastify({ logger: false });
   const runCommand = dependencies.storage?.runCommand ?? inMemoryCommandRunner(dependencies);
-  const commandService = (repository: WaitlistRepository, publisher: EventPublisher) => new WaitlistApplicationService(
-    repository,
-    publisher,
-    dependencies.farePricing,
-    dependencies.capacityAvailability,
-    dependencies.journeyOrder,
-    dependencies.now,
-    dependencies.offerManagement,
-  );
+  const sharedApplicationService = dependencies.applicationService;
+  const commandService = dependencies.storage || !sharedApplicationService
+    ? (repository: WaitlistRepository, publisher: EventPublisher) => new WaitlistApplicationService(
+      repository,
+      publisher,
+      dependencies.farePricing,
+      dependencies.capacityAvailability,
+      dependencies.journeyOrder,
+      dependencies.now,
+      dependencies.offerManagement,
+    )
+    : () => sharedApplicationService;
   const idempotencyStore = dependencies.idempotencyStore ?? defaultIdempotency;
 
   app.addHook("onRequest", async (request, reply) => {

--- a/services/waitlist/src/bootstrap.ts
+++ b/services/waitlist/src/bootstrap.ts
@@ -18,19 +18,23 @@ function consumedStream(envelope: EventEnvelope): string {
 export async function bootstrap(options: BootstrapOptions = {}) {
   const messaging = await createRedisMessagingAdapters(runtimeRedisUrl(options));
   const storage = process.env.DATABASE_URL ? await startWaitlistStorage(runtimeRedisUrl(options)) : undefined;
-  const app = createApp({ publisher: messaging.publisher, idempotencyStore: storage?.idempotencyStore, storage });
+  const applicationService = storage ? undefined : new WaitlistApplicationService(undefined, messaging.publisher);
+  const app = createApp({ publisher: messaging.publisher, idempotencyStore: storage?.idempotencyStore, storage, applicationService });
   const abortController = new AbortController();
-  const memoryEventService = new WaitlistApplicationService(undefined, messaging.publisher);
+  const inMemoryApplicationService = (): WaitlistApplicationService => {
+    if (!applicationService) throw new Error("In-memory waitlist application service is not available");
+    return applicationService;
+  };
   const eventService = {
     handleCapacityFreed: (event: WaitlistCapacityFreed, correlationId: string | undefined, envelope: EventEnvelope) => storage
       ? storage.runConsumedEvent(envelope.eventId, consumedStream(envelope), (repository, publisher) => new WaitlistApplicationService(repository, publisher).handleCapacityFreed(event, correlationId))
-      : memoryEventService.handleCapacityFreed(event, correlationId),
+      : inMemoryApplicationService().handleCapacityFreed(event, correlationId),
     handleJourneyOrderConfirmed: (orderId: string, correlationId: string | undefined, envelope: EventEnvelope) => storage
       ? storage.runConsumedEvent(envelope.eventId, consumedStream(envelope), (repository, publisher) => new WaitlistApplicationService(repository, publisher).handleJourneyOrderConfirmed(orderId, correlationId))
-      : memoryEventService.handleJourneyOrderConfirmed(orderId, correlationId),
+      : inMemoryApplicationService().handleJourneyOrderConfirmed(orderId, correlationId),
     handleJourneyOrderCancelled: (orderId: string, _correlationId: string | undefined, envelope: EventEnvelope) => storage
       ? storage.runConsumedEvent(envelope.eventId, consumedStream(envelope), (repository, publisher) => new WaitlistApplicationService(repository, publisher).handleJourneyOrderCancelled(orderId))
-      : memoryEventService.handleJourneyOrderCancelled(orderId),
+      : inMemoryApplicationService().handleJourneyOrderCancelled(orderId),
   };
   const subscription = messaging.subscriber.subscribe(SUBSCRIBED_STREAMS, CONSUMER_GROUP, consumerName(options.instanceId ?? process.env.HOSTNAME), createWaitlistEventHandler(eventService), abortController.signal);
   subscription.catch((error: unknown) => {
@@ -40,14 +44,14 @@ export async function bootstrap(options: BootstrapOptions = {}) {
   const expiryTimer = setInterval(() => {
     const operation = storage
       ? storage.runCommand((repository, publisher) => new WaitlistApplicationService(repository, publisher).expireDueOffers())
-      : memoryEventService.expireDueOffers();
+      : inMemoryApplicationService().expireDueOffers();
     operation.catch((error: unknown) => app.log.error({ err: error }, "waitlist offer expiry scan failed"));
   }, Number.parseInt(process.env.WAITLIST_EXPIRY_SCAN_MS ?? "60000", 10));
   expiryTimer.unref();
   const archivalTimer = setInterval(() => {
     const operation = storage
       ? storage.runCommand((repository, publisher) => new WaitlistApplicationService(repository, publisher).archiveTerminalRequests())
-      : memoryEventService.archiveTerminalRequests();
+      : inMemoryApplicationService().archiveTerminalRequests();
     operation.catch((error: unknown) => app.log.error({ err: error }, "waitlist archival sweep failed"));
   }, Number.parseInt(process.env.WAITLIST_ARCHIVAL_SWEEP_MS ?? "300000", 10));
   archivalTimer.unref();

--- a/services/waitlist/tests/app.test.ts
+++ b/services/waitlist/tests/app.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { InMemoryWaitlistRepository, WaitlistApplicationService } from "../src/application.js";
 import { createApp, resetWaitlistStore } from "../src/app.js";
 
 test("health endpoint returns 200", async () => {
@@ -260,6 +261,41 @@ test("on-demand archival sweep closes cancelled request and contract GET still r
 
   const queueAfter = await app.inject({ method: "GET", url: "/api/v1/waitlist/segments/seg-archive/2026-07-20/queue" });
   assert.equal(queueAfter.json().totalQueued, 0);
+  await app.close();
+});
+
+test("in-memory app can share an application service with periodic archival", async () => {
+  const applicationService = new WaitlistApplicationService(new InMemoryWaitlistRepository());
+  const app = createApp({ applicationService });
+  const create = await app.inject({
+    method: "POST",
+    url: "/api/v1/waitlist-requests",
+    headers: { "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c143" },
+    payload: {
+      accountId: "acc-1",
+      travelerRef: "tvl-shared-archive",
+      segmentRef: "seg-shared-archive",
+      travelClass: "SECOND",
+      deadline: "2026-07-20T00:00:00.000Z",
+      paymentGuaranteeRef: "pay-auth-shared-archive",
+      itineraryRef: "itn-shared-archive",
+      intentFingerprint: "intent-shared-archive",
+    },
+  });
+  assert.equal(create.statusCode, 201);
+  const waitlistRequestId = create.json().waitlistRequestId;
+
+  const cancel = await app.inject({ method: "POST", url: `/api/v1/waitlist-requests/${waitlistRequestId}/cancel`, headers: { "Idempotency-Key": "0194f2e0-7b3e-7610-8284-5c26e8b0c144" }, payload: { reason: "traveler requested cancellation" } });
+  assert.equal(cancel.statusCode, 200);
+
+  const archived = await applicationService.archiveTerminalRequests();
+  assert.equal(archived.length, 1);
+  assert.equal(archived[0]?.waitlistRequestId, waitlistRequestId);
+  assert.equal(archived[0]?.status, "CLOSED");
+
+  const get = await app.inject({ method: "GET", url: `/api/v1/waitlist-requests/${waitlistRequestId}` });
+  assert.equal(get.statusCode, 200);
+  assert.equal(get.json().status, "CLOSED");
   await app.close();
 });
 


### PR DESCRIPTION
## Summary\n- Share the in-memory WaitlistApplicationService between bootstrap timers/event handling and the HTTP app\n- Keep Postgres storage command paths transactional while preserving on-demand archival\n- Add regression coverage for shared in-memory archival behavior\n\n## Validation\n- cd services/waitlist && npm run build\n- cd services/waitlist && npm test