### PR TITLE
REQ-351 Preserve optional walking edge weights

### DIFF
--- a/docs/08-contracts/api/place-network.md
+++ b/docs/08-contracts/api/place-network.md
@@ -56,7 +56,7 @@ Registers a new geographic place.
 | `code` | string | Short code, if set. |
 | `timezone` | string | IANA timezone, if set. |
 | `status` | enum | Current status. |
-| `nodes` | array | List of associated transport nodes using the TransportNode shape below, including optional access-time weights when configured. |
+| `nodes` | array | List of associated transport nodes using a summary shape (`nodeId`, `displayName`, `servingModes`, and optional access-time weights when configured). |
 
 **Error codes:** `NOT_FOUND`
 
@@ -82,7 +82,7 @@ Registers a new geographic place.
 | `displayName` | string | yes | Display name (e.g. "Platform 3"). |
 | `servingModes` | string[] | yes | Transport modes served (e.g. `["RAIL"]`). |
 | `accessTimeMinutes` | integer | no | Non-negative walking/wayfinding access-time weight in whole minutes for entering/leaving this node. Omitted when unknown. |
-| `walkingEdges` | array | no | Optional directed walking/access edges from this node to adjacent transport nodes. Each item is `{toNodeId, walkingTimeMinutes}` where `toNodeId` is a TransportNode ID (`tnd-<uuid>` or configured node ref) and `walkingTimeMinutes` is a non-negative integer in whole minutes. Omitted or empty when no edge weights are configured. |
+| `walkingEdges` | array | no | Optional directed walking/access edges from this node to adjacent transport nodes. Each item is `{toNodeId, walkingTimeMinutes}` where `toNodeId` is a TransportNode ID (`tnd-<uuid>` or configured node ref) and `walkingTimeMinutes` is an optional non-negative integer in whole minutes. Omit `walkingTimeMinutes` when the edge exists but its weight is unknown; explicit `0` is a valid zero-minute weight. Omit `walkingEdges` or use an empty array when no edges are configured. |
 
 **Response (201):**
 
@@ -93,7 +93,7 @@ Registers a new geographic place.
 | `displayName` | string | Display name. |
 | `servingModes` | string[] | Transport modes. |
 | `accessTimeMinutes` | integer | Optional; same semantics and minute units as request. Present only when configured. |
-| `walkingEdges` | array | Optional; same `{toNodeId, walkingTimeMinutes}` directed edge shape as request. Present only when one or more edge weights are configured. |
+| `walkingEdges` | array | Optional; same `{toNodeId, walkingTimeMinutes}` directed edge shape as request. Present only when one or more walking/access edges are configured; per-edge `walkingTimeMinutes` is omitted when unknown and present as `0` when explicitly configured as zero. |
 | `createdAt` | timestamp | Creation time. |
 
 **Error codes:** `VALIDATION_FAILED`, `NOT_FOUND` (placeId), `CONFLICT`

--- a/docs/08-contracts/events/place-network.md
+++ b/docs/08-contracts/events/place-network.md
@@ -38,4 +38,4 @@ Last updated: 2026-06-28
 | `displayName` | string | yes | Display name. |
 | `servingModes` | string[] | yes | Transport modes served. |
 | `accessTimeMinutes` | integer | no | Non-negative walking/wayfinding access-time weight in whole minutes for entering/leaving this node. Omitted when unknown. |
-| `walkingEdges` | array | no | Optional directed walking/access edges from this node to adjacent transport nodes. Each item is `{toNodeId, walkingTimeMinutes}` where `toNodeId` is a TransportNode ID (`tnd-<uuid>` or configured node ref) and `walkingTimeMinutes` is a non-negative integer in whole minutes. Omitted or empty when no edge weights are configured. |
+| `walkingEdges` | array | no | Optional directed walking/access edges from this node to adjacent transport nodes. Each item is `{toNodeId, walkingTimeMinutes}` where `toNodeId` is a TransportNode ID (`tnd-<uuid>` or configured node ref) and `walkingTimeMinutes` is an optional non-negative integer in whole minutes. Omit `walkingTimeMinutes` when the edge exists but its weight is unknown; explicit `0` is a valid zero-minute weight. Omit `walkingEdges` or use an empty array when no edges are configured. |

