### PR TITLE
REQ-363 activate post-sales external consumers

### DIFF
--- a/services/post-sales/migrations/001_post_sales_persistence.sql
+++ b/services/post-sales/migrations/001_post_sales_persistence.sql
@@ -16,4 +16,22 @@ CREATE INDEX IF NOT EXISTS idx_post_sales_active_refunds_case_id ON post_sales_a
 CREATE TABLE IF NOT EXISTS outbox (seq bigserial PRIMARY KEY, event_id text NOT NULL UNIQUE, stream text NOT NULL, envelope jsonb NOT NULL, created_at timestamptz NOT NULL DEFAULT now(), published_at timestamptz);
 CREATE INDEX IF NOT EXISTS idx_outbox_unpublished_seq ON outbox (seq) WHERE published_at IS NULL;
 CREATE TABLE IF NOT EXISTS processed_events (event_id text PRIMARY KEY, stream text, processed_at timestamptz NOT NULL DEFAULT now());
+CREATE TABLE IF NOT EXISTS post_sales_ancillary_projections (
+  ancillary_order_item_id text PRIMARY KEY,
+  journey_order_id text NOT NULL,
+  status text NOT NULL,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_post_sales_ancillary_projections_journey_order_id ON post_sales_ancillary_projections(journey_order_id);
+CREATE INDEX IF NOT EXISTS idx_post_sales_ancillary_projections_status ON post_sales_ancillary_projections(status);
+CREATE TABLE IF NOT EXISTS post_sales_dispatch_projections (
+  ride_request_id text PRIMARY KEY,
+  rider_account_id text NOT NULL,
+  status text NOT NULL,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_post_sales_dispatch_projections_rider_account_id ON post_sales_dispatch_projections(rider_account_id);
+CREATE INDEX IF NOT EXISTS idx_post_sales_dispatch_projections_status ON post_sales_dispatch_projections(status);
 CREATE TABLE IF NOT EXISTS idempotency_records (key text PRIMARY KEY, request_hash text NOT NULL, status_code int NOT NULL, response_body jsonb, created_at timestamptz NOT NULL DEFAULT now());

--- a/services/post-sales/src/main/java/com/trainticket/postsales/adapters/messaging/RedisSubscriptionLifecycle.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/adapters/messaging/RedisSubscriptionLifecycle.java
@@ -21,7 +21,9 @@ public class RedisSubscriptionLifecycle {
             List.of(
                 RedisStreamNames.forProducer("capacity-availability"),
                 RedisStreamNames.forProducer("journey-order"),
-                RedisStreamNames.forProducer("disruption-recovery")
+                RedisStreamNames.forProducer("disruption-recovery"),
+                RedisStreamNames.forProducer("ancillary-service"),
+                RedisStreamNames.forProducer("dispatch")
             ),
             RedisStreamNames.CONSUMER_GROUP,
             properties.consumerName(),

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/AncillaryPostSalesProjection.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/AncillaryPostSalesProjection.java
@@ -1,0 +1,142 @@
+package com.trainticket.postsales.application;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record AncillaryPostSalesProjection(
+    String ancillaryOrderItemId,
+    String journeyOrderId,
+    String travelerRef,
+    String segmentRef,
+    String catalogItemId,
+    String serviceType,
+    String status,
+    String previousStatus,
+    ExternalMoney payableAmount,
+    ExternalMoney refundableAmount,
+    ExternalMoney refundedAmount,
+    String recommendation,
+    String reasonCode,
+    String postSalesCaseId,
+    String refundRef,
+    String failureCode,
+    Boolean compensable,
+    Map<String, Object> fulfillmentFact,
+    String sourceEventId,
+    String lastEventId,
+    String lastEventType,
+    Instant lastOccurredAt,
+    long aggregateVersion
+) {
+    public AncillaryPostSalesProjection {
+        ancillaryOrderItemId = requireText(ancillaryOrderItemId, "ancillaryOrderItemId");
+        journeyOrderId = requireText(journeyOrderId, "journeyOrderId");
+        travelerRef = requireText(travelerRef, "travelerRef");
+        status = requireText(status, "status");
+        lastEventId = requireText(lastEventId, "lastEventId");
+        lastEventType = requireText(lastEventType, "lastEventType");
+        if (fulfillmentFact != null) {
+            fulfillmentFact = Map.copyOf(fulfillmentFact);
+        }
+    }
+
+    public static AncillaryPostSalesProjection fromEvent(
+        String eventId,
+        String eventType,
+        Instant occurredAt,
+        Map<?, ?> payload
+    ) {
+        Map<String, Object> fulfillmentFact = objectMap(payload.get("fulfillmentFact"));
+        return new AncillaryPostSalesProjection(
+            text(payload, "ancillaryOrderItemId"),
+            text(payload, "journeyOrderId"),
+            text(payload, "travelerRef"),
+            optionalText(payload, "segmentRef"),
+            optionalText(payload, "catalogItemId"),
+            optionalText(payload, "serviceType"),
+            text(payload, "status"),
+            optionalText(payload, "previousStatus"),
+            ExternalMoney.fromPayloadValue(payload.get("payableAmount")),
+            ExternalMoney.fromPayloadValue(payload.get("refundableAmount")),
+            ExternalMoney.fromPayloadValue(payload.get("refundedAmount")),
+            optionalText(payload, "recommendation"),
+            optionalText(payload, "reasonCode"),
+            optionalText(payload, "postSalesCaseId"),
+            optionalText(payload, "refundRef"),
+            optionalText(payload, "failureCode"),
+            optionalBoolean(payload, "compensable"),
+            fulfillmentFact,
+            optionalText(payload, "sourceEventId"),
+            eventId,
+            eventType,
+            occurredAt,
+            optionalLong(payload, "aggregateVersion")
+        );
+    }
+
+    public AncillaryPostSalesProjection withPostSalesCaseId(String linkedPostSalesCaseId) {
+        return new AncillaryPostSalesProjection(
+            ancillaryOrderItemId,
+            journeyOrderId,
+            travelerRef,
+            segmentRef,
+            catalogItemId,
+            serviceType,
+            status,
+            previousStatus,
+            payableAmount,
+            refundableAmount,
+            refundedAmount,
+            recommendation,
+            reasonCode,
+            linkedPostSalesCaseId,
+            refundRef,
+            failureCode,
+            compensable,
+            fulfillmentFact,
+            sourceEventId,
+            lastEventId,
+            lastEventType,
+            lastOccurredAt,
+            aggregateVersion
+        );
+    }
+
+    private static String text(Map<?, ?> payload, String field) {
+        String value = optionalText(payload, field);
+        if (value == null) {
+            throw new IllegalArgumentException("event payload missing " + field);
+        }
+        return value;
+    }
+
+    private static String optionalText(Map<?, ?> payload, String field) {
+        Object value = payload.get(field);
+        return value instanceof String text && !text.isBlank() ? text : null;
+    }
+
+    private static Boolean optionalBoolean(Map<?, ?> payload, String field) {
+        Object value = payload.get(field);
+        return value instanceof Boolean booleanValue ? booleanValue : null;
+    }
+
+    private static long optionalLong(Map<?, ?> payload, String field) {
+        Object value = payload.get(field);
+        return value instanceof Number number ? number.longValue() : 0L;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> objectMap(Object value) {
+        if (!(value instanceof Map<?, ?> map)) {
+            return null;
+        }
+        return (Map<String, Object>) map;
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " is required");
+        }
+        return value;
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/DispatchPostSalesProjection.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/DispatchPostSalesProjection.java
@@ -1,0 +1,45 @@
+package com.trainticket.postsales.application;
+
+import java.time.Instant;
+
+public record DispatchPostSalesProjection(
+    String rideRequestId,
+    String rideAssignmentId,
+    String riderAccountId,
+    String travelerRef,
+    String pickupRef,
+    String dropoffRef,
+    String driverRef,
+    String vehicleRef,
+    String intentFingerprint,
+    String finalFareRef,
+    String reason,
+    String status,
+    String previousStatus,
+    Instant startedAt,
+    Instant endedAt,
+    Instant cancelledAt,
+    Instant recordedAt,
+    Instant failedAt,
+    String lastEventId,
+    String lastEventType,
+    Instant lastOccurredAt
+) {
+    public DispatchPostSalesProjection {
+        rideRequestId = requireText(rideRequestId, "rideRequestId");
+        riderAccountId = requireText(riderAccountId, "riderAccountId");
+        travelerRef = requireText(travelerRef, "travelerRef");
+        pickupRef = requireText(pickupRef, "pickupRef");
+        dropoffRef = requireText(dropoffRef, "dropoffRef");
+        status = requireText(status, "status");
+        lastEventId = requireText(lastEventId, "lastEventId");
+        lastEventType = requireText(lastEventType, "lastEventType");
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " is required");
+        }
+        return value;
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/ExternalMoney.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/ExternalMoney.java
@@ -1,0 +1,31 @@
+package com.trainticket.postsales.application;
+
+import java.util.Map;
+
+public record ExternalMoney(String currency, long minorUnits) {
+    public ExternalMoney {
+        currency = requireText(currency, "currency");
+    }
+
+    static ExternalMoney fromPayloadValue(Object value) {
+        if (!(value instanceof Map<?, ?> map)) {
+            return null;
+        }
+        Object currencyValue = map.get("currency");
+        Object minorUnitsValue = map.get("minorUnits");
+        if (!(currencyValue instanceof String currency) || currency.isBlank()) {
+            return null;
+        }
+        if (minorUnitsValue instanceof Number number) {
+            return new ExternalMoney(currency, number.longValue());
+        }
+        return null;
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " is required");
+        }
+        return value;
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/InMemoryPostSalesExternalEventProjectionStore.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/InMemoryPostSalesExternalEventProjectionStore.java
@@ -1,0 +1,32 @@
+package com.trainticket.postsales.application;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryPostSalesExternalEventProjectionStore implements PostSalesExternalEventProjectionStore {
+    private final ConcurrentMap<String, AncillaryPostSalesProjection> ancillaryByItemId = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, DispatchPostSalesProjection> dispatchByRideRequestId = new ConcurrentHashMap<>();
+
+    @Override
+    public void saveAncillary(AncillaryPostSalesProjection projection) {
+        ancillaryByItemId.put(projection.ancillaryOrderItemId(), projection);
+    }
+
+    @Override
+    public Optional<AncillaryPostSalesProjection> findAncillaryByItemId(String ancillaryOrderItemId) {
+        return Optional.ofNullable(ancillaryByItemId.get(ancillaryOrderItemId));
+    }
+
+    @Override
+    public void saveDispatch(DispatchPostSalesProjection projection) {
+        dispatchByRideRequestId.put(projection.rideRequestId(), projection);
+    }
+
+    @Override
+    public Optional<DispatchPostSalesProjection> findDispatchByRideRequestId(String rideRequestId) {
+        return Optional.ofNullable(dispatchByRideRequestId.get(rideRequestId));
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
@@ -22,6 +22,8 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,16 +34,25 @@ public class PostSalesApplicationService {
     private final EventPublisher eventPublisher;
     private final AdjustmentQuotePort adjustmentQuotePort;
     private final PostSalesPolicyContextStore policyContextStore;
+    private final PostSalesExternalEventProjectionStore externalEventProjectionStore;
     private final Clock clock;
     private final RefundPolicyEngine refundPolicyEngine = new RefundPolicyEngine();
     private final ChangePolicyEngine changePolicyEngine = new ChangePolicyEngine();
 
     public PostSalesApplicationService(PostSalesRepository repository, EventPublisher eventPublisher,
             AdjustmentQuotePort adjustmentQuotePort, PostSalesPolicyContextStore policyContextStore, Clock clock) {
+        this(repository, eventPublisher, adjustmentQuotePort, policyContextStore, new InMemoryPostSalesExternalEventProjectionStore(), clock);
+    }
+
+    @Autowired
+    public PostSalesApplicationService(PostSalesRepository repository, EventPublisher eventPublisher,
+            AdjustmentQuotePort adjustmentQuotePort, PostSalesPolicyContextStore policyContextStore,
+            PostSalesExternalEventProjectionStore externalEventProjectionStore, Clock clock) {
         this.repository = repository;
         this.eventPublisher = eventPublisher;
         this.adjustmentQuotePort = adjustmentQuotePort;
         this.policyContextStore = policyContextStore;
+        this.externalEventProjectionStore = externalEventProjectionStore;
         this.clock = clock;
     }
 
@@ -237,6 +248,75 @@ public class PostSalesApplicationService {
 
     public void recordPolicyContext(PostSalesPolicyContext context) {
         policyContextStore.save(context);
+    }
+
+    public void recordAncillaryProjection(AncillaryPostSalesProjection projection) {
+        externalEventProjectionStore.saveAncillary(projection);
+        policyContextStore.findByOrderId(projection.journeyOrderId())
+            .map(context -> context.withAncillaryComponent(
+                money(projection.refundableAmount()),
+                "FULFILLED".equals(projection.status())
+            ))
+            .ifPresent(policyContextStore::save);
+    }
+
+    public void recordDispatchProjection(DispatchPostSalesProjection projection) {
+        externalEventProjectionStore.saveDispatch(projection);
+    }
+
+    public PostSalesCase openCompensationForAncillaryFailure(AncillaryPostSalesProjection projection) {
+        String idempotencyKey = "ancillary-service:" + projection.lastEventId() + ":compensation";
+        return open(new OpenCaseCommand(
+            projection.journeyOrderId(),
+            PostSalesCaseType.COMPENSATION,
+            scopeForAncillary(projection),
+            reasonOrDefault(projection.failureCode(), "ANCILLARY_FAILURE"),
+            "ancillary-service",
+            idempotencyKey,
+            "cmd-" + projection.lastEventId(),
+            projection.lastEventId()
+        ));
+    }
+
+    public PostSalesCase linkRefundForAncillaryCancellation(AncillaryPostSalesProjection projection) {
+        String idempotencyKey = "ancillary-service:" + projection.lastEventId() + ":refund";
+        return repository.findByIdempotencyKey(idempotencyKey)
+            .or(() -> existingActiveRefundCaseForOrder(projection.journeyOrderId()))
+            .orElseGet(() -> open(new OpenCaseCommand(
+                projection.journeyOrderId(),
+                PostSalesCaseType.REFUND,
+                scopeForAncillary(projection),
+                reasonOrDefault(projection.reasonCode(), "ANCILLARY_CANCELLED"),
+                "ancillary-service",
+                idempotencyKey,
+                "cmd-" + projection.lastEventId(),
+                projection.lastEventId()
+            )));
+    }
+
+    private Optional<PostSalesCase> existingActiveRefundCaseForOrder(String journeyOrderId) {
+        return repository.findActiveRefundCaseForOrder(journeyOrderId);
+    }
+
+    private static PostSalesScope scopeForAncillary(AncillaryPostSalesProjection projection) {
+        return new PostSalesScope(
+            List.of(projection.ancillaryOrderItemId()),
+            optionalList(projection.segmentRef()),
+            List.of(projection.travelerRef()),
+            List.of()
+        );
+    }
+
+    private static List<String> optionalList(String value) {
+        return value == null || value.isBlank() ? List.of() : List.of(value);
+    }
+
+    private static Money money(ExternalMoney externalMoney) {
+        return externalMoney == null ? null : Money.fromMinorUnits(externalMoney.minorUnits(), externalMoney.currency());
+    }
+
+    private static String reasonOrDefault(String reason, String fallback) {
+        return reason == null || reason.isBlank() ? fallback : reason;
     }
 
     private static RefundClassification classify(String reasonCode) {

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesEventHandler.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesEventHandler.java
@@ -3,6 +3,8 @@ package com.trainticket.postsales.application;
 import com.trainticket.platformkit.messaging.EventEnvelope;
 import java.util.Map;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -10,30 +12,36 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 public class PostSalesEventHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostSalesEventHandler.class);
+
     private final ConsumedEventLog consumedEventLog;
     private final PostSalesApplicationService applicationService;
+    private final PostSalesExternalEventPolicy externalEventPolicy;
     private final TransactionTemplate transactionTemplate;
 
     public PostSalesEventHandler(ConsumedEventLog consumedEventLog, PostSalesApplicationService applicationService) {
-        this(consumedEventLog, applicationService, (PlatformTransactionManager) null);
+        this(consumedEventLog, applicationService, new PostSalesExternalEventPolicy(applicationService), (PlatformTransactionManager) null);
     }
 
     @Autowired
     public PostSalesEventHandler(
         ConsumedEventLog consumedEventLog,
         PostSalesApplicationService applicationService,
+        PostSalesExternalEventPolicy externalEventPolicy,
         Optional<PlatformTransactionManager> transactionManager
     ) {
-        this(consumedEventLog, applicationService, transactionManager.orElse(null));
+        this(consumedEventLog, applicationService, externalEventPolicy, transactionManager.orElse(null));
     }
 
     PostSalesEventHandler(
         ConsumedEventLog consumedEventLog,
         PostSalesApplicationService applicationService,
+        PostSalesExternalEventPolicy externalEventPolicy,
         PlatformTransactionManager transactionManager
     ) {
         this.consumedEventLog = consumedEventLog;
         this.applicationService = applicationService;
+        this.externalEventPolicy = externalEventPolicy;
         this.transactionTemplate = transactionManager == null ? null : new TransactionTemplate(transactionManager);
     }
 
@@ -64,6 +72,11 @@ public class PostSalesEventHandler {
                 if (segmentBookingRef != null) {
                     applicationService.applyForSegmentBooking(segmentBookingRef, envelope.eventId(), envelope.correlationId());
                 }
+            } else if (externalEventPolicy.handles(envelope.eventType())) {
+                externalEventPolicy.handle(envelope);
+            } else {
+                LOGGER.warn("ack-skip post-sales event={} eventId={} producer={} reason=UNKNOWN_EVENT_TYPE",
+                    envelope.eventType(), envelope.eventId(), envelope.producer());
             }
             return EventSubscriber.HandlerResult.SUCCESS;
         } catch (RuntimeException exception) {

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesExternalEventPolicy.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesExternalEventPolicy.java
@@ -1,0 +1,136 @@
+package com.trainticket.postsales.application;
+
+import com.trainticket.platformkit.messaging.EventEnvelope;
+import com.trainticket.postsales.domain.PostSalesCase;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PostSalesExternalEventPolicy {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostSalesExternalEventPolicy.class);
+    private static final Set<String> ANCILLARY_EVENT_TYPES = Set.of(
+        "AncillaryOrderItemFulfilled",
+        "AncillaryOrderItemFailed",
+        "AncillaryOrderItemCancelled",
+        "AncillaryOrderItemRefundPending",
+        "AncillaryOrderItemRefunded",
+        "AncillaryFulfillmentFactRecorded"
+    );
+    private static final Set<String> DISPATCH_EVENT_TYPES = Set.of(
+        "DispatchUserCancelled",
+        "DispatchNoShowRecorded",
+        "RideEnded",
+        "DispatchFailed"
+    );
+
+    private final PostSalesApplicationService applicationService;
+
+    public PostSalesExternalEventPolicy(PostSalesApplicationService applicationService) {
+        this.applicationService = applicationService;
+    }
+
+    public boolean handles(String eventType) {
+        return ANCILLARY_EVENT_TYPES.contains(eventType) || DISPATCH_EVENT_TYPES.contains(eventType);
+    }
+
+    public void handle(EventEnvelope envelope) {
+        if (ANCILLARY_EVENT_TYPES.contains(envelope.eventType())) {
+            payload(envelope).ifPresentOrElse(
+                payload -> handleAncillary(envelope, payload),
+                () -> ackSkipMalformedPayload(envelope, "payload-not-object")
+            );
+            return;
+        }
+        if (DISPATCH_EVENT_TYPES.contains(envelope.eventType())) {
+            payload(envelope).ifPresentOrElse(
+                payload -> applicationService.recordDispatchProjection(dispatchProjection(envelope, payload)),
+                () -> ackSkipMalformedPayload(envelope, "payload-not-object")
+            );
+        }
+    }
+
+    private void handleAncillary(EventEnvelope envelope, Map<?, ?> payload) {
+        AncillaryPostSalesProjection projection = AncillaryPostSalesProjection.fromEvent(
+            envelope.eventId(),
+            envelope.eventType(),
+            envelope.occurredAt(),
+            payload
+        );
+        if ("AncillaryOrderItemCancelled".equals(envelope.eventType()) && isPositive(projection.refundableAmount())) {
+            PostSalesCase linkedCase = applicationService.linkRefundForAncillaryCancellation(projection);
+            applicationService.recordAncillaryProjection(projection.withPostSalesCaseId(linkedCase.caseId()));
+            return;
+        }
+        applicationService.recordAncillaryProjection(projection);
+        if ("AncillaryOrderItemFailed".equals(envelope.eventType()) && Boolean.TRUE.equals(projection.compensable())) {
+            applicationService.openCompensationForAncillaryFailure(projection);
+        }
+    }
+
+    private DispatchPostSalesProjection dispatchProjection(EventEnvelope envelope, Map<?, ?> payload) {
+        return new DispatchPostSalesProjection(
+            text(payload, "rideRequestId"),
+            optionalText(payload, "rideAssignmentId"),
+            text(payload, "riderAccountId"),
+            text(payload, "travelerRef"),
+            text(payload, "pickupRef"),
+            text(payload, "dropoffRef"),
+            optionalText(payload, "driverRef"),
+            optionalText(payload, "vehicleRef"),
+            optionalText(payload, "intentFingerprint"),
+            optionalText(payload, "finalFareRef"),
+            optionalText(payload, "reason"),
+            text(payload, "status"),
+            optionalText(payload, "previousStatus"),
+            instant(payload, "startedAt"),
+            instant(payload, "endedAt"),
+            instant(payload, "cancelledAt"),
+            instant(payload, "recordedAt"),
+            instant(payload, "failedAt"),
+            envelope.eventId(),
+            envelope.eventType(),
+            envelope.occurredAt()
+        );
+    }
+
+    private static Optional<Map<?, ?>> payload(EventEnvelope envelope) {
+        return envelope.payload() instanceof Map<?, ?> map ? Optional.of(map) : Optional.empty();
+    }
+
+    private static boolean isPositive(ExternalMoney money) {
+        return money != null && money.minorUnits() > 0;
+    }
+
+    private static String text(Map<?, ?> payload, String field) {
+        String value = optionalText(payload, field);
+        if (value == null) {
+            throw new IllegalArgumentException("event payload missing " + field);
+        }
+        return value;
+    }
+
+    private static String optionalText(Map<?, ?> payload, String field) {
+        Object value = payload.get(field);
+        return value instanceof String text && !text.isBlank() ? text : null;
+    }
+
+    private static Instant instant(Map<?, ?> payload, String field) {
+        String value = optionalText(payload, field);
+        return value == null ? null : Instant.parse(value);
+    }
+
+    private static void ackSkipMalformedPayload(EventEnvelope envelope, String reason) {
+        LOGGER.warn(
+            "ack-skip post-sales external event={} eventId={} producer={} reason={}",
+            envelope.eventType(),
+            envelope.eventId(),
+            envelope.producer(),
+            reason
+        );
+    }
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesExternalEventProjectionStore.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesExternalEventProjectionStore.java
@@ -1,0 +1,13 @@
+package com.trainticket.postsales.application;
+
+import java.util.Optional;
+
+public interface PostSalesExternalEventProjectionStore {
+    void saveAncillary(AncillaryPostSalesProjection projection);
+
+    Optional<AncillaryPostSalesProjection> findAncillaryByItemId(String ancillaryOrderItemId);
+
+    void saveDispatch(DispatchPostSalesProjection projection);
+
+    Optional<DispatchPostSalesProjection> findDispatchByRideRequestId(String rideRequestId);
+}

--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesPolicyContext.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesPolicyContext.java
@@ -78,6 +78,21 @@ public record PostSalesPolicyContext(
         );
     }
 
+    public PostSalesPolicyContext withAncillaryComponent(Money ancillaryAmount, boolean ancillaryUsed) {
+        if (ancillaryAmount == null) {
+            return this;
+        }
+        return new PostSalesPolicyContext(
+            journeyOrderId,
+            departureTime,
+            travelerTypesByRef,
+            groupSize,
+            appliedChangeCount,
+            originalFare,
+            refundComponents.withAncillary(ancillaryAmount, ancillaryUsed)
+        );
+    }
+
     public record RefundWaterfallComponents(
         Money baseFare,
         Money taxes,
@@ -99,6 +114,20 @@ public record PostSalesPolicyContext(
         public static RefundWaterfallComponents empty(Currency currency) {
             Money zero = Money.zero(currency);
             return new RefundWaterfallComponents(zero, zero, zero, zero, zero, zero, false);
+        }
+
+        public RefundWaterfallComponents withAncillary(Money ancillaryAmount, boolean used) {
+            Money compatibleAmount = convertIfZeroCurrency(ancillaryAmount, baseFare);
+            compatibleAmount.compareTo(baseFare);
+            return new RefundWaterfallComponents(
+                baseFare,
+                taxes,
+                platformServiceFee,
+                supplierServiceFee,
+                compatibleAmount,
+                discounts,
+                used || ancillaryUsed
+            );
         }
 
         public RefundWaterfall toWaterfall(Money fallbackBaseFare) {

--- a/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/PostgresPostSalesExternalEventProjectionStore.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/infrastructure/persistence/PostgresPostSalesExternalEventProjectionStore.java
@@ -1,0 +1,86 @@
+package com.trainticket.postsales.infrastructure.persistence;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.postsales.application.AncillaryPostSalesProjection;
+import com.trainticket.postsales.application.DispatchPostSalesProjection;
+import com.trainticket.postsales.application.PostSalesExternalEventProjectionStore;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Primary
+@ConditionalOnBean(DataSource.class)
+public class PostgresPostSalesExternalEventProjectionStore implements PostSalesExternalEventProjectionStore {
+    private final JdbcTemplate jdbc;
+    private final ObjectMapper objectMapper;
+
+    public PostgresPostSalesExternalEventProjectionStore(DataSource dataSource, ObjectMapper objectMapper) {
+        this.jdbc = new JdbcTemplate(dataSource);
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void saveAncillary(AncillaryPostSalesProjection projection) {
+        jdbc.update("""
+            INSERT INTO post_sales_ancillary_projections (ancillary_order_item_id, journey_order_id, status, data, updated_at)
+            VALUES (?, ?, ?, ?::jsonb, now())
+            ON CONFLICT (ancillary_order_item_id) DO UPDATE
+            SET journey_order_id = EXCLUDED.journey_order_id,
+                status = EXCLUDED.status,
+                data = EXCLUDED.data,
+                updated_at = now()
+            """, projection.ancillaryOrderItemId(), projection.journeyOrderId(), projection.status(), write(projection));
+    }
+
+    @Override
+    public Optional<AncillaryPostSalesProjection> findAncillaryByItemId(String ancillaryOrderItemId) {
+        return jdbc.query(
+            "SELECT data FROM post_sales_ancillary_projections WHERE ancillary_order_item_id = ?",
+            rs -> rs.next() ? Optional.of(read(rs.getString("data"), AncillaryPostSalesProjection.class)) : Optional.empty(),
+            ancillaryOrderItemId
+        );
+    }
+
+    @Override
+    public void saveDispatch(DispatchPostSalesProjection projection) {
+        jdbc.update("""
+            INSERT INTO post_sales_dispatch_projections (ride_request_id, rider_account_id, status, data, updated_at)
+            VALUES (?, ?, ?, ?::jsonb, now())
+            ON CONFLICT (ride_request_id) DO UPDATE
+            SET rider_account_id = EXCLUDED.rider_account_id,
+                status = EXCLUDED.status,
+                data = EXCLUDED.data,
+                updated_at = now()
+            """, projection.rideRequestId(), projection.riderAccountId(), projection.status(), write(projection));
+    }
+
+    @Override
+    public Optional<DispatchPostSalesProjection> findDispatchByRideRequestId(String rideRequestId) {
+        return jdbc.query(
+            "SELECT data FROM post_sales_dispatch_projections WHERE ride_request_id = ?",
+            rs -> rs.next() ? Optional.of(read(rs.getString("data"), DispatchPostSalesProjection.class)) : Optional.empty(),
+            rideRequestId
+        );
+    }
+
+    private String write(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("post-sales external projection could not be encoded", exception);
+        }
+    }
+
+    private <T> T read(String json, Class<T> type) {
+        try {
+            return objectMapper.readValue(json, type);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("post-sales external projection could not be decoded", exception);
+        }
+    }
+}

--- a/services/post-sales/src/test/java/com/trainticket/postsales/application/MessagingPortsTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/application/MessagingPortsTest.java
@@ -1,17 +1,20 @@
 package com.trainticket.postsales.application;
 
 import com.trainticket.platformkit.messaging.EventEnvelope;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.trainticket.postsales.domain.PostSalesCase;
+import com.trainticket.postsales.domain.PostSalesCaseStatus;
 import com.trainticket.postsales.domain.PostSalesCaseType;
 import com.trainticket.postsales.domain.PostSalesScope;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
@@ -131,6 +134,161 @@ class MessagingPortsTest {
     }
 
     @Test
+    void handlesAncillaryCancellationWithEventIdDedupAndOpensRefundCase() {
+        RecordingConsumedEventLog log = new RecordingConsumedEventLog();
+        InMemoryPostSalesRepository repository = new InMemoryPostSalesRepository();
+        InMemoryPostSalesPolicyContextStore contextStore = new InMemoryPostSalesPolicyContextStore();
+        InMemoryPostSalesExternalEventProjectionStore projectionStore = new InMemoryPostSalesExternalEventProjectionStore();
+        PostSalesApplicationService service = new PostSalesApplicationService(
+            repository,
+            ignored -> { },
+            ignored -> java.util.Optional.empty(),
+            contextStore,
+            projectionStore,
+            java.time.Clock.fixed(Instant.parse("2026-07-05T10:30:00Z"), java.time.ZoneOffset.UTC)
+        );
+        PostSalesEventHandler handler = new PostSalesEventHandler(
+            log,
+            service,
+            new PostSalesExternalEventPolicy(service),
+            (org.springframework.transaction.PlatformTransactionManager) null
+        );
+        EventEnvelope envelope = new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d101",
+            "AncillaryOrderItemCancelled",
+            Instant.parse("2026-07-05T10:29:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0d111",
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d112",
+            "ancillary-service",
+            1,
+            ancillaryCancelledPayload()
+        );
+
+        assertEquals(EventSubscriber.HandlerResult.SUCCESS, handler.handle(envelope));
+        assertEquals(EventSubscriber.HandlerResult.SUCCESS, handler.handle(envelope));
+
+        assertEquals(1, log.recorded.size());
+        AncillaryPostSalesProjection projection = projectionStore.findAncillaryByItemId("aoi-1").orElseThrow();
+        assertEquals("CANCELLED", projection.status());
+        PostSalesCase opened = repository.findByIdempotencyKey("ancillary-service:evt-0194f2e0-7b3e-7610-8284-5c26e8b0d101:refund").orElseThrow();
+        assertEquals(opened.caseId(), projection.postSalesCaseId());
+        assertEquals(PostSalesCaseType.REFUND, opened.caseType());
+        assertEquals(List.of("aoi-1"), opened.scope().orderItemRefs());
+    }
+
+    @Test
+    void linksLaterAncillaryCancellationToExistingActiveRefundCase() {
+        RecordingConsumedEventLog log = new RecordingConsumedEventLog();
+        InMemoryPostSalesRepository repository = new InMemoryPostSalesRepository();
+        InMemoryPostSalesExternalEventProjectionStore projectionStore = new InMemoryPostSalesExternalEventProjectionStore();
+        PostSalesApplicationService service = new PostSalesApplicationService(
+            repository,
+            ignored -> { },
+            ignored -> java.util.Optional.empty(),
+            new InMemoryPostSalesPolicyContextStore(),
+            projectionStore,
+            java.time.Clock.fixed(Instant.parse("2026-07-05T10:30:00Z"), java.time.ZoneOffset.UTC)
+        );
+        PostSalesCase activeMainRefund = PostSalesCase.rehydrate(
+            "case-main-refund-1",
+            "ord-ancillary-1",
+            PostSalesCaseType.REFUND,
+            PostSalesScope.ticket("ticket-1", "seg-1", "tvl-1", "ent-1"),
+            "CUSTOMER_REQUEST",
+            "acct-1",
+            "main-refund-key-1",
+            PostSalesCaseStatus.OPENED,
+            null,
+            List.of(),
+            null,
+            null,
+            List.of()
+        );
+        repository.save(activeMainRefund);
+        PostSalesEventHandler handler = new PostSalesEventHandler(
+            log,
+            service,
+            new PostSalesExternalEventPolicy(service),
+            (org.springframework.transaction.PlatformTransactionManager) null
+        );
+        Map<String, Object> secondCancellationPayload = ancillaryCancelledPayload();
+        secondCancellationPayload.put("ancillaryOrderItemId", "aoi-2");
+        EventEnvelope envelope = new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d104",
+            "AncillaryOrderItemCancelled",
+            Instant.parse("2026-07-05T10:29:30Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0d117",
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d118",
+            "ancillary-service",
+            1,
+            secondCancellationPayload
+        );
+
+        assertEquals(EventSubscriber.HandlerResult.SUCCESS, handler.handle(envelope));
+
+        assertEquals(1, log.recorded.size());
+        assertEquals(1, repository.findAll().size());
+        AncillaryPostSalesProjection projection = projectionStore.findAncillaryByItemId("aoi-2").orElseThrow();
+        assertEquals("CANCELLED", projection.status());
+        assertEquals("case-main-refund-1", projection.postSalesCaseId());
+    }
+
+    @Test
+    void handlesDispatchRideEndedProjection() {
+        RecordingConsumedEventLog log = new RecordingConsumedEventLog();
+        InMemoryPostSalesExternalEventProjectionStore projectionStore = new InMemoryPostSalesExternalEventProjectionStore();
+        PostSalesApplicationService service = new PostSalesApplicationService(
+            new InMemoryPostSalesRepository(),
+            ignored -> { },
+            ignored -> java.util.Optional.empty(),
+            new InMemoryPostSalesPolicyContextStore(),
+            projectionStore,
+            java.time.Clock.systemUTC()
+        );
+        PostSalesEventHandler handler = new PostSalesEventHandler(
+            log,
+            service,
+            new PostSalesExternalEventPolicy(service),
+            (org.springframework.transaction.PlatformTransactionManager) null
+        );
+        EventEnvelope envelope = new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d102",
+            "RideEnded",
+            Instant.parse("2026-07-05T10:40:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0d113",
+            "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0d114",
+            "dispatch",
+            1,
+            dispatchRideEndedPayload()
+        );
+
+        assertEquals(EventSubscriber.HandlerResult.SUCCESS, handler.handle(envelope));
+
+        DispatchPostSalesProjection projection = projectionStore.findDispatchByRideRequestId("rrq-1").orElseThrow();
+        assertEquals("COMPLETED", projection.status());
+        assertEquals("fare-final-1", projection.finalFareRef());
+    }
+
+    @Test
+    void unknownEventTypeIsAckSkipped() {
+        RecordingConsumedEventLog log = new RecordingConsumedEventLog();
+        PostSalesEventHandler handler = new PostSalesEventHandler(log, new NoOpPostSalesApplicationService());
+        EventEnvelope envelope = new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0d103",
+            "ConformantUnknownFact",
+            Instant.parse("2026-07-05T10:30:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0d115",
+            "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0d116",
+            "dispatch",
+            1,
+            Map.of("status", "NEW_STATE")
+        );
+
+        assertDoesNotThrow(() -> assertEquals(EventSubscriber.HandlerResult.SUCCESS, handler.handle(envelope)));
+        assertEquals(1, log.recorded.size());
+    }
+
+    @Test
     void fakeSubscriberUsesDeliveryCountForDlqDecision() {
         FakeDeliveryCounterSubscriber subscriber = new FakeDeliveryCounterSubscriber();
         EventEnvelope envelope = new EventEnvelope(
@@ -151,6 +309,42 @@ class MessagingPortsTest {
 
         assertEquals(1, subscriber.dlq.size());
         assertEquals("evt-0194f2e0-7b3e-7610-8284-5c26e8b0d004", subscriber.dlq.getFirst().eventId());
+    }
+
+    private static Map<String, Object> dispatchRideEndedPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("rideRequestId", "rrq-1");
+        payload.put("rideAssignmentId", "ras-1");
+        payload.put("riderAccountId", "acct-1");
+        payload.put("travelerRef", "tvl-1");
+        payload.put("pickupRef", "place-pickup");
+        payload.put("dropoffRef", "place-dropoff");
+        payload.put("driverRef", "drv-1");
+        payload.put("vehicleRef", "veh-1");
+        payload.put("startedAt", "2026-07-05T10:10:00Z");
+        payload.put("endedAt", "2026-07-05T10:40:00Z");
+        payload.put("finalFareRef", "fare-final-1");
+        payload.put("status", "COMPLETED");
+        return payload;
+    }
+
+    private static Map<String, Object> ancillaryCancelledPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("ancillaryOrderItemId", "aoi-1");
+        payload.put("journeyOrderId", "ord-ancillary-1");
+        payload.put("travelerRef", "tvl-1");
+        payload.put("segmentRef", "seg-1");
+        payload.put("catalogItemId", "aci-1");
+        payload.put("serviceType", "MEAL");
+        payload.put("payableAmount", Map.of("currency", "CNY", "minorUnits", 1000));
+        payload.put("refundableAmount", Map.of("currency", "CNY", "minorUnits", 800));
+        payload.put("reasonCode", "JOURNEY_ORDER_CANCELLED");
+        payload.put("source", "JOURNEY_ORDER_CANCELLED");
+        payload.put("previousStatus", "CONFIRMED");
+        payload.put("status", "CANCELLED");
+        payload.put("cancelledAt", "2026-07-05T10:29:00Z");
+        payload.put("aggregateVersion", 4);
+        return payload;
     }
 
     private static PostSalesCase approvedCase() {


### PR DESCRIPTION
## Summary
- Subscribe post-sales to ancillary-service and dispatch streams.
- Consume ancillary lifecycle/refund/fulfillment facts and dispatch outcome facts with processed eventId dedup.
- Persist post-sales read projections and open ancillary-linked refund/compensation cases where applicable.

## Validation
- cd services/post-sales && mvn test