### PR TITLE
REQ-369 Activate payment ancillary refund consumer

### DIFF
--- a/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/PaymentSubscriptionRunner.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/PaymentSubscriptionRunner.java
@@ -22,7 +22,12 @@ public class PaymentSubscriptionRunner implements CommandLineRunner {
     @Override
     public void run(String... args) {
         subscriber.subscribe(
-            List.of(RedisStreamNames.BOOKING_ORCHESTRATION_STREAM, RedisStreamNames.POST_SALES_STREAM, RedisStreamNames.PAYMENT_CHANNEL_STREAM),
+            List.of(
+                RedisStreamNames.BOOKING_ORCHESTRATION_STREAM,
+                RedisStreamNames.POST_SALES_STREAM,
+                RedisStreamNames.PAYMENT_CHANNEL_STREAM,
+                RedisStreamNames.ANCILLARY_SERVICE_STREAM
+            ),
             RedisStreamNames.PAYMENT_GROUP,
             "payment-" + UUID.randomUUID(),
             handler

--- a/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/RedisStreamNames.java
+++ b/services/payment/src/main/java/com/trainticket/payment/adapters/messaging/RedisStreamNames.java
@@ -4,6 +4,7 @@ final class RedisStreamNames {
     static final String BOOKING_ORCHESTRATION_STREAM = "events:booking-orchestration";
     static final String POST_SALES_STREAM = "events:post-sales";
     static final String PAYMENT_CHANNEL_STREAM = "events:payment-channel";
+    static final String ANCILLARY_SERVICE_STREAM = "events:ancillary-service";
     static final String PAYMENT_GROUP = "payment";
 
     private RedisStreamNames() {

--- a/services/payment/src/main/java/com/trainticket/payment/application/InboundEventPayload.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/InboundEventPayload.java
@@ -36,16 +36,7 @@ final class InboundEventPayload {
     }
 
     Money requiredMoney(String field) {
-        Map<?, ?> money = asMap(payload.get(field), field);
-        Object currency = money.get("currency");
-        Object minorUnits = money.get("minorUnits");
-        if (!(currency instanceof String currencyCode) || currencyCode.isBlank()) {
-            throw new DomainRuleViolation(field + ".currency is required");
-        }
-        if (!(minorUnits instanceof Number number)) {
-            throw new DomainRuleViolation(field + ".minorUnits is required");
-        }
-        return Money.fromMinorUnits(number.longValue(), currencyCode);
+        return moneyFromObject(payload.get(field), field);
     }
 
     Money moneyFromApprovedActions() {
@@ -95,8 +86,12 @@ final class InboundEventPayload {
                 return text;
             }
         }
-        Object direct = payload.get("orderId");
-        return direct instanceof String text && !text.isBlank() ? text : null;
+        return optionalTextValue("orderId");
+    }
+
+    String optionalTextValue(String field) {
+        Object value = payload.get(field);
+        return value instanceof String text && !text.isBlank() ? text : null;
     }
 
     private static Money moneyFromObject(Object value, String field) {

--- a/services/payment/src/main/java/com/trainticket/payment/application/PaymentInboundEventHandler.java
+++ b/services/payment/src/main/java/com/trainticket/payment/application/PaymentInboundEventHandler.java
@@ -31,6 +31,9 @@ public class PaymentInboundEventHandler implements EventSubscriber.EventHandler 
             }
             dispatch(envelope);
             return HandlerResult.SUCCESS;
+        } catch (AckSkipEventException exception) {
+            LOGGER.warn("eventType={} eventId={} ack-skipped: {}", envelope.eventType(), envelope.eventId(), exception.getMessage());
+            return HandlerResult.SUCCESS;
         } catch (DomainRuleViolation | IllegalArgumentException exception) {
             // The nested command transaction may already be rollback-only, so a
             // clean commit of SUCCESS is impossible here anyway; classify FATAL
@@ -66,6 +69,8 @@ public class PaymentInboundEventHandler implements EventSubscriber.EventHandler 
             handleChannelRefundSucceeded(envelope);
         } else if ("ChannelRefundFailed".equals(envelope.eventType()) || "ChannelRefundMissed".equals(envelope.eventType())) {
             handleChannelRefundFailed(envelope);
+        } else if ("AncillaryOrderItemRefundPending".equals(envelope.eventType())) {
+            handleAncillaryOrderItemRefundPending(envelope);
         }
     }
 
@@ -157,30 +162,56 @@ public class PaymentInboundEventHandler implements EventSubscriber.EventHandler 
             // nothing to refund, so this event is a no-op for payment.
             return;
         }
-        com.trainticket.payment.domain.ChannelRef route = paymentCommands.getIntent(intentId).channelRef();
-        if (route != null && isSimChannel(route.channel()) && route.channelOrderId() != null && route.channelTransactionId() != null) {
-            paymentCommands.requestRefund(
-                intentId,
-                amount,
-                reason == null ? "post-sales-approved" : reason,
-                caseId,
-                caseId,
-                envelope.correlationId(),
-                route
-            );
+        requestRefund(intentId, amount, reason == null ? "post-sales-approved" : reason, caseId, caseId, envelope.correlationId());
+    }
+
+    private void handleAncillaryOrderItemRefundPending(EventEnvelope envelope) {
+        InboundEventPayload payload = InboundEventPayload.from(envelope);
+        String recommendation = payload.requiredText("recommendation");
+        if ("NO_REFUND".equals(recommendation) || "MANUAL_REVIEW".equals(recommendation)) {
             return;
         }
-        paymentCommands.requestRefund(
+        if (!"FULL_REFUND".equals(recommendation) && !"PARTIAL_REFUND".equals(recommendation)) {
+            throw new AckSkipEventException("unknown ancillary refund recommendation " + recommendation);
+        }
+        Money amount = payload.requiredMoney("refundableAmount");
+        if (amount.isZero()) {
+            return;
+        }
+        String intentId = paymentCommands.findIntentIdByBusinessRef(payload.requiredText("journeyOrderId")).orElse(null);
+        if (intentId == null) {
+            throw new AckSkipEventException("no payment intent found for ancillary refund request");
+        }
+        requestRefund(
             intentId,
             amount,
-            reason == null ? "post-sales-approved" : reason,
-            caseId,
-            caseId,
+            payload.requiredText("reasonCode"),
+            businessCaseRef(payload),
+            "ancillary-refund:" + envelope.eventId(),
             envelope.correlationId()
         );
     }
 
-    private static boolean isSimChannel(String channel) {
-        return "ALIPAY_SIM".equals(channel) || "WECHAT_SIM".equals(channel) || "UNIONPAY_SIM".equals(channel);
+    private void requestRefund(String intentId, Money amount, String reason, String businessCaseRef, String idempotencyKey, String correlationId) {
+        com.trainticket.payment.domain.ChannelRef route = paymentCommands.getIntent(intentId).channelRef();
+        if (route != null && route.channel() != null && route.channelOrderId() != null && route.channelTransactionId() != null) {
+            paymentCommands.requestRefund(intentId, amount, reason, businessCaseRef, idempotencyKey, correlationId, route);
+            return;
+        }
+        paymentCommands.requestRefund(intentId, amount, reason, businessCaseRef, idempotencyKey, correlationId);
+    }
+
+    private static String businessCaseRef(InboundEventPayload payload) {
+        String postSalesCaseId = payload.optionalTextValue("postSalesCaseId");
+        if (postSalesCaseId != null) {
+            return postSalesCaseId;
+        }
+        return "ancillary:" + payload.requiredText("ancillaryOrderItemId");
+    }
+
+    private static final class AckSkipEventException extends RuntimeException {
+        private AckSkipEventException(String message) {
+            super(message);
+        }
     }
 }

--- a/services/payment/src/test/java/com/trainticket/payment/application/PaymentMessagingApplicationTest.java
+++ b/services/payment/src/test/java/com/trainticket/payment/application/PaymentMessagingApplicationTest.java
@@ -3,6 +3,7 @@ package com.trainticket.payment.application;
 import com.trainticket.platformkit.messaging.EventEnvelope;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.trainticket.payment.domain.Money;
@@ -96,6 +97,31 @@ class PaymentMessagingApplicationTest {
     }
 
     @Test
+    void ancillaryRefundPendingRequestsRefundAndDeduplicatesByEnvelopeEventId() {
+        FakeEventPublisher publisher = new FakeEventPublisher();
+        PaymentCommandService commands = testPaymentCommandService(Clock.fixed(Instant.parse("2026-07-05T10:30:00Z"), ZoneOffset.UTC), publisher);
+        String paymentIntentId = commands.createIntent("jo-ancillary", "purchase", Money.fromMinorUnits(1000, "CNY"), "trav-1", "idem-create-ancillary", "corr-create").paymentIntentId();
+        commands.captureIntent(paymentIntentId, "idem-capture-ancillary", "corr-create");
+        PaymentInboundEventHandler handler = new PaymentInboundEventHandler(new ConsumedEventDeduplicator(), commands);
+        EventEnvelope refundPending = ancillaryRefundPending("evt-0194f2e0-7b3e-7610-8284-5c26e8b0c006", "jo-ancillary", 400L);
+
+        assertEquals(HandlerResult.SUCCESS, handler.handle(refundPending));
+        assertEquals(HandlerResult.SUCCESS, handler.handle(refundPending));
+
+        EventEnvelope requested = publisher.published().stream()
+            .filter(envelope -> "RefundRequested".equals(envelope.eventType()))
+            .findFirst()
+            .orElse(null);
+        assertNotNull(requested);
+        Map<?, ?> payload = assertInstanceOf(Map.class, requested.payload());
+        assertEquals(paymentIntentId, payload.get("paymentIntentId"));
+        assertEquals("ancillary:aoi-1", payload.get("businessCaseRef"));
+        assertEquals("SERVICE_NOT_PROVIDED", payload.get("reason"));
+        assertEquals(Map.of("currency", "CNY", "minorUnits", 400L), payload.get("amount"));
+        assertEquals(1, publisher.published().stream().filter(envelope -> "RefundRequested".equals(envelope.eventType())).count());
+    }
+
+    @Test
     void mapsRefundFailedPayloadToContractShape() {
         EventEnvelope envelope = EventEnvelopeMapper.fromDomainEvent(new com.trainticket.payment.domain.RefundFailed(
             new EventEnvelope(
@@ -149,6 +175,33 @@ class PaymentMessagingApplicationTest {
                 "segmentRef", "seg-1",
                 "travelerRef", "trav-1",
                 "idempotencyKey", idempotencyKey
+            )
+        );
+    }
+
+    private static EventEnvelope ancillaryRefundPending(String eventId, String journeyOrderId, long refundableMinorUnits) {
+        return new EventEnvelope(
+            eventId,
+            "AncillaryOrderItemRefundPending",
+            Instant.parse("2026-07-05T10:31:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c444",
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c112",
+            "ancillary-service",
+            1,
+            Map.ofEntries(
+                Map.entry("ancillaryOrderItemId", "aoi-1"),
+                Map.entry("journeyOrderId", journeyOrderId),
+                Map.entry("travelerRef", "trav-1"),
+                Map.entry("catalogItemId", "aci-1"),
+                Map.entry("serviceType", "MEAL"),
+                Map.entry("payableAmount", Map.of("currency", "CNY", "minorUnits", 600L)),
+                Map.entry("refundableAmount", Map.of("currency", "CNY", "minorUnits", refundableMinorUnits)),
+                Map.entry("recommendation", "PARTIAL_REFUND"),
+                Map.entry("reasonCode", "SERVICE_NOT_PROVIDED"),
+                Map.entry("previousStatus", "CANCELLED"),
+                Map.entry("status", "REFUND_PENDING"),
+                Map.entry("requestedAt", "2026-07-05T10:31:00Z"),
+                Map.entry("aggregateVersion", 3)
             )
         );
     }


### PR DESCRIPTION
## Summary
- Subscribe payment to events:ancillary-service
- Handle AncillaryOrderItemRefundPending by requesting a Payment refund using envelope eventId-based idempotency/dedup
- Add unit coverage for ancillary refund handling and duplicate eventId skip

## Validation
- (cd platform/java-kit && mvn install -DskipTests)
- (cd services/payment && mvn test)
- (cd services/payment && mvn -q -Dtest=PaymentMessagingApplicationTest test)