### PR TITLE
REQ-365 Activate ancillary finance settlement consumers

### DIFF
--- a/services/finance-settlement/migrations/005_ancillary_financial_facts.sql
+++ b/services/finance-settlement/migrations/005_ancillary_financial_facts.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS ancillary_financial_facts (
+  event_id                 text PRIMARY KEY,
+  event_type               text NOT NULL,
+  fact_kind                text NOT NULL,
+  ancillary_order_item_id  text NOT NULL,
+  journey_order_id         text NOT NULL,
+  service_type             text NOT NULL,
+  supplier_ref             text,
+  payable_currency         text,
+  payable_amount           numeric(19, 4),
+  refundable_currency      text,
+  refundable_amount        numeric(19, 4),
+  refunded_currency        text,
+  refunded_amount          numeric(19, 4),
+  retained_currency        text,
+  retained_amount          numeric(19, 4),
+  occurred_at              timestamptz NOT NULL,
+  updated_at               timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ancillary_financial_facts_journey_order
+  ON ancillary_financial_facts (journey_order_id, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ancillary_financial_facts_item
+  ON ancillary_financial_facts (ancillary_order_item_id, occurred_at DESC);

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/adapters/http/FinanceSettlementController.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/adapters/http/FinanceSettlementController.java
@@ -1,11 +1,13 @@
 package com.trainticket.financesettlement.adapters.http;
 
+import com.trainticket.financesettlement.application.AncillaryFinancialFact;
 import com.trainticket.financesettlement.application.BenefitCostEntry;
 import com.trainticket.financesettlement.application.ChannelStatementProjection;
 import com.trainticket.financesettlement.application.DomainEventEnvelopeMapper;
 import com.trainticket.financesettlement.application.FinanceSettlementApplicationService;
 import com.trainticket.financesettlement.application.FinanceSettlementApplicationService.Page;
 import com.trainticket.financesettlement.domain.Invoice;
+import com.trainticket.financesettlement.domain.Money;
 import com.trainticket.financesettlement.domain.ReconciliationBatch;
 import com.trainticket.financesettlement.domain.ReconciliationEntry;
 import com.trainticket.financesettlement.domain.SupplierSettlement;
@@ -97,6 +99,16 @@ public class FinanceSettlementController {
     ) {
         Page<BenefitCostEntry> page = service.listBenefitCosts(accountId, limit, offset);
         return new PagedResponse<>(page.items().stream().map(BenefitCostResponse::from).toList(), page.total(), page.limit(), page.offset());
+    }
+
+    @GetMapping("/api/v1/ancillary-financial-facts")
+    public PagedResponse<AncillaryFinancialFactResponse> listAncillaryFinancialFacts(
+        @RequestParam(required = false) String journeyOrderId,
+        @RequestParam(defaultValue = "20") int limit,
+        @RequestParam(defaultValue = "0") int offset
+    ) {
+        Page<AncillaryFinancialFact> page = service.listAncillaryFinancialFacts(journeyOrderId, limit, offset);
+        return new PagedResponse<>(page.items().stream().map(AncillaryFinancialFactResponse::from).toList(), page.total(), page.limit(), page.offset());
     }
 
     @GetMapping("/api/v1/reconciliation-cases")
@@ -311,6 +323,38 @@ public class FinanceSettlementController {
         }
     }
 
+    public record AncillaryFinancialFactResponse(
+        String eventId,
+        String eventType,
+        String factKind,
+        String ancillaryOrderItemId,
+        String journeyOrderId,
+        String serviceType,
+        String supplierRef,
+        Map<String, Object> payableAmount,
+        Map<String, Object> refundableAmount,
+        Map<String, Object> refundedAmount,
+        Map<String, Object> retainedAmount,
+        Instant occurredAt
+    ) {
+        static AncillaryFinancialFactResponse from(AncillaryFinancialFact fact) {
+            return new AncillaryFinancialFactResponse(
+                fact.eventId(),
+                fact.eventType(),
+                fact.factKind(),
+                fact.ancillaryOrderItemId(),
+                fact.journeyOrderId(),
+                fact.serviceType(),
+                fact.supplierRef(),
+                moneyPayloadOrNull(fact.payableAmount()),
+                moneyPayloadOrNull(fact.refundableAmount()),
+                moneyPayloadOrNull(fact.refundedAmount()),
+                moneyPayloadOrNull(fact.retainedAmount()),
+                fact.occurredAt()
+            );
+        }
+    }
+
     public record GenerateInvoiceRequest(String orderId) {}
 
     public record InvoiceResponse(
@@ -331,6 +375,10 @@ public class FinanceSettlementController {
                 invoice.generatedAt()
             );
         }
+    }
+
+    private static Map<String, Object> moneyPayloadOrNull(Money money) {
+        return money == null ? null : DomainEventEnvelopeMapper.moneyPayload(money);
     }
 
     public record PagedResponse<T>(List<T> items, long total, int limit, int offset) {}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/adapters/messaging/RedisMessagingProperties.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/adapters/messaging/RedisMessagingProperties.java
@@ -13,7 +13,8 @@ public class RedisMessagingProperties {
         "events:booking-orchestration",
         "events:post-sales",
         "events:wallet-promotion",
-        "events:payment-channel"
+        "events:payment-channel",
+        "events:ancillary-service"
     );
 
     private final String url;

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/AncillaryFinancialFact.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/AncillaryFinancialFact.java
@@ -1,0 +1,38 @@
+package com.trainticket.financesettlement.application;
+
+import com.trainticket.financesettlement.domain.Money;
+import java.time.Instant;
+import java.util.Objects;
+
+public record AncillaryFinancialFact(
+    String eventId,
+    String eventType,
+    String factKind,
+    String ancillaryOrderItemId,
+    String journeyOrderId,
+    String serviceType,
+    String supplierRef,
+    Money payableAmount,
+    Money refundableAmount,
+    Money refundedAmount,
+    Money retainedAmount,
+    Instant occurredAt
+) {
+    public AncillaryFinancialFact {
+        eventId = requireText(eventId, "eventId");
+        eventType = requireText(eventType, "eventType");
+        factKind = requireText(factKind, "factKind");
+        ancillaryOrderItemId = requireText(ancillaryOrderItemId, "ancillaryOrderItemId");
+        journeyOrderId = requireText(journeyOrderId, "journeyOrderId");
+        serviceType = requireText(serviceType, "serviceType");
+        supplierRef = supplierRef == null || supplierRef.isBlank() ? null : supplierRef;
+        occurredAt = Objects.requireNonNull(occurredAt, "occurredAt is required");
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " is required");
+        }
+        return value;
+    }
+}

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementApplicationService.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementApplicationService.java
@@ -196,6 +196,17 @@ public class FinanceSettlementApplicationService {
         return new Page<>(items, projections.countBenefitCostEntries(accountId), limit, offset);
     }
 
+    public Page<AncillaryFinancialFact> listAncillaryFinancialFacts(String journeyOrderId, int limit, int offset) {
+        if (limit < 1 || limit > 100) {
+            throw new ValidationException("limit must be between 1 and 100");
+        }
+        if (offset < 0) {
+            throw new ValidationException("offset must not be negative");
+        }
+        List<AncillaryFinancialFact> items = projections.findAncillaryFinancialFacts(journeyOrderId, limit, offset);
+        return new Page<>(items, projections.countAncillaryFinancialFacts(journeyOrderId), limit, offset);
+    }
+
     public Invoice generateInvoice(String orderId, String correlationId) {
         requireText(orderId, "orderId");
         return invoices.findByOrderId(orderId).orElseGet(() -> {

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementEventHandler.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementEventHandler.java
@@ -159,6 +159,7 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
                 if (service != null) applyPostSales(envelope, payload);
             }
             case "BenefitIssued", "BenefitRedeemed", "BenefitRedemptionReversed", "BenefitRevoked", "BenefitExpired" -> recordBenefitCostEntry(envelope, payload);
+            case "AncillaryOrderItemFulfilled", "AncillaryOrderItemCancelled", "AncillaryOrderItemRefundPending", "AncillaryOrderItemRefunded", "AncillaryFulfillmentFactRecorded" -> handleAncillaryFinancialEvent(envelope, payload);
             case "ChannelStatementGenerated", "ChannelStatementFrozen" -> recordChannelStatement(envelope, payload);
             case "ChannelStatementLineMatched" -> recordChannelStatementLine(envelope, payload);
             case "ReconciliationDiscrepancyOpened" -> openChannelDiscrepancy(envelope, payload);
@@ -279,6 +280,248 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
             normalizedBenefitCostEventType(envelope.eventType()),
             benefitOccurredAt(envelope, payload)
         ));
+    }
+
+    private void handleAncillaryFinancialEvent(EventEnvelope envelope, Map<String, Object> payload) {
+        AncillaryFinancialFact fact = ancillaryFinancialFact(envelope, payload);
+        projections.saveAncillaryFinancialFact(fact);
+        if (service == null) {
+            return;
+        }
+        switch (envelope.eventType()) {
+            case "AncillaryOrderItemFulfilled" -> recognizeAncillaryRevenue(envelope, fact);
+            case "AncillaryOrderItemCancelled" -> accrueAncillaryRetention(envelope, fact);
+            case "AncillaryOrderItemRefundPending" -> recordAncillaryRefundPending(envelope, fact, payload);
+            case "AncillaryOrderItemRefunded" -> applyAncillaryRefund(envelope, fact);
+            case "AncillaryFulfillmentFactRecorded" -> reconcileAncillaryFulfillmentFact(envelope, fact, payload);
+            default -> { }
+        }
+    }
+
+    private AncillaryFinancialFact ancillaryFinancialFact(EventEnvelope envelope, Map<String, Object> payload) {
+        Money payableAmount = optionalMoney(payload, "payableAmount").orElse(null);
+        Money refundableAmount = optionalMoney(payload, "refundableAmount").orElse(null);
+        Money refundedAmount = optionalMoney(payload, "refundedAmount").orElse(null);
+        Money retainedAmount = retainedAncillaryAmount(envelope.eventType(), payableAmount, refundableAmount, refundedAmount);
+        return new AncillaryFinancialFact(
+            envelope.eventId(),
+            envelope.eventType(),
+            ancillaryFactKind(envelope.eventType()),
+            text(payload, "ancillaryOrderItemId"),
+            text(payload, "journeyOrderId"),
+            ancillaryServiceType(payload),
+            supplierReferenceForAncillary(payload),
+            payableAmount,
+            refundableAmount,
+            refundedAmount,
+            retainedAmount,
+            ancillaryOccurredAt(envelope, payload)
+        );
+    }
+
+    private void recognizeAncillaryRevenue(EventEnvelope envelope, AncillaryFinancialFact fact) {
+        Money payableAmount = fact.payableAmount();
+        if (payableAmount == null || payableAmount.isZero()) {
+            return;
+        }
+        if (hasRevenueRecognitionForSourceEvent(fact.eventId())) {
+            return;
+        }
+        RevenueRecognition recognition = RevenueRecognition.recognize(
+            fact.journeyOrderId(),
+            fact.ancillaryOrderItemId(),
+            "ancillary",
+            payableAmount,
+            "ancillary-fulfillment-v1",
+            fact.eventId(),
+            fact.occurredAt(),
+            clock.instant(),
+            causationIdOrEventId(envelope),
+            envelope.correlationId()
+        );
+        service.saveAndPublish(recognition);
+        service.accrueFeesForPaymentCapture(fact.journeyOrderId(), payableAmount, Money.zero(payableAmount.currency()), fact.eventId(), clock.instant(), causationIdOrEventId(envelope), envelope.correlationId());
+    }
+
+    private void accrueAncillaryRetention(EventEnvelope envelope, AncillaryFinancialFact fact) {
+        Money retainedAmount = fact.retainedAmount();
+        if (retainedAmount == null || retainedAmount.isZero()) {
+            return;
+        }
+        service.accrueFeesForRefund(fact.journeyOrderId(), retainedAmount, retainedAmount.currency(), fact.eventId(), clock.instant(), causationIdOrEventId(envelope), envelope.correlationId());
+    }
+
+    private void recordAncillaryRefundPending(EventEnvelope envelope, AncillaryFinancialFact fact, Map<String, Object> payload) {
+        Money refundableAmount = fact.refundableAmount();
+        if (refundableAmount == null || refundableAmount.isZero()) {
+            return;
+        }
+        optionalText(payload, "postSalesCaseId").ifPresent(caseId -> projections.saveApprovedRefund(caseId, refundableAmount));
+        projections.saveApprovedRefund(fact.ancillaryOrderItemId(), refundableAmount);
+        projections.saveApprovedRefund(fact.journeyOrderId() + ":" + fact.ancillaryOrderItemId(), refundableAmount);
+        if ("MANUAL_REVIEW".equals(optionalText(payload, "recommendation").orElse(""))) {
+            ReconciliationCase open = ReconciliationCase.open(
+                fact.journeyOrderId(),
+                "",
+                "refund-lag",
+                refundableAmount.negate(),
+                Money.zero(refundableAmount.currency()),
+                "Ancillary refund pending requires manual finance review for item " + fact.ancillaryOrderItemId(),
+                clock.instant(),
+                causationIdOrEventId(envelope),
+                envelope.correlationId()
+            );
+            service.saveAndPublish(open);
+        }
+    }
+
+    private void applyAncillaryRefund(EventEnvelope envelope, AncillaryFinancialFact fact) {
+        Money refundedAmount = fact.refundedAmount();
+        if (refundedAmount == null || refundedAmount.isZero()) {
+            return;
+        }
+        Optional<RevenueRecognition> matchingRecognition = serviceRevenue(fact.journeyOrderId()).stream()
+            .filter(recognition -> fact.ancillaryOrderItemId().equals(recognition.orderItemId()))
+            .filter(recognition -> "ancillary".equals(recognition.componentCode()))
+            .filter(recognition -> !recognition.reversed())
+            .filter(recognition -> sameCurrency(recognition.amount(), refundedAmount))
+            .filter(recognition -> recognition.amount().compareTo(refundedAmount) >= 0)
+            .findFirst();
+        if (matchingRecognition.isEmpty()) {
+            ReconciliationCase open = ReconciliationCase.open(
+                fact.journeyOrderId(),
+                "",
+                "refund-lag",
+                refundedAmount.negate(),
+                Money.zero(refundedAmount.currency()),
+                "Ancillary refund could not be matched to recognized revenue for item " + fact.ancillaryOrderItemId(),
+                clock.instant(),
+                causationIdOrEventId(envelope),
+                envelope.correlationId()
+            );
+            service.saveAndPublish(open);
+            return;
+        }
+        RevenueRecognition originalRecognition = matchingRecognition.get();
+        int firstUnpublishedEventIndex = originalRecognition.domainEvents().size();
+        originalRecognition.reverse(
+            "ancillary refund recorded",
+            fact.eventId(),
+            refundedAmount,
+            clock.instant(),
+            causationIdOrEventId(envelope),
+            causationIdOrEventId(envelope),
+            envelope.correlationId()
+        );
+        service.saveAndPublish(originalRecognition, firstUnpublishedEventIndex);
+        service.accrueFeesForRefund(fact.journeyOrderId(), refundedAmount, refundedAmount.currency(), fact.eventId(), clock.instant(), causationIdOrEventId(envelope), envelope.correlationId());
+    }
+
+    private void reconcileAncillaryFulfillmentFact(EventEnvelope envelope, AncillaryFinancialFact fact, Map<String, Object> payload) {
+        if (!"FULFILLED".equals(optionalText(payload, "status").orElse(""))) {
+            return;
+        }
+        List<RevenueRecognition> recognitions = serviceRevenue(fact.journeyOrderId()).stream()
+            .filter(recognition -> fact.ancillaryOrderItemId().equals(recognition.orderItemId()))
+            .filter(recognition -> "ancillary".equals(recognition.componentCode()))
+            .toList();
+        Money actual = recognitions.stream()
+            .map(RevenueRecognition::netAmount)
+            .filter(amount -> fact.payableAmount() == null || sameCurrency(amount, fact.payableAmount()))
+            .reduce(fact.payableAmount() == null ? Money.zero(Currency.getInstance("CNY")) : Money.zero(fact.payableAmount().currency()), Money::plus);
+        Money expected = fact.payableAmount() == null ? actual : fact.payableAmount();
+        if (!recognitions.isEmpty() && sameMoney(expected, actual)) {
+            service.publishReconciliationCompleted(
+                fact.journeyOrderId(),
+                "",
+                expected,
+                actual,
+                recognitions.stream().map(RevenueRecognition::revenueRecognitionId).toList(),
+                List.of(fact.eventId()),
+                "MATCHED",
+                clock.instant(),
+                causationIdOrEventId(envelope),
+                envelope.correlationId()
+            );
+        }
+    }
+
+    private boolean hasRevenueRecognitionForSourceEvent(String sourceEventId) {
+        return serviceRevenueBySourceEvent(sourceEventId).isPresent();
+    }
+
+    private Optional<RevenueRecognition> serviceRevenueBySourceEvent(String sourceEventId) {
+        return projections.findAncillaryFinancialFact(sourceEventId)
+            .stream()
+            .flatMap(fact -> serviceRevenue(fact.journeyOrderId()).stream())
+            .filter(recognition -> sourceEventId.equals(recognition.sourceEventId()))
+            .findFirst();
+    }
+
+    private static String ancillaryFactKind(String eventType) {
+        return switch (eventType) {
+            case "AncillaryOrderItemFulfilled" -> "REVENUE_RECOGNITION";
+            case "AncillaryOrderItemCancelled" -> "RETENTION_FACT";
+            case "AncillaryOrderItemRefundPending" -> "REFUND_PENDING";
+            case "AncillaryOrderItemRefunded" -> "REFUND_RECORDED";
+            case "AncillaryFulfillmentFactRecorded" -> "SUPPLIER_COST_FACT";
+            default -> "UNKNOWN";
+        };
+    }
+
+    private static Money retainedAncillaryAmount(String eventType, Money payableAmount, Money refundableAmount, Money refundedAmount) {
+        if ("AncillaryOrderItemCancelled".equals(eventType) && payableAmount != null && refundableAmount != null && sameCurrency(payableAmount, refundableAmount)) {
+            Money retainedAmount = payableAmount.minus(refundableAmount);
+            return retainedAmount.isNegative() ? Money.zero(payableAmount.currency()) : retainedAmount;
+        }
+        if ("AncillaryOrderItemRefunded".equals(eventType) && payableAmount != null && refundedAmount != null && sameCurrency(payableAmount, refundedAmount)) {
+            Money retainedAmount = payableAmount.minus(refundedAmount);
+            return retainedAmount.isNegative() ? Money.zero(payableAmount.currency()) : retainedAmount;
+        }
+        return null;
+    }
+
+    private static String ancillaryServiceType(Map<String, Object> payload) {
+        return optionalText(payload, "serviceType")
+            .or(() -> catalogSnapshot(payload).flatMap(snapshot -> optionalText(snapshot, "serviceType")))
+            .orElseThrow(() -> new IllegalArgumentException("serviceType is required"));
+    }
+
+    private static String supplierReferenceForAncillary(Map<String, Object> payload) {
+        return optionalText(payload, "providerRef")
+            .or(() -> optionalText(payload, "entitlementRef"))
+            .or(() -> fulfillmentFact(payload).flatMap(fact -> optionalText(fact, "providerRef")))
+            .orElse(null);
+    }
+
+    private static Instant ancillaryOccurredAt(EventEnvelope envelope, Map<String, Object> payload) {
+        String timestampField = switch (envelope.eventType()) {
+            case "AncillaryOrderItemFulfilled" -> "fulfilledAt";
+            case "AncillaryOrderItemCancelled" -> "cancelledAt";
+            case "AncillaryOrderItemRefundPending" -> "requestedAt";
+            case "AncillaryOrderItemRefunded" -> "refundedAt";
+            case "AncillaryFulfillmentFactRecorded" -> null;
+            default -> null;
+        };
+        if (timestampField != null) {
+            return optionalText(payload, timestampField).map(Instant::parse).orElse(envelope.occurredAt());
+        }
+        return fulfillmentFact(payload)
+            .flatMap(fact -> optionalText(fact, "occurredAt"))
+            .map(Instant::parse)
+            .orElse(envelope.occurredAt());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Optional<Map<String, Object>> catalogSnapshot(Map<String, Object> payload) {
+        Object value = payload.get("catalogSnapshot");
+        return value instanceof Map<?, ?> raw ? Optional.of((Map<String, Object>) raw) : Optional.empty();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Optional<Map<String, Object>> fulfillmentFact(Map<String, Object> payload) {
+        Object value = payload.get("fulfillmentFact");
+        return value instanceof Map<?, ?> raw ? Optional.of((Map<String, Object>) raw) : Optional.empty();
     }
 
     private static Money benefitCostAmount(String eventType, Map<String, Object> payload) {
@@ -540,6 +783,11 @@ public class FinanceSettlementEventHandler implements EventSubscriber.EventHandl
     private static Optional<String> optionalText(Map<String, Object> payload, String name) {
         Object value = payload.get(name);
         return value instanceof String text && !text.isBlank() ? Optional.of(text) : Optional.empty();
+    }
+
+    private static Optional<Money> optionalMoney(Map<String, Object> payload, String name) {
+        Object value = payload.get(name);
+        return value == null ? Optional.empty() : Optional.of(money(value, name));
     }
 
     @SuppressWarnings("unchecked")

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementProjectionRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/FinanceSettlementProjectionRepository.java
@@ -30,6 +30,14 @@ public interface FinanceSettlementProjectionRepository {
 
     long countBenefitCostEntries(String accountId);
 
+    default void saveAncillaryFinancialFact(AncillaryFinancialFact fact) {}
+
+    default Optional<AncillaryFinancialFact> findAncillaryFinancialFact(String eventId) { return Optional.empty(); }
+
+    default List<AncillaryFinancialFact> findAncillaryFinancialFacts(String journeyOrderId, int limit, int offset) { return List.of(); }
+
+    default long countAncillaryFinancialFacts(String journeyOrderId) { return 0; }
+
     default void saveChannelStatement(ChannelStatementProjection statement) {}
 
     default Optional<ChannelStatementProjection> findChannelStatement(String channelStatementId) { return Optional.empty(); }

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemoryFinanceSettlementProjectionRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/application/InMemoryFinanceSettlementProjectionRepository.java
@@ -14,6 +14,7 @@ public class InMemoryFinanceSettlementProjectionRepository implements FinanceSet
     private final ConcurrentMap<String, FinanceSettlementEventHandler.PaymentCaptureFact> capturesByOrderId = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, Money> approvedRefundsByCaseId = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, BenefitCostEntry> benefitCostEntriesByEventId = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, AncillaryFinancialFact> ancillaryFinancialFactsByEventId = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, ChannelStatementProjection> channelStatementsById = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, ChannelStatementLineProjection> channelStatementLinesById = new ConcurrentHashMap<>();
 
@@ -90,6 +91,33 @@ public class InMemoryFinanceSettlementProjectionRepository implements FinanceSet
     public long countBenefitCostEntries(String accountId) {
         return benefitCostEntriesByEventId.values().stream()
             .filter(entry -> accountId == null || accountId.isBlank() || accountId.equals(entry.accountId()))
+            .count();
+    }
+
+    @Override
+    public void saveAncillaryFinancialFact(AncillaryFinancialFact fact) {
+        ancillaryFinancialFactsByEventId.put(fact.eventId(), fact);
+    }
+
+    @Override
+    public Optional<AncillaryFinancialFact> findAncillaryFinancialFact(String eventId) {
+        return Optional.ofNullable(ancillaryFinancialFactsByEventId.get(eventId));
+    }
+
+    @Override
+    public List<AncillaryFinancialFact> findAncillaryFinancialFacts(String journeyOrderId, int limit, int offset) {
+        return ancillaryFinancialFactsByEventId.values().stream()
+            .filter(fact -> journeyOrderId == null || journeyOrderId.isBlank() || journeyOrderId.equals(fact.journeyOrderId()))
+            .sorted(Comparator.comparing(AncillaryFinancialFact::occurredAt).reversed().thenComparing(AncillaryFinancialFact::eventId))
+            .skip(offset)
+            .limit(limit)
+            .toList();
+    }
+
+    @Override
+    public long countAncillaryFinancialFacts(String journeyOrderId) {
+        return ancillaryFinancialFactsByEventId.values().stream()
+            .filter(fact -> journeyOrderId == null || journeyOrderId.isBlank() || journeyOrderId.equals(fact.journeyOrderId()))
             .count();
     }
 

--- a/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/PostgresFinanceSettlementProjectionRepository.java
+++ b/services/finance-settlement/src/main/java/com/trainticket/financesettlement/infrastructure/persistence/PostgresFinanceSettlementProjectionRepository.java
@@ -1,6 +1,7 @@
 package com.trainticket.financesettlement.infrastructure.persistence;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import com.trainticket.financesettlement.application.AncillaryFinancialFact;
 import com.trainticket.financesettlement.application.BenefitCostEntry;
 import com.trainticket.financesettlement.application.ChannelStatementLineProjection;
 import com.trainticket.financesettlement.application.ChannelStatementProjection;
@@ -291,6 +292,87 @@ public class PostgresFinanceSettlementProjectionRepository implements FinanceSet
     }
 
     @Override
+    public void saveAncillaryFinancialFact(AncillaryFinancialFact fact) {
+        jdbc.update(
+            """
+                INSERT INTO ancillary_financial_facts(event_id, event_type, fact_kind, ancillary_order_item_id, journey_order_id,
+                  service_type, supplier_ref, payable_currency, payable_amount, refundable_currency, refundable_amount,
+                  refunded_currency, refunded_amount, retained_currency, retained_amount, occurred_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (event_id) DO UPDATE SET
+                  event_type = EXCLUDED.event_type,
+                  fact_kind = EXCLUDED.fact_kind,
+                  ancillary_order_item_id = EXCLUDED.ancillary_order_item_id,
+                  journey_order_id = EXCLUDED.journey_order_id,
+                  service_type = EXCLUDED.service_type,
+                  supplier_ref = EXCLUDED.supplier_ref,
+                  payable_currency = EXCLUDED.payable_currency,
+                  payable_amount = EXCLUDED.payable_amount,
+                  refundable_currency = EXCLUDED.refundable_currency,
+                  refundable_amount = EXCLUDED.refundable_amount,
+                  refunded_currency = EXCLUDED.refunded_currency,
+                  refunded_amount = EXCLUDED.refunded_amount,
+                  retained_currency = EXCLUDED.retained_currency,
+                  retained_amount = EXCLUDED.retained_amount,
+                  occurred_at = EXCLUDED.occurred_at,
+                  updated_at = now()
+                """,
+            fact.eventId(),
+            fact.eventType(),
+            fact.factKind(),
+            fact.ancillaryOrderItemId(),
+            fact.journeyOrderId(),
+            fact.serviceType(),
+            fact.supplierRef(),
+            currencyCode(fact.payableAmount()),
+            amountValue(fact.payableAmount()),
+            currencyCode(fact.refundableAmount()),
+            amountValue(fact.refundableAmount()),
+            currencyCode(fact.refundedAmount()),
+            amountValue(fact.refundedAmount()),
+            currencyCode(fact.retainedAmount()),
+            amountValue(fact.retainedAmount()),
+            Timestamp.from(fact.occurredAt())
+        );
+    }
+
+    @Override
+    public Optional<AncillaryFinancialFact> findAncillaryFinancialFact(String eventId) {
+        return jdbc.query(
+            "SELECT * FROM ancillary_financial_facts WHERE event_id = ?",
+            rs -> rs.next() ? Optional.of(mapAncillaryFinancialFact(rs)) : Optional.empty(),
+            eventId
+        );
+    }
+
+    @Override
+    public List<AncillaryFinancialFact> findAncillaryFinancialFacts(String journeyOrderId, int limit, int offset) {
+        if (journeyOrderId == null || journeyOrderId.isBlank()) {
+            return jdbc.query(
+                "SELECT * FROM ancillary_financial_facts ORDER BY occurred_at DESC, event_id ASC LIMIT ? OFFSET ?",
+                (rs, rowNum) -> mapAncillaryFinancialFact(rs),
+                limit,
+                offset
+            );
+        }
+        return jdbc.query(
+            "SELECT * FROM ancillary_financial_facts WHERE journey_order_id = ? ORDER BY occurred_at DESC, event_id ASC LIMIT ? OFFSET ?",
+            (rs, rowNum) -> mapAncillaryFinancialFact(rs),
+            journeyOrderId,
+            limit,
+            offset
+        );
+    }
+
+    @Override
+    public long countAncillaryFinancialFacts(String journeyOrderId) {
+        Long count = journeyOrderId == null || journeyOrderId.isBlank()
+            ? jdbc.queryForObject("SELECT count(*) FROM ancillary_financial_facts", Long.class)
+            : jdbc.queryForObject("SELECT count(*) FROM ancillary_financial_facts WHERE journey_order_id = ?", Long.class, journeyOrderId);
+        return count == null ? 0L : count;
+    }
+
+    @Override
     public void saveChannelStatement(ChannelStatementProjection s) {
         jdbc.update(
             """
@@ -345,6 +427,23 @@ public class PostgresFinanceSettlementProjectionRepository implements FinanceSet
         return count == null ? 0L : count;
     }
 
+    private AncillaryFinancialFact mapAncillaryFinancialFact(java.sql.ResultSet rs) throws java.sql.SQLException {
+        return new AncillaryFinancialFact(
+            rs.getString("event_id"),
+            rs.getString("event_type"),
+            rs.getString("fact_kind"),
+            rs.getString("ancillary_order_item_id"),
+            rs.getString("journey_order_id"),
+            rs.getString("service_type"),
+            rs.getString("supplier_ref"),
+            nullableMoney(rs.getString("payable_currency"), rs.getString("payable_amount")),
+            nullableMoney(rs.getString("refundable_currency"), rs.getString("refundable_amount")),
+            nullableMoney(rs.getString("refunded_currency"), rs.getString("refunded_amount")),
+            nullableMoney(rs.getString("retained_currency"), rs.getString("retained_amount")),
+            rs.getTimestamp("occurred_at").toInstant()
+        );
+    }
+
     private ChannelStatementProjection mapStatement(java.sql.ResultSet rs) throws java.sql.SQLException {
         return new ChannelStatementProjection(
             rs.getString("channel_statement_id"),
@@ -362,6 +461,18 @@ public class PostgresFinanceSettlementProjectionRepository implements FinanceSet
             rs.getTimestamp("frozen_at") == null ? null : rs.getTimestamp("frozen_at").toInstant(),
             rs.getString("source_event_id")
         );
+    }
+
+    private static String currencyCode(Money money) {
+        return money == null ? null : money.currency().getCurrencyCode();
+    }
+
+    private static BigDecimal amountValue(Money money) {
+        return money == null ? null : money.amount();
+    }
+
+    private static Money nullableMoney(String currency, String amount) {
+        return currency == null || amount == null ? null : money(currency, amount);
     }
 
     private static Money money(String currency, String amount) {

--- a/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/MessagingTest.java
+++ b/services/finance-settlement/src/test/java/com/trainticket/financesettlement/application/MessagingTest.java
@@ -467,6 +467,119 @@ class MessagingTest {
     }
 
     @Test
+    void ancillaryFulfilledRecognizesRevenueRecordsFactAndDeduplicatesReplay() {
+        InMemoryConsumedEventLogRepository consumedEvents = new InMemoryConsumedEventLogRepository();
+        InMemoryFinanceSettlementProjectionRepository projections = new InMemoryFinanceSettlementProjectionRepository();
+        RecordingPublisher publisher = new RecordingPublisher();
+        FinanceSettlementApplicationService service = new FinanceSettlementApplicationService(
+            new InMemoryRevenueRepository(), new InMemoryReconciliationRepository(), new InMemoryInvoiceRepository(), projections,
+            publisher, new DomainEventEnvelopeMapper(), Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC));
+        FinanceSettlementEventHandler handler = new FinanceSettlementEventHandler(
+            consumedEvents,
+            new InMemoryPaymentIntentOrderReferenceRepository(),
+            new InMemorySegmentBookingOrderReferenceRepository(),
+            projections,
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC),
+            service
+        );
+        EventEnvelope fulfilled = new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e401", "AncillaryOrderItemFulfilled", Instant.parse("2026-07-05T09:59:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e401", "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0e401", "ancillary-service", 1, Map.ofEntries(
+                Map.entry("ancillaryOrderItemId", "aoi-0194f2e0-7b3e-7610-8284-5c26e8b0e401"),
+                Map.entry("journeyOrderId", "ord-ancillary-1"),
+                Map.entry("travelerRef", "trav-1"),
+                Map.entry("segmentRef", "seg-1"),
+                Map.entry("catalogSnapshot", Map.of(
+                    "catalogItemId", "aci-meal-1",
+                    "catalogItemVersion", 3,
+                    "serviceType", "MEAL",
+                    "attachmentScope", "SEGMENT",
+                    "displayName", "Dinner meal",
+                    "unitPrice", Map.of("currency", "CNY", "minorUnits", 3500),
+                    "purchaseCutoffHoursBeforeDeparture", 2,
+                    "eligibilityRuleVersion", "ancillary-eligibility-v1",
+                    "fulfillmentMethod", "PROVIDER_CONFIRMATION"
+                )),
+                Map.entry("payableAmount", Map.of("currency", "CNY", "minorUnits", 3500)),
+                Map.entry("refundableAmount", Map.of("currency", "CNY", "minorUnits", 0)),
+                Map.entry("fulfillmentFact", Map.of(
+                    "fulfillmentFactId", "aff-1",
+                    "factType", "MEAL_ISSUED",
+                    "providerRef", "meal-provider-1",
+                    "occurredAt", "2026-07-05T09:58:30Z",
+                    "recordedAt", "2026-07-05T09:59:00Z",
+                    "performedBy", "PROVIDER",
+                    "idempotencyRef", "provider-meal-1",
+                    "compensable", false
+                )),
+                Map.entry("previousStatus", "FULFILLMENT_READY"),
+                Map.entry("status", "FULFILLED"),
+                Map.entry("fulfilledAt", "2026-07-05T09:59:00Z"),
+                Map.entry("aggregateVersion", 5)
+            ));
+
+        assertEquals(HandlerResult.SUCCESS, handler.handle(fulfilled));
+        assertEquals(HandlerResult.SUCCESS, handler.handle(fulfilled));
+
+        assertEquals(1, consumedEvents.saveCount);
+        AncillaryFinancialFact fact = projections.findAncillaryFinancialFact(fulfilled.eventId()).orElseThrow();
+        assertEquals("REVENUE_RECOGNITION", fact.factKind());
+        assertEquals("ord-ancillary-1", fact.journeyOrderId());
+        assertEquals("MEAL", fact.serviceType());
+        assertEquals("meal-provider-1", fact.supplierRef());
+        assertEquals(Money.of("CNY", "35.00"), fact.payableAmount());
+        EventEnvelope recognized = publisher.published.stream().filter(e -> "RevenueRecognized".equals(e.eventType())).findFirst().orElseThrow();
+        assertEquals("ancillary", ((Map<?, ?>) recognized.payload()).get("componentCode"));
+        assertEquals("aoi-0194f2e0-7b3e-7610-8284-5c26e8b0e401", ((Map<?, ?>) recognized.payload()).get("orderItemId"));
+        assertEquals(3500L, ((Map<?, ?>) ((Map<?, ?>) recognized.payload()).get("amount")).get("minorUnits"));
+        assertEquals(1, publisher.published.stream().filter(e -> "RevenueRecognized".equals(e.eventType())).count());
+    }
+
+    @Test
+    void ancillaryRefundPendingStoresRefundReadModelWithoutPublishingForAutomaticReview() {
+        InMemoryConsumedEventLogRepository consumedEvents = new InMemoryConsumedEventLogRepository();
+        InMemoryFinanceSettlementProjectionRepository projections = new InMemoryFinanceSettlementProjectionRepository();
+        RecordingPublisher publisher = new RecordingPublisher();
+        FinanceSettlementApplicationService service = new FinanceSettlementApplicationService(
+            new InMemoryRevenueRepository(), new InMemoryReconciliationRepository(), new InMemoryInvoiceRepository(), projections,
+            publisher, new DomainEventEnvelopeMapper(), Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC));
+        FinanceSettlementEventHandler handler = new FinanceSettlementEventHandler(
+            consumedEvents,
+            new InMemoryPaymentIntentOrderReferenceRepository(),
+            new InMemorySegmentBookingOrderReferenceRepository(),
+            projections,
+            Clock.fixed(Instant.parse("2026-07-05T10:00:00Z"), ZoneOffset.UTC),
+            service
+        );
+
+        HandlerResult result = handler.handle(new EventEnvelope(
+            "evt-0194f2e0-7b3e-7610-8284-5c26e8b0e402", "AncillaryOrderItemRefundPending", Instant.parse("2026-07-05T10:01:00Z"),
+            "corr-0194f2e0-7b3e-7610-8284-5c26e8b0e402", null, "ancillary-service", 1, Map.ofEntries(
+                Map.entry("ancillaryOrderItemId", "aoi-refund-1"),
+                Map.entry("journeyOrderId", "ord-ancillary-refund"),
+                Map.entry("travelerRef", "trav-1"),
+                Map.entry("catalogItemId", "aci-meal-1"),
+                Map.entry("serviceType", "MEAL"),
+                Map.entry("payableAmount", Map.of("currency", "CNY", "minorUnits", 3500)),
+                Map.entry("refundableAmount", Map.of("currency", "CNY", "minorUnits", 3000)),
+                Map.entry("recommendation", "PARTIAL_REFUND"),
+                Map.entry("reasonCode", "USER_CANCELLED"),
+                Map.entry("postSalesCaseId", "psc-ancillary-1"),
+                Map.entry("previousStatus", "CANCELLED"),
+                Map.entry("status", "REFUND_PENDING"),
+                Map.entry("requestedAt", "2026-07-05T10:00:30Z"),
+                Map.entry("aggregateVersion", 6)
+            )));
+
+        assertEquals(HandlerResult.SUCCESS, result);
+        assertEquals(Money.of("CNY", "30.00"), projections.findApprovedRefund("psc-ancillary-1").orElseThrow());
+        AncillaryFinancialFact fact = projections.findAncillaryFinancialFact("evt-0194f2e0-7b3e-7610-8284-5c26e8b0e402").orElseThrow();
+        assertEquals("REFUND_PENDING", fact.factKind());
+        assertEquals(Money.of("CNY", "30.00"), fact.refundableAmount());
+        assertTrue(publisher.published.isEmpty());
+    }
+
+    @Test
     void unknownWalletEventTypeAckSkipsWithoutCostEntry() {
         InMemoryConsumedEventLogRepository consumedEvents = new InMemoryConsumedEventLogRepository();
         InMemoryFinanceSettlementProjectionRepository projections = new InMemoryFinanceSettlementProjectionRepository();


### PR DESCRIPTION
## Summary
- Subscribe finance-settlement to events:ancillary-service
- Consume ancillary fulfilled/cancelled/refund/fulfillment-fact events with eventId dedup through the existing handler
- Persist ancillary financial facts and expose a read model endpoint

## Validation
- cd platform/java-kit && mvn -q install -DskipTests
- cd services/finance-settlement && mvn -q -Dtest=MessagingTest test
- cd services/finance-settlement && mvn -q test