### PR TITLE
REQ-364 activate fulfillment external consumers

### DIFF
--- a/services/fulfillment/internal/adapters/messaging/redis.go
+++ b/services/fulfillment/internal/adapters/messaging/redis.go
@@ -40,7 +40,7 @@ func (s *RedisSubscriber) Subscribe(ctx context.Context, streams []string, group
 }
 
 func FulfillmentSubscriptions() []string {
-	return []string{streamPrefix + "entitlement-ticketing", streamPrefix + "booking-orchestration"}
+	return []string{streamPrefix + "entitlement-ticketing", streamPrefix + "booking-orchestration", streamPrefix + "ancillary-service", streamPrefix + "dispatch"}
 }
 func FulfillmentGroup() string { return consumerGroup }
 

--- a/services/fulfillment/internal/adapters/postgres/repository.go
+++ b/services/fulfillment/internal/adapters/postgres/repository.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/trainticket/greenfield/platform/go-kit/storage"
@@ -105,6 +106,56 @@ func (r *FulfillmentRepository) FindSegmentStatusByCommandID(ctx context.Context
 	return decodeSegmentStatus(raw)
 }
 
+func (r *FulfillmentRepository) SaveAncillaryHandoff(ctx context.Context, handoff *domain.AncillaryFulfillmentHandoff) error {
+	data, err := json.Marshal(ancillaryHandoffSnapshotFromDomain(handoff))
+	if err != nil {
+		return err
+	}
+	_, err = r.db.DBFor(ctx).Exec(ctx, `INSERT INTO ancillary_fulfillment_handoffs(ancillary_order_item_id, data) VALUES ($1, $2) ON CONFLICT (ancillary_order_item_id) DO UPDATE SET data = EXCLUDED.data, updated_at = now()`, handoff.AncillaryOrderItemID, data)
+	return err
+}
+
+func (r *FulfillmentRepository) FindAncillaryHandoff(ctx context.Context, ancillaryOrderItemID string) (*domain.AncillaryFulfillmentHandoff, error) {
+	rows, err := r.db.DBFor(ctx).Query(ctx, `SELECT data FROM ancillary_fulfillment_handoffs WHERE ancillary_order_item_id = $1 LIMIT 1`, strings.TrimSpace(ancillaryOrderItemID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return nil, application.ErrNotFound
+	}
+	var raw json.RawMessage
+	if err := rows.Scan(&raw); err != nil {
+		return nil, err
+	}
+	return decodeAncillaryHandoff(raw)
+}
+
+func (r *FulfillmentRepository) SaveRideExecution(ctx context.Context, view *domain.RideExecutionView) error {
+	data, err := json.Marshal(rideExecutionSnapshotFromDomain(view))
+	if err != nil {
+		return err
+	}
+	_, err = r.db.DBFor(ctx).Exec(ctx, `INSERT INTO ride_execution_views(ride_request_id, data) VALUES ($1, $2) ON CONFLICT (ride_request_id) DO UPDATE SET data = EXCLUDED.data, updated_at = now()`, view.RideRequestID, data)
+	return err
+}
+
+func (r *FulfillmentRepository) FindRideExecution(ctx context.Context, rideRequestID string) (*domain.RideExecutionView, error) {
+	rows, err := r.db.DBFor(ctx).Query(ctx, `SELECT data FROM ride_execution_views WHERE ride_request_id = $1 LIMIT 1`, strings.TrimSpace(rideRequestID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return nil, application.ErrNotFound
+	}
+	var raw json.RawMessage
+	if err := rows.Scan(&raw); err != nil {
+		return nil, err
+	}
+	return decodeRideExecution(raw)
+}
+
 type segmentStatusSnapshot struct {
 	SegmentStatusRecordID string                           `json:"segmentStatusRecordId"`
 	CommandID             string                           `json:"commandId"`
@@ -138,6 +189,65 @@ func decodeSegmentStatus(raw []byte) (*domain.SegmentStatusRecord, error) {
 		return nil, err
 	}
 	return &domain.SegmentStatusRecord{SegmentStatusRecordID: domain.SegmentStatusRecordID(s.SegmentStatusRecordID), CommandID: s.CommandID, SegmentRef: domain.SegmentRef(s.SegmentRef), ScheduledServiceRef: s.ScheduledServiceRef, ServiceDate: s.ServiceDate, Status: domain.SegmentOperationalStatus(s.Status), EstimatedArrivalAt: utcPtr(s.EstimatedArrivalAt), ArrivedAt: utcPtr(s.ArrivedAt), CancelledAt: utcPtr(s.CancelledAt), ObservedAt: s.ObservedAt.UTC(), SourceSystem: s.SourceSystem, CreatedAt: s.CreatedAt.UTC()}, nil
+}
+
+type ancillaryHandoffSnapshot struct {
+	AncillaryOrderItemID string                            `json:"ancillaryOrderItemId"`
+	JourneyOrderID       string                            `json:"journeyOrderId"`
+	TravelerRef          string                            `json:"travelerRef"`
+	SegmentRef           string                            `json:"segmentRef,omitempty"`
+	CatalogItemID        string                            `json:"catalogItemId"`
+	ServiceType          string                            `json:"serviceType"`
+	EntitlementRef       string                            `json:"entitlementRef,omitempty"`
+	ProviderRef          string                            `json:"providerRef,omitempty"`
+	Status               string                            `json:"status"`
+	ReadyAt              *time.Time                        `json:"readyAt,omitempty"`
+	Facts                []domain.AncillaryFulfillmentFact `json:"facts"`
+	CreatedAt            time.Time                         `json:"createdAt"`
+	UpdatedAt            time.Time                         `json:"updatedAt"`
+}
+
+func ancillaryHandoffSnapshotFromDomain(h *domain.AncillaryFulfillmentHandoff) ancillaryHandoffSnapshot {
+	return ancillaryHandoffSnapshot{AncillaryOrderItemID: h.AncillaryOrderItemID, JourneyOrderID: string(h.JourneyOrderID), TravelerRef: string(h.TravelerRef), SegmentRef: string(h.SegmentRef), CatalogItemID: h.CatalogItemID, ServiceType: h.ServiceType, EntitlementRef: string(h.EntitlementRef), ProviderRef: h.ProviderRef, Status: h.Status, ReadyAt: utcPtr(h.ReadyAt), Facts: append([]domain.AncillaryFulfillmentFact(nil), h.Facts...), CreatedAt: h.CreatedAt.UTC(), UpdatedAt: h.UpdatedAt.UTC()}
+}
+
+func decodeAncillaryHandoff(raw []byte) (*domain.AncillaryFulfillmentHandoff, error) {
+	var s ancillaryHandoffSnapshot
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil, err
+	}
+	return &domain.AncillaryFulfillmentHandoff{AncillaryOrderItemID: s.AncillaryOrderItemID, JourneyOrderID: domain.OrderRef(s.JourneyOrderID), TravelerRef: domain.TravelerRef(s.TravelerRef), SegmentRef: domain.SegmentRef(s.SegmentRef), CatalogItemID: s.CatalogItemID, ServiceType: s.ServiceType, EntitlementRef: domain.EntitlementRef(s.EntitlementRef), ProviderRef: s.ProviderRef, Status: s.Status, ReadyAt: utcPtr(s.ReadyAt), Facts: append([]domain.AncillaryFulfillmentFact(nil), s.Facts...), CreatedAt: s.CreatedAt.UTC(), UpdatedAt: s.UpdatedAt.UTC()}, nil
+}
+
+type rideExecutionSnapshot struct {
+	RideRequestID    string                         `json:"rideRequestId"`
+	RideAssignmentID string                         `json:"rideAssignmentId"`
+	RiderAccountID   string                         `json:"riderAccountId"`
+	TravelerRef      string                         `json:"travelerRef"`
+	PickupRef        string                         `json:"pickupRef"`
+	DropoffRef       string                         `json:"dropoffRef"`
+	DriverRef        string                         `json:"driverRef"`
+	VehicleRef       string                         `json:"vehicleRef"`
+	Status           string                         `json:"status"`
+	DriverArrivedAt  *time.Time                     `json:"driverArrivedAt,omitempty"`
+	RideStartedAt    *time.Time                     `json:"rideStartedAt,omitempty"`
+	RideEndedAt      *time.Time                     `json:"rideEndedAt,omitempty"`
+	FinalFareRef     string                         `json:"finalFareRef,omitempty"`
+	Evidence         []domain.RideExecutionEvidence `json:"evidence"`
+	CreatedAt        time.Time                      `json:"createdAt"`
+	UpdatedAt        time.Time                      `json:"updatedAt"`
+}
+
+func rideExecutionSnapshotFromDomain(v *domain.RideExecutionView) rideExecutionSnapshot {
+	return rideExecutionSnapshot{RideRequestID: v.RideRequestID, RideAssignmentID: v.RideAssignmentID, RiderAccountID: v.RiderAccountID, TravelerRef: string(v.TravelerRef), PickupRef: v.PickupRef, DropoffRef: v.DropoffRef, DriverRef: v.DriverRef, VehicleRef: v.VehicleRef, Status: v.Status, DriverArrivedAt: utcPtr(v.DriverArrivedAt), RideStartedAt: utcPtr(v.RideStartedAt), RideEndedAt: utcPtr(v.RideEndedAt), FinalFareRef: v.FinalFareRef, Evidence: append([]domain.RideExecutionEvidence(nil), v.Evidence...), CreatedAt: v.CreatedAt.UTC(), UpdatedAt: v.UpdatedAt.UTC()}
+}
+
+func decodeRideExecution(raw []byte) (*domain.RideExecutionView, error) {
+	var s rideExecutionSnapshot
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil, err
+	}
+	return &domain.RideExecutionView{RideRequestID: s.RideRequestID, RideAssignmentID: s.RideAssignmentID, RiderAccountID: s.RiderAccountID, TravelerRef: domain.TravelerRef(s.TravelerRef), PickupRef: s.PickupRef, DropoffRef: s.DropoffRef, DriverRef: s.DriverRef, VehicleRef: s.VehicleRef, Status: s.Status, DriverArrivedAt: utcPtr(s.DriverArrivedAt), RideStartedAt: utcPtr(s.RideStartedAt), RideEndedAt: utcPtr(s.RideEndedAt), FinalFareRef: s.FinalFareRef, Evidence: append([]domain.RideExecutionEvidence(nil), s.Evidence...), CreatedAt: s.CreatedAt.UTC(), UpdatedAt: s.UpdatedAt.UTC()}, nil
 }
 
 type ProcessedEvents struct{ db ContextDBProvider }

--- a/services/fulfillment/internal/application/ports.go
+++ b/services/fulfillment/internal/application/ports.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 	"time"
@@ -30,6 +31,7 @@ var (
 	ErrSubscribeFailed     = errors.New("subscribe failed")
 	ErrTransientHandler    = errors.New("transient handler error")
 	ErrFatalHandler        = errors.New("fatal handler error")
+	ErrAckSkip             = errors.New("ack skip")
 )
 
 type EventEnvelope = kitmsg.EventEnvelope
@@ -55,6 +57,16 @@ type SegmentStatusRepository interface {
 	FindSegmentStatusByCommandID(ctx context.Context, commandID string) (*domain.SegmentStatusRecord, error)
 }
 
+type AncillaryHandoffRepository interface {
+	SaveAncillaryHandoff(ctx context.Context, handoff *domain.AncillaryFulfillmentHandoff) error
+	FindAncillaryHandoff(ctx context.Context, ancillaryOrderItemID string) (*domain.AncillaryFulfillmentHandoff, error)
+}
+
+type RideExecutionRepository interface {
+	SaveRideExecution(ctx context.Context, view *domain.RideExecutionView) error
+	FindRideExecution(ctx context.Context, rideRequestID string) (*domain.RideExecutionView, error)
+}
+
 type ConsumedEventLog interface {
 	Claim(ctx context.Context, eventID string) (bool, error)
 }
@@ -66,15 +78,19 @@ type IDGenerator func(prefix string) string
 type Clock func() time.Time
 
 type Service struct {
-	repo     FulfillmentRepository
-	segments SegmentStatusRepository
-	pub      EventPublisher
-	consumed ConsumedEventLog
-	idGen    IDGenerator
-	clock    Clock
-	uow      UnitOfWork
-	mu       sync.Mutex
-	tickets  map[string]TicketProjection
+	repo       FulfillmentRepository
+	segments   SegmentStatusRepository
+	ancillary  AncillaryHandoffRepository
+	rides      RideExecutionRepository
+	pub        EventPublisher
+	consumed   ConsumedEventLog
+	idGen      IDGenerator
+	clock      Clock
+	uow        UnitOfWork
+	mu         sync.Mutex
+	tickets    map[string]TicketProjection
+	ancInMem   map[string]*domain.AncillaryFulfillmentHandoff
+	ridesInMem map[string]*domain.RideExecutionView
 }
 
 type TicketProjection struct {
@@ -94,7 +110,9 @@ func NewService(repo FulfillmentRepository, publisher EventPublisher, consumed C
 		clock = func() time.Time { return time.Now().UTC() }
 	}
 	segments, _ := repo.(SegmentStatusRepository)
-	return &Service{repo: repo, segments: segments, pub: publisher, consumed: consumed, idGen: idGen, clock: clock, tickets: map[string]TicketProjection{}}
+	ancillary, _ := repo.(AncillaryHandoffRepository)
+	rides, _ := repo.(RideExecutionRepository)
+	return &Service{repo: repo, segments: segments, ancillary: ancillary, rides: rides, pub: publisher, consumed: consumed, idGen: idGen, clock: clock, tickets: map[string]TicketProjection{}, ancInMem: map[string]*domain.AncillaryFulfillmentHandoff{}, ridesInMem: map[string]*domain.RideExecutionView{}}
 }
 
 func (s *Service) WithUnitOfWork(uow UnitOfWork) *Service {
@@ -107,6 +125,20 @@ func (s *Service) WithUnitOfWork(uow UnitOfWork) *Service {
 func (s *Service) WithSegmentStatusRepository(repo SegmentStatusRepository) *Service {
 	if s != nil {
 		s.segments = repo
+	}
+	return s
+}
+
+func (s *Service) WithAncillaryHandoffRepository(repo AncillaryHandoffRepository) *Service {
+	if s != nil {
+		s.ancillary = repo
+	}
+	return s
+}
+
+func (s *Service) WithRideExecutionRepository(repo RideExecutionRepository) *Service {
+	if s != nil {
+		s.rides = repo
 	}
 	return s
 }
@@ -342,6 +374,10 @@ func (s *Service) HandleSubscribedEvent(ctx context.Context, envelope EventEnvel
 		}
 	}
 	if err := s.applySubscribedEvent(ctx, envelope); err != nil {
+		if errors.Is(err, ErrAckSkip) {
+			log.Printf("WARN service=%s eventId=%s producer=%s eventType=%s ack-skip subscribed event: %v", ProducerName, envelope.EventID, envelope.Producer, envelope.EventType, err)
+			return nil
+		}
 		if errors.Is(err, ErrDomainRuleViolation) || errors.Is(err, ErrNotFound) {
 			return kitmsg.FatalHandlerError(err)
 		}
@@ -361,6 +397,16 @@ func (s *Service) applySubscribedEvent(ctx context.Context, envelope EventEnvelo
 		return s.applyEntitlementVoided(envelope.Payload)
 	case "SegmentTicketed":
 		return s.applySegmentTicketed(ctx, envelope.Payload)
+	case "AncillaryOrderItemFulfillmentReady":
+		return s.applyAncillaryFulfillmentReady(ctx, envelope.EventID, envelope.Payload)
+	case "AncillaryFulfillmentFactRecorded":
+		return s.applyAncillaryFulfillmentFactRecorded(ctx, envelope.EventID, envelope.Payload)
+	case "DriverArrived":
+		return s.applyDriverArrived(ctx, envelope.EventID, envelope.Payload)
+	case "RideStarted":
+		return s.applyRideStarted(ctx, envelope.EventID, envelope.Payload)
+	case "RideEnded":
+		return s.applyRideEnded(ctx, envelope.EventID, envelope.Payload)
 	default:
 		return nil
 	}
@@ -449,6 +495,194 @@ func (s *Service) applyEntitlementVoided(payload json.RawMessage) error {
 		}
 	}
 	return nil
+}
+
+func (s *Service) applyAncillaryFulfillmentReady(ctx context.Context, sourceEventID string, payload json.RawMessage) error {
+	var event ancillaryReadyEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return fmt.Errorf("%w: invalid AncillaryOrderItemFulfillmentReady payload: %v", ErrDomainRuleViolation, err)
+	}
+	if err := validateAncillaryReadyEvent(event); err != nil {
+		return err
+	}
+	handoff, err := s.ancillaryHandoffFor(ctx, event.AncillaryOrderItemID, domain.OrderRef(event.JourneyOrderID), domain.TravelerRef(event.TravelerRef), domain.SegmentRef(event.SegmentRef), event.CatalogSnapshot.CatalogItemID, event.CatalogSnapshot.ServiceType)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrDomainRuleViolation, err)
+	}
+	if err := handoff.MarkReady(event.Status, event.ReadyAt, event.ProviderRef, domain.EntitlementRef(event.EntitlementRef)); err != nil {
+		return fmt.Errorf("%w: %v", ErrAckSkip, err)
+	}
+	return s.saveAncillaryHandoff(ctx, handoff)
+}
+
+func (s *Service) applyAncillaryFulfillmentFactRecorded(ctx context.Context, sourceEventID string, payload json.RawMessage) error {
+	var event ancillaryFactRecordedEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return fmt.Errorf("%w: invalid AncillaryFulfillmentFactRecorded payload: %v", ErrDomainRuleViolation, err)
+	}
+	if err := validateAncillaryFactRecordedEvent(event); err != nil {
+		return err
+	}
+	handoff, err := s.ancillaryHandoffFor(ctx, event.AncillaryOrderItemID, domain.OrderRef(event.JourneyOrderID), domain.TravelerRef(event.TravelerRef), domain.SegmentRef(event.SegmentRef), event.CatalogItemID, event.ServiceType)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrAckSkip, err)
+	}
+	fact := domain.AncillaryFulfillmentFact{FulfillmentFactID: event.FulfillmentFact.FulfillmentFactID, FactType: event.FulfillmentFact.FactType, ProviderRef: event.FulfillmentFact.ProviderRef, PlaceRef: event.FulfillmentFact.PlaceRef, OccurredAt: event.FulfillmentFact.OccurredAt.UTC(), RecordedAt: event.FulfillmentFact.RecordedAt.UTC(), PerformedBy: event.FulfillmentFact.PerformedBy, IdempotencyRef: event.FulfillmentFact.IdempotencyRef, Compensable: event.FulfillmentFact.Compensable, SourceEventID: sourceEventID}
+	if err := handoff.RecordFact(event.Status, fact); err != nil {
+		return fmt.Errorf("%w: %v", ErrAckSkip, err)
+	}
+	return s.saveAncillaryHandoff(ctx, handoff)
+}
+
+func (s *Service) applyDriverArrived(ctx context.Context, sourceEventID string, payload json.RawMessage) error {
+	var event dispatchArrivalEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return fmt.Errorf("%w: invalid DriverArrived payload: %v", ErrDomainRuleViolation, err)
+	}
+	if err := validateDispatchFields(event.dispatchFields, "DRIVER_ARRIVED"); err != nil {
+		return err
+	}
+	if event.ArrivedAt.IsZero() {
+		return fmt.Errorf("%w: arrivedAt is required", ErrDomainRuleViolation)
+	}
+	view, err := s.rideExecutionFor(ctx, event.RideRequestID, domain.TravelerRef(event.TravelerRef))
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrAckSkip, err)
+	}
+	if err := view.DriverArrived(sourceEventID, event.ArrivedAt, rideSnapshot(event.dispatchFields)); err != nil {
+		return fmt.Errorf("%w: %v", ErrAckSkip, err)
+	}
+	return s.saveRideExecution(ctx, view)
+}
+
+func (s *Service) applyRideStarted(ctx context.Context, sourceEventID string, payload json.RawMessage) error {
+	var event dispatchStartedEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return fmt.Errorf("%w: invalid RideStarted payload: %v", ErrDomainRuleViolation, err)
+	}
+	if err := validateDispatchFields(event.dispatchFields, "PICKED_UP"); err != nil {
+		return err
+	}
+	if event.StartedAt.IsZero() {
+		return fmt.Errorf("%w: startedAt is required", ErrDomainRuleViolation)
+	}
+	view, err := s.rideExecutionFor(ctx, event.RideRequestID, domain.TravelerRef(event.TravelerRef))
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrAckSkip, err)
+	}
+	if err := view.RideStarted(sourceEventID, event.StartedAt, rideSnapshot(event.dispatchFields)); err != nil {
+		return fmt.Errorf("%w: %v", ErrAckSkip, err)
+	}
+	return s.saveRideExecution(ctx, view)
+}
+
+func (s *Service) applyRideEnded(ctx context.Context, sourceEventID string, payload json.RawMessage) error {
+	var event dispatchEndedEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return fmt.Errorf("%w: invalid RideEnded payload: %v", ErrDomainRuleViolation, err)
+	}
+	if err := validateDispatchFields(event.dispatchFields, "COMPLETED"); err != nil {
+		return err
+	}
+	if event.StartedAt.IsZero() || event.EndedAt.IsZero() {
+		return fmt.Errorf("%w: startedAt and endedAt are required", ErrDomainRuleViolation)
+	}
+	view, err := s.rideExecutionFor(ctx, event.RideRequestID, domain.TravelerRef(event.TravelerRef))
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrAckSkip, err)
+	}
+	if err := view.RideEnded(sourceEventID, event.StartedAt, event.EndedAt, rideSnapshot(event.dispatchFields), event.FinalFareRef); err != nil {
+		return fmt.Errorf("%w: %v", ErrAckSkip, err)
+	}
+	return s.saveRideExecution(ctx, view)
+}
+
+func (s *Service) ancillaryHandoffFor(ctx context.Context, id string, journeyOrderID domain.OrderRef, travelerRef domain.TravelerRef, segmentRef domain.SegmentRef, catalogItemID, serviceType string) (*domain.AncillaryFulfillmentHandoff, error) {
+	if s.ancillary != nil {
+		handoff, err := s.ancillary.FindAncillaryHandoff(ctx, id)
+		if err == nil {
+			return handoff, nil
+		}
+		if !errors.Is(err, ErrNotFound) {
+			return nil, err
+		}
+	} else {
+		s.mu.Lock()
+		handoff, ok := s.ancInMem[strings.TrimSpace(id)]
+		s.mu.Unlock()
+		if ok {
+			return cloneAncillaryHandoff(handoff), nil
+		}
+	}
+	return domain.NewAncillaryFulfillmentHandoff(id, journeyOrderID, travelerRef, segmentRef, catalogItemID, serviceType)
+}
+
+func (s *Service) saveAncillaryHandoff(ctx context.Context, handoff *domain.AncillaryFulfillmentHandoff) error {
+	if s.ancillary != nil {
+		return s.ancillary.SaveAncillaryHandoff(ctx, handoff)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ancInMem[handoff.AncillaryOrderItemID] = cloneAncillaryHandoff(handoff)
+	return nil
+}
+
+func (s *Service) rideExecutionFor(ctx context.Context, rideRequestID string, travelerRef domain.TravelerRef) (*domain.RideExecutionView, error) {
+	if s.rides != nil {
+		view, err := s.rides.FindRideExecution(ctx, rideRequestID)
+		if err == nil {
+			return view, nil
+		}
+		if !errors.Is(err, ErrNotFound) {
+			return nil, err
+		}
+	} else {
+		s.mu.Lock()
+		view, ok := s.ridesInMem[strings.TrimSpace(rideRequestID)]
+		s.mu.Unlock()
+		if ok {
+			return cloneRideExecution(view), nil
+		}
+	}
+	return domain.NewRideExecutionView(rideRequestID, travelerRef)
+}
+
+func (s *Service) saveRideExecution(ctx context.Context, view *domain.RideExecutionView) error {
+	if s.rides != nil {
+		return s.rides.SaveRideExecution(ctx, view)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ridesInMem[view.RideRequestID] = cloneRideExecution(view)
+	return nil
+}
+
+func (s *Service) GetAncillaryHandoff(ctx context.Context, ancillaryOrderItemID string) (*domain.AncillaryFulfillmentHandoff, error) {
+	id := strings.TrimSpace(ancillaryOrderItemID)
+	if s.ancillary != nil {
+		return s.ancillary.FindAncillaryHandoff(ctx, id)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	handoff, ok := s.ancInMem[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return cloneAncillaryHandoff(handoff), nil
+}
+
+func (s *Service) GetRideExecution(ctx context.Context, rideRequestID string) (*domain.RideExecutionView, error) {
+	id := strings.TrimSpace(rideRequestID)
+	if s.rides != nil {
+		return s.rides.FindRideExecution(ctx, id)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	view, ok := s.ridesInMem[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return cloneRideExecution(view), nil
 }
 
 func (s *Service) readyRecordForCommand(ctx context.Context, entitlementID domain.EntitlementRef, segmentBookingID domain.SegmentBookingRef, journeyOrderID domain.OrderRef, travelerID domain.TravelerRef, segmentRef domain.SegmentRef) (*domain.FulfillmentRecord, error) {
@@ -809,6 +1043,107 @@ type segmentCompletedPayload struct {
 	CompletionSource    domain.CompletionSource    `json:"completionSource"`
 }
 
+type ancillaryReadyEvent struct {
+	AncillaryOrderItemID string                   `json:"ancillaryOrderItemId"`
+	JourneyOrderID       string                   `json:"journeyOrderId"`
+	TravelerRef          string                   `json:"travelerRef"`
+	SegmentRef           string                   `json:"segmentRef"`
+	CatalogSnapshot      ancillaryCatalogSnapshot `json:"catalogSnapshot"`
+	ProviderRef          string                   `json:"providerRef"`
+	EntitlementRef       string                   `json:"entitlementRef"`
+	Status               string                   `json:"status"`
+	ReadyAt              time.Time                `json:"readyAt"`
+}
+
+type ancillaryCatalogSnapshot struct {
+	CatalogItemID string `json:"catalogItemId"`
+	ServiceType   string `json:"serviceType"`
+}
+
+type ancillaryFactRecordedEvent struct {
+	AncillaryOrderItemID string               `json:"ancillaryOrderItemId"`
+	JourneyOrderID       string               `json:"journeyOrderId"`
+	TravelerRef          string               `json:"travelerRef"`
+	SegmentRef           string               `json:"segmentRef"`
+	CatalogItemID        string               `json:"catalogItemId"`
+	ServiceType          string               `json:"serviceType"`
+	FulfillmentFact      ancillaryFactPayload `json:"fulfillmentFact"`
+	Status               string               `json:"status"`
+}
+
+type ancillaryFactPayload struct {
+	FulfillmentFactID string    `json:"fulfillmentFactId"`
+	FactType          string    `json:"factType"`
+	ProviderRef       string    `json:"providerRef"`
+	PlaceRef          string    `json:"placeRef"`
+	OccurredAt        time.Time `json:"occurredAt"`
+	RecordedAt        time.Time `json:"recordedAt"`
+	PerformedBy       string    `json:"performedBy"`
+	IdempotencyRef    string    `json:"idempotencyRef"`
+	Compensable       bool      `json:"compensable"`
+}
+
+type dispatchFields struct {
+	RideRequestID    string `json:"rideRequestId"`
+	RideAssignmentID string `json:"rideAssignmentId"`
+	RiderAccountID   string `json:"riderAccountId"`
+	TravelerRef      string `json:"travelerRef"`
+	PickupRef        string `json:"pickupRef"`
+	DropoffRef       string `json:"dropoffRef"`
+	DriverRef        string `json:"driverRef"`
+	VehicleRef       string `json:"vehicleRef"`
+	Status           string `json:"status"`
+}
+
+type dispatchArrivalEvent struct {
+	dispatchFields
+	ArrivedAt time.Time `json:"arrivedAt"`
+}
+
+type dispatchStartedEvent struct {
+	dispatchFields
+	StartedAt time.Time `json:"startedAt"`
+}
+
+type dispatchEndedEvent struct {
+	dispatchFields
+	StartedAt    time.Time `json:"startedAt"`
+	EndedAt      time.Time `json:"endedAt"`
+	FinalFareRef string    `json:"finalFareRef"`
+}
+
+func validateAncillaryReadyEvent(event ancillaryReadyEvent) error {
+	if strings.TrimSpace(event.AncillaryOrderItemID) == "" || strings.TrimSpace(event.JourneyOrderID) == "" || strings.TrimSpace(event.TravelerRef) == "" || strings.TrimSpace(event.CatalogSnapshot.CatalogItemID) == "" || strings.TrimSpace(event.CatalogSnapshot.ServiceType) == "" || event.ReadyAt.IsZero() {
+		return fmt.Errorf("%w: missing required AncillaryOrderItemFulfillmentReady field", ErrDomainRuleViolation)
+	}
+	return nil
+}
+
+func validateAncillaryFactRecordedEvent(event ancillaryFactRecordedEvent) error {
+	if strings.TrimSpace(event.AncillaryOrderItemID) == "" || strings.TrimSpace(event.JourneyOrderID) == "" || strings.TrimSpace(event.TravelerRef) == "" || strings.TrimSpace(event.CatalogItemID) == "" || strings.TrimSpace(event.ServiceType) == "" {
+		return fmt.Errorf("%w: missing required AncillaryFulfillmentFactRecorded field", ErrDomainRuleViolation)
+	}
+	fact := event.FulfillmentFact
+	if strings.TrimSpace(fact.FulfillmentFactID) == "" || strings.TrimSpace(fact.FactType) == "" || strings.TrimSpace(fact.PerformedBy) == "" || strings.TrimSpace(fact.IdempotencyRef) == "" || fact.OccurredAt.IsZero() || fact.RecordedAt.IsZero() {
+		return fmt.Errorf("%w: missing required AncillaryFulfillmentFactRecorded fulfillmentFact field", ErrDomainRuleViolation)
+	}
+	return nil
+}
+
+func validateDispatchFields(fields dispatchFields, expectedStatus string) error {
+	if strings.TrimSpace(fields.RideRequestID) == "" || strings.TrimSpace(fields.RideAssignmentID) == "" || strings.TrimSpace(fields.RiderAccountID) == "" || strings.TrimSpace(fields.TravelerRef) == "" || strings.TrimSpace(fields.PickupRef) == "" || strings.TrimSpace(fields.DropoffRef) == "" || strings.TrimSpace(fields.DriverRef) == "" || strings.TrimSpace(fields.VehicleRef) == "" || strings.TrimSpace(fields.Status) == "" {
+		return fmt.Errorf("%w: missing required dispatch handoff field", ErrDomainRuleViolation)
+	}
+	if strings.TrimSpace(fields.Status) != expectedStatus {
+		return fmt.Errorf("%w: unexpected dispatch status %q for expected %s", ErrAckSkip, fields.Status, expectedStatus)
+	}
+	return nil
+}
+
+func rideSnapshot(fields dispatchFields) domain.RideAssignmentSnapshot {
+	return domain.RideAssignmentSnapshot{RideAssignmentID: fields.RideAssignmentID, RiderAccountID: fields.RiderAccountID, TravelerRef: domain.TravelerRef(fields.TravelerRef), PickupRef: fields.PickupRef, DropoffRef: fields.DropoffRef, DriverRef: fields.DriverRef, VehicleRef: fields.VehicleRef}
+}
+
 func MarshalDomainEventPayload(event domain.DomainEvent) (json.RawMessage, error) {
 	var payload any
 	switch e := event.(type) {
@@ -842,10 +1177,12 @@ type InMemoryRepository struct {
 	byTuple          map[string]domain.FulfillmentRecordID
 	segmentByID      map[domain.SegmentStatusRecordID]*domain.SegmentStatusRecord
 	segmentByCommand map[string]domain.SegmentStatusRecordID
+	ancillary        map[string]*domain.AncillaryFulfillmentHandoff
+	rides            map[string]*domain.RideExecutionView
 }
 
 func NewInMemoryRepository() *InMemoryRepository {
-	return &InMemoryRepository{byID: map[domain.FulfillmentRecordID]*domain.FulfillmentRecord{}, byTuple: map[string]domain.FulfillmentRecordID{}, segmentByID: map[domain.SegmentStatusRecordID]*domain.SegmentStatusRecord{}, segmentByCommand: map[string]domain.SegmentStatusRecordID{}}
+	return &InMemoryRepository{byID: map[domain.FulfillmentRecordID]*domain.FulfillmentRecord{}, byTuple: map[string]domain.FulfillmentRecordID{}, segmentByID: map[domain.SegmentStatusRecordID]*domain.SegmentStatusRecord{}, segmentByCommand: map[string]domain.SegmentStatusRecordID{}, ancillary: map[string]*domain.AncillaryFulfillmentHandoff{}, rides: map[string]*domain.RideExecutionView{}}
 }
 
 func (r *InMemoryRepository) Save(_ context.Context, record *domain.FulfillmentRecord) error {
@@ -898,6 +1235,40 @@ func (r *InMemoryRepository) FindSegmentStatusByCommandID(_ context.Context, com
 	return cloneSegmentStatus(r.segmentByID[id]), nil
 }
 
+func (r *InMemoryRepository) SaveAncillaryHandoff(_ context.Context, handoff *domain.AncillaryFulfillmentHandoff) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.ancillary[handoff.AncillaryOrderItemID] = cloneAncillaryHandoff(handoff)
+	return nil
+}
+
+func (r *InMemoryRepository) FindAncillaryHandoff(_ context.Context, ancillaryOrderItemID string) (*domain.AncillaryFulfillmentHandoff, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	handoff, ok := r.ancillary[strings.TrimSpace(ancillaryOrderItemID)]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return cloneAncillaryHandoff(handoff), nil
+}
+
+func (r *InMemoryRepository) SaveRideExecution(_ context.Context, view *domain.RideExecutionView) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.rides[view.RideRequestID] = cloneRideExecution(view)
+	return nil
+}
+
+func (r *InMemoryRepository) FindRideExecution(_ context.Context, rideRequestID string) (*domain.RideExecutionView, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	view, ok := r.rides[strings.TrimSpace(rideRequestID)]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return cloneRideExecution(view), nil
+}
+
 func cloneSegmentStatus(record *domain.SegmentStatusRecord) *domain.SegmentStatusRecord {
 	if record == nil {
 		return nil
@@ -920,6 +1291,40 @@ func cloneSegmentStatus(record *domain.SegmentStatusRecord) *domain.SegmentStatu
 
 func tupleKey(entitlementID domain.EntitlementRef, segmentBookingID domain.SegmentBookingRef, segmentRef domain.SegmentRef) string {
 	return string(entitlementID) + "|" + string(segmentBookingID) + "|" + string(segmentRef)
+}
+
+func cloneAncillaryHandoff(handoff *domain.AncillaryFulfillmentHandoff) *domain.AncillaryFulfillmentHandoff {
+	if handoff == nil {
+		return nil
+	}
+	copy := *handoff
+	if handoff.ReadyAt != nil {
+		t := *handoff.ReadyAt
+		copy.ReadyAt = &t
+	}
+	copy.Facts = append([]domain.AncillaryFulfillmentFact(nil), handoff.Facts...)
+	return &copy
+}
+
+func cloneRideExecution(view *domain.RideExecutionView) *domain.RideExecutionView {
+	if view == nil {
+		return nil
+	}
+	copy := *view
+	if view.DriverArrivedAt != nil {
+		t := *view.DriverArrivedAt
+		copy.DriverArrivedAt = &t
+	}
+	if view.RideStartedAt != nil {
+		t := *view.RideStartedAt
+		copy.RideStartedAt = &t
+	}
+	if view.RideEndedAt != nil {
+		t := *view.RideEndedAt
+		copy.RideEndedAt = &t
+	}
+	copy.Evidence = append([]domain.RideExecutionEvidence(nil), view.Evidence...)
+	return &copy
 }
 
 func cloneRecord(record *domain.FulfillmentRecord) *domain.FulfillmentRecord {

--- a/services/fulfillment/internal/application/service_test.go
+++ b/services/fulfillment/internal/application/service_test.go
@@ -1,9 +1,11 @@
 package application
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log"
 	"strings"
 	"testing"
 	"time"
@@ -282,6 +284,96 @@ func TestFulfillmentCompletedPublishesContractEvent(t *testing.T) {
 	}
 	if _, ok := payload["segmentRef"]; ok {
 		t.Fatalf("FulfillmentCompleted payload must match contract exactly, got segmentRef")
+	}
+}
+
+func TestConsumesAncillaryFulfillmentReadyAndFact(t *testing.T) {
+	repo := NewInMemoryRepository()
+	log := NewInMemoryConsumedEventLog()
+	service := NewService(repo, NoopPublisher{}, log, nil, nil)
+	ready := EventEnvelope{EventID: "evt-anc-ready", EventType: "AncillaryOrderItemFulfillmentReady", Producer: "ancillary-service", SchemaVersion: 1, Payload: json.RawMessage(`{"ancillaryOrderItemId":"aoi-ready1","journeyOrderId":"ord-ready1","travelerRef":"tvl-ready1","segmentRef":"seg-ready1","catalogSnapshot":{"catalogItemId":"aci-meal1","serviceType":"MEAL"},"providerRef":"voucher-123","entitlementRef":"ent-ready1","previousStatus":"CONFIRMED","status":"FULFILLMENT_READY","readyAt":"2026-07-05T10:00:00Z","aggregateVersion":3}`)}
+	if err := service.HandleSubscribedEvent(context.Background(), ready); err != nil {
+		t.Fatalf("ready event: %v", err)
+	}
+	handoff, err := repo.FindAncillaryHandoff(context.Background(), "aoi-ready1")
+	if err != nil {
+		t.Fatalf("find handoff: %v", err)
+	}
+	if handoff.Status != "FULFILLMENT_READY" || handoff.ProviderRef != "voucher-123" || handoff.ReadyAt == nil {
+		t.Fatalf("unexpected ready handoff: %#v", handoff)
+	}
+	fact := EventEnvelope{EventID: "evt-anc-fact", EventType: "AncillaryFulfillmentFactRecorded", Producer: "ancillary-service", SchemaVersion: 1, Payload: json.RawMessage(`{"ancillaryOrderItemId":"aoi-ready1","journeyOrderId":"ord-ready1","travelerRef":"tvl-ready1","segmentRef":"seg-ready1","catalogItemId":"aci-meal1","serviceType":"MEAL","fulfillmentFact":{"fulfillmentFactId":"aff-fact1","factType":"MEAL_ISSUED","providerRef":"voucher-123","occurredAt":"2026-07-05T10:05:00Z","recordedAt":"2026-07-05T10:06:00Z","performedBy":"PROVIDER","idempotencyRef":"provider-event-1","compensable":false},"previousStatus":"FULFILLMENT_READY","status":"FULFILLED","aggregateVersion":4}`)}
+	if err := service.HandleSubscribedEvent(context.Background(), fact); err != nil {
+		t.Fatalf("fact event: %v", err)
+	}
+	if err := service.HandleSubscribedEvent(context.Background(), fact); err != nil {
+		t.Fatalf("duplicate fact event: %v", err)
+	}
+	handoff, err = repo.FindAncillaryHandoff(context.Background(), "aoi-ready1")
+	if err != nil {
+		t.Fatalf("find handoff after fact: %v", err)
+	}
+	if handoff.Status != "FULFILLED" || len(handoff.Facts) != 1 || handoff.Facts[0].SourceEventID != "evt-anc-fact" {
+		t.Fatalf("unexpected fact handoff: %#v", handoff)
+	}
+}
+
+func TestConsumesDispatchRideLifecycle(t *testing.T) {
+	repo := NewInMemoryRepository()
+	service := NewService(repo, NoopPublisher{}, NewInMemoryConsumedEventLog(), nil, nil)
+	arrived := EventEnvelope{EventID: "evt-ride-arrived", EventType: "DriverArrived", Producer: "dispatch", SchemaVersion: 1, Payload: json.RawMessage(`{"rideRequestId":"rrq-ride1","rideAssignmentId":"ras-ride1","riderAccountId":"acct-1","travelerRef":"tvl-ride1","pickupRef":"place-a","dropoffRef":"place-b","driverRef":"drv-1","vehicleRef":"veh-1","arrivedAt":"2026-07-05T10:00:00Z","status":"DRIVER_ARRIVED"}`)}
+	if err := service.HandleSubscribedEvent(context.Background(), arrived); err != nil {
+		t.Fatalf("arrived: %v", err)
+	}
+	ended := EventEnvelope{EventID: "evt-ride-ended", EventType: "RideEnded", Producer: "dispatch", SchemaVersion: 1, Payload: json.RawMessage(`{"rideRequestId":"rrq-ride1","rideAssignmentId":"ras-ride1","riderAccountId":"acct-1","travelerRef":"tvl-ride1","pickupRef":"place-a","dropoffRef":"place-b","driverRef":"drv-1","vehicleRef":"veh-1","startedAt":"2026-07-05T10:03:00Z","endedAt":"2026-07-05T10:30:00Z","finalFareRef":"fare-final-1","status":"COMPLETED"}`)}
+	if err := service.HandleSubscribedEvent(context.Background(), ended); err != nil {
+		t.Fatalf("ended: %v", err)
+	}
+	view, err := repo.FindRideExecution(context.Background(), "rrq-ride1")
+	if err != nil {
+		t.Fatalf("find ride execution: %v", err)
+	}
+	if view.Status != "COMPLETED" || view.DriverArrivedAt == nil || view.RideEndedAt == nil || view.FinalFareRef != "fare-final-1" || len(view.Evidence) != 2 {
+		t.Fatalf("unexpected ride view: %#v", view)
+	}
+}
+
+func TestAckSkipsUnexpectedExternalLifecycleStatusesWithWarn(t *testing.T) {
+	repo := NewInMemoryRepository()
+	service := NewService(repo, NoopPublisher{}, NewInMemoryConsumedEventLog(), nil, nil)
+	var logs bytes.Buffer
+	originalWriter := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(originalWriter) })
+
+	wrongDispatch := EventEnvelope{EventID: "evt-ride-bad-status", EventType: "DriverArrived", Producer: "dispatch", SchemaVersion: 1, Payload: json.RawMessage(`{"rideRequestId":"rrq-badstatus1","rideAssignmentId":"ras-badstatus1","riderAccountId":"acct-1","travelerRef":"tvl-badstatus1","pickupRef":"place-a","dropoffRef":"place-b","driverRef":"drv-1","vehicleRef":"veh-1","arrivedAt":"2026-07-05T10:00:00Z","status":"ASSIGNED"}`)}
+	if err := service.HandleSubscribedEvent(context.Background(), wrongDispatch); err != nil {
+		t.Fatalf("wrong dispatch status should be ack-skipped, got %v", err)
+	}
+	if _, err := repo.FindRideExecution(context.Background(), "rrq-badstatus1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("wrong dispatch status mutated ride view: %v", err)
+	}
+	if got := logs.String(); !strings.Contains(got, "WARN") || !strings.Contains(got, "evt-ride-bad-status") || !strings.Contains(got, "ack-skip") {
+		t.Fatalf("expected WARN ack-skip log for dispatch status, got %q", got)
+	}
+
+	ready := EventEnvelope{EventID: "evt-anc-bad-ready", EventType: "AncillaryOrderItemFulfillmentReady", Producer: "ancillary-service", SchemaVersion: 1, Payload: json.RawMessage(`{"ancillaryOrderItemId":"aoi-badstatus1","journeyOrderId":"ord-badstatus1","travelerRef":"tvl-badstatus1","segmentRef":"seg-badstatus1","catalogSnapshot":{"catalogItemId":"aci-meal1","serviceType":"MEAL"},"providerRef":"voucher-123","previousStatus":"CONFIRMED","status":"FULFILLMENT_READY","readyAt":"2026-07-05T10:00:00Z","aggregateVersion":3}`)}
+	if err := service.HandleSubscribedEvent(context.Background(), ready); err != nil {
+		t.Fatalf("ready event: %v", err)
+	}
+	wrongAncillaryFact := EventEnvelope{EventID: "evt-anc-bad-status", EventType: "AncillaryFulfillmentFactRecorded", Producer: "ancillary-service", SchemaVersion: 1, Payload: json.RawMessage(`{"ancillaryOrderItemId":"aoi-badstatus1","journeyOrderId":"ord-badstatus1","travelerRef":"tvl-badstatus1","segmentRef":"seg-badstatus1","catalogItemId":"aci-meal1","serviceType":"MEAL","fulfillmentFact":{"fulfillmentFactId":"aff-badstatus1","factType":"MEAL_ISSUED","providerRef":"voucher-123","occurredAt":"2026-07-05T10:05:00Z","recordedAt":"2026-07-05T10:06:00Z","performedBy":"PROVIDER","idempotencyRef":"provider-event-1","compensable":false},"previousStatus":"FULFILLMENT_READY","status":"SOMETHING_NEW","aggregateVersion":4}`)}
+	if err := service.HandleSubscribedEvent(context.Background(), wrongAncillaryFact); err != nil {
+		t.Fatalf("wrong ancillary status should be ack-skipped, got %v", err)
+	}
+	handoff, err := repo.FindAncillaryHandoff(context.Background(), "aoi-badstatus1")
+	if err != nil {
+		t.Fatalf("find handoff: %v", err)
+	}
+	if handoff.Status != "FULFILLMENT_READY" || len(handoff.Facts) != 0 {
+		t.Fatalf("wrong ancillary status mutated handoff: %#v", handoff)
+	}
+	if got := logs.String(); !strings.Contains(got, "evt-anc-bad-status") {
+		t.Fatalf("expected WARN ack-skip log for ancillary status, got %q", got)
 	}
 }
 

--- a/services/fulfillment/internal/domain/external_handoffs.go
+++ b/services/fulfillment/internal/domain/external_handoffs.go
@@ -1,0 +1,291 @@
+package domain
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// AncillaryFulfillmentHandoff is Fulfillment's local evidence/read model for
+// ancillary services that are ready for provider or voucher handoff and for the
+// fulfillment facts later recorded by Ancillary Service.
+type AncillaryFulfillmentHandoff struct {
+	AncillaryOrderItemID string
+	JourneyOrderID       OrderRef
+	TravelerRef          TravelerRef
+	SegmentRef           SegmentRef
+	CatalogItemID        string
+	ServiceType          string
+	EntitlementRef       EntitlementRef
+	ProviderRef          string
+	Status               string
+	ReadyAt              *time.Time
+	Facts                []AncillaryFulfillmentFact
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+}
+
+type AncillaryFulfillmentFact struct {
+	FulfillmentFactID string
+	FactType          string
+	ProviderRef       string
+	PlaceRef          string
+	OccurredAt        time.Time
+	RecordedAt        time.Time
+	PerformedBy       string
+	IdempotencyRef    string
+	Compensable       bool
+	SourceEventID     string
+}
+
+func NewAncillaryFulfillmentHandoff(ancillaryOrderItemID string, journeyOrderID OrderRef, travelerRef TravelerRef, segmentRef SegmentRef, catalogItemID, serviceType string) (*AncillaryFulfillmentHandoff, error) {
+	now := timeNow().UTC()
+	handoff := &AncillaryFulfillmentHandoff{
+		AncillaryOrderItemID: strings.TrimSpace(ancillaryOrderItemID),
+		JourneyOrderID:       journeyOrderID,
+		TravelerRef:          travelerRef,
+		SegmentRef:           segmentRef,
+		CatalogItemID:        strings.TrimSpace(catalogItemID),
+		ServiceType:          strings.TrimSpace(serviceType),
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+	return handoff, handoff.Validate()
+}
+
+func (h *AncillaryFulfillmentHandoff) MarkReady(status string, readyAt time.Time, providerRef string, entitlementRef EntitlementRef) error {
+	if h == nil {
+		return fmt.Errorf("ancillary handoff is nil")
+	}
+	if strings.TrimSpace(status) != "FULFILLMENT_READY" {
+		return fmt.Errorf("unexpected ancillary ready status %q", status)
+	}
+	if readyAt.IsZero() {
+		return fmt.Errorf("readyAt is required")
+	}
+	if strings.TrimSpace(string(entitlementRef)) != "" {
+		if err := entitlementRef.Validate(); err != nil {
+			return err
+		}
+		h.EntitlementRef = entitlementRef
+	}
+	h.ProviderRef = strings.TrimSpace(providerRef)
+	h.Status = "FULFILLMENT_READY"
+	at := readyAt.UTC()
+	h.ReadyAt = &at
+	h.UpdatedAt = timeNow().UTC()
+	return h.Validate()
+}
+
+func (h *AncillaryFulfillmentHandoff) RecordFact(status string, fact AncillaryFulfillmentFact) error {
+	if h == nil {
+		return fmt.Errorf("ancillary handoff is nil")
+	}
+	if !isAncillaryFactStatus(status) {
+		return fmt.Errorf("unexpected ancillary fulfillment fact status %q", status)
+	}
+	if err := fact.Validate(); err != nil {
+		return err
+	}
+	for _, existing := range h.Facts {
+		if existing.SourceEventID == fact.SourceEventID || existing.FulfillmentFactID == fact.FulfillmentFactID {
+			h.Status = strings.TrimSpace(status)
+			h.UpdatedAt = timeNow().UTC()
+			return nil
+		}
+	}
+	h.Facts = append(h.Facts, fact)
+	h.Status = strings.TrimSpace(status)
+	if strings.TrimSpace(h.ProviderRef) == "" && strings.TrimSpace(fact.ProviderRef) != "" {
+		h.ProviderRef = strings.TrimSpace(fact.ProviderRef)
+	}
+	h.UpdatedAt = timeNow().UTC()
+	return h.Validate()
+}
+
+func isAncillaryFactStatus(status string) bool {
+	switch strings.TrimSpace(status) {
+	case "FULFILLMENT_READY", "FULFILLED", "FAILED":
+		return true
+	default:
+		return false
+	}
+}
+
+func (h *AncillaryFulfillmentHandoff) Validate() error {
+	if h == nil {
+		return fmt.Errorf("ancillary handoff is nil")
+	}
+	if !strings.HasPrefix(strings.TrimSpace(h.AncillaryOrderItemID), "aoi-") {
+		return fmt.Errorf("invalid ancillaryOrderItemId: %q", h.AncillaryOrderItemID)
+	}
+	if err := h.JourneyOrderID.Validate(); err != nil {
+		return err
+	}
+	if err := h.TravelerRef.Validate(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(string(h.SegmentRef)) != "" {
+		if err := h.SegmentRef.Validate(); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(h.CatalogItemID) == "" {
+		return fmt.Errorf("catalogItemId is required")
+	}
+	if strings.TrimSpace(h.ServiceType) == "" {
+		return fmt.Errorf("serviceType is required")
+	}
+	if strings.TrimSpace(string(h.EntitlementRef)) != "" {
+		if err := h.EntitlementRef.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f AncillaryFulfillmentFact) Validate() error {
+	if !strings.HasPrefix(strings.TrimSpace(f.FulfillmentFactID), "aff-") {
+		return fmt.Errorf("invalid fulfillmentFactId: %q", f.FulfillmentFactID)
+	}
+	if strings.TrimSpace(f.FactType) == "" {
+		return fmt.Errorf("factType is required")
+	}
+	if strings.TrimSpace(f.PerformedBy) == "" {
+		return fmt.Errorf("performedBy is required")
+	}
+	if strings.TrimSpace(f.IdempotencyRef) == "" {
+		return fmt.Errorf("idempotencyRef is required")
+	}
+	if strings.TrimSpace(f.SourceEventID) == "" {
+		return fmt.Errorf("sourceEventId is required")
+	}
+	if f.OccurredAt.IsZero() {
+		return fmt.Errorf("occurredAt is required")
+	}
+	if f.RecordedAt.IsZero() {
+		return fmt.Errorf("recordedAt is required")
+	}
+	return nil
+}
+
+// RideExecutionView is Fulfillment's local read model for Dispatch handoff facts.
+type RideExecutionView struct {
+	RideRequestID    string
+	RideAssignmentID string
+	RiderAccountID   string
+	TravelerRef      TravelerRef
+	PickupRef        string
+	DropoffRef       string
+	DriverRef        string
+	VehicleRef       string
+	Status           string
+	DriverArrivedAt  *time.Time
+	RideStartedAt    *time.Time
+	RideEndedAt      *time.Time
+	FinalFareRef     string
+	Evidence         []RideExecutionEvidence
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+}
+
+type RideExecutionEvidence struct {
+	EventType     string
+	SourceEventID string
+	OccurredAt    time.Time
+}
+
+func NewRideExecutionView(rideRequestID string, travelerRef TravelerRef) (*RideExecutionView, error) {
+	now := timeNow().UTC()
+	view := &RideExecutionView{RideRequestID: strings.TrimSpace(rideRequestID), TravelerRef: travelerRef, CreatedAt: now, UpdatedAt: now}
+	return view, view.Validate()
+}
+
+func (v *RideExecutionView) DriverArrived(sourceEventID string, occurredAt time.Time, assignment RideAssignmentSnapshot) error {
+	if err := v.applyRideSnapshot("DriverArrived", sourceEventID, "DRIVER_ARRIVED", occurredAt, assignment); err != nil {
+		return err
+	}
+	at := occurredAt.UTC()
+	v.DriverArrivedAt = &at
+	return nil
+}
+
+func (v *RideExecutionView) RideStarted(sourceEventID string, occurredAt time.Time, assignment RideAssignmentSnapshot) error {
+	if err := v.applyRideSnapshot("RideStarted", sourceEventID, "PICKED_UP", occurredAt, assignment); err != nil {
+		return err
+	}
+	at := occurredAt.UTC()
+	v.RideStartedAt = &at
+	return nil
+}
+
+func (v *RideExecutionView) RideEnded(sourceEventID string, startedAt time.Time, endedAt time.Time, assignment RideAssignmentSnapshot, finalFareRef string) error {
+	if err := v.applyRideSnapshot("RideEnded", sourceEventID, "COMPLETED", endedAt, assignment); err != nil {
+		return err
+	}
+	if !startedAt.IsZero() && v.RideStartedAt == nil {
+		start := startedAt.UTC()
+		v.RideStartedAt = &start
+	}
+	end := endedAt.UTC()
+	v.RideEndedAt = &end
+	v.FinalFareRef = strings.TrimSpace(finalFareRef)
+	return nil
+}
+
+type RideAssignmentSnapshot struct {
+	RideAssignmentID string
+	RiderAccountID   string
+	TravelerRef      TravelerRef
+	PickupRef        string
+	DropoffRef       string
+	DriverRef        string
+	VehicleRef       string
+}
+
+func (v *RideExecutionView) applyRideSnapshot(eventType, sourceEventID, status string, occurredAt time.Time, assignment RideAssignmentSnapshot) error {
+	if v == nil {
+		return fmt.Errorf("ride execution view is nil")
+	}
+	if strings.TrimSpace(sourceEventID) == "" {
+		return fmt.Errorf("sourceEventId is required")
+	}
+	if occurredAt.IsZero() {
+		return fmt.Errorf("occurredAt is required")
+	}
+	if assignment.TravelerRef != "" && v.TravelerRef != "" && assignment.TravelerRef != v.TravelerRef {
+		return fmt.Errorf("travelerRef mismatch")
+	}
+	v.RideAssignmentID = strings.TrimSpace(assignment.RideAssignmentID)
+	v.RiderAccountID = strings.TrimSpace(assignment.RiderAccountID)
+	if assignment.TravelerRef != "" {
+		v.TravelerRef = assignment.TravelerRef
+	}
+	v.PickupRef = strings.TrimSpace(assignment.PickupRef)
+	v.DropoffRef = strings.TrimSpace(assignment.DropoffRef)
+	v.DriverRef = strings.TrimSpace(assignment.DriverRef)
+	v.VehicleRef = strings.TrimSpace(assignment.VehicleRef)
+	v.Status = status
+	for _, evidence := range v.Evidence {
+		if evidence.SourceEventID == sourceEventID {
+			v.UpdatedAt = timeNow().UTC()
+			return v.Validate()
+		}
+	}
+	v.Evidence = append(v.Evidence, RideExecutionEvidence{EventType: eventType, SourceEventID: sourceEventID, OccurredAt: occurredAt.UTC()})
+	v.UpdatedAt = timeNow().UTC()
+	return v.Validate()
+}
+
+func (v *RideExecutionView) Validate() error {
+	if v == nil {
+		return fmt.Errorf("ride execution view is nil")
+	}
+	if !strings.HasPrefix(strings.TrimSpace(v.RideRequestID), "rrq-") {
+		return fmt.Errorf("invalid rideRequestId: %q", v.RideRequestID)
+	}
+	if err := v.TravelerRef.Validate(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/services/fulfillment/migrations/003_external_handoffs.sql
+++ b/services/fulfillment/migrations/003_external_handoffs.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS ancillary_fulfillment_handoffs (
+  ancillary_order_item_id text PRIMARY KEY,
+  data                    jsonb NOT NULL,
+  updated_at              timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS ride_execution_views (
+  ride_request_id text PRIMARY KEY,
+  data            jsonb NOT NULL,
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- Subscribe fulfillment to ancillary-service and dispatch event streams.
- Consume AncillaryOrderItemFulfillmentReady, AncillaryFulfillmentFactRecorded, DriverArrived, RideStarted, and RideEnded with processed-event dedup and ack-skip handling for unknown states.
- Add durable fulfillment read models for ancillary handoffs and ride execution evidence.

## Validation
- go test ./services/fulfillment/...