--- a/services/place-network/internal/adapters/postgres/snapshots.go
+++ b/services/place-network/internal/adapters/postgres/snapshots.go
@@ -25,7 +25,7 @@ type placeSnapshot struct {
 
 type walkingEdgeSnapshot struct {
 	ToNodeID           string `json:"toNodeId"`
-	WalkingTimeMinutes int    `json:"walkingTimeMinutes"`
+	WalkingTimeMinutes *int   `json:"walkingTimeMinutes,omitempty"`
 }
 
 type nodeSnapshot struct {
@@ -49,7 +49,7 @@ func placeSnapshotFromDomain(place domain.Place) placeSnapshot {
 func nodeSnapshotFromDomain(node domain.TransportNode) nodeSnapshot {
 	walkingEdges := make([]walkingEdgeSnapshot, len(node.WalkingEdges))
 	for i, edge := range node.WalkingEdges {
-		walkingEdges[i] = walkingEdgeSnapshot{ToNodeID: string(edge.ToNodeID), WalkingTimeMinutes: edge.WalkingTimeMinutes}
+		walkingEdges[i] = walkingEdgeSnapshot{ToNodeID: string(edge.ToNodeID), WalkingTimeMinutes: copyInt(edge.WalkingTimeMinutes)}
 	}
 	return nodeSnapshot{ID: string(node.ID), PlaceID: string(node.PlaceID), DisplayName: node.DisplayName, ServingModes: append([]domain.TransportMode(nil), node.ServingModes...), AccessTimeMinutes: copyInt(node.AccessTimeMinutes), WalkingEdges: walkingEdges, CreatedAt: node.CreatedAt.UTC()}
 }

--- a/services/place-network/internal/adapters/postgres/snapshots_test.go
+++ b/services/place-network/internal/adapters/postgres/snapshots_test.go
@@ -1,0 +1,68 @@
+package postgres
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/trainticket/greenfield/services/place-network/internal/domain"
+)
+
+func TestNodeSnapshotPreservesOptionalWalkingEdgeWeight(t *testing.T) {
+	node, err := domain.NewTransportNode("tnd-source", "plc-source", "Source", []domain.TransportMode{domain.TransportModeTrain})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	zero := 0
+	node.SetAccessWeights(nil, []domain.WalkingEdge{{ToNodeID: "tnd-unknown"}, {ToNodeID: "tnd-zero", WalkingTimeMinutes: &zero}})
+	node.MarkCreatedAt(time.Date(2026, 7, 5, 10, 30, 0, 0, time.UTC))
+
+	data, err := json.Marshal(nodeSnapshotFromDomain(node))
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal raw snapshot: %v", err)
+	}
+	assertRawWalkingEdgesOmitUnknownAndKeepZero(t, raw)
+
+	decoded, err := decodeNode(data)
+	if err != nil {
+		t.Fatalf("decode node: %v", err)
+	}
+	if len(decoded.WalkingEdges) != 2 {
+		t.Fatalf("expected two walking edges, got %#v", decoded.WalkingEdges)
+	}
+	if decoded.WalkingEdges[0].WalkingTimeMinutes != nil {
+		t.Fatalf("omitted walkingTimeMinutes must decode as nil: %#v", decoded.WalkingEdges[0])
+	}
+	if decoded.WalkingEdges[1].WalkingTimeMinutes == nil || *decoded.WalkingEdges[1].WalkingTimeMinutes != 0 {
+		t.Fatalf("explicit zero walkingTimeMinutes must decode as zero: %#v", decoded.WalkingEdges[1])
+	}
+}
+
+func assertRawWalkingEdgesOmitUnknownAndKeepZero(t *testing.T, body map[string]any) {
+	t.Helper()
+	edges, ok := body["walkingEdges"].([]any)
+	if !ok || len(edges) != 2 {
+		t.Fatalf("expected two walking edges, got %#v", body["walkingEdges"])
+	}
+	unknown, ok := edges[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected first walking edge object, got %#v", edges[0])
+	}
+	if unknown["toNodeId"] != "tnd-unknown" {
+		t.Fatalf("unexpected first walking edge: %#v", unknown)
+	}
+	if _, exists := unknown["walkingTimeMinutes"]; exists {
+		t.Fatalf("omitted walkingTimeMinutes must stay omitted, got %#v", unknown)
+	}
+	zero, ok := edges[1].(map[string]any)
+	if !ok {
+		t.Fatalf("expected second walking edge object, got %#v", edges[1])
+	}
+	if zero["toNodeId"] != "tnd-zero" || zero["walkingTimeMinutes"] != float64(0) {
+		t.Fatalf("explicit zero walkingTimeMinutes must stay zero, got %#v", zero)
+	}
+}

--- a/services/place-network/internal/application/service.go
+++ b/services/place-network/internal/application/service.go
@@ -105,7 +105,7 @@ func (s *Service) CreatePlace(ctx context.Context, req CreatePlaceRequest) (*Cre
 
 type WalkingEdgeResponse struct {
 	ToNodeID           string `json:"toNodeId"`
-	WalkingTimeMinutes int    `json:"walkingTimeMinutes"`
+	WalkingTimeMinutes *int   `json:"walkingTimeMinutes,omitempty"`
 }
 
 type NodeSummary struct {
@@ -194,7 +194,7 @@ func (s *Service) ListPlaces(ctx context.Context, req ListPlacesRequest) (*ListP
 
 type WalkingEdgeRequest struct {
 	ToNodeID           string
-	WalkingTimeMinutes int
+	WalkingTimeMinutes *int
 }
 
 type CreateTransportNodeRequest struct {
@@ -329,7 +329,7 @@ func walkingEdgesToResponse(edges []domain.WalkingEdge) []WalkingEdgeResponse {
 	}
 	out := make([]WalkingEdgeResponse, len(edges))
 	for i, edge := range edges {
-		out[i] = WalkingEdgeResponse{ToNodeID: string(edge.ToNodeID), WalkingTimeMinutes: edge.WalkingTimeMinutes}
+		out[i] = WalkingEdgeResponse{ToNodeID: string(edge.ToNodeID), WalkingTimeMinutes: copyInt(edge.WalkingTimeMinutes)}
 	}
 	return out
 }
@@ -340,7 +340,7 @@ func walkingEdgesToPayload(edges []domain.WalkingEdge) []domain.WalkingEdgePaylo
 	}
 	out := make([]domain.WalkingEdgePayload, len(edges))
 	for i, edge := range edges {
-		out[i] = domain.WalkingEdgePayload{ToNodeID: edge.ToNodeID, WalkingTimeMinutes: edge.WalkingTimeMinutes}
+		out[i] = domain.WalkingEdgePayload{ToNodeID: edge.ToNodeID, WalkingTimeMinutes: copyInt(edge.WalkingTimeMinutes)}
 	}
 	return out
 }

--- a/services/place-network/internal/domain/events.go
+++ b/services/place-network/internal/domain/events.go
@@ -25,7 +25,7 @@ type PlaceUpdatedEvent struct {
 
 type WalkingEdgePayload struct {
 	ToNodeID           TransportNodeID `json:"toNodeId"`
-	WalkingTimeMinutes int             `json:"walkingTimeMinutes"`
+	WalkingTimeMinutes *int            `json:"walkingTimeMinutes,omitempty"`
 }
 
 type TransportNodeUpdatedEvent struct {

--- a/services/place-network/internal/domain/master_data.go
+++ b/services/place-network/internal/domain/master_data.go
@@ -127,7 +127,7 @@ func (p Place) Validate() error {
 
 type WalkingEdge struct {
 	ToNodeID           TransportNodeID
-	WalkingTimeMinutes int
+	WalkingTimeMinutes *int
 }
 
 // TransportNode binds a transport-meaningful node to a canonical Place. Service
@@ -159,15 +159,10 @@ func NewTransportNode(id TransportNodeID, placeID PlaceID, displayName string, s
 }
 
 func (n *TransportNode) SetAccessWeights(accessTimeMinutes *int, walkingEdges []WalkingEdge) {
-	if accessTimeMinutes == nil {
-		n.AccessTimeMinutes = nil
-	} else {
-		minutes := *accessTimeMinutes
-		n.AccessTimeMinutes = &minutes
-	}
+	n.AccessTimeMinutes = copyInt(accessTimeMinutes)
 	n.WalkingEdges = make([]WalkingEdge, len(walkingEdges))
 	for i, edge := range walkingEdges {
-		n.WalkingEdges[i] = WalkingEdge{ToNodeID: TransportNodeID(strings.TrimSpace(string(edge.ToNodeID))), WalkingTimeMinutes: edge.WalkingTimeMinutes}
+		n.WalkingEdges[i] = WalkingEdge{ToNodeID: TransportNodeID(strings.TrimSpace(string(edge.ToNodeID))), WalkingTimeMinutes: copyInt(edge.WalkingTimeMinutes)}
 	}
 }
 
@@ -207,7 +202,7 @@ func (n TransportNode) Validate() error {
 		if toNodeID == "" {
 			return fmt.Errorf("walking edge toNodeId is required")
 		}
-		if edge.WalkingTimeMinutes < 0 {
+		if edge.WalkingTimeMinutes != nil && *edge.WalkingTimeMinutes < 0 {
 			return fmt.Errorf("walkingTimeMinutes must be non-negative")
 		}
 		if _, exists := seenEdges[toNodeID]; exists {
@@ -216,6 +211,14 @@ func (n TransportNode) Validate() error {
 		seenEdges[toNodeID] = struct{}{}
 	}
 	return nil
+}
+
+func copyInt(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	copied := *value
+	return &copied
 }
 
 type ProviderMappingStatus string

--- a/services/place-network/internal/domain/master_data_test.go
+++ b/services/place-network/internal/domain/master_data_test.go
@@ -31,6 +31,36 @@ func TestNewTransportNodeRequiresServingMode(t *testing.T) {
 	}
 }
 
+func TestTransportNodeWalkingEdgeWeightIsOptionalAndNonNegative(t *testing.T) {
+	node, err := NewTransportNode("node-sha-hongqiao", "place-sha-hongqiao", "Shanghai Hongqiao Railway Station", []TransportMode{TransportModeTrain})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	zero := 0
+	node.SetAccessWeights(nil, []WalkingEdge{{ToNodeID: "node-unknown"}, {ToNodeID: "node-zero", WalkingTimeMinutes: &zero}})
+	if err := node.Validate(); err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+	if node.WalkingEdges[0].WalkingTimeMinutes != nil {
+		t.Fatalf("omitted walkingTimeMinutes must stay nil: %#v", node.WalkingEdges[0])
+	}
+	if node.WalkingEdges[1].WalkingTimeMinutes == nil || *node.WalkingEdges[1].WalkingTimeMinutes != 0 {
+		t.Fatalf("explicit zero walkingTimeMinutes must stay zero: %#v", node.WalkingEdges[1])
+	}
+}
+
+func TestTransportNodeRejectsNegativeWalkingEdgeWeight(t *testing.T) {
+	node, err := NewTransportNode("node-sha-hongqiao", "place-sha-hongqiao", "Shanghai Hongqiao Railway Station", []TransportMode{TransportModeTrain})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	negative := -1
+	node.SetAccessWeights(nil, []WalkingEdge{{ToNodeID: "node-other", WalkingTimeMinutes: &negative}})
+	if err := node.Validate(); err == nil || !strings.Contains(err.Error(), "walkingTimeMinutes") {
+		t.Fatalf("expected walkingTimeMinutes validation error, got %v", err)
+	}
+}
+
 func TestProviderPlaceMappingStandardRequiresTargetAndConfidence(t *testing.T) {
 	validFrom := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
 	_, err := NewProviderPlaceMapping("cr", "rail-import", "AOH", "Shanghai Hongqiao", nil, ProviderMappingStandard, 0.95, validFrom, nil, "")

--- a/services/place-network/internal/http/handler.go
+++ b/services/place-network/internal/http/handler.go
@@ -94,7 +94,7 @@ func (h *Handler) CreateTransportNode(ctx *gin.Context) {
 		AccessTimeMinutes *int     `json:"accessTimeMinutes"`
 		WalkingEdges      []struct {
 			ToNodeID           string `json:"toNodeId" binding:"required"`
-			WalkingTimeMinutes int    `json:"walkingTimeMinutes"`
+			WalkingTimeMinutes *int   `json:"walkingTimeMinutes,omitempty"`
 		} `json:"walkingEdges"`
 	}
 	if err := ctx.ShouldBindJSON(&req); err != nil {

--- a/services/place-network/internal/http/handler_test.go
+++ b/services/place-network/internal/http/handler_test.go
@@ -123,9 +123,30 @@ func TestGetTransportNodeHappyPath(t *testing.T) {
 	}
 	var resp application.GetTransportNodeResponse
 	decode(t, rec, &resp)
-	if resp.NodeID != created.NodeID || resp.PlaceID != place.PlaceID || resp.CreatedAt != "2026-07-05T10:30:00Z" || resp.AccessTimeMinutes == nil || *resp.AccessTimeMinutes != 7 || len(resp.WalkingEdges) != 1 || resp.WalkingEdges[0].ToNodeID != "tnd-next" || resp.WalkingEdges[0].WalkingTimeMinutes != 5 {
+	if resp.NodeID != created.NodeID || resp.PlaceID != place.PlaceID || resp.CreatedAt != "2026-07-05T10:30:00Z" || resp.AccessTimeMinutes == nil || *resp.AccessTimeMinutes != 7 || len(resp.WalkingEdges) != 1 || resp.WalkingEdges[0].ToNodeID != "tnd-next" || resp.WalkingEdges[0].WalkingTimeMinutes == nil || *resp.WalkingEdges[0].WalkingTimeMinutes != 5 {
 		t.Fatalf("unexpected response: %#v", resp)
 	}
+}
+
+func TestWalkingEdgeWalkingTimeDistinguishesOmittedFromExplicitZero(t *testing.T) {
+	router := setupTestRouter(nil)
+	place := createPlace(t, router, "Transfer Station", "STATION", "0194f2e0-7b3e-7010-8284-5c26e8b00010")
+	rec := performJSON(router, http.MethodPost, "/api/v1/transport-nodes", map[string]any{"placeId": place.PlaceID, "displayName": "Transfer Hall", "servingModes": []string{"TRAIN"}, "walkingEdges": []map[string]any{{"toNodeId": "tnd-unknown"}, {"toNodeId": "tnd-zero", "walkingTimeMinutes": 0}}}, "0194f2e0-7b3e-7011-8284-5c26e8b00011")
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var created map[string]any
+	decode(t, rec, &created)
+	assertWalkingEdgesOmitUnknownAndKeepZero(t, created)
+
+	nodeID, _ := created["nodeId"].(string)
+	getRec := perform(router, http.MethodGet, "/api/v1/transport-nodes/"+nodeID, nil)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", getRec.Code, getRec.Body.String())
+	}
+	var fetched map[string]any
+	decode(t, getRec, &fetched)
+	assertWalkingEdgesOmitUnknownAndKeepZero(t, fetched)
 }
 
 func TestValidationFailureErrorBody(t *testing.T) {
@@ -234,6 +255,31 @@ func createPlaceWithReferenceData(t *testing.T, router *gin.Engine, name, placeT
 	var resp application.CreatePlaceResponse
 	decode(t, rec, &resp)
 	return resp
+}
+
+func assertWalkingEdgesOmitUnknownAndKeepZero(t *testing.T, body map[string]any) {
+	t.Helper()
+	edges, ok := body["walkingEdges"].([]any)
+	if !ok || len(edges) != 2 {
+		t.Fatalf("expected two walking edges, got %#v", body["walkingEdges"])
+	}
+	unknown, ok := edges[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected first walking edge object, got %#v", edges[0])
+	}
+	if unknown["toNodeId"] != "tnd-unknown" {
+		t.Fatalf("unexpected first walking edge: %#v", unknown)
+	}
+	if _, exists := unknown["walkingTimeMinutes"]; exists {
+		t.Fatalf("omitted walkingTimeMinutes must stay omitted, got %#v", unknown)
+	}
+	zero, ok := edges[1].(map[string]any)
+	if !ok {
+		t.Fatalf("expected second walking edge object, got %#v", edges[1])
+	}
+	if zero["toNodeId"] != "tnd-zero" || zero["walkingTimeMinutes"] != float64(0) {
+		t.Fatalf("explicit zero walkingTimeMinutes must stay zero, got %#v", zero)
+	}
 }
 
 func performJSON(router *gin.Engine, method, path string, body any, idempotencyKey string) *httptest.ResponseRecorder {

--- a/services/transfer-management/src/transfer_management/topology.py
+++ b/services/transfer-management/src/transfer_management/topology.py
@@ -20,7 +20,7 @@ class PlaceNetworkValidationError(ValueError):
 @dataclass(frozen=True, slots=True)
 class WalkingEdge:
     toNodeId: str
-    walkingTimeMinutes: int
+    walkingTimeMinutes: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -54,7 +54,7 @@ class TopologySnapshot:
 
     @property
     def walkingTimeMinutes(self) -> int | None:
-        direct_edges = [edge.walkingTimeMinutes for edge in self.fromNode.walkingEdges if edge.toNodeId == self.toNode.nodeId]
+        direct_edges = [edge.walkingTimeMinutes for edge in self.fromNode.walkingEdges if edge.toNodeId == self.toNode.nodeId and edge.walkingTimeMinutes is not None]
         return min(direct_edges) if direct_edges else None
 
 
@@ -154,7 +154,5 @@ def _walking_edges(value: Any) -> tuple[WalkingEdge, ...]:
         if not to_node_id:
             raise PlaceNetworkUnavailable("place-network walkingEdges item missing toNodeId")
         walking_time = _optional_non_negative_int(item.get("walkingTimeMinutes"), "walkingTimeMinutes")
-        if walking_time is None:
-            raise PlaceNetworkUnavailable("place-network walkingEdges item missing walkingTimeMinutes")
         edges.append(WalkingEdge(to_node_id, walking_time))
     return tuple(edges)

--- a/services/transfer-management/tests/test_topology.py
+++ b/services/transfer-management/tests/test_topology.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+
+from transfer_management.topology import (
+    PlaceNetworkUnavailable,
+    TopologyNode,
+    TopologySnapshot,
+    WalkingEdge,
+    _walking_edges,
+)
+
+
+def test_omitted_walking_edge_weight_is_unknown_and_allows_fallback() -> None:
+    snapshot = TopologySnapshot(
+        TopologyNode("tnd-a", "plc-a", "STATION", "v1", walkingEdges=(WalkingEdge("tnd-b"),)),
+        TopologyNode("tnd-b", "plc-b", "STATION", "v1"),
+    )
+
+    assert snapshot.walkingTimeMinutes is None
+    assert snapshot.mctAccessTimeMinutes is None
+
+
+def test_explicit_zero_walking_edge_weight_is_valid_zero() -> None:
+    snapshot = TopologySnapshot(
+        TopologyNode(
+            "tnd-a",
+            "plc-a",
+            "STATION",
+            "v1",
+            walkingEdges=(WalkingEdge("tnd-b"), WalkingEdge("tnd-b", 0), WalkingEdge("tnd-b", 5)),
+        ),
+        TopologyNode("tnd-b", "plc-b", "STATION", "v1"),
+    )
+
+    assert snapshot.walkingTimeMinutes == 0
+    assert snapshot.mctAccessTimeMinutes == 0
+
+
+def test_place_network_walking_edges_accept_omitted_and_zero_weights() -> None:
+    edges = _walking_edges([
+        {"toNodeId": "tnd-unknown"},
+        {"toNodeId": "tnd-zero", "walkingTimeMinutes": 0},
+    ])
+
+    assert edges == (WalkingEdge("tnd-unknown"), WalkingEdge("tnd-zero", 0))
+
+
+def test_place_network_walking_edges_reject_negative_weights() -> None:
+    with pytest.raises(PlaceNetworkUnavailable):
+        _walking_edges([{"toNodeId": "tnd-negative", "walkingTimeMinutes": -1}])


### PR DESCRIPTION
## Summary
- Decode and carry walkingEdges[].walkingTimeMinutes as optional in place-network so omitted stays omitted while explicit 0 is preserved.
- Persist/serialize optional walking edge weights through snapshots, HTTP responses, and events.
- Accept omitted place-network walking edge weights in transfer-management as unknown to keep fallback behavior.
- Correct Get Place docs to describe node summary shape and clarify optional per-edge walking weights.

## Validation
- go test ./services/place-network/...
- python3 -m compileall services/transfer-management/src/transfer_management services/transfer-management/tests/test_topology.py
- uv run pytest tests (from services/transfer-management)
- python3 -m pytest tests (from services/transfer-management) failed: pytest is not installed outside uv environment