### PR TITLE
REQ-361 activate journey-order deferred consumers

### DIFF
--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/adapters/messaging/RedisJourneyOrderSubscriptions.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/adapters/messaging/RedisJourneyOrderSubscriptions.java
@@ -10,7 +10,10 @@ public final class RedisJourneyOrderSubscriptions {
         "events:traveler-profile",
         "events:risk-compliance",
         "events:account",
-        "events:entitlement-ticketing"
+        "events:entitlement-ticketing",
+        "events:ancillary-service",
+        "events:identity-verification",
+        "events:transfer-management"
     );
     private static final String GROUP = "journey-order";
 

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/application/service/InMemoryJourneyOrderStateRepository.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/application/service/InMemoryJourneyOrderStateRepository.java
@@ -29,6 +29,13 @@ public class InMemoryJourneyOrderStateRepository implements JourneyOrderStateRep
     }
 
     @Override
+    public List<OrderManagementService.StoredOrder> findOrdersByTraveler(String travelerId) {
+        return orders.values().stream()
+            .filter(order -> order.order().travelers().stream().anyMatch(traveler -> traveler.travelerId().equals(travelerId)))
+            .toList();
+    }
+
+    @Override
     public List<OrderManagementService.StoredOrder> listOrders(String accountId, String status, int limit, int offset) {
         return orders.values().stream()
             .filter(order -> accountId == null || accountId.isBlank() || order.order().accountId().equals(accountId))

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/application/service/JourneyOrderStateRepository.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/application/service/JourneyOrderStateRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 public interface JourneyOrderStateRepository {
     Optional<OrderManagementService.StoredOrder> findOrder(String orderId);
+    List<OrderManagementService.StoredOrder> findOrdersByTraveler(String travelerId);
     List<OrderManagementService.StoredOrder> listOrders(String accountId, String status, int limit, int offset);
     long countOrders(String accountId, String status);
     void saveOrder(JourneyOrder order, String idempotencyKey);

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/application/service/OrderManagementService.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/application/service/OrderManagementService.java
@@ -391,7 +391,19 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
                 case "AccountClosureStarted" -> handleAccountClosureStarted(envelope);
                 case "AccountClosed" -> handleAccountClosed(envelope);
                 case "EntitlementIssued" -> handleEntitlementIssued(envelope);
-                case "OfferExpired", "OfferQuoted",
+                case "AncillaryOrderItemSelected" -> handleAncillaryOrderItemSnapshot(envelope);
+                case "AncillaryOrderItemPendingConfirmation", "AncillaryOrderItemConfirmed", "AncillaryOrderItemFulfillmentReady",
+                    "AncillaryOrderItemFulfilled", "AncillaryOrderItemFailed", "AncillaryOrderItemRefunded" -> handleAncillaryOrderItemLifecycle(envelope);
+                case "AncillaryOrderItemCancelled" -> handleAncillaryOrderItemCancelled(envelope);
+                case "ConnectionContractConfirmed" -> handleConnectionContractConfirmed(envelope);
+                case "ConnectionMissed" -> handleConnectionMissed(envelope);
+                case "ConnectionRecovered" -> handleConnectionRecovered(envelope);
+                case "CredentialRegistered" -> handleCredentialRegistered(envelope);
+                case "VerificationCaseStarted" -> handleVerificationCaseStarted(envelope);
+                case "VerificationPassed", "VerificationFailed" -> handleVerificationOutcome(envelope);
+                case "EligibilityCertificateRegistered", "EligibilityCertificateVerified" -> handleEligibilityCertificate(envelope);
+                case "EligibilityUsageReserved", "EligibilityUsageConfirmed", "EligibilityUsageReleased" -> handleEligibilityUsage(envelope);
+                case "OfferExpired", "OfferQuoted", "AncillaryOfferQuoted", "AncillaryOfferExpired",
                     "TravelerProfileUpdated", "TravelerSnapshotUpdated", "TravelerDocumentVerified", "TravelerEligibilityChanged",
                     "SessionOpened", "SessionRevoked", "PreferenceUpdated" -> new EventSubscriber.Success();
                 default -> new EventSubscriber.Success();
@@ -401,6 +413,7 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
         } catch (InvalidEventPayload ex) {
             return new EventSubscriber.FatalError(ex.getMessage());
         } catch (NotFoundException ex) {
+            stateRepository.recordProcessedEvent(envelope.eventId(), envelope.producer());
             return ackSkipMissingOrder(envelope);
         } catch (DataAccessException ex) {
             LOGGER.error("DataAccessException handling {} eventId={}: {}", envelope.eventType(), envelope.eventId(), ex.getMessage(), ex);
@@ -616,6 +629,226 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
         return new EventSubscriber.Success();
     }
 
+    private EventSubscriber.HandlerResult handleAncillaryOrderItemSnapshot(EventEnvelope envelope) {
+        requirePayloadFields(envelope, "ancillaryOrderItemId", "journeyOrderId", "travelerRef", "payableAmount", "status");
+        StoredOrder stored = storedOrderFromPayload(envelope);
+        JourneyOrder order = stored.order();
+        try {
+            order.addOrUpdateAncillaryOrderItem(
+                requiredTextPayload(envelope, "ancillaryOrderItemId"),
+                requiredTextPayload(envelope, "travelerRef"),
+                textPayload(envelope, "segmentRef", ""),
+                ancillaryCatalogItemId(envelope),
+                ancillaryServiceType(envelope),
+                moneyPayload(envelope, "payableAmount"),
+                envelope.occurredAt(),
+                requiredTextPayload(envelope, "status")
+            );
+        } catch (DomainRuleViolation | IllegalStateException ex) {
+            return ackSkipStateRace(envelope, order);
+        }
+        stateRepository.saveOrder(order, stored.idempotencyKey());
+        return new EventSubscriber.Success();
+    }
+
+    private EventSubscriber.HandlerResult handleAncillaryOrderItemLifecycle(EventEnvelope envelope) {
+        requirePayloadFields(envelope, "ancillaryOrderItemId", "journeyOrderId", "status");
+        StoredOrder stored = storedOrderFromPayload(envelope);
+        JourneyOrder order = stored.order();
+        try {
+            order.recordAncillaryOrderItemLifecycle(
+                requiredTextPayload(envelope, "ancillaryOrderItemId"),
+                textPayload(envelope, "serviceType", "UNKNOWN"),
+                requiredTextPayload(envelope, "status"),
+                envelope.occurredAt(),
+                ancillaryReason(envelope)
+            );
+        } catch (DomainRuleViolation | IllegalStateException ex) {
+            return ackSkipStateRace(envelope, order);
+        }
+        stateRepository.saveOrder(order, stored.idempotencyKey());
+        return new EventSubscriber.Success();
+    }
+
+    private EventSubscriber.HandlerResult handleAncillaryOrderItemCancelled(EventEnvelope envelope) {
+        requirePayloadFields(envelope, "ancillaryOrderItemId", "journeyOrderId", "serviceType", "reasonCode", "status");
+        StoredOrder stored = storedOrderFromPayload(envelope);
+        JourneyOrder order = stored.order();
+        try {
+            order.cancelAncillaryOrderItem(
+                requiredTextPayload(envelope, "ancillaryOrderItemId"),
+                requiredTextPayload(envelope, "serviceType"),
+                requiredTextPayload(envelope, "reasonCode"),
+                envelope.occurredAt()
+            );
+        } catch (DomainRuleViolation | IllegalStateException ex) {
+            return ackSkipStateRace(envelope, order);
+        }
+        stateRepository.saveOrder(order, stored.idempotencyKey());
+        return new EventSubscriber.Success();
+    }
+
+    private EventSubscriber.HandlerResult handleConnectionContractConfirmed(EventEnvelope envelope) {
+        requirePayloadFields(envelope, "connectionContractId", "connectionId", "contractType", "status", "confirmedAt");
+        StoredOrder stored = storedOrderFromAcceptedByRef(envelope);
+        JourneyOrder order = stored.order();
+        try {
+            order.recordTransferContractConfirmed(
+                requiredTextPayload(envelope, "connectionId"),
+                requiredTextPayload(envelope, "connectionContractId"),
+                requiredTextPayload(envelope, "contractType"),
+                envelope.occurredAt()
+            );
+        } catch (DomainRuleViolation | IllegalStateException ex) {
+            return ackSkipStateRace(envelope, order);
+        }
+        stateRepository.saveOrder(order, stored.idempotencyKey());
+        return new EventSubscriber.Success();
+    }
+
+    private EventSubscriber.HandlerResult handleConnectionMissed(EventEnvelope envelope) {
+        requirePayloadFields(envelope, "connection", "contractType", "recoveryRequired", "missedAt");
+        StoredOrder stored = storedOrderFromConnection(envelope);
+        JourneyOrder order = stored.order();
+        try {
+            order.recordConnectionMissed(
+                requiredConnectionText(envelope, "connectionId"),
+                requiredTextPayload(envelope, "contractType"),
+                booleanPayload(envelope, "recoveryRequired"),
+                envelope.occurredAt()
+            );
+        } catch (DomainRuleViolation | IllegalStateException ex) {
+            return ackSkipStateRace(envelope, order);
+        }
+        stateRepository.saveOrder(order, stored.idempotencyKey());
+        return new EventSubscriber.Success();
+    }
+
+    private EventSubscriber.HandlerResult handleConnectionRecovered(EventEnvelope envelope) {
+        requirePayloadFields(envelope, "connection", "status", "riskLevel", "recoveredAt");
+        StoredOrder stored = storedOrderFromConnection(envelope);
+        JourneyOrder order = stored.order();
+        try {
+            order.recordConnectionRecovered(
+                requiredConnectionText(envelope, "connectionId"),
+                textPayload(envelope, "recoveryCaseId", null),
+                textPayload(envelope, "replacementConnectionId", null),
+                envelope.occurredAt()
+            );
+        } catch (DomainRuleViolation | IllegalStateException ex) {
+            return ackSkipStateRace(envelope, order);
+        }
+        stateRepository.saveOrder(order, stored.idempotencyKey());
+        return new EventSubscriber.Success();
+    }
+
+    private EventSubscriber.HandlerResult handleCredentialRegistered(EventEnvelope envelope) {
+        requirePayloadFields(envelope, "credentialRecordId", "travelerId", "credentialStatus", "registeredAt");
+        return updateOrdersForTraveler(
+            requiredTextPayload(envelope, "travelerId"),
+            envelope,
+            (order) -> order.recordTravelerVerificationStatus(
+                requiredTextPayload(envelope, "travelerId"),
+                requiredTextPayload(envelope, "credentialStatus"),
+                requiredTextPayload(envelope, "credentialRecordId"),
+                envelope.occurredAt()
+            )
+        );
+    }
+
+    private EventSubscriber.HandlerResult handleVerificationCaseStarted(EventEnvelope envelope) {
+        requirePayloadFields(envelope, "verificationCaseId", "travelerId", "credentialRecordId", "purpose", "verificationStatus", "startedAt");
+        return updateOrdersForTraveler(
+            requiredTextPayload(envelope, "travelerId"),
+            envelope,
+            (order) -> order.recordTravelerVerificationStatus(
+                requiredTextPayload(envelope, "travelerId"),
+                requiredTextPayload(envelope, "verificationStatus"),
+                requiredTextPayload(envelope, "verificationCaseId"),
+                envelope.occurredAt()
+            )
+        );
+    }
+
+    private EventSubscriber.HandlerResult handleVerificationOutcome(EventEnvelope envelope) {
+        requirePayloadFields(envelope, "verificationCaseId", "travelerId", "credentialRecordId", "verificationStatus", "completedAt");
+        return updateOrdersForTraveler(
+            requiredTextPayload(envelope, "travelerId"),
+            envelope,
+            (order) -> order.recordTravelerVerificationStatus(
+                requiredTextPayload(envelope, "travelerId"),
+                requiredTextPayload(envelope, "verificationStatus"),
+                requiredTextPayload(envelope, "verificationCaseId"),
+                envelope.occurredAt()
+            )
+        );
+    }
+
+    private EventSubscriber.HandlerResult handleEligibilityCertificate(EventEnvelope envelope) {
+        requirePayloadFields(envelope, "eligibilityCertificateId", "travelerId", "eligibilityType", "certificateStatus");
+        return updateOrdersForTraveler(
+            requiredTextPayload(envelope, "travelerId"),
+            envelope,
+            (order) -> order.recordTravelerEligibilityStatus(
+                requiredTextPayload(envelope, "travelerId"),
+                requiredTextPayload(envelope, "eligibilityCertificateId"),
+                requiredTextPayload(envelope, "eligibilityType"),
+                requiredTextPayload(envelope, "certificateStatus"),
+                envelope.occurredAt()
+            )
+        );
+    }
+
+    private EventSubscriber.HandlerResult handleEligibilityUsage(EventEnvelope envelope) {
+        requirePayloadFields(envelope, "usageReservationId", "eligibilityCertificateId", "travelerId");
+        StoredOrder directOrder = textPayload(envelope, "journeyOrderId", null) == null ? null : storedOrderFromPayload(envelope);
+        if (directOrder != null) {
+            JourneyOrder order = directOrder.order();
+            try {
+                order.recordTravelerEligibilityStatus(
+                    requiredTextPayload(envelope, "travelerId"),
+                    requiredTextPayload(envelope, "eligibilityCertificateId"),
+                    textPayload(envelope, "eligibilityType", "USAGE"),
+                    usageStatus(envelope),
+                    envelope.occurredAt()
+                );
+            } catch (DomainRuleViolation | IllegalStateException ex) {
+                return ackSkipStateRace(envelope, order);
+            }
+            stateRepository.saveOrder(order, directOrder.idempotencyKey());
+            return new EventSubscriber.Success();
+        }
+        return updateOrdersForTraveler(
+            requiredTextPayload(envelope, "travelerId"),
+            envelope,
+            (order) -> order.recordTravelerEligibilityStatus(
+                requiredTextPayload(envelope, "travelerId"),
+                requiredTextPayload(envelope, "eligibilityCertificateId"),
+                textPayload(envelope, "eligibilityType", "USAGE"),
+                usageStatus(envelope),
+                envelope.occurredAt()
+            )
+        );
+    }
+
+    private EventSubscriber.HandlerResult updateOrdersForTraveler(String travelerId, EventEnvelope envelope, java.util.function.Consumer<JourneyOrder> updater) {
+        List<StoredOrder> storedOrders = stateRepository.findOrdersByTraveler(travelerId);
+        if (storedOrders.isEmpty()) {
+            LOGGER.warn("ack-skip journey-order event={} eventId={} travelerId={} reason=NO_MATCHING_ORDER", envelope.eventType(), envelope.eventId(), travelerId);
+            return new EventSubscriber.Success();
+        }
+        for (StoredOrder stored : storedOrders) {
+            JourneyOrder order = stored.order();
+            try {
+                updater.accept(order);
+            } catch (DomainRuleViolation | IllegalStateException ex) {
+                ackSkipStateRace(envelope, order);
+                continue;
+            }
+            stateRepository.saveOrder(order, stored.idempotencyKey());
+        }
+        return new EventSubscriber.Success();
+    }
 
     private void confirmIdentityPreOrderCheck(String orderId, String causationId, String correlationId) {
         stateRepository.findIdentityPreOrderCheckId(orderId)
@@ -658,6 +891,19 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
         if (orderId == null || orderId.isBlank()) {
             throw new InvalidEventPayload("event payload missing orderId/businessRef");
         }
+        return storedOrderFromId(orderId);
+    }
+
+    private StoredOrder storedOrderFromAcceptedByRef(EventEnvelope envelope) {
+        String acceptedByRef = requiredTextPayload(envelope, "acceptedByRef");
+        if (!acceptedByRef.startsWith("ord-")) {
+            throw new NotFoundException("Connection contract acceptance is not linked to a JourneyOrder: " + acceptedByRef);
+        }
+        return storedOrderFromId(acceptedByRef);
+    }
+
+    private StoredOrder storedOrderFromConnection(EventEnvelope envelope) {
+        String orderId = requiredConnectionText(envelope, "journeyOrderId");
         return storedOrderFromId(orderId);
     }
 
@@ -718,14 +964,112 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
         if (orderId == null) {
             orderId = textPayload(envelope, "journeyOrderId", null);
         }
+        if (orderId == null) {
+            orderId = connectionText(envelope, "journeyOrderId", null);
+        }
         return orderId == null ? "unknown" : orderId;
     }
 
-    private static String textPayload(EventEnvelope envelope, String field, String fallback) {
-        if (!(envelope.payload() instanceof Map<?, ?> payload)) {
+    private static String ancillaryCatalogItemId(EventEnvelope envelope) {
+        String catalogItemId = textPayload(envelope, "catalogItemId", null);
+        if (catalogItemId != null) {
+            return catalogItemId;
+        }
+        Object snapshot = objectPayload(envelope, "catalogSnapshot");
+        if (snapshot instanceof Map<?, ?> catalogSnapshot) {
+            Object value = catalogSnapshot.get("catalogItemId");
+            if (value != null && !String.valueOf(value).isBlank()) {
+                return String.valueOf(value);
+            }
+        }
+        throw new InvalidEventPayload("event payload missing catalogItemId");
+    }
+
+    private static String ancillaryServiceType(EventEnvelope envelope) {
+        String serviceType = textPayload(envelope, "serviceType", null);
+        if (serviceType != null) {
+            return serviceType;
+        }
+        Object snapshot = objectPayload(envelope, "catalogSnapshot");
+        if (snapshot instanceof Map<?, ?> catalogSnapshot) {
+            Object value = catalogSnapshot.get("serviceType");
+            if (value != null && !String.valueOf(value).isBlank()) {
+                return String.valueOf(value);
+            }
+        }
+        throw new InvalidEventPayload("event payload missing serviceType");
+    }
+
+    private static String ancillaryReason(EventEnvelope envelope) {
+        String reason = textPayload(envelope, "failureCode", null);
+        if (reason == null) {
+            reason = textPayload(envelope, "refundRef", null);
+        }
+        if (reason == null) {
+            reason = textPayload(envelope, "status", "ancillary lifecycle update");
+        }
+        return reason;
+    }
+
+    private static String usageStatus(EventEnvelope envelope) {
+        return switch (envelope.eventType()) {
+            case "EligibilityUsageReserved" -> "RESERVED";
+            case "EligibilityUsageConfirmed" -> "CONFIRMED";
+            case "EligibilityUsageReleased" -> "RELEASED";
+            default -> requiredTextPayload(envelope, "status");
+        };
+    }
+
+    private static Money moneyPayload(EventEnvelope envelope, String field) {
+        Object value = objectPayload(envelope, field);
+        if (!(value instanceof Map<?, ?> money)) {
+            throw new InvalidEventPayload("event payload missing " + field);
+        }
+        Object currency = money.get("currency");
+        Object minorUnits = money.get("minorUnits");
+        if (currency == null || String.valueOf(currency).isBlank() || minorUnits == null) {
+            throw new InvalidEventPayload("event payload missing " + field + ".currency/minorUnits");
+        }
+        return Money.fromMinorUnits(Long.parseLong(String.valueOf(minorUnits)), String.valueOf(currency));
+    }
+
+    private static boolean booleanPayload(EventEnvelope envelope, String field) {
+        Object value = objectPayload(envelope, field);
+        if (value == null) {
+            throw new InvalidEventPayload("event payload missing " + field);
+        }
+        if (value instanceof Boolean bool) {
+            return bool;
+        }
+        return Boolean.parseBoolean(String.valueOf(value));
+    }
+
+    private static String requiredConnectionText(EventEnvelope envelope, String field) {
+        String value = connectionText(envelope, field, null);
+        if (value == null || value.isBlank()) {
+            throw new InvalidEventPayload("event payload missing connection." + field);
+        }
+        return value;
+    }
+
+    private static String connectionText(EventEnvelope envelope, String field, String fallback) {
+        Object connection = objectPayload(envelope, "connection");
+        if (!(connection instanceof Map<?, ?> connectionMap)) {
             return fallback;
         }
-        Object value = payload.get(field);
+        Object value = connectionMap.get(field);
+        return value == null ? fallback : String.valueOf(value);
+    }
+
+    private static Object objectPayload(EventEnvelope envelope, String field) {
+        if (!(envelope.payload() instanceof Map<?, ?> payload)) {
+            return null;
+        }
+        return payload.get(field);
+    }
+
+    private static String textPayload(EventEnvelope envelope, String field, String fallback) {
+        Object value = objectPayload(envelope, field);
         return value == null ? fallback : String.valueOf(value);
     }
 

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/application/service/OrderManagementService.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/application/service/OrderManagementService.java
@@ -708,8 +708,11 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
 
     private EventSubscriber.HandlerResult handleConnectionMissed(EventEnvelope envelope) {
         requirePayloadFields(envelope, "connection", "contractType", "recoveryRequired", "missedAt");
-        StoredOrder stored = storedOrderFromConnection(envelope);
-        JourneyOrder order = stored.order();
+        Optional<StoredOrder> stored = storedOrderFromConnection(envelope);
+        if (stored.isEmpty()) {
+            return ackSkipUnlinkedConnection(envelope);
+        }
+        JourneyOrder order = stored.get().order();
         try {
             order.recordConnectionMissed(
                 requiredConnectionText(envelope, "connectionId"),
@@ -720,14 +723,17 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
         } catch (DomainRuleViolation | IllegalStateException ex) {
             return ackSkipStateRace(envelope, order);
         }
-        stateRepository.saveOrder(order, stored.idempotencyKey());
+        stateRepository.saveOrder(order, stored.get().idempotencyKey());
         return new EventSubscriber.Success();
     }
 
     private EventSubscriber.HandlerResult handleConnectionRecovered(EventEnvelope envelope) {
         requirePayloadFields(envelope, "connection", "status", "riskLevel", "recoveredAt");
-        StoredOrder stored = storedOrderFromConnection(envelope);
-        JourneyOrder order = stored.order();
+        Optional<StoredOrder> stored = storedOrderFromConnection(envelope);
+        if (stored.isEmpty()) {
+            return ackSkipUnlinkedConnection(envelope);
+        }
+        JourneyOrder order = stored.get().order();
         try {
             order.recordConnectionRecovered(
                 requiredConnectionText(envelope, "connectionId"),
@@ -738,7 +744,7 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
         } catch (DomainRuleViolation | IllegalStateException ex) {
             return ackSkipStateRace(envelope, order);
         }
-        stateRepository.saveOrder(order, stored.idempotencyKey());
+        stateRepository.saveOrder(order, stored.get().idempotencyKey());
         return new EventSubscriber.Success();
     }
 
@@ -902,9 +908,12 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
         return storedOrderFromId(acceptedByRef);
     }
 
-    private StoredOrder storedOrderFromConnection(EventEnvelope envelope) {
-        String orderId = requiredConnectionText(envelope, "journeyOrderId");
-        return storedOrderFromId(orderId);
+    private Optional<StoredOrder> storedOrderFromConnection(EventEnvelope envelope) {
+        String orderId = connectionText(envelope, "journeyOrderId", null);
+        if (orderId == null || orderId.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.of(storedOrderFromId(orderId));
     }
 
     private StoredOrder storedOrderFromId(String orderId) {
@@ -922,6 +931,12 @@ public class OrderManagementService implements JourneyOrderService, JourneyOrder
     private static EventSubscriber.HandlerResult ackSkipStateRace(EventEnvelope envelope, JourneyOrder order) {
         LOGGER.warn("ack-skip journey-order event={} eventId={} orderId={} currentStatus={} reason=STATE_RACE_OR_RULE_NOOP",
             envelope.eventType(), envelope.eventId(), order.orderId(), order.state());
+        return new EventSubscriber.Success();
+    }
+
+    private static EventSubscriber.HandlerResult ackSkipUnlinkedConnection(EventEnvelope envelope) {
+        LOGGER.warn("ack-skip journey-order event={} eventId={} connectionId={} reason=NO_LINKED_ORDER",
+            envelope.eventType(), envelope.eventId(), connectionText(envelope, "connectionId", "unknown"));
         return new EventSubscriber.Success();
     }
 

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrder.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/domain/JourneyOrder.java
@@ -46,7 +46,7 @@ public final class JourneyOrder {
         this.channelRef = requireText(channelRef, "channelRef");
         this.idempotencyKey = requireText(idempotencyKey, "idempotencyKey");
         this.offerSnapshot = Objects.requireNonNull(offerSnapshot, "offerSnapshot is required");
-        this.travelers = List.copyOf(Objects.requireNonNull(travelers, "travelers are required"));
+        this.travelers = new ArrayList<>(Objects.requireNonNull(travelers, "travelers are required"));
         this.segments = List.copyOf(Objects.requireNonNull(segments, "segments are required"));
         this.orderItems = new ArrayList<>(Objects.requireNonNull(orderItems, "orderItems are required"));
         this.timeline = new ArrayList<>();
@@ -131,7 +131,7 @@ public final class JourneyOrder {
     public String channelRef() { return channelRef; }
     public String idempotencyKey() { return idempotencyKey; }
     public OfferSnapshotRef offerSnapshot() { return offerSnapshot; }
-    public List<TravelerRef> travelers() { return travelers; }
+    public List<TravelerRef> travelers() { return List.copyOf(travelers); }
     public List<SegmentOrderSnapshot> segments() { return segments; }
     public List<OrderItem> orderItems() { return List.copyOf(orderItems); }
     public List<TimelineFact> timeline() { return List.copyOf(timeline); }
@@ -243,6 +243,175 @@ public final class JourneyOrder {
         ));
     }
 
+    public void addOrUpdateAncillaryOrderItem(
+        String ancillaryOrderItemId,
+        String travelerRef,
+        String segmentRef,
+        String catalogItemId,
+        String serviceType,
+        Money payableAmount,
+        Instant occurredAt,
+        String status
+    ) {
+        requireNonTerminalForDetailUpdates();
+        if (orderItems.stream().noneMatch(item -> item.orderItemId().equals(ancillaryOrderItemId))) {
+            orderItems.add(new OrderItem(
+                ancillaryOrderItemId,
+                OrderItemType.ANCILLARY_SERVICE,
+                "ancillary " + requireText(serviceType, "serviceType"),
+                Money.zero(Objects.requireNonNull(payableAmount, "payableAmount is required").currency()),
+                requireText(catalogItemId, "catalogItemId"),
+                List.of(new OrderLineBinding(ancillaryOrderItemId, requireText(travelerRef, "travelerRef"), blankToEmpty(segmentRef), ancillaryOrderItemId))
+            ));
+            monetarySummary = MonetarySummary.fromItems(orderItems);
+        }
+        recordTimeline(
+            "AncillaryOrderItem" + requireText(status, "status"),
+            occurredAt,
+            "ancillary-service",
+            "ancillary order item " + status,
+            Map.of("ancillaryOrderItemId", ancillaryOrderItemId, "serviceType", serviceType)
+        );
+    }
+
+    public void recordAncillaryOrderItemLifecycle(
+        String ancillaryOrderItemId,
+        String serviceType,
+        String status,
+        Instant occurredAt,
+        String reason
+    ) {
+        requireNonTerminalForDetailUpdates();
+        String safeServiceType = serviceType == null || serviceType.isBlank() ? "UNKNOWN" : serviceType;
+        recordTimeline(
+            "AncillaryOrderItem" + requireText(status, "status"),
+            occurredAt,
+            "ancillary-service",
+            reason == null || reason.isBlank() ? "ancillary order item " + status : reason,
+            Map.of("ancillaryOrderItemId", requireText(ancillaryOrderItemId, "ancillaryOrderItemId"), "serviceType", safeServiceType)
+        );
+    }
+
+    public void cancelAncillaryOrderItem(String ancillaryOrderItemId, String serviceType, String reason, Instant occurredAt) {
+        requireNonTerminalForDetailUpdates();
+        orderItems.stream()
+            .filter(item -> item.orderItemId().equals(ancillaryOrderItemId))
+            .findFirst()
+            .ifPresent(item -> item.cancel(reason));
+        monetarySummary = MonetarySummary.fromItems(orderItems);
+        recordAncillaryOrderItemLifecycle(ancillaryOrderItemId, serviceType, "CANCELLED", occurredAt, reason);
+    }
+
+    public void recordTransferContractConfirmed(String connectionId, String connectionContractId, String contractType, Instant occurredAt) {
+        requireNonTerminalForDetailUpdates();
+        recordTimeline(
+            "ConnectionContractConfirmed",
+            occurredAt,
+            "transfer-management",
+            "connection contract confirmed",
+            Map.of(
+                "connectionId", requireText(connectionId, "connectionId"),
+                "connectionContractId", requireText(connectionContractId, "connectionContractId"),
+                "contractType", requireText(contractType, "contractType")
+            )
+        );
+    }
+
+    public void recordConnectionMissed(String connectionId, String contractType, boolean recoveryRequired, Instant occurredAt) {
+        requireNonTerminalForDetailUpdates();
+        recordTimeline(
+            "ConnectionMissed",
+            occurredAt,
+            "transfer-management",
+            recoveryRequired ? "connection missed; recovery required" : "connection missed",
+            Map.of(
+                "connectionId", requireText(connectionId, "connectionId"),
+                "contractType", requireText(contractType, "contractType"),
+                "recoveryRequired", Boolean.toString(recoveryRequired)
+            )
+        );
+    }
+
+    public void recordConnectionRecovered(String connectionId, String recoveryCaseId, String replacementConnectionId, Instant occurredAt) {
+        requireNonTerminalForDetailUpdates();
+        Map<String, String> attributes = new java.util.LinkedHashMap<>();
+        attributes.put("connectionId", requireText(connectionId, "connectionId"));
+        if (recoveryCaseId != null && !recoveryCaseId.isBlank()) {
+            attributes.put("recoveryCaseId", recoveryCaseId);
+        }
+        if (replacementConnectionId != null && !replacementConnectionId.isBlank()) {
+            attributes.put("replacementConnectionId", replacementConnectionId);
+        }
+        recordTimeline("ConnectionRecovered", occurredAt, "transfer-management", "connection recovered", attributes);
+    }
+
+    public void recordTravelerVerificationStatus(String travelerId, String status, String referenceId, Instant occurredAt) {
+        requireNonTerminalForDetailUpdates();
+        TravelerRef existing = travelers.stream()
+            .filter(traveler -> traveler.travelerId().equals(travelerId))
+            .findFirst()
+            .orElseThrow(() -> new DomainRuleViolation("unknown traveler " + travelerId));
+        if ("PASSED".equals(status)) {
+            replaceTraveler(existing, new TravelerRef(
+                existing.travelerId(),
+                existing.travelerType(),
+                existing.maskedDocumentRef(),
+                new EligibilityRef(referenceId, "IDENTITY_VERIFICATION", "identity-verification", null, occurredAt)
+            ));
+        }
+        recordTimeline(
+            "TravelerVerification" + requireText(status, "status"),
+            occurredAt,
+            "identity-verification",
+            "traveler verification " + status,
+            Map.of("travelerId", travelerId, "verificationRef", requireText(referenceId, "referenceId"))
+        );
+    }
+
+    public void recordTravelerEligibilityStatus(String travelerId, String eligibilityCertificateId, String eligibilityType, String status, Instant occurredAt) {
+        requireNonTerminalForDetailUpdates();
+        TravelerRef existing = travelers.stream()
+            .filter(traveler -> traveler.travelerId().equals(travelerId))
+            .findFirst()
+            .orElseThrow(() -> new DomainRuleViolation("unknown traveler " + travelerId));
+        if ("ACTIVE".equals(status) || "CONFIRMED".equals(status)) {
+            replaceTraveler(existing, new TravelerRef(
+                existing.travelerId(),
+                existing.travelerType(),
+                existing.maskedDocumentRef(),
+                new EligibilityRef(eligibilityCertificateId, eligibilityType, "identity-verification", null, occurredAt)
+            ));
+        }
+        recordTimeline(
+            "TravelerEligibility" + requireText(status, "status"),
+            occurredAt,
+            "identity-verification",
+            "traveler eligibility " + status,
+            Map.of("travelerId", travelerId, "eligibilityCertificateId", eligibilityCertificateId, "eligibilityType", eligibilityType)
+        );
+    }
+
+    private void replaceTraveler(TravelerRef existing, TravelerRef replacement) {
+        int index = travelers.indexOf(existing);
+        if (index < 0) {
+            throw new DomainRuleViolation("unknown traveler " + existing.travelerId());
+        }
+        travelers.set(index, replacement);
+    }
+
+    private void requireNonTerminalForDetailUpdates() {
+        if (isTerminalState()) {
+            throw new DomainRuleViolation("terminal JourneyOrder cannot accept detail projection updates");
+        }
+    }
+
+    private boolean isTerminalState() {
+        return switch (state) {
+            case CANCELLED, COMPLETED, FAILED -> true;
+            default -> false;
+        };
+    }
+
     private void requireCreateInvariants() {
         if (travelers.isEmpty()) {
             throw new DomainRuleViolation("JourneyOrder requires at least one traveler snapshot");
@@ -294,6 +463,10 @@ public final class JourneyOrder {
 
     private static String blankToNull(String value) {
         return value == null || value.isBlank() ? null : value;
+    }
+
+    private static String blankToEmpty(String value) {
+        return value == null || value.isBlank() ? "" : value;
     }
 
     private static String requireText(String value, String name) {

--- a/services/journey-order/src/main/java/com/trainticket/journeyorder/infrastructure/persistence/PostgresJourneyOrderStateRepository.java
+++ b/services/journey-order/src/main/java/com/trainticket/journeyorder/infrastructure/persistence/PostgresJourneyOrderStateRepository.java
@@ -77,6 +77,26 @@ public class PostgresJourneyOrderStateRepository implements JourneyOrderStateRep
     }
 
     @Override
+    public List<OrderManagementService.StoredOrder> findOrdersByTraveler(String travelerId) {
+        return jdbc.query(
+            """
+                SELECT id
+                FROM journey_order_snapshots
+                WHERE data->'travelers' @> ?::jsonb
+                ORDER BY (data->>'createdAt')::timestamptz DESC
+                """,
+            (rs, rowNum) -> findOrder(rs.getString("id")).orElseThrow(),
+            travelerContainmentJson(travelerId)
+        );
+    }
+
+    private String travelerContainmentJson(String travelerId) {
+        com.fasterxml.jackson.databind.node.ArrayNode array = mapper.createArrayNode();
+        array.addObject().put("travelerId", travelerId);
+        return array.toString();
+    }
+
+    @Override
     public List<OrderManagementService.StoredOrder> listOrders(String accountId, String status, int limit, int offset) {
         boolean byAccount = accountId != null && !accountId.isBlank();
         boolean byStatus = status != null && !status.isBlank();

--- a/services/journey-order/src/test/java/com/trainticket/journeyorder/application/OrderManagementServiceTest.java
+++ b/services/journey-order/src/test/java/com/trainticket/journeyorder/application/OrderManagementServiceTest.java
@@ -626,6 +626,44 @@ class OrderManagementServiceTest {
     }
 
     @Test
+    void connectionMissedWithoutLinkedOrderIsAckSkippedAndDeduplicated() {
+        InMemoryJourneyOrderStateRepository repository = new InMemoryJourneyOrderStateRepository();
+        OrderManagementService orderService = new OrderManagementService(envelope -> published.add(envelope), FIXED_CLOCK, repository);
+
+        EventEnvelope missed = new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d026",
+            "ConnectionMissed",
+            Instant.parse("2026-07-05T10:10:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0d027",
+            "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0d028",
+            "transfer-management",
+            1,
+            Map.of(
+                "connection", Map.of(
+                    "connectionId", "con-0194f2e0-7b3e-7610-8284-5c26e8b0d029",
+                    "transferPlanId", "tpl-0194f2e0-7b3e-7610-8284-5c26e8b0d030",
+                    "itineraryRef", "itn-unlinked",
+                    "previousSegmentRef", "seg-1",
+                    "nextSegmentRef", "seg-2",
+                    "travelerRefs", List.of("tvl-unlinked")
+                ),
+                "previousStatus", "AT_RISK",
+                "status", "MISSED",
+                "riskLevel", "MISSED",
+                "contractType", "PROTECTED",
+                "missedAt", "2026-07-05T10:10:00Z",
+                "missedCause", "PREVIOUS_SEGMENT_DELAYED",
+                "window", Map.of("availableMinutes", 0, "mctMinutes", 10),
+                "recoveryRequired", true
+            )
+        );
+
+        assertEquals(new EventSubscriber.Success(), orderService.handle(missed));
+        assertEquals(new EventSubscriber.Success(), orderService.handle(missed));
+        assertTrue(repository.isEventProcessed(missed.eventId()));
+    }
+
+    @Test
     void verificationPassedLinksTravelerStatus() {
         InMemoryJourneyOrderStateRepository repository = new InMemoryJourneyOrderStateRepository();
         OrderManagementService orderService = new OrderManagementService(envelope -> published.add(envelope), FIXED_CLOCK, repository);

--- a/services/journey-order/src/test/java/com/trainticket/journeyorder/application/OrderManagementServiceTest.java
+++ b/services/journey-order/src/test/java/com/trainticket/journeyorder/application/OrderManagementServiceTest.java
@@ -551,6 +551,120 @@ class OrderManagementServiceTest {
 
 
     @Test
+    void ancillaryOrderItemSelectedAddsOrderDetailWithEventIdDedup() {
+        InMemoryJourneyOrderStateRepository repository = new InMemoryJourneyOrderStateRepository();
+        OrderManagementService orderService = new OrderManagementService(envelope -> published.add(envelope), FIXED_CLOCK, repository);
+        JourneyOrderResult created = orderService.createOrder(
+            new JourneyOrderRequest("account-ancillary", "offer-ancillary", 1, List.of("tvl-1"), List.of("seg-1")),
+            "idem-ancillary-selected",
+            "corr-1"
+        );
+        published.clear();
+
+        EventEnvelope selected = ancillarySelectedEvent(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d001",
+            created.orderId()
+        );
+
+        assertEquals(new EventSubscriber.Success(), orderService.handle(selected));
+        assertEquals(new EventSubscriber.Success(), orderService.handle(selected));
+
+        com.trainticket.journeyorder.domain.JourneyOrder stored = repository.findOrder(created.orderId()).orElseThrow().order();
+        assertEquals(2, stored.orderItems().size());
+        assertTrue(stored.orderItems().stream().anyMatch(item -> item.orderItemId().equals("aoi-0194f2e0-7b3e-7610-8284-5c26e8b0d010")));
+        assertEquals(1, stored.timeline().stream()
+            .filter(fact -> fact.factType().equals("AncillaryOrderItemSELECTED"))
+            .count());
+        assertTrue(repository.isEventProcessed(selected.eventId()));
+    }
+
+    @Test
+    void connectionMissedRecordsRecoveryDisplay() {
+        InMemoryJourneyOrderStateRepository repository = new InMemoryJourneyOrderStateRepository();
+        OrderManagementService orderService = new OrderManagementService(envelope -> published.add(envelope), FIXED_CLOCK, repository);
+        JourneyOrderResult created = orderService.createOrder(
+            new JourneyOrderRequest("account-transfer", "offer-transfer", 1, List.of("tvl-1"), List.of("seg-1")),
+            "idem-transfer-missed",
+            "corr-1"
+        );
+
+        EventSubscriber.HandlerResult result = orderService.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d021",
+            "ConnectionMissed",
+            Instant.parse("2026-07-05T10:10:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0d022",
+            "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0d023",
+            "transfer-management",
+            1,
+            Map.of(
+                "connection", Map.of(
+                    "connectionId", "con-0194f2e0-7b3e-7610-8284-5c26e8b0d024",
+                    "transferPlanId", "tpl-0194f2e0-7b3e-7610-8284-5c26e8b0d025",
+                    "itineraryRef", "itn-1",
+                    "journeyOrderId", created.orderId(),
+                    "previousSegmentRef", "seg-1",
+                    "nextSegmentRef", "seg-2",
+                    "travelerRefs", List.of("tvl-1")
+                ),
+                "previousStatus", "AT_RISK",
+                "status", "MISSED",
+                "riskLevel", "MISSED",
+                "contractType", "PROTECTED",
+                "missedAt", "2026-07-05T10:10:00Z",
+                "missedCause", "PREVIOUS_SEGMENT_DELAYED",
+                "window", Map.of("availableMinutes", 0, "mctMinutes", 10),
+                "recoveryRequired", true
+            )
+        ));
+
+        assertEquals(new EventSubscriber.Success(), result);
+        com.trainticket.journeyorder.domain.JourneyOrder stored = repository.findOrder(created.orderId()).orElseThrow().order();
+        assertTrue(stored.timeline().stream().anyMatch(fact ->
+            fact.factType().equals("ConnectionMissed")
+                && fact.attributes().get("connectionId").equals("con-0194f2e0-7b3e-7610-8284-5c26e8b0d024")
+                && fact.attributes().get("recoveryRequired").equals("true")));
+    }
+
+    @Test
+    void verificationPassedLinksTravelerStatus() {
+        InMemoryJourneyOrderStateRepository repository = new InMemoryJourneyOrderStateRepository();
+        OrderManagementService orderService = new OrderManagementService(envelope -> published.add(envelope), FIXED_CLOCK, repository);
+        JourneyOrderResult created = orderService.createOrder(
+            new JourneyOrderRequest("account-verification", "offer-verification", 1, List.of("tvl-verified"), List.of("seg-1")),
+            "idem-verification-passed",
+            "corr-1"
+        );
+
+        EventSubscriber.HandlerResult result = orderService.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d031",
+            "VerificationPassed",
+            Instant.parse("2026-07-05T10:11:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0d032",
+            "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0d033",
+            "identity-verification",
+            1,
+            Map.ofEntries(
+                Map.entry("verificationCaseId", "ivc-0194f2e0-7b3e-7610-8284-5c26e8b0d034"),
+                Map.entry("travelerId", "tvl-verified"),
+                Map.entry("credentialRecordId", "crd-0194f2e0-7b3e-7610-8284-5c26e8b0d035"),
+                Map.entry("simOutcome", "MATCH"),
+                Map.entry("simResultRef", "simop-1"),
+                Map.entry("verificationStatus", "PASSED"),
+                Map.entry("validFrom", "2026-07-05T10:11:00Z"),
+                Map.entry("validUntil", "2027-07-05T10:11:00Z"),
+                Map.entry("policyVersion", "identity-v1"),
+                Map.entry("completedAt", "2026-07-05T10:11:00Z"),
+                Map.entry("aggregateVersion", 2)
+            )
+        ));
+
+        assertEquals(new EventSubscriber.Success(), result);
+        com.trainticket.journeyorder.domain.JourneyOrder stored = repository.findOrder(created.orderId()).orElseThrow().order();
+        assertTrue(stored.timeline().stream().anyMatch(fact -> fact.factType().equals("TravelerVerificationPASSED")));
+        assertEquals("ivc-0194f2e0-7b3e-7610-8284-5c26e8b0d034", stored.travelers().getFirst().eligibilityRef().eligibilityId());
+    }
+
+    @Test
     void orderConfirmationConfirmsIdentityPreOrderCheck() {
         InMemoryJourneyOrderStateRepository repository = new InMemoryJourneyOrderStateRepository();
         RecordingIdentityVerificationPort identity = new RecordingIdentityVerificationPort();
@@ -617,6 +731,44 @@ class OrderManagementServiceTest {
         if (obj == null) throw new AssertionError("Expected non-null");
     }
 
+
+    private static EventEnvelope ancillarySelectedEvent(String eventId, String orderId) {
+        return new EventEnvelope(
+            eventId,
+            "AncillaryOrderItemSelected",
+            Instant.parse("2026-07-05T10:05:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0d011",
+            "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0d012",
+            "ancillary-service",
+            1,
+            Map.ofEntries(
+                Map.entry("ancillaryOrderItemId", "aoi-0194f2e0-7b3e-7610-8284-5c26e8b0d010"),
+                Map.entry("journeyOrderId", orderId),
+                Map.entry("travelerRef", "tvl-1"),
+                Map.entry("segmentRef", "seg-1"),
+                Map.entry("entitlementRef", "ent-1"),
+                Map.entry("ancillaryOfferId", "aof-0194f2e0-7b3e-7610-8284-5c26e8b0d013"),
+                Map.entry("offerVersion", 1),
+                Map.entry("catalogSnapshot", Map.of(
+                    "catalogItemId", "aci-0194f2e0-7b3e-7610-8284-5c26e8b0d014",
+                    "serviceType", "MEAL",
+                    "displayName", "Dinner",
+                    "attachmentScope", "SEGMENT",
+                    "unitPrice", Map.of("currency", "CNY", "minorUnits", 2500),
+                    "purchaseCutoffHoursBeforeDeparture", 2,
+                    "eligibilityRuleVersion", "ancillary-v1",
+                    "fulfillmentMethod", "VOUCHER"
+                )),
+                Map.entry("quantity", 1),
+                Map.entry("payableAmount", Map.of("currency", "CNY", "minorUnits", 2500)),
+                Map.entry("refundableAmount", Map.of("currency", "CNY", "minorUnits", 2500)),
+                Map.entry("assessedFees", List.of()),
+                Map.entry("status", "SELECTED"),
+                Map.entry("selectedAt", "2026-07-05T10:05:00Z"),
+                Map.entry("aggregateVersion", 1)
+            )
+        );
+    }
 
     private static EventEnvelope entitlementIssuedEvent(String eventId, String orderId) {
         return new EventEnvelope(


### PR DESCRIPTION
## Summary
- Subscribe journey-order to ancillary-service, identity-verification, and transfer-management streams.
- Consume contract-defined ancillary order-item, transfer responsibility/recovery, and identity verification/eligibility events with processed event dedup.
- Add order-detail/recovery/verification projection updates and unit coverage for newly consumed events.

## Validation
- Installed platform/java-kit locally with `mvn install -q`.
- `cd services/journey-order && mvn test -q` passes.