### PR TITLE
REQ-362 Activate offer deferred consumers

### DIFF
--- a/services/offer-management/migrations/001_offer_storage.sql
+++ b/services/offer-management/migrations/001_offer_storage.sql
@@ -30,6 +30,47 @@ CREATE TABLE IF NOT EXISTS offer_upstream_travelers (
   updated_at timestamptz NOT NULL DEFAULT now()
 );
 
+CREATE TABLE IF NOT EXISTS offer_upstream_transfer_plans (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS offer_upstream_connection_contracts (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS offer_upstream_connection_contracts_connection_idx
+  ON offer_upstream_connection_contracts ((data->>'connectionId'));
+
+CREATE TABLE IF NOT EXISTS offer_upstream_mct_rules (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS offer_upstream_ancillary_catalog (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS offer_upstream_ancillary_offers (
+  id         text PRIMARY KEY,
+  version    bigint NOT NULL,
+  data       jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS offer_upstream_ancillary_offers_traveler_idx
+  ON offer_upstream_ancillary_offers ((data->>'travelerRef'));
+
 CREATE TABLE IF NOT EXISTS outbox (
   seq          bigserial PRIMARY KEY,
   event_id     text NOT NULL UNIQUE,

--- a/services/offer-management/src/adapters/messaging/stream-config.ts
+++ b/services/offer-management/src/adapters/messaging/stream-config.ts
@@ -8,6 +8,8 @@ export const SUBSCRIBED_STREAMS: readonly string[] = [
   "events:fare-pricing",
   "events:trip-planning",
   "events:traveler-profile",
+  "events:transfer-management",
+  "events:ancillary-service",
 ];
 
 export function consumerName(instanceId?: string): string {

--- a/services/offer-management/src/adapters/storage/upstream-state-repository.ts
+++ b/services/offer-management/src/adapters/storage/upstream-state-repository.ts
@@ -3,8 +3,13 @@ import { type PoolClient, type QueryResult } from "pg";
 import {
   fareQuoteStorageKey,
   type StoredAvailability,
+  type StoredAncillaryCatalogItem,
+  type StoredAncillaryOffer,
+  type StoredConnectionContract,
   type StoredFareQuote,
   type StoredItinerary,
+  type StoredMctRule,
+  type StoredTransferPlanEvaluation,
   type StoredTraveler,
   type UpstreamStateRepository,
 } from "../../application/upstream-state.js";
@@ -59,6 +64,59 @@ export class PostgresUpstreamStateRepository implements UpstreamStateRepository 
     await this.saveTraveler({ ...existing, eligibilityRef: undefined });
   }
 
+  async saveTransferPlanEvaluation(evaluation: StoredTransferPlanEvaluation): Promise<void> {
+    await upsertSnapshot(this.client, "offer_upstream_transfer_plans", evaluation.itineraryRef, serializeTransferPlanEvaluation(evaluation));
+  }
+
+  async findTransferPlanEvaluation(itineraryRef: string): Promise<StoredTransferPlanEvaluation | undefined> {
+    const row = await findSnapshot<StoredTransferPlanEvaluationSnapshot>(this.client, "offer_upstream_transfer_plans", itineraryRef);
+    return row ? reviveTransferPlanEvaluation(row) : undefined;
+  }
+
+  async saveConnectionContract(contract: StoredConnectionContract): Promise<void> {
+    await upsertSnapshot(this.client, "offer_upstream_connection_contracts", contract.connectionContractId, serializeConnectionContract(contract));
+  }
+
+  async findConnectionContracts(connectionIds: readonly string[]): Promise<readonly StoredConnectionContract[]> {
+    if (connectionIds.length === 0) return [];
+    const result = await this.client.query(
+      "SELECT data FROM offer_upstream_connection_contracts WHERE data->>'connectionId' = ANY($1::text[])",
+      [connectionIds],
+    ) as QueryResult<{ data: StoredConnectionContractSnapshot }>;
+    return result.rows.map((row) => reviveConnectionContract(row.data));
+  }
+
+  async saveMctRule(rule: StoredMctRule): Promise<void> {
+    await upsertSnapshot(this.client, "offer_upstream_mct_rules", `${rule.mctRuleId}:${rule.version}`, serializeMctRule(rule));
+  }
+
+  async findPublishedMctRules(): Promise<readonly StoredMctRule[]> {
+    const rows = await findSnapshots<StoredMctRuleSnapshot>(this.client, "offer_upstream_mct_rules");
+    return rows.map(reviveMctRule).filter((rule) => rule.status === "PUBLISHED");
+  }
+
+  async saveAncillaryCatalogItem(item: StoredAncillaryCatalogItem): Promise<void> {
+    await upsertSnapshot(this.client, "offer_upstream_ancillary_catalog", item.catalogItemId, serializeAncillaryCatalogItem(item));
+  }
+
+  async findPublishedAncillaryCatalogItems(): Promise<readonly StoredAncillaryCatalogItem[]> {
+    const rows = await findSnapshots<StoredAncillaryCatalogItemSnapshot>(this.client, "offer_upstream_ancillary_catalog");
+    return rows.map(reviveAncillaryCatalogItem).filter((item) => item.status === "PUBLISHED");
+  }
+
+  async saveAncillaryOffer(offer: StoredAncillaryOffer): Promise<void> {
+    await upsertSnapshot(this.client, "offer_upstream_ancillary_offers", offer.ancillaryOfferId, serializeAncillaryOffer(offer));
+  }
+
+  async findAncillaryOffers(travelerRefs: readonly string[]): Promise<readonly StoredAncillaryOffer[]> {
+    if (travelerRefs.length === 0) return [];
+    const result = await this.client.query(
+      "SELECT data FROM offer_upstream_ancillary_offers WHERE data->>'travelerRef' = ANY($1::text[])",
+      [travelerRefs],
+    ) as QueryResult<{ data: StoredAncillaryOfferSnapshot }>;
+    return result.rows.map((row) => reviveAncillaryOffer(row.data));
+  }
+
   clear(): void {
     // PostgreSQL-backed repositories are scoped to the database lifecycle.
   }
@@ -80,6 +138,11 @@ type StoredFareQuoteSnapshot = Omit<StoredFareQuote, "validFrom" | "validUntil">
 }>;
 
 type StoredTravelerSnapshot = StoredTraveler;
+type StoredTransferPlanEvaluationSnapshot = Omit<StoredTransferPlanEvaluation, "evaluatedAt"> & Readonly<{ evaluatedAt: string }>;
+type StoredConnectionContractSnapshot = Omit<StoredConnectionContract, "proposedAt"> & Readonly<{ proposedAt: string }>;
+type StoredMctRuleSnapshot = Omit<StoredMctRule, "validFrom" | "validUntil" | "publishedAt"> & Readonly<{ validFrom: string; validUntil?: string; publishedAt: string }>;
+type StoredAncillaryCatalogItemSnapshot = Omit<StoredAncillaryCatalogItem, "updatedAt"> & Readonly<{ updatedAt: string }>;
+type StoredAncillaryOfferSnapshot = Omit<StoredAncillaryOffer, "validFrom" | "expiresAt" | "quotedAt" | "expiredAt"> & Readonly<{ validFrom: string; expiresAt: string; quotedAt?: string; expiredAt?: string }>;
 
 async function upsertSnapshot(client: PoolClient, tableName: UpstreamTableName, id: string, data: unknown): Promise<void> {
   await upsertSnapshots(client, tableName, [{ id, data }]);
@@ -114,6 +177,11 @@ async function findSnapshot<T>(client: PoolClient, tableName: UpstreamTableName,
     [id],
   ) as QueryResult<{ data: T }>;
   return result.rows[0]?.data;
+}
+
+async function findSnapshots<T>(client: PoolClient, tableName: UpstreamTableName): Promise<readonly T[]> {
+  const result = await client.query(`SELECT data FROM ${tableName}`) as QueryResult<{ data: T }>;
+  return result.rows.map((row) => row.data);
 }
 
 function serializeItinerary(itinerary: StoredItinerary): StoredItinerarySnapshot {
@@ -175,5 +243,59 @@ function reviveTraveler(snapshot: StoredTravelerSnapshot): StoredTraveler {
   return snapshot;
 }
 
+function serializeTransferPlanEvaluation(evaluation: StoredTransferPlanEvaluation): StoredTransferPlanEvaluationSnapshot {
+  return { ...evaluation, evaluatedAt: evaluation.evaluatedAt.toISOString() };
+}
+
+function reviveTransferPlanEvaluation(snapshot: StoredTransferPlanEvaluationSnapshot): StoredTransferPlanEvaluation {
+  return { ...snapshot, evaluatedAt: new Date(snapshot.evaluatedAt) };
+}
+
+function serializeConnectionContract(contract: StoredConnectionContract): StoredConnectionContractSnapshot {
+  return { ...contract, proposedAt: contract.proposedAt.toISOString() };
+}
+
+function reviveConnectionContract(snapshot: StoredConnectionContractSnapshot): StoredConnectionContract {
+  return { ...snapshot, proposedAt: new Date(snapshot.proposedAt) };
+}
+
+function serializeMctRule(rule: StoredMctRule): StoredMctRuleSnapshot {
+  return { ...rule, validFrom: rule.validFrom.toISOString(), validUntil: rule.validUntil?.toISOString(), publishedAt: rule.publishedAt.toISOString() };
+}
+
+function reviveMctRule(snapshot: StoredMctRuleSnapshot): StoredMctRule {
+  return { ...snapshot, validFrom: new Date(snapshot.validFrom), validUntil: snapshot.validUntil ? new Date(snapshot.validUntil) : undefined, publishedAt: new Date(snapshot.publishedAt) };
+}
+
+function serializeAncillaryCatalogItem(item: StoredAncillaryCatalogItem): StoredAncillaryCatalogItemSnapshot {
+  return { ...item, updatedAt: item.updatedAt.toISOString() };
+}
+
+function reviveAncillaryCatalogItem(snapshot: StoredAncillaryCatalogItemSnapshot): StoredAncillaryCatalogItem {
+  return { ...snapshot, updatedAt: new Date(snapshot.updatedAt) };
+}
+
+function serializeAncillaryOffer(offer: StoredAncillaryOffer): StoredAncillaryOfferSnapshot {
+  return { ...offer, validFrom: offer.validFrom.toISOString(), expiresAt: offer.expiresAt.toISOString(), quotedAt: offer.quotedAt?.toISOString(), expiredAt: offer.expiredAt?.toISOString() };
+}
+
+function reviveAncillaryOffer(snapshot: StoredAncillaryOfferSnapshot): StoredAncillaryOffer {
+  return {
+    ...snapshot,
+    validFrom: new Date(snapshot.validFrom),
+    expiresAt: new Date(snapshot.expiresAt),
+    quotedAt: snapshot.quotedAt ? new Date(snapshot.quotedAt) : undefined,
+    expiredAt: snapshot.expiredAt ? new Date(snapshot.expiredAt) : undefined,
+  };
+}
+
 type UpstreamSnapshot = Readonly<{ id: string; data: unknown }>;
-type UpstreamTableName = "offer_upstream_itineraries" | "offer_upstream_fare_quotes" | "offer_upstream_travelers";
+type UpstreamTableName =
+  | "offer_upstream_itineraries"
+  | "offer_upstream_fare_quotes"
+  | "offer_upstream_travelers"
+  | "offer_upstream_transfer_plans"
+  | "offer_upstream_connection_contracts"
+  | "offer_upstream_mct_rules"
+  | "offer_upstream_ancillary_catalog"
+  | "offer_upstream_ancillary_offers";

--- a/services/offer-management/src/app.test.ts
+++ b/services/offer-management/src/app.test.ts
@@ -353,6 +353,87 @@ describe("Offer Management HTTP API — POST /api/v1/offers", () => {
     assert.deepEqual(second.json(), first.json());
   });
 
+
+  it("adds transfer and ancillary disclosures from newly consumed upstream events", async () => {
+    const repository = await seededUpstreamRepository();
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + 60 * 60 * 1000).toISOString();
+    const occurredAt = now.toISOString();
+
+    await applyUpstreamEvent(repository, makeEnvelope("TransferPlanEvaluated", "transfer-management", {
+      transferPlanId: "tpl-1",
+      itineraryRef: "itin-456",
+      planningSnapshotVersion: 1,
+      status: "EVALUATED",
+      evaluationVersion: 2,
+      connectionIds: ["con-1"],
+      riskPolicyVersion: "builtin-v1",
+      evaluatedAt: occurredAt,
+    }));
+    await applyUpstreamEvent(repository, makeEnvelope("ConnectionContractProposed", "transfer-management", {
+      connectionContractId: "cct-1",
+      connectionId: "con-1",
+      contractType: "PROTECTED",
+      status: "ELIGIBLE",
+      responsibleParty: "PLATFORM",
+      coverageSummary: "Protected connection coverage is available.",
+      disclosureVersion: "disc-v1",
+      proposedAt: occurredAt,
+    }));
+    await applyUpstreamEvent(repository, makeEnvelope("MctRulePublished", "transfer-management", {
+      mctRuleId: "mct-1",
+      version: 1,
+      previousStatus: "DRAFT",
+      status: "PUBLISHED",
+      fromNodeType: "STATION",
+      toNodeType: "STATION",
+      transferCategory: "SAME_STATION",
+      minimumMinutes: 12,
+      conditions: {},
+      validFrom: occurredAt,
+      publishedBy: { actorType: "SYSTEM", actorId: "system" },
+      publishedAt: occurredAt,
+    }));
+    await applyUpstreamEvent(repository, makeEnvelope("AncillaryCatalogItemPublished", "ancillary-service", {
+      catalogItemId: "aci-1",
+      version: 1,
+      serviceType: "LOUNGE",
+      displayName: "Station lounge",
+      attachmentScope: "JOURNEY",
+      modalities: ["train"],
+      price: { currency: "CNY", minorUnits: 1200 },
+      salesWindow: { startAt: occurredAt, endAt: expiresAt },
+      purchaseCutoffHoursBeforeDeparture: 1,
+      eligibilityRuleVersion: "elig-v1",
+      requiresEntitlementRef: false,
+      requiresSegmentRef: false,
+      fulfillmentMethod: "VOUCHER",
+      status: "PUBLISHED",
+      publishedAt: occurredAt,
+      aggregateVersion: 1,
+    }));
+
+    const app = createApp({}, { upstreamRepository: repository });
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/offers",
+      headers: { "idempotency-key": uuidV7() },
+      body: { accountId: "acct-1", channelId: "web", itineraryRef: "itin-456", travelerRefs: ["tvl-001"] },
+    });
+
+    assert.equal(response.statusCode, 201);
+    const body = response.json() as { offerId: string };
+    const detail = await app.inject({ method: "GET", url: `/api/v1/offers/${body.offerId}` });
+    assert.equal(detail.statusCode, 200);
+    const detailBody = detail.json() as { riskDisclosures: readonly { messageCode: string; relatedRef?: string; text: string }[] };
+    assert.ok(detailBody.riskDisclosures.some((disclosure) => disclosure.messageCode === "TRANSFER_PLAN_EVALUATED" && disclosure.relatedRef === "tpl-1"));
+    assert.ok(detailBody.riskDisclosures.some((disclosure) => disclosure.messageCode === "CONNECTION_CONTRACT_ELIGIBLE" && disclosure.text === "Protected connection coverage is available."));
+    assert.ok(detailBody.riskDisclosures.some((disclosure) => disclosure.messageCode === "MCT_RULE_PUBLISHED" && disclosure.relatedRef === "mct-1"));
+    assert.ok(detailBody.riskDisclosures.some((disclosure) => disclosure.messageCode === "ANCILLARY_CATALOG_ITEM_AVAILABLE" && disclosure.relatedRef === "aci-1"));
+
+    await app.close();
+  });
+
   it("rejects idempotency key reused with different body using 422 IDEMPOTENCY_KEY_REUSED", async () => {
     const upstreamRepository = await seededUpstreamRepository();
     const app = createApp({}, { upstreamRepository });

--- a/services/offer-management/src/application/upstream-state.ts
+++ b/services/offer-management/src/application/upstream-state.ts
@@ -1,4 +1,4 @@
-import { DomainError, mapStatusToConfidence, type AvailabilityConfidence, type OfferItem, type PassengerMix, type PriceGuaranteeLevel, type PriceSnapshot, type QuoteOfferCommand, type TravelerRef, type TravelerType } from "../domain.js";
+import { DomainError, mapStatusToConfidence, type AvailabilityConfidence, type OfferItem, type PassengerMix, type PriceGuaranteeLevel, type PriceSnapshot, type QuoteOfferCommand, type RiskDisclosure, type TravelerRef, type TravelerType } from "../domain.js";
 import { type EventEnvelope, type EventHandler } from "../ports/messaging.js";
 
 import { createHash } from "node:crypto";
@@ -60,6 +60,87 @@ export type StoredTraveler = Readonly<{
   maskedDocumentRef?: string;
   eligibilityRef?: TravelerRef["eligibilityRef"];
 }>;
+export type StoredTransferPlanEvaluation = Readonly<{
+  transferPlanId: string;
+  itineraryRef: string;
+  planningSnapshotVersion: number;
+  journeyOrderId?: string;
+  status: "EVALUATED" | "UNSERVICEABLE";
+  evaluationVersion: number;
+  connectionIds: readonly string[];
+  riskPolicyVersion: string;
+  evaluatedAt: Date;
+  unserviceableReasons: readonly string[];
+}>;
+
+export type StoredConnectionContract = Readonly<{
+  connectionContractId: string;
+  connectionId: string;
+  contractType: string;
+  status: "PROPOSED" | "ELIGIBLE" | "REJECTED";
+  responsibleParty: string;
+  coverageSummary: string;
+  disclosureVersion: string;
+  termsSnapshotRef?: string;
+  proposedAt: Date;
+}>;
+
+export type StoredMctRule = Readonly<{
+  mctRuleId: string;
+  version: number;
+  previousStatus: string;
+  status: "PUBLISHED";
+  fromNodeType: string;
+  toNodeType: string;
+  transferCategory: string;
+  minimumMinutes: number;
+  conditions: Record<string, unknown>;
+  validFrom: Date;
+  validUntil?: Date;
+  publishedAt: Date;
+}>;
+
+export type StoredAncillaryCatalogItem = Readonly<{
+  catalogItemId: string;
+  version: number;
+  serviceType: string;
+  displayName?: string;
+  attachmentScope?: string;
+  modalities: readonly string[];
+  supplierRef?: string;
+  price?: MoneyLike;
+  salesWindow?: Readonly<{ startAt?: string; endAt?: string }>;
+  serviceWindow?: Readonly<{ startAt?: string; endAt?: string }>;
+  purchaseCutoffHoursBeforeDeparture?: number;
+  eligibilityRuleVersion?: string;
+  requiresEntitlementRef?: boolean;
+  requiresSegmentRef?: boolean;
+  fulfillmentMethod?: string;
+  status: "PUBLISHED" | "SUSPENDED" | "SUPERSEDED";
+  replacementCatalogItemId?: string;
+  updatedAt: Date;
+}>;
+
+export type StoredAncillaryOffer = Readonly<{
+  ancillaryOfferId: string;
+  offerVersion: number;
+  journeyOrderId?: string;
+  offerRef?: string;
+  travelerRef: string;
+  segmentRef?: string;
+  catalogItemId: string;
+  serviceType: string;
+  displayName: string;
+  quantity: number;
+  unitPrice: MoneyLike;
+  totalPrice: MoneyLike;
+  validFrom: Date;
+  expiresAt: Date;
+  status: "QUOTED" | "EXPIRED";
+  quotedAt?: Date;
+  expiredAt?: Date;
+}>;
+
 
 export interface UpstreamStateRepository {
   saveItinerary(itinerary: StoredItinerary): Promise<void>;
@@ -70,6 +151,16 @@ export interface UpstreamStateRepository {
   saveTraveler(traveler: StoredTraveler): Promise<void>;
   findTraveler(travelerId: string): Promise<StoredTraveler | undefined>;
   removeTravelerEligibility(travelerId: string, eligibilityId: string): Promise<void>;
+  saveTransferPlanEvaluation(evaluation: StoredTransferPlanEvaluation): Promise<void>;
+  findTransferPlanEvaluation(itineraryRef: string): Promise<StoredTransferPlanEvaluation | undefined>;
+  saveConnectionContract(contract: StoredConnectionContract): Promise<void>;
+  findConnectionContracts(connectionIds: readonly string[]): Promise<readonly StoredConnectionContract[]>;
+  saveMctRule(rule: StoredMctRule): Promise<void>;
+  findPublishedMctRules(): Promise<readonly StoredMctRule[]>;
+  saveAncillaryCatalogItem(item: StoredAncillaryCatalogItem): Promise<void>;
+  findPublishedAncillaryCatalogItems(): Promise<readonly StoredAncillaryCatalogItem[]>;
+  saveAncillaryOffer(offer: StoredAncillaryOffer): Promise<void>;
+  findAncillaryOffers(travelerRefs: readonly string[]): Promise<readonly StoredAncillaryOffer[]>;
   clear(): void;
 }
 
@@ -77,6 +168,11 @@ export class InMemoryUpstreamStateRepository implements UpstreamStateRepository 
   private readonly itineraries = new Map<string, StoredItinerary>();
   private readonly fareQuotesByKey = new Map<string, StoredFareQuote>();
   private readonly travelers = new Map<string, StoredTraveler>();
+  private readonly transferPlanEvaluationsByItinerary = new Map<string, StoredTransferPlanEvaluation>();
+  private readonly connectionContractsById = new Map<string, StoredConnectionContract>();
+  private readonly mctRulesById = new Map<string, StoredMctRule>();
+  private readonly ancillaryCatalogItemsById = new Map<string, StoredAncillaryCatalogItem>();
+  private readonly ancillaryOffersById = new Map<string, StoredAncillaryOffer>();
 
   async saveItinerary(itinerary: StoredItinerary): Promise<void> {
     this.itineraries.set(itinerary.itineraryRef, itinerary);
@@ -115,10 +211,60 @@ export class InMemoryUpstreamStateRepository implements UpstreamStateRepository 
     }
   }
 
+  async saveTransferPlanEvaluation(evaluation: StoredTransferPlanEvaluation): Promise<void> {
+    const existing = this.transferPlanEvaluationsByItinerary.get(evaluation.itineraryRef);
+    if (!existing || evaluation.evaluationVersion >= existing.evaluationVersion) {
+      this.transferPlanEvaluationsByItinerary.set(evaluation.itineraryRef, evaluation);
+    }
+  }
+
+  async findTransferPlanEvaluation(itineraryRef: string): Promise<StoredTransferPlanEvaluation | undefined> {
+    return this.transferPlanEvaluationsByItinerary.get(itineraryRef);
+  }
+
+  async saveConnectionContract(contract: StoredConnectionContract): Promise<void> {
+    this.connectionContractsById.set(contract.connectionContractId, contract);
+  }
+
+  async findConnectionContracts(connectionIds: readonly string[]): Promise<readonly StoredConnectionContract[]> {
+    const ids = new Set(connectionIds);
+    return [...this.connectionContractsById.values()].filter((contract) => ids.has(contract.connectionId));
+  }
+
+  async saveMctRule(rule: StoredMctRule): Promise<void> {
+    this.mctRulesById.set(`${rule.mctRuleId}:${rule.version}`, rule);
+  }
+
+  async findPublishedMctRules(): Promise<readonly StoredMctRule[]> {
+    return [...this.mctRulesById.values()].filter((rule) => rule.status === "PUBLISHED");
+  }
+
+  async saveAncillaryCatalogItem(item: StoredAncillaryCatalogItem): Promise<void> {
+    this.ancillaryCatalogItemsById.set(item.catalogItemId, item);
+  }
+
+  async findPublishedAncillaryCatalogItems(): Promise<readonly StoredAncillaryCatalogItem[]> {
+    return [...this.ancillaryCatalogItemsById.values()].filter((item) => item.status === "PUBLISHED");
+  }
+
+  async saveAncillaryOffer(offer: StoredAncillaryOffer): Promise<void> {
+    this.ancillaryOffersById.set(offer.ancillaryOfferId, offer);
+  }
+
+  async findAncillaryOffers(travelerRefs: readonly string[]): Promise<readonly StoredAncillaryOffer[]> {
+    const refs = new Set(travelerRefs);
+    return [...this.ancillaryOffersById.values()].filter((offer) => refs.has(offer.travelerRef));
+  }
+
   clear(): void {
     this.itineraries.clear();
     this.fareQuotesByKey.clear();
     this.travelers.clear();
+    this.transferPlanEvaluationsByItinerary.clear();
+    this.connectionContractsById.clear();
+    this.mctRulesById.clear();
+    this.ancillaryCatalogItemsById.clear();
+    this.ancillaryOffersById.clear();
   }
 }
 
@@ -163,6 +309,26 @@ export async function applyUpstreamEvents(repository: UpstreamStateRepository, e
         break;
       case "EligibilityExpired":
         await expireEligibility(repository, envelope.payload);
+        break;
+      case "TransferPlanEvaluated":
+        await storeTransferPlanEvaluation(repository, envelope.payload);
+        break;
+      case "ConnectionContractProposed":
+        await storeConnectionContract(repository, envelope.payload);
+        break;
+      case "MctRulePublished":
+        await storeMctRule(repository, envelope.payload);
+        break;
+      case "AncillaryCatalogItemPublished":
+      case "AncillaryCatalogItemSuspended":
+      case "AncillaryCatalogItemSuperseded":
+        await storeAncillaryCatalogItem(repository, envelope.eventType, envelope.payload);
+        break;
+      case "AncillaryOfferQuoted":
+        await storeAncillaryOffer(repository, envelope.payload);
+        break;
+      case "AncillaryOfferExpired":
+        await expireAncillaryOffer(repository, envelope.payload);
         break;
       default:
         break;
@@ -270,7 +436,7 @@ export async function buildQuoteOfferCommand(repository: UpstreamStateRepository
     validityWindow: { startsAt: quotedAt, expiresAt: offerExpiresAt },
     items,
     priceSnapshot,
-    riskDisclosures: [],
+    riskDisclosures: await buildRiskDisclosures(repository, request.itineraryRef, request.travelerRefs, quotedAt),
     quotedAt,
   };
 }
@@ -385,6 +551,254 @@ async function expireEligibility(repository: UpstreamStateRepository, payload: R
   }
 }
 
+async function storeTransferPlanEvaluation(repository: UpstreamStateRepository, payload: Record<string, unknown>): Promise<void> {
+  const transferPlanId = stringField(payload, "transferPlanId");
+  const itineraryRef = stringField(payload, "itineraryRef");
+  const status = transferPlanStatus(stringField(payload, "status"));
+  const evaluatedAt = dateField(payload, "evaluatedAt");
+  const planningSnapshotVersion = numberField(payload, "planningSnapshotVersion");
+  const evaluationVersion = numberField(payload, "evaluationVersion");
+  const riskPolicyVersion = stringField(payload, "riskPolicyVersion");
+  if (!transferPlanId || !itineraryRef || !status || !evaluatedAt || planningSnapshotVersion === undefined || evaluationVersion === undefined || !riskPolicyVersion) return;
+  await repository.saveTransferPlanEvaluation({
+    transferPlanId,
+    itineraryRef,
+    planningSnapshotVersion,
+    journeyOrderId: stringField(payload, "journeyOrderId"),
+    status,
+    evaluationVersion,
+    connectionIds: stringArray(payload.connectionIds),
+    riskPolicyVersion,
+    evaluatedAt,
+    unserviceableReasons: stringArray(payload.unserviceableReasons),
+  });
+}
+
+async function storeConnectionContract(repository: UpstreamStateRepository, payload: Record<string, unknown>): Promise<void> {
+  const connectionContractId = stringField(payload, "connectionContractId");
+  const connectionId = stringField(payload, "connectionId");
+  const contractType = stringField(payload, "contractType");
+  const status = connectionContractStatus(stringField(payload, "status"));
+  const responsibleParty = stringField(payload, "responsibleParty");
+  const coverageSummary = stringField(payload, "coverageSummary");
+  const disclosureVersion = stringField(payload, "disclosureVersion");
+  const proposedAt = dateField(payload, "proposedAt");
+  if (!connectionContractId || !connectionId || !contractType || !status || !responsibleParty || !coverageSummary || !disclosureVersion || !proposedAt) return;
+  await repository.saveConnectionContract({
+    connectionContractId,
+    connectionId,
+    contractType,
+    status,
+    responsibleParty,
+    coverageSummary,
+    disclosureVersion,
+    termsSnapshotRef: stringField(payload, "termsSnapshotRef"),
+    proposedAt,
+  });
+}
+
+async function storeMctRule(repository: UpstreamStateRepository, payload: Record<string, unknown>): Promise<void> {
+  const mctRuleId = stringField(payload, "mctRuleId");
+  const version = numberField(payload, "version");
+  const previousStatus = stringField(payload, "previousStatus");
+  const status = stringField(payload, "status");
+  const fromNodeType = stringField(payload, "fromNodeType");
+  const toNodeType = stringField(payload, "toNodeType");
+  const transferCategory = stringField(payload, "transferCategory");
+  const minimumMinutes = numberField(payload, "minimumMinutes");
+  const conditions = objectField(payload, "conditions");
+  const validFrom = dateField(payload, "validFrom");
+  const publishedAt = dateField(payload, "publishedAt");
+  if (!mctRuleId || version === undefined || !previousStatus || status !== "PUBLISHED" || !fromNodeType || !toNodeType || !transferCategory || minimumMinutes === undefined || !conditions || !validFrom || !publishedAt) return;
+  await repository.saveMctRule({
+    mctRuleId,
+    version,
+    previousStatus,
+    status,
+    fromNodeType,
+    toNodeType,
+    transferCategory,
+    minimumMinutes,
+    conditions,
+    validFrom,
+    validUntil: dateField(payload, "validUntil"),
+    publishedAt,
+  });
+}
+
+async function storeAncillaryCatalogItem(repository: UpstreamStateRepository, eventType: string, payload: Record<string, unknown>): Promise<void> {
+  const catalogItemId = stringField(payload, "catalogItemId");
+  const version = numberField(payload, "version");
+  const serviceType = stringField(payload, "serviceType");
+  const status = ancillaryCatalogStatus(stringField(payload, "status"));
+  if (!catalogItemId || version === undefined || !serviceType || !status) return;
+  const existing = (await repository.findPublishedAncillaryCatalogItems()).find((item) => item.catalogItemId === catalogItemId);
+  await repository.saveAncillaryCatalogItem({
+    catalogItemId,
+    version,
+    serviceType,
+    displayName: stringField(payload, "displayName") ?? existing?.displayName,
+    attachmentScope: stringField(payload, "attachmentScope") ?? existing?.attachmentScope,
+    modalities: stringArray(payload.modalities),
+    supplierRef: stringField(payload, "supplierRef") ?? existing?.supplierRef,
+    price: moneyField(payload, "price") ?? existing?.price,
+    salesWindow: (objectField(payload, "salesWindow") as StoredAncillaryCatalogItem["salesWindow"]) ?? existing?.salesWindow,
+    serviceWindow: (objectField(payload, "serviceWindow") as StoredAncillaryCatalogItem["serviceWindow"]) ?? existing?.serviceWindow,
+    purchaseCutoffHoursBeforeDeparture: numberField(payload, "purchaseCutoffHoursBeforeDeparture") ?? existing?.purchaseCutoffHoursBeforeDeparture,
+    eligibilityRuleVersion: stringField(payload, "eligibilityRuleVersion") ?? existing?.eligibilityRuleVersion,
+    requiresEntitlementRef: booleanField(payload, "requiresEntitlementRef") ?? existing?.requiresEntitlementRef,
+    requiresSegmentRef: booleanField(payload, "requiresSegmentRef") ?? existing?.requiresSegmentRef,
+    fulfillmentMethod: stringField(payload, "fulfillmentMethod") ?? existing?.fulfillmentMethod,
+    status,
+    replacementCatalogItemId: stringField(payload, "replacementCatalogItemId"),
+    updatedAt: dateField(payload, eventType === "AncillaryCatalogItemPublished" ? "publishedAt" : eventType === "AncillaryCatalogItemSuspended" ? "suspendedAt" : "supersededAt") ?? new Date(),
+  });
+}
+
+async function storeAncillaryOffer(repository: UpstreamStateRepository, payload: Record<string, unknown>): Promise<void> {
+  const ancillaryOfferId = stringField(payload, "ancillaryOfferId");
+  const offerVersion = numberField(payload, "offerVersion");
+  const travelerRef = stringField(payload, "travelerRef");
+  const catalogSnapshot = objectField(payload, "catalogSnapshot");
+  const catalogItemId = stringField(catalogSnapshot, "catalogItemId");
+  const serviceType = stringField(catalogSnapshot, "serviceType");
+  const displayName = stringField(catalogSnapshot, "displayName");
+  const quantity = numberField(payload, "quantity");
+  const unitPrice = moneyField(payload, "unitPrice");
+  const totalPrice = moneyField(payload, "totalPrice");
+  const validFrom = dateField(payload, "validFrom");
+  const expiresAt = dateField(payload, "expiresAt");
+  const quotedAt = dateField(payload, "quotedAt");
+  if (!ancillaryOfferId || offerVersion === undefined || !travelerRef || !catalogItemId || !serviceType || !displayName || quantity === undefined || !unitPrice || !totalPrice || !validFrom || !expiresAt) return;
+  await repository.saveAncillaryOffer({
+    ancillaryOfferId,
+    offerVersion,
+    journeyOrderId: stringField(payload, "journeyOrderId"),
+    offerRef: stringField(payload, "offerRef"),
+    travelerRef,
+    segmentRef: stringField(payload, "segmentRef"),
+    catalogItemId,
+    serviceType,
+    displayName,
+    quantity,
+    unitPrice,
+    totalPrice,
+    validFrom,
+    expiresAt,
+    status: "QUOTED",
+    quotedAt,
+  });
+}
+
+async function expireAncillaryOffer(repository: UpstreamStateRepository, payload: Record<string, unknown>): Promise<void> {
+  const ancillaryOfferId = stringField(payload, "ancillaryOfferId");
+  const offerVersion = numberField(payload, "offerVersion");
+  const travelerRef = stringField(payload, "travelerRef");
+  const catalogItemId = stringField(payload, "catalogItemId");
+  const expiredAt = dateField(payload, "expiredAt");
+  if (!ancillaryOfferId || offerVersion === undefined || !travelerRef || !catalogItemId || !expiredAt) return;
+  const existing = (await repository.findAncillaryOffers([travelerRef])).find((offer) => offer.ancillaryOfferId === ancillaryOfferId);
+  await repository.saveAncillaryOffer({
+    ancillaryOfferId,
+    offerVersion,
+    journeyOrderId: stringField(payload, "journeyOrderId") ?? existing?.journeyOrderId,
+    travelerRef,
+    segmentRef: existing?.segmentRef,
+    catalogItemId,
+    serviceType: existing?.serviceType ?? "UNKNOWN",
+    displayName: existing?.displayName ?? catalogItemId,
+    quantity: existing?.quantity ?? 1,
+    unitPrice: existing?.unitPrice ?? { currency: "XXX", minorUnits: 0 },
+    totalPrice: existing?.totalPrice ?? { currency: "XXX", minorUnits: 0 },
+    validFrom: existing?.validFrom ?? expiredAt,
+    expiresAt: existing?.expiresAt ?? expiredAt,
+    status: "EXPIRED",
+    expiredAt,
+  });
+}
+
+async function buildRiskDisclosures(repository: UpstreamStateRepository, itineraryRef: string, travelerRefs: readonly string[], at: Date): Promise<readonly RiskDisclosure[]> {
+  const disclosures: RiskDisclosure[] = [];
+  const evaluation = await repository.findTransferPlanEvaluation(itineraryRef);
+  if (evaluation) {
+    disclosures.push({
+      disclosureId: `transfer-plan:${evaluation.transferPlanId}:${evaluation.evaluationVersion}`,
+      severity: evaluation.status === "UNSERVICEABLE" ? "blocking" : "info",
+      messageCode: evaluation.status === "UNSERVICEABLE" ? "TRANSFER_PLAN_UNSERVICEABLE" : "TRANSFER_PLAN_EVALUATED",
+      templateVersion: "transfer-management.v1",
+      relatedRef: evaluation.transferPlanId,
+      mustAccept: evaluation.status === "UNSERVICEABLE",
+      text:
+        evaluation.status === "UNSERVICEABLE"
+          ? `Transfer plan ${evaluation.transferPlanId} is unserviceable: ${evaluation.unserviceableReasons.join(", ") || "UNSERVICEABLE"}.`
+          : `Transfer plan ${evaluation.transferPlanId} was evaluated with policy ${evaluation.riskPolicyVersion}.`,
+    });
+    const contracts = await repository.findConnectionContracts(evaluation.connectionIds);
+    for (const contract of contracts) {
+      disclosures.push({
+        disclosureId: `connection-contract:${contract.connectionContractId}`,
+        severity: contract.status === "REJECTED" ? "warning" : "info",
+        messageCode: `CONNECTION_CONTRACT_${contract.status}`,
+        templateVersion: contract.disclosureVersion,
+        relatedRef: contract.connectionId,
+        mustAccept: contract.status !== "REJECTED",
+        text: contract.coverageSummary,
+      });
+    }
+  }
+
+  const activeMctRules = (await repository.findPublishedMctRules()).filter((rule) => mctRuleIsActive(rule, at));
+  for (const rule of activeMctRules.slice(0, 10)) {
+    disclosures.push({
+      disclosureId: `mct-rule:${rule.mctRuleId}:${rule.version}`,
+      severity: "info",
+      messageCode: "MCT_RULE_PUBLISHED",
+      templateVersion: "transfer-management.v1",
+      relatedRef: rule.mctRuleId,
+      mustAccept: false,
+      text: `${rule.transferCategory} minimum connection time is ${rule.minimumMinutes} minutes.`,
+    });
+  }
+
+  const activeCatalogItems = (await repository.findPublishedAncillaryCatalogItems()).filter((item) => catalogItemIsInSalesWindow(item, at));
+  for (const item of activeCatalogItems.slice(0, 10)) {
+    disclosures.push({
+      disclosureId: `ancillary-catalog:${item.catalogItemId}:${item.version}`,
+      severity: "info",
+      messageCode: "ANCILLARY_CATALOG_ITEM_AVAILABLE",
+      templateVersion: item.eligibilityRuleVersion ?? "ancillary-service.v1",
+      relatedRef: item.catalogItemId,
+      mustAccept: false,
+      text: `${item.displayName ?? item.catalogItemId} ancillary service is available for quote display.`,
+    });
+  }
+
+  const quotedAncillaryOffers = (await repository.findAncillaryOffers(travelerRefs)).filter((offer) => offer.status === "QUOTED" && offer.expiresAt.getTime() > at.getTime());
+  for (const offer of quotedAncillaryOffers) {
+    disclosures.push({
+      disclosureId: `ancillary-offer:${offer.ancillaryOfferId}:${offer.offerVersion}`,
+      severity: "info",
+      messageCode: "ANCILLARY_OFFER_QUOTED",
+      templateVersion: "ancillary-service.v1",
+      relatedRef: offer.catalogItemId,
+      mustAccept: false,
+      text: `${offer.displayName} ancillary offer is available until ${offer.expiresAt.toISOString()}.`,
+    });
+  }
+
+  return disclosures;
+}
+
+function mctRuleIsActive(rule: StoredMctRule, at: Date): boolean {
+  return rule.validFrom.getTime() <= at.getTime() && (!rule.validUntil || rule.validUntil.getTime() > at.getTime());
+}
+
+function catalogItemIsInSalesWindow(item: StoredAncillaryCatalogItem, at: Date): boolean {
+  const startAt = item.salesWindow?.startAt ? new Date(item.salesWindow.startAt) : undefined;
+  const endAt = item.salesWindow?.endAt ? new Date(item.salesWindow.endAt) : undefined;
+  return (!startAt || Number.isNaN(startAt.getTime()) || startAt.getTime() <= at.getTime()) && (!endAt || Number.isNaN(endAt.getTime()) || endAt.getTime() > at.getTime());
+}
+
 function availabilitySnapshots(itinerary: Record<string, unknown>, segmentRefs: readonly string[]): ReadonlyMap<string, StoredAvailability> {
   const bySegment = new Map<string, StoredAvailability>();
   for (const candidate of [...arrayOfObjects(itinerary.availabilitySnapshots), ...arrayOfObjects(itinerary.availabilityHint ? [itinerary.availabilityHint] : [])]) {
@@ -444,9 +858,16 @@ function stringField(source: unknown, key: string): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 }
 
-function booleanField(source: Record<string, unknown>, key: string): boolean | undefined {
-  const value = source[key];
+function booleanField(source: unknown, key: string): boolean | undefined {
+  if (!source || typeof source !== "object") return undefined;
+  const value = (source as Record<string, unknown>)[key];
   return typeof value === "boolean" ? value : undefined;
+}
+
+function numberField(source: unknown, key: string): number | undefined {
+  if (!source || typeof source !== "object") return undefined;
+  const value = (source as Record<string, unknown>)[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function dateField(source: unknown, key: string): Date | undefined {
@@ -461,6 +882,18 @@ function moneyField(source: Record<string, unknown>, key: string): MoneyLike | u
   const currency = stringField(value, "currency");
   const minorUnits = value?.minorUnits;
   return currency && typeof minorUnits === "number" && Number.isFinite(minorUnits) ? { currency, minorUnits } : undefined;
+}
+
+function transferPlanStatus(value: string | undefined): StoredTransferPlanEvaluation["status"] | undefined {
+  return value === "EVALUATED" || value === "UNSERVICEABLE" ? value : undefined;
+}
+
+function connectionContractStatus(value: string | undefined): StoredConnectionContract["status"] | undefined {
+  return value === "PROPOSED" || value === "ELIGIBLE" || value === "REJECTED" ? value : undefined;
+}
+
+function ancillaryCatalogStatus(value: string | undefined): StoredAncillaryCatalogItem["status"] | undefined {
+  return value === "PUBLISHED" || value === "SUSPENDED" || value === "SUPERSEDED" ? value : undefined;
 }
 
 function availabilityStatus(value: string | undefined): StoredAvailability["status"] | undefined {


### PR DESCRIPTION
## Summary
- Subscribe offer-management to transfer-management and ancillary-service streams.
- Persist TransferPlanEvaluated, ConnectionContractProposed, MctRulePublished, ancillary catalog item, and ancillary offer facts with processed_events dedup in the existing storage flow.
- Surface transfer feasibility, connection contract, MCT, and ancillary display facts as quote-time risk disclosures.

## Validation
- npm --prefix services/offer-management run build
- npm --prefix services/offer-management test