### PR TITLE
REQ-368 consume transfer MCT rules in trip planning

### DIFF
--- a/services/trip-planning/migrations/001_trip_planning_storage.sql
+++ b/services/trip-planning/migrations/001_trip_planning_storage.sql
@@ -33,6 +33,21 @@ CREATE TABLE IF NOT EXISTS plan_nodes (
   updated_at timestamptz NOT NULL DEFAULT now()
 );
 CREATE INDEX IF NOT EXISTS idx_plan_nodes_place ON plan_nodes (place_id, node_id);
+CREATE TABLE IF NOT EXISTS plan_mct_rules (
+  mct_rule_id text NOT NULL,
+  version integer NOT NULL,
+  status text NOT NULL,
+  from_node_type text NOT NULL,
+  to_node_type text NOT NULL,
+  transfer_category text NOT NULL,
+  minimum_minutes integer NOT NULL,
+  valid_from timestamptz,
+  valid_until timestamptz,
+  data jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (mct_rule_id, version)
+);
+CREATE INDEX IF NOT EXISTS idx_plan_mct_rules_lookup ON plan_mct_rules (status, from_node_type, to_node_type, transfer_category);
 CREATE TABLE IF NOT EXISTS itinerary_snapshots (
   id text PRIMARY KEY,
   version bigint NOT NULL,

--- a/services/trip-planning/src/trip_planning/adapters/messaging/redis_streams.py
+++ b/services/trip-planning/src/trip_planning/adapters/messaging/redis_streams.py
@@ -15,6 +15,7 @@ TRIP_PLANNING_SUBSCRIPTIONS = (
     "events:place-network",
     "events:service-plan",
     "events:capacity-availability",
+    "events:transfer-management",
 )
 TRIP_PLANNING_CONSUMER_GROUP = "trip-planning"
 SUBSCRIBER_RESTART_DELAY_SECONDS = 1.0

--- a/services/trip-planning/src/trip_planning/adapters/storage/postgres.py
+++ b/services/trip-planning/src/trip_planning/adapters/storage/postgres.py
@@ -7,8 +7,9 @@ from datetime import UTC, datetime
 from typing import Any, Mapping
 
 from train_ticket_platform.storage import OptimisticConcurrencyError, OutboxAppender, SnapshotRepository
-from trip_planning.domain import AvailabilityHint, Itinerary, LegCandidate, PriceHint
+from trip_planning.domain import Itinerary, MinimumConnectionTimeRule
 from trip_planning.events import EventEnvelope
+from trip_planning.read_model import SegmentRecord, build_itineraries
 
 
 _CLEAR_TABLE_SQL = (
@@ -16,6 +17,7 @@ _CLEAR_TABLE_SQL = (
     "DELETE FROM plan_services",
     "DELETE FROM plan_segments",
     "DELETE FROM plan_nodes",
+    "DELETE FROM plan_mct_rules",
     "DELETE FROM itinerary_snapshots",
 )
 
@@ -130,35 +132,53 @@ class PostgresPlanStore:
             place = str(payload.get("placeId", ""))
             if node and place:
                 conn.execute("INSERT INTO plan_nodes(node_id, version, place_id, data) VALUES (%s, 1, %s, %s) ON CONFLICT (node_id) DO UPDATE SET version = plan_nodes.version + 1, place_id = EXCLUDED.place_id, data = EXCLUDED.data, updated_at = now()", (node, place, _jsonb_payload(dict(payload))))
+        elif event_type == "MctRulePublished":
+            rule = MinimumConnectionTimeRule.from_transfer_event(payload)
+            conn.execute(
+                "INSERT INTO plan_mct_rules(mct_rule_id, version, status, from_node_type, to_node_type, transfer_category, minimum_minutes, valid_from, valid_until, data) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s) ON CONFLICT (mct_rule_id, version) DO UPDATE SET status = EXCLUDED.status, from_node_type = EXCLUDED.from_node_type, to_node_type = EXCLUDED.to_node_type, transfer_category = EXCLUDED.transfer_category, minimum_minutes = EXCLUDED.minimum_minutes, valid_from = EXCLUDED.valid_from, valid_until = EXCLUDED.valid_until, data = EXCLUDED.data, updated_at = now()",
+                (rule.mct_rule_id, rule.version, rule.status, rule.from_node_type, rule.to_node_type, rule.transfer_category, rule.minimum_minutes, rule.valid_from, rule.valid_until, _jsonb_payload(dict(payload))),
+            )
+        elif event_type == "MctRuleRetired":
+            rule_id = str(payload.get("mctRuleId", ""))
+            version = int(payload.get("version", 0))
+            if rule_id and version:
+                conn.execute("DELETE FROM plan_mct_rules WHERE mct_rule_id = %s AND version = %s", (rule_id, version))
 
     def candidates(self, origin_ref: str, destination_ref: str, departure_date: str) -> list[Itinerary]:
         with self._pool.connection() as conn:
-            rows = conn.execute(
+            segment_rows = conn.execute(
                 """
-                WITH requested_origin AS (SELECT place_id FROM plan_nodes WHERE node_id = %s),
-                     requested_destination AS (SELECT place_id FROM plan_nodes WHERE node_id = %s),
-                     origin_refs AS (SELECT %s AS ref UNION SELECT node_id FROM plan_nodes WHERE place_id = %s UNION SELECT node_id FROM plan_nodes WHERE place_id = (SELECT place_id FROM requested_origin)),
-                     destination_refs AS (SELECT %s AS ref UNION SELECT node_id FROM plan_nodes WHERE place_id = %s UNION SELECT node_id FROM plan_nodes WHERE place_id = (SELECT place_id FROM requested_destination))
                 SELECT segment_ref, scheduled_service_ref, origin_stop_ref, destination_stop_ref, departure_time, arrival_time
                   FROM plan_segments
                  WHERE departure_date = %s::date
-                   AND origin_stop_ref IN (SELECT ref FROM origin_refs WHERE ref IS NOT NULL)
-                   AND destination_stop_ref IN (SELECT ref FROM destination_refs WHERE ref IS NOT NULL)
                  ORDER BY departure_time, segment_ref
                 """,
-                (origin_ref, destination_ref, origin_ref, origin_ref, destination_ref, destination_ref, departure_date),
+                (departure_date,),
             ).fetchall()
-        return [self._itinerary_from_row(row) for row in rows]
-
-    def _itinerary_from_row(self, row: Any) -> Itinerary:
-        seg_ref, service_ref, origin, destination, departure_time, arrival_time = row
-        departure = departure_time.astimezone(UTC)
-        arrival = arrival_time.astimezone(UTC)
-        return Itinerary(
-            legs=(LegCandidate(service_plan_ref=str(service_ref or ""), service_segment_ref=str(seg_ref), origin_stop_ref=str(origin), destination_stop_ref=str(destination), departure_time=departure, arrival_time=arrival, mode="train", stop_refs=(str(origin), str(destination)), segment_refs=(str(seg_ref),)),),
-            price_hint=PriceHint(amount_minor=0, currency="CNY", snapshot_ref=f"fare-snapshot:{seg_ref}", captured_at=departure, confidence=50),
-            availability_hint=AvailabilityHint(status="UNKNOWN", snapshot_ref=f"availability-snapshot:{seg_ref}", captured_at=departure, confidence=50),
-            planning_snapshot_refs=(f"planning-snapshot:{seg_ref}",),
+            node_rows = conn.execute("SELECT node_id, place_id, data FROM plan_nodes").fetchall()
+            rule_rows = conn.execute("SELECT data FROM plan_mct_rules WHERE status = 'PUBLISHED'").fetchall()
+        segments = tuple(
+            SegmentRecord(
+                segment_ref=str(row[0]),
+                scheduled_service_ref=str(row[1] or ""),
+                origin_stop_ref=str(row[2]),
+                destination_stop_ref=str(row[3]),
+                departure_time=row[4].astimezone(UTC),
+                arrival_time=row[5].astimezone(UTC),
+            )
+            for row in segment_rows
+        )
+        node_place = {str(row[0]): str(row[1]) for row in node_rows}
+        node_payloads = {str(row[0]): dict(row[2] or {}) for row in node_rows}
+        mct_rules = tuple(MinimumConnectionTimeRule.from_transfer_event(dict(row[0] or {})) for row in rule_rows)
+        return build_itineraries(
+            origin_ref=origin_ref,
+            destination_ref=destination_ref,
+            departure_date=departure_date,
+            segments=segments,
+            node_place=node_place,
+            node_payloads=node_payloads,
+            mct_rules=mct_rules,
         )
 
     def save_itinerary(self, itinerary: Mapping[str, object]) -> None:

--- a/services/trip-planning/src/trip_planning/api.py
+++ b/services/trip-planning/src/trip_planning/api.py
@@ -16,9 +16,10 @@ from fastapi.responses import JSONResponse
 
 from train_ticket_platform.observability import init_opentelemetry
 from .application import search_itineraries, search_itineraries_from_payload
-from .domain import AvailabilityHint, Itinerary, LegCandidate, PriceHint, TripIntent, TripPlanningValidationError
+from .domain import AvailabilityHint, Itinerary, LegCandidate, MinimumConnectionTimeRule, PriceHint, TripIntent, TripPlanningValidationError
 from .application_ports import EventPublisher, EventSubscriber
 from .events import PublishFailed, build_itinerary_proposed_event, new_uuid7
+from .read_model import build_itineraries, segment_from_payload
 from train_ticket_platform.idempotency import configure_idempotency_middleware
 from train_ticket_platform.storage import DatabaseConfig, DatabasePool, OptimisticConcurrencyError, OutboxRelay, PostgresIdempotencyStore, ReadinessGate, run_migrations
 
@@ -249,6 +250,8 @@ class PlanStore:
         self.services: dict[str, dict[str, object]] = {}
         self.segments: dict[str, dict[str, object]] = {}
         self.node_place: dict[str, str] = {}
+        self.node_payloads: dict[str, dict[str, object]] = {}
+        self.mct_rules: dict[tuple[str, int], MinimumConnectionTimeRule] = {}
         self.applied_event_ids: set[str] = set()
 
     def clear(self) -> None:
@@ -256,6 +259,8 @@ class PlanStore:
             self.services.clear()
             self.segments.clear()
             self.node_place.clear()
+            self.node_payloads.clear()
+            self.mct_rules.clear()
             self.applied_event_ids.clear()
 
     def apply_envelope(self, envelope: Any) -> bool:
@@ -287,8 +292,18 @@ class PlanStore:
         elif event_type in ("TransportNodeRegistered", "TransportNodeAdded", "TransportNodeUpdated"):
             node = str(payload.get("nodeId", ""))
             place = str(payload.get("placeId", ""))
-            if node and place:
-                self.node_place[node] = place
+            if node:
+                self.node_payloads[node] = dict(payload)
+                if place:
+                    self.node_place[node] = place
+        elif event_type == "MctRulePublished":
+            rule = MinimumConnectionTimeRule.from_transfer_event(payload)
+            self.mct_rules[(rule.mct_rule_id, rule.version)] = rule
+        elif event_type == "MctRuleRetired":
+            rule_id = str(payload.get("mctRuleId", ""))
+            version = int(payload.get("version", 0))
+            if rule_id and version:
+                self.mct_rules.pop((rule_id, version), None)
 
     def _matches(self, stop_ref: str, requested: str) -> bool:
         requested_place = self.node_place.get(requested)
@@ -301,50 +316,24 @@ class PlanStore:
         )
 
     def candidates(self, origin_ref: str, destination_ref: str, departure_date: str) -> list[Itinerary]:
-        found: list[Itinerary] = []
         with self._lock:
-            for seg_ref, seg in self.segments.items():
-                origin_stop = str(seg.get("originStopRef", ""))
-                destination_stop = str(seg.get("destinationStopRef", ""))
-                departure_raw = str(seg.get("departureTime", ""))
-                if not departure_raw.startswith(departure_date):
-                    continue
-                if not (self._matches(origin_stop, origin_ref) and self._matches(destination_stop, destination_ref)):
-                    continue
-                departure_time = datetime.fromisoformat(departure_raw.replace("Z", "+00:00"))
-                arrival_raw = str(seg.get("arrivalTime", departure_raw))
-                arrival_time = datetime.fromisoformat(arrival_raw.replace("Z", "+00:00"))
-                service_ref = str(seg.get("scheduledServiceRef", ""))
-                found.append(Itinerary(
-                    legs=(
-                        LegCandidate(
-                            service_plan_ref=service_ref,
-                            service_segment_ref=seg_ref,
-                            origin_stop_ref=origin_stop,
-                            destination_stop_ref=destination_stop,
-                            departure_time=departure_time,
-                            arrival_time=arrival_time,
-                            mode="train",
-                            stop_refs=(origin_stop, destination_stop),
-                            segment_refs=(seg_ref,),
-                        ),
-                    ),
-                    price_hint=PriceHint(
-                        amount_minor=0,
-                        currency="CNY",
-                        snapshot_ref=f"fare-snapshot:{seg_ref}",
-                        captured_at=departure_time,
-                        confidence=50,
-                    ),
-                    availability_hint=AvailabilityHint(
-                        status="UNKNOWN",
-                        snapshot_ref=f"availability-snapshot:{seg_ref}",
-                        captured_at=departure_time,
-                        confidence=50,
-                    ),
-                    planning_snapshot_refs=(f"planning-snapshot:{seg_ref}",),
-                ))
-        return found
+            segments = tuple(
+                record
+                for seg_ref, payload in self.segments.items()
+                if (record := segment_from_payload(seg_ref, payload)) is not None
+            )
+            node_place = dict(self.node_place)
+            node_payloads = {node_id: dict(payload) for node_id, payload in self.node_payloads.items()}
+            mct_rules = tuple(self.mct_rules.values())
+        return build_itineraries(
+            origin_ref=origin_ref,
+            destination_ref=destination_ref,
+            departure_date=departure_date,
+            segments=segments,
+            node_place=node_place,
+            node_payloads=node_payloads,
+            mct_rules=mct_rules,
+        )
 
 
 _plan_store = PlanStore()

--- a/services/trip-planning/src/trip_planning/domain.py
+++ b/services/trip-planning/src/trip_planning/domain.py
@@ -16,6 +16,8 @@ _ALLOWED_AVAILABILITY_STATUSES = {
     "UNKNOWN",
     "UNAVAILABLE",
 }
+_ALLOWED_MCT_RULE_STATUSES = {"PUBLISHED", "RETIRED"}
+_WILDCARD_RULE_VALUE = "ANY"
 _PRICE_HINT_DISCLAIMER = (
     "Price hint is a non-authoritative planning snapshot. It is not an offer, "
     "does not freeze fare rules, and cannot be used as a payment amount."
@@ -62,6 +64,143 @@ def _tuple_of_refs(values: Sequence[str], field_name: str) -> tuple[str, ...]:
 def stable_ref(prefix: str, parts: Iterable[str]) -> str:
     digest = sha256("|".join(parts).encode("utf-8")).hexdigest()[:16]
     return f"{prefix}_{digest}"
+
+@dataclass(frozen=True)
+class MinimumConnectionTimeRule:
+    """Published transfer-management MCT rule used to filter connecting itineraries."""
+
+    mct_rule_id: str
+    version: int
+    status: str
+    from_node_type: str
+    to_node_type: str
+    transfer_category: str
+    minimum_minutes: int
+    conditions: Mapping[str, Any] = field(default_factory=dict)
+    valid_from: datetime | None = None
+    valid_until: datetime | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "mct_rule_id", _require_ref(self.mct_rule_id, "mct_rule_id"))
+        if self.version <= 0:
+            raise TripPlanningValidationError("mct rule version must be positive")
+        status = _require_ref(self.status, "status").upper()
+        if status not in _ALLOWED_MCT_RULE_STATUSES:
+            raise TripPlanningValidationError(f"unsupported mct rule status: {status}")
+        object.__setattr__(self, "status", status)
+        for field_name in ("from_node_type", "to_node_type", "transfer_category"):
+            object.__setattr__(self, field_name, _require_ref(getattr(self, field_name), field_name).upper())
+        if self.minimum_minutes < 0:
+            raise TripPlanningValidationError("minimum_minutes cannot be negative")
+        if self.valid_from is not None:
+            object.__setattr__(self, "valid_from", _parse_datetime(self.valid_from, "valid_from"))
+        if self.valid_until is not None:
+            object.__setattr__(self, "valid_until", _parse_datetime(self.valid_until, "valid_until"))
+        if self.valid_from and self.valid_until and self.valid_from >= self.valid_until:
+            raise TripPlanningValidationError("valid_from must be before valid_until")
+
+    @classmethod
+    def from_transfer_event(cls, payload: Mapping[str, Any]) -> "MinimumConnectionTimeRule":
+        return cls(
+            mct_rule_id=payload.get("mctRuleId"),
+            version=int(payload.get("version", 0)),
+            status=payload.get("status", ""),
+            from_node_type=payload.get("fromNodeType", _WILDCARD_RULE_VALUE),
+            to_node_type=payload.get("toNodeType", _WILDCARD_RULE_VALUE),
+            transfer_category=payload.get("transferCategory", _WILDCARD_RULE_VALUE),
+            minimum_minutes=int(payload.get("minimumMinutes", 0)),
+            conditions=dict(payload.get("conditions") or {}),
+            valid_from=payload.get("validFrom"),
+            valid_until=payload.get("validUntil"),
+        )
+
+    @property
+    def snapshot_ref(self) -> str:
+        return f"mct-rule:{self.mct_rule_id}:v{self.version}"
+
+    def is_effective_at(self, at_time: datetime) -> bool:
+        if self.status != "PUBLISHED":
+            return False
+        if self.valid_from and at_time < self.valid_from:
+            return False
+        if self.valid_until and at_time >= self.valid_until:
+            return False
+        return True
+
+    def matches(self, from_node_type: str, to_node_type: str, transfer_category: str, at_time: datetime) -> bool:
+        if not self.is_effective_at(at_time):
+            return False
+        return (
+            self._matches_value(self.from_node_type, from_node_type)
+            and self._matches_value(self.to_node_type, to_node_type)
+            and self._matches_value(self.transfer_category, transfer_category)
+        )
+
+    @staticmethod
+    def _matches_value(rule_value: str, actual_value: str) -> bool:
+        return rule_value == _WILDCARD_RULE_VALUE or rule_value == actual_value
+
+
+def required_connection_minutes(
+    from_node_ref: str,
+    to_node_ref: str,
+    *,
+    at_time: datetime,
+    node_payloads: Mapping[str, Mapping[str, Any]],
+    rules: Sequence[MinimumConnectionTimeRule],
+    default_minutes: int,
+) -> tuple[int, MinimumConnectionTimeRule | None]:
+    from_node = node_payloads.get(from_node_ref, {})
+    to_node = node_payloads.get(to_node_ref, {})
+    from_node_type = _node_type(from_node)
+    to_node_type = _node_type(to_node)
+    category = _transfer_category(from_node_ref, to_node_ref, from_node, to_node)
+    matching_rules = [
+        rule
+        for rule in rules
+        if rule.matches(from_node_type, to_node_type, category, at_time)
+    ]
+    if not matching_rules:
+        return default_minutes, None
+    selected = max(
+        matching_rules,
+        key=lambda rule: (
+            _specificity(rule.from_node_type, rule.to_node_type, rule.transfer_category),
+            rule.valid_from or datetime.min,
+            rule.version,
+            rule.mct_rule_id,
+        ),
+    )
+    return selected.minimum_minutes, selected
+
+
+def _node_type(node_payload: Mapping[str, Any]) -> str:
+    value = node_payload.get("nodeType") or node_payload.get("placeType") or node_payload.get("type")
+    if isinstance(value, str) and value.strip():
+        return value.strip().upper()
+    serving_modes = node_payload.get("servingModes")
+    if isinstance(serving_modes, Sequence) and not isinstance(serving_modes, (str, bytes)):
+        modes = {str(mode).upper() for mode in serving_modes}
+        if "TRAIN" in modes:
+            return "STATION"
+    return "OTHER"
+
+
+def _transfer_category(
+    from_node_ref: str,
+    to_node_ref: str,
+    from_node: Mapping[str, Any],
+    to_node: Mapping[str, Any],
+) -> str:
+    if from_node_ref == to_node_ref:
+        return "SAME_STATION"
+    if from_node.get("placeId") and from_node.get("placeId") == to_node.get("placeId"):
+        return "IN_STATION"
+    return "CROSS_STATION"
+
+
+def _specificity(*values: str) -> int:
+    return sum(1 for value in values if value != _WILDCARD_RULE_VALUE)
 
 
 @dataclass(frozen=True)

--- a/services/trip-planning/src/trip_planning/read_model.py
+++ b/services/trip-planning/src/trip_planning/read_model.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from .domain import AvailabilityHint, Itinerary, LegCandidate, MinimumConnectionTimeRule, PriceHint, required_connection_minutes
+
+
+@dataclass(frozen=True)
+class SegmentRecord:
+    segment_ref: str
+    scheduled_service_ref: str
+    origin_stop_ref: str
+    destination_stop_ref: str
+    departure_time: datetime
+    arrival_time: datetime
+
+
+def parse_datetime(value: datetime | str) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def segment_from_payload(segment_ref: str, payload: Mapping[str, object]) -> SegmentRecord | None:
+    origin = str(payload.get("originStopRef", ""))
+    destination = str(payload.get("destinationStopRef", ""))
+    departure_raw = str(payload.get("departureTime", ""))
+    if not segment_ref or not origin or not destination or not departure_raw:
+        return None
+    departure = parse_datetime(departure_raw)
+    arrival = parse_datetime(str(payload.get("arrivalTime", departure_raw)))
+    return SegmentRecord(
+        segment_ref=segment_ref,
+        scheduled_service_ref=str(payload.get("scheduledServiceRef", "")),
+        origin_stop_ref=origin,
+        destination_stop_ref=destination,
+        departure_time=departure,
+        arrival_time=arrival,
+    )
+
+
+def build_itineraries(
+    *,
+    origin_ref: str,
+    destination_ref: str,
+    departure_date: str,
+    segments: Sequence[SegmentRecord],
+    node_place: Mapping[str, str],
+    node_payloads: Mapping[str, Mapping[str, object]],
+    mct_rules: Sequence[MinimumConnectionTimeRule],
+    default_min_connection_minutes: int = 5,
+) -> list[Itinerary]:
+    dated_segments = [segment for segment in segments if segment.departure_time.date().isoformat() == departure_date]
+    found: list[Itinerary] = []
+    seen_refs: set[str] = set()
+
+    for segment in dated_segments:
+        if _matches(segment.origin_stop_ref, origin_ref, node_place) and _matches(segment.destination_stop_ref, destination_ref, node_place):
+            itinerary = _itinerary_from_segments((segment,), ())
+            if itinerary.itinerary_ref not in seen_refs:
+                found.append(itinerary)
+                seen_refs.add(str(itinerary.itinerary_ref))
+
+    for first in dated_segments:
+        if not _matches(first.origin_stop_ref, origin_ref, node_place):
+            continue
+        for second in dated_segments:
+            if first.segment_ref == second.segment_ref:
+                continue
+            if not _same_connection_point(first.destination_stop_ref, second.origin_stop_ref, node_place):
+                continue
+            if not _matches(second.destination_stop_ref, destination_ref, node_place):
+                continue
+            wait_minutes = int((second.departure_time - first.arrival_time).total_seconds() // 60)
+            if wait_minutes < 0:
+                continue
+            required_minutes, applied_rule = required_connection_minutes(
+                first.destination_stop_ref,
+                second.origin_stop_ref,
+                at_time=first.arrival_time,
+                node_payloads=node_payloads,
+                rules=mct_rules,
+                default_minutes=default_min_connection_minutes,
+            )
+            if wait_minutes < required_minutes:
+                continue
+            rule_refs = () if applied_rule is None else (applied_rule.snapshot_ref,)
+            itinerary = _itinerary_from_segments((first, second), rule_refs)
+            if itinerary.itinerary_ref not in seen_refs:
+                found.append(itinerary)
+                seen_refs.add(str(itinerary.itinerary_ref))
+
+    found.sort(key=lambda itinerary: (itinerary.departure_time, itinerary.arrival_time, itinerary.itinerary_ref or ""))
+    return found
+
+
+def _matches(stop_ref: str, requested: str, node_place: Mapping[str, str]) -> bool:
+    requested_place = node_place.get(requested)
+    stop_place = node_place.get(stop_ref)
+    return (
+        stop_ref == requested
+        or stop_place == requested
+        or (requested_place is not None and stop_ref == requested_place)
+        or (requested_place is not None and stop_place == requested_place)
+    )
+
+
+def _same_connection_point(left_ref: str, right_ref: str, node_place: Mapping[str, str]) -> bool:
+    if left_ref == right_ref:
+        return True
+    left_place = node_place.get(left_ref)
+    right_place = node_place.get(right_ref)
+    return left_place is not None and left_place == right_place
+
+
+def _itinerary_from_segments(segments: tuple[SegmentRecord, ...], mct_snapshot_refs: tuple[str, ...]) -> Itinerary:
+    legs = tuple(
+        LegCandidate(
+            service_plan_ref=segment.scheduled_service_ref,
+            service_segment_ref=segment.segment_ref,
+            origin_stop_ref=segment.origin_stop_ref,
+            destination_stop_ref=segment.destination_stop_ref,
+            departure_time=segment.departure_time,
+            arrival_time=segment.arrival_time,
+            mode="train",
+            stop_refs=(segment.origin_stop_ref, segment.destination_stop_ref),
+            segment_refs=(segment.segment_ref,),
+        )
+        for segment in segments
+    )
+    first_departure = segments[0].departure_time
+    snapshot_ref = "+".join(segment.segment_ref for segment in segments)
+    return Itinerary(
+        legs=legs,
+        price_hint=PriceHint(
+            amount_minor=0,
+            currency="CNY",
+            snapshot_ref=f"fare-snapshot:{snapshot_ref}",
+            captured_at=first_departure,
+            confidence=50,
+        ),
+        availability_hint=AvailabilityHint(
+            status="UNKNOWN",
+            snapshot_ref=f"availability-snapshot:{snapshot_ref}",
+            captured_at=first_departure,
+            confidence=50,
+        ),
+        planning_snapshot_refs=tuple(f"planning-snapshot:{segment.segment_ref}" for segment in segments) + mct_snapshot_refs,
+    )

--- a/services/trip-planning/tests/test_lifecycle.py
+++ b/services/trip-planning/tests/test_lifecycle.py
@@ -43,7 +43,7 @@ class ProductionMessagingWiringTest(unittest.TestCase):
             wait_for_handlers(subscriber)
             self.assertEqual(len(subscriber.handlers), 1)
             streams, group, consumer_name, _handler = subscriber.handlers[0]
-            self.assertEqual(streams, ["events:place-network", "events:service-plan", "events:capacity-availability"])
+            self.assertEqual(streams, ["events:place-network", "events:service-plan", "events:capacity-availability", "events:transfer-management"])
             self.assertEqual(group, "trip-planning")
             self.assertTrue(consumer_name.startswith("trip-planning-"))
             event = EventEnvelope(eventId="evt-upstream", eventType="PlaceUpdated", producer="place-network", payload={"placeRef": "station:A"})

--- a/services/trip-planning/tests/test_plan_index_replay.py
+++ b/services/trip-planning/tests/test_plan_index_replay.py
@@ -50,6 +50,75 @@ class PlanIndexReplayTest(unittest.TestCase):
         self.assertEqual(leg["originStopRef"], "node-origin-new")
         self.assertEqual(leg["destinationStopRef"], "node-destination-new")
 
+    def test_transfer_management_mct_rule_filters_infeasible_connections(self) -> None:
+        plan_store = PlanStore()
+        for envelope in _connecting_sequence_events():
+            plan_store.apply_envelope(envelope)
+
+        before_rule = plan_store.candidates("plc-origin", "plc-destination", "2026-08-01")
+        self.assertEqual(len(before_rule), 1)
+        self.assertEqual([leg.service_segment_ref for leg in before_rule[0].legs], ["seg-origin-hub", "seg-hub-destination"])
+
+        applied = plan_store.apply_envelope(EventEnvelope(
+            eventId="evt-mct-published",
+            eventType="MctRulePublished",
+            producer="transfer-management",
+            payload={
+                "mctRuleId": "mct-cross-station",
+                "version": 1,
+                "previousStatus": "VALIDATED",
+                "status": "PUBLISHED",
+                "fromNodeType": "STATION",
+                "toNodeType": "STATION",
+                "transferCategory": "SAME_STATION",
+                "minimumMinutes": 20,
+                "conditions": {},
+                "validFrom": "2026-01-01T00:00:00Z",
+                "publishedBy": {"actorType": "SYSTEM", "actorId": "ops"},
+                "publishedAt": "2026-07-01T00:00:00Z",
+            },
+        ))
+        duplicate_applied = plan_store.apply_envelope(EventEnvelope(
+            eventId="evt-mct-published",
+            eventType="MctRulePublished",
+            producer="transfer-management",
+            payload={
+                "mctRuleId": "mct-cross-station",
+                "version": 1,
+                "previousStatus": "VALIDATED",
+                "status": "PUBLISHED",
+                "fromNodeType": "STATION",
+                "toNodeType": "STATION",
+                "transferCategory": "SAME_STATION",
+                "minimumMinutes": 0,
+                "conditions": {},
+                "validFrom": "2026-01-01T00:00:00Z",
+                "publishedBy": {"actorType": "SYSTEM", "actorId": "ops"},
+                "publishedAt": "2026-07-01T00:00:00Z",
+            },
+        ))
+
+        self.assertTrue(applied)
+        self.assertFalse(duplicate_applied)
+        self.assertEqual(plan_store.candidates("plc-origin", "plc-destination", "2026-08-01"), [])
+
+        plan_store.apply_envelope(EventEnvelope(
+            eventId="evt-mct-retired",
+            eventType="MctRuleRetired",
+            producer="transfer-management",
+            payload={
+                "mctRuleId": "mct-cross-station",
+                "version": 1,
+                "previousStatus": "PUBLISHED",
+                "status": "RETIRED",
+                "retiredBy": {"actorType": "SYSTEM", "actorId": "ops"},
+                "retireReason": "superseded",
+                "retiredAt": "2026-07-02T00:00:00Z",
+            },
+        ))
+
+        self.assertEqual(len(plan_store.candidates("plc-origin", "plc-destination", "2026-08-01")), 1)
+
     def test_place_search_matches_any_node_for_same_place_not_first_node_only(self) -> None:
         old_nodes = [
             EventEnvelope(
@@ -93,6 +162,55 @@ class PlanIndexReplayTest(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["itineraries"][0]["legs"][0]["serviceSegmentRef"], "seg-real-080")
+
+
+def _connecting_sequence_events() -> list[EventEnvelope]:
+    return [
+        EventEnvelope(
+            eventId="evt-origin-node-connect",
+            eventType="TransportNodeRegistered",
+            producer="place-network",
+            payload={"nodeId": "node-origin", "placeId": "plc-origin", "displayName": "origin", "servingModes": ["TRAIN"]},
+        ),
+        EventEnvelope(
+            eventId="evt-hub-arrival-node",
+            eventType="TransportNodeRegistered",
+            producer="place-network",
+            payload={"nodeId": "node-hub-arrival", "placeId": "plc-hub", "displayName": "hub arrival", "servingModes": ["TRAIN"]},
+        ),
+        EventEnvelope(
+            eventId="evt-destination-node-connect",
+            eventType="TransportNodeRegistered",
+            producer="place-network",
+            payload={"nodeId": "node-destination", "placeId": "plc-destination", "displayName": "destination", "servingModes": ["TRAIN"]},
+        ),
+        EventEnvelope(
+            eventId="evt-seg-origin-hub",
+            eventType="ServicePlanChanged",
+            producer="service-plan",
+            payload={
+                "segmentRef": "seg-origin-hub",
+                "scheduledServiceRef": "ss-origin-hub",
+                "originStopRef": "node-origin",
+                "destinationStopRef": "node-hub-arrival",
+                "departureTime": "2026-08-01T09:00:00Z",
+                "arrivalTime": "2026-08-01T10:00:00Z",
+            },
+        ),
+        EventEnvelope(
+            eventId="evt-seg-hub-destination",
+            eventType="ServicePlanChanged",
+            producer="service-plan",
+            payload={
+                "segmentRef": "seg-hub-destination",
+                "scheduledServiceRef": "ss-hub-destination",
+                "originStopRef": "node-hub-arrival",
+                "destinationStopRef": "node-destination",
+                "departureTime": "2026-08-01T10:10:00Z",
+                "arrivalTime": "2026-08-01T11:00:00Z",
+            },
+        ),
+    ]
 
 
 def _standard_api_sequence_events() -> list[EventEnvelope]:


### PR DESCRIPTION
## Summary
- subscribe trip-planning to events:transfer-management
- consume MctRulePublished/MctRuleRetired into durable/in-memory MCT read models with eventId dedup via existing processed_events guard
- apply active MCT rules when assembling connecting itinerary candidates

## Validation
- python3 -m compileall services/trip-planning/src/trip_planning
- cd services/trip-planning && uv run pytest -q