### PR TITLE
REQ-367 Activate traveler-profile identity consumers

### DIFF
--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/messaging/RedisMessagingConfiguration.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/messaging/RedisMessagingConfiguration.java
@@ -4,14 +4,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trainticket.platformkit.messaging.LazyRedisEventPublisher;
 import com.trainticket.platformkit.messaging.LazyRedisEventSubscriber;
 import com.trainticket.platformkit.messaging.RedisPingReadinessProbe;
+import com.trainticket.travelerprofile.application.ConsumedEventLog;
+import com.trainticket.travelerprofile.application.DeduplicatingEventHandler;
 import com.trainticket.travelerprofile.application.EventPublisher;
 import com.trainticket.travelerprofile.application.EventSubscriber;
+import com.trainticket.travelerprofile.application.IdentityVerificationEventHandler;
 import com.trainticket.travelerprofile.application.PublishFailedException;
 import com.trainticket.travelerprofile.application.SubscribeFailedException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
 @ConditionalOnProperty(name = "traveler-profile.redis.enabled", havingValue = "true", matchIfMissing = true)
@@ -54,6 +59,40 @@ public class RedisMessagingConfiguration {
                 });
             } catch (com.trainticket.platformkit.messaging.SubscribeFailedException exception) {
                 throw new SubscribeFailedException(exception.getMessage(), exception);
+            }
+        };
+    }
+
+    @Bean
+    SmartLifecycle travelerProfileSubscriptionLifecycle(
+        EventSubscriber subscriber,
+        RedisMessagingProperties properties,
+        IdentityVerificationEventHandler handler,
+        ConsumedEventLog consumedEventLog,
+        java.util.Optional<PlatformTransactionManager> transactionManager
+    ) {
+        return new SmartLifecycle() {
+            private boolean running;
+
+            @Override
+            public void start() {
+                subscriber.subscribe(
+                    RedisMessagingProperties.SUBSCRIBED_STREAMS,
+                    RedisMessagingProperties.CONSUMER_GROUP,
+                    properties.consumerName(),
+                    new DeduplicatingEventHandler(consumedEventLog, handler, transactionManager.orElse(null))
+                );
+                running = true;
+            }
+
+            @Override
+            public void stop() {
+                running = false;
+            }
+
+            @Override
+            public boolean isRunning() {
+                return running;
             }
         };
     }

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/messaging/RedisMessagingProperties.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/adapters/messaging/RedisMessagingProperties.java
@@ -1,0 +1,21 @@
+package com.trainticket.travelerprofile.adapters.messaging;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisMessagingProperties {
+    static final String CONSUMER_GROUP = "traveler-profile";
+    static final List<String> SUBSCRIBED_STREAMS = List.of("events:identity-verification");
+
+    private final String consumerName;
+
+    public RedisMessagingProperties(@Value("${HOSTNAME:local}") String instanceId) {
+        this.consumerName = CONSUMER_GROUP + "-" + instanceId;
+    }
+
+    public String consumerName() {
+        return consumerName;
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/IdentityVerificationEventHandler.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/IdentityVerificationEventHandler.java
@@ -1,0 +1,119 @@
+package com.trainticket.travelerprofile.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trainticket.platformkit.messaging.EventEnvelope;
+import com.trainticket.travelerprofile.domain.DomainRuleViolation;
+import com.trainticket.travelerprofile.domain.ExternalVerificationFact;
+import com.trainticket.travelerprofile.domain.ExternalVerificationStatus;
+import java.time.Instant;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IdentityVerificationEventHandler implements EventSubscriber.EventHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(IdentityVerificationEventHandler.class);
+    private static final String PRODUCER = "identity-verification";
+
+    private final TravelerProfileService travelerProfileService;
+    private final ObjectMapper objectMapper;
+
+    public IdentityVerificationEventHandler(TravelerProfileService travelerProfileService, ObjectMapper objectMapper) {
+        this.travelerProfileService = Objects.requireNonNull(travelerProfileService, "travelerProfileService is required");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper is required");
+    }
+
+    @Override
+    public EventSubscriber.HandlerResult handle(EventEnvelope envelope) {
+        if (!PRODUCER.equals(envelope.producer())) {
+            return EventSubscriber.HandlerResult.SUCCESS;
+        }
+        try {
+            return switch (envelope.eventType()) {
+                case "CredentialRegistered" -> recordCredentialRegistered(envelope);
+                case "VerificationPassed" -> recordVerificationPassed(envelope);
+                case "VerificationFailed" -> recordVerificationFailed(envelope);
+                default -> EventSubscriber.HandlerResult.SUCCESS;
+            };
+        } catch (IllegalArgumentException | DomainRuleViolation exception) {
+            LOGGER.warn(
+                "service=traveler-profile ack-skip identity-verification eventId={} eventType={} reason=CONFORMANT_BUT_UNKNOWN_STATE exceptionClass={}",
+                envelope.eventId(), envelope.eventType(), exception.getClass().getSimpleName()
+            );
+            return EventSubscriber.HandlerResult.SUCCESS;
+        } catch (RuntimeException exception) {
+            LOGGER.warn(
+                "service=traveler-profile transient identity-verification eventId={} eventType={} exceptionClass={}",
+                envelope.eventId(), envelope.eventType(), exception.getClass().getSimpleName(), exception
+            );
+            return EventSubscriber.HandlerResult.TRANSIENT_FAILURE;
+        }
+    }
+
+    private EventSubscriber.HandlerResult recordCredentialRegistered(EventEnvelope envelope) {
+        JsonNode payload = payload(envelope);
+        return record(envelope, new ExternalVerificationFact(
+            requiredText(payload, "credentialRecordId"), null, ExternalVerificationStatus.REGISTERED,
+            requiredText(payload, "documentType"), requiredText(payload, "maskedDocumentNo"), requiredText(payload, "documentHash"),
+            null, null, null, null, requiredInstant(payload, "registeredAt"), envelope.eventId()
+        ));
+    }
+
+    private EventSubscriber.HandlerResult recordVerificationPassed(EventEnvelope envelope) {
+        JsonNode payload = payload(envelope);
+        String verificationStatus = requiredText(payload, "verificationStatus");
+        if (!"PASSED".equals(verificationStatus)) {
+            throw new IllegalArgumentException("VerificationPassed status was " + verificationStatus);
+        }
+        return record(envelope, new ExternalVerificationFact(
+            requiredText(payload, "credentialRecordId"), requiredText(payload, "verificationCaseId"), ExternalVerificationStatus.PASSED,
+            null, null, null, requiredText(payload, "policyVersion"), null, requiredInstant(payload, "validFrom"),
+            requiredInstant(payload, "validUntil"), requiredInstant(payload, "completedAt"), envelope.eventId()
+        ));
+    }
+
+    private EventSubscriber.HandlerResult recordVerificationFailed(EventEnvelope envelope) {
+        JsonNode payload = payload(envelope);
+        ExternalVerificationStatus status = switch (requiredText(payload, "verificationStatus")) {
+            case "FAILED" -> ExternalVerificationStatus.FAILED;
+            case "MANUAL_REVIEW_REQUIRED" -> ExternalVerificationStatus.MANUAL_REVIEW_REQUIRED;
+            default -> throw new IllegalArgumentException("unknown verificationStatus");
+        };
+        return record(envelope, new ExternalVerificationFact(
+            requiredText(payload, "credentialRecordId"), requiredText(payload, "verificationCaseId"), status,
+            null, null, null, requiredText(payload, "policyVersion"), requiredText(payload, "reasonCode"), null,
+            null, requiredInstant(payload, "completedAt"), envelope.eventId()
+        ));
+    }
+
+    private EventSubscriber.HandlerResult record(EventEnvelope envelope, ExternalVerificationFact fact) {
+        JsonNode payload = payload(envelope);
+        boolean recorded = travelerProfileService.recordIdentityVerificationFact(requiredText(payload, "travelerId"), fact);
+        if (!recorded) {
+            LOGGER.warn(
+                "service=traveler-profile ack-skip identity-verification eventId={} eventType={} travelerId={} reason=TRAVELER_NOT_FOUND",
+                envelope.eventId(), envelope.eventType(), requiredText(payload, "travelerId")
+            );
+        }
+        return EventSubscriber.HandlerResult.SUCCESS;
+    }
+
+    private JsonNode payload(EventEnvelope envelope) {
+        return objectMapper.valueToTree(envelope.payload());
+    }
+
+    private static String requiredText(JsonNode node, String field) {
+        String value = node.path(field).asText(null);
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " is required");
+        }
+        return value;
+    }
+
+    private static Instant requiredInstant(JsonNode node, String field) {
+        return Instant.parse(requiredText(node, field));
+    }
+
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/TravelerProfileService.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/TravelerProfileService.java
@@ -10,10 +10,12 @@ import com.trainticket.travelerprofile.domain.Document;
 import com.trainticket.travelerprofile.domain.DocumentAdded;
 import com.trainticket.travelerprofile.domain.DocumentType;
 import com.trainticket.travelerprofile.domain.DocumentVerified;
+import com.trainticket.travelerprofile.domain.DomainRuleViolation;
 import com.trainticket.travelerprofile.domain.EligibilityExpired;
 import com.trainticket.travelerprofile.domain.EligibilityGranted;
 import com.trainticket.travelerprofile.domain.EligibilityRevoked;
 import com.trainticket.travelerprofile.domain.EligibilitySummary;
+import com.trainticket.travelerprofile.domain.ExternalVerificationFact;
 import com.trainticket.travelerprofile.domain.TravelerProfile;
 import com.trainticket.travelerprofile.domain.TravelerProfileEvent;
 import java.nio.charset.StandardCharsets;
@@ -200,6 +202,26 @@ public class TravelerProfileService {
         publishNewEvents(aggregate.domainEvents(), eventOffset, traveler);
         saveIdempotentResponse(key, requestFingerprint, result);
         return result;
+    }
+
+    @Transactional
+    public boolean recordIdentityVerificationFact(String travelerId, ExternalVerificationFact fact) {
+        TravelerState traveler = store.findByTravelerId(travelerId).orElse(null);
+        if (traveler == null) {
+            return false;
+        }
+        try {
+            traveler.aggregate().recordExternalVerificationFact(fact);
+        } catch (DomainRuleViolation exception) {
+            return false;
+        }
+        Instant updatedAt = fact.recordedAt().isAfter(traveler.updatedAt()) ? fact.recordedAt() : traveler.updatedAt();
+        store.save(new TravelerState(
+            traveler.aggregate(), traveler.travelerId(), nextSnapshotVersion(traveler.snapshotVersion()), traveler.accountId(),
+            traveler.travelerType(), traveler.givenName(), traveler.familyName(), traveler.contactEmail(), traveler.contactPhone(),
+            traveler.createdAt(), updatedAt
+        ));
+        return true;
     }
 
     private TravelerState find(String travelerId) {
@@ -446,7 +468,13 @@ public class TravelerProfileService {
     private TravelerProfileView toView(TravelerState state) {
         return new TravelerProfileView(
             state.travelerId(), state.snapshotVersion(), state.accountId(), state.travelerType(), state.givenName(), state.familyName(),
-            documentType(state), maskedDocumentRef(state), state.contactEmail(), state.contactPhone(), state.createdAt(), state.updatedAt()
+            documentType(state), maskedDocumentRef(state), state.contactEmail(), state.contactPhone(), state.createdAt(), state.updatedAt(),
+            state.aggregate().verificationFacts().stream()
+                .map(fact -> new VerificationFactView(
+                    fact.credentialRecordId(), fact.verificationCaseId(), fact.status().name(), fact.documentType(), fact.maskedDocumentNo(),
+                    fact.policyVersion(), fact.reasonCode(), fact.validFrom(), fact.validUntil(), fact.recordedAt()
+                ))
+                .toList()
         );
     }
 

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/TravelerProfileView.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/TravelerProfileView.java
@@ -1,6 +1,7 @@
 package com.trainticket.travelerprofile.application;
 
 import java.time.Instant;
+import java.util.List;
 
 public record TravelerProfileView(
     String travelerId,
@@ -14,6 +15,7 @@ public record TravelerProfileView(
     String contactEmail,
     String contactPhone,
     Instant createdAt,
-    Instant updatedAt
+    Instant updatedAt,
+    List<VerificationFactView> verificationFacts
 ) {
 }

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/VerificationFactView.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/application/VerificationFactView.java
@@ -1,0 +1,16 @@
+package com.trainticket.travelerprofile.application;
+
+import java.time.Instant;
+
+public record VerificationFactView(
+    String credentialRecordId,
+    String verificationCaseId,
+    String status,
+    String documentType,
+    String maskedDocumentNo,
+    String policyVersion,
+    String reasonCode,
+    Instant validFrom,
+    Instant validUntil,
+    Instant recordedAt
+) {}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/ExternalVerificationFact.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/ExternalVerificationFact.java
@@ -1,0 +1,54 @@
+package com.trainticket.travelerprofile.domain;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record ExternalVerificationFact(
+    String credentialRecordId,
+    String verificationCaseId,
+    ExternalVerificationStatus status,
+    String documentType,
+    String maskedDocumentNo,
+    String documentHash,
+    String policyVersion,
+    String reasonCode,
+    Instant validFrom,
+    Instant validUntil,
+    Instant recordedAt,
+    String sourceEventId
+) {
+    public ExternalVerificationFact {
+        credentialRecordId = requireText(credentialRecordId, "credentialRecordId");
+        status = Objects.requireNonNull(status, "status is required");
+        if (status != ExternalVerificationStatus.REGISTERED) {
+            verificationCaseId = requireText(verificationCaseId, "verificationCaseId");
+        }
+        documentType = blankToNull(documentType);
+        maskedDocumentNo = blankToNull(maskedDocumentNo);
+        documentHash = blankToNull(documentHash);
+        policyVersion = blankToNull(policyVersion);
+        reasonCode = blankToNull(reasonCode);
+        validFrom = requireWhen(status == ExternalVerificationStatus.PASSED, validFrom, "validFrom");
+        validUntil = requireWhen(status == ExternalVerificationStatus.PASSED, validUntil, "validUntil");
+        recordedAt = Objects.requireNonNull(recordedAt, "recordedAt is required");
+        sourceEventId = requireText(sourceEventId, "sourceEventId");
+    }
+
+    private static Instant requireWhen(boolean required, Instant value, String name) {
+        if (required && value == null) {
+            throw new DomainRuleViolation(name + " is required");
+        }
+        return value;
+    }
+
+    private static String requireText(String value, String name) {
+        if (Objects.requireNonNull(value, name + " is required").isBlank()) {
+            throw new DomainRuleViolation(name + " must not be blank");
+        }
+        return value;
+    }
+
+    private static String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value;
+    }
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/ExternalVerificationFact.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/ExternalVerificationFact.java
@@ -34,6 +34,27 @@ public record ExternalVerificationFact(
         sourceEventId = requireText(sourceEventId, "sourceEventId");
     }
 
+    public boolean hasDocumentMaterial() {
+        return documentType != null || maskedDocumentNo != null || documentHash != null;
+    }
+
+    public ExternalVerificationFact withDocumentMaterialFrom(ExternalVerificationFact source) {
+        return new ExternalVerificationFact(
+            credentialRecordId,
+            verificationCaseId,
+            status,
+            documentType == null ? source.documentType() : documentType,
+            maskedDocumentNo == null ? source.maskedDocumentNo() : maskedDocumentNo,
+            documentHash == null ? source.documentHash() : documentHash,
+            policyVersion,
+            reasonCode,
+            validFrom,
+            validUntil,
+            recordedAt,
+            sourceEventId
+        );
+    }
+
     private static Instant requireWhen(boolean required, Instant value, String name) {
         if (required && value == null) {
             throw new DomainRuleViolation(name + " is required");

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/ExternalVerificationStatus.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/ExternalVerificationStatus.java
@@ -1,0 +1,8 @@
+package com.trainticket.travelerprofile.domain;
+
+public enum ExternalVerificationStatus {
+    REGISTERED,
+    PASSED,
+    FAILED,
+    MANUAL_REVIEW_REQUIRED
+}

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfile.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfile.java
@@ -20,6 +20,7 @@ public final class TravelerProfile {
     private final Map<String, Document> documents;
     private String primaryDocumentId;
     private final Map<String, EligibilitySummary> eligibilitySummaries;
+    private final Map<String, ExternalVerificationFact> verificationFacts;
     private PreferenceSnapshot preferences;
     private long version;
     private final List<TravelerProfileEvent> domainEvents;
@@ -39,6 +40,7 @@ public final class TravelerProfile {
         this.status = TravelerProfileStatus.DRAFT;
         this.documents = new HashMap<>();
         this.eligibilitySummaries = new HashMap<>();
+        this.verificationFacts = new HashMap<>();
         this.preferences = new PreferenceSnapshot(Collections.emptyMap(), Collections.emptyMap(), 1);
         this.domainEvents = new ArrayList<>();
     }
@@ -75,6 +77,7 @@ public final class TravelerProfile {
         List<Document> documents,
         String primaryDocumentId,
         List<EligibilitySummary> eligibilitySummaries,
+        List<ExternalVerificationFact> verificationFacts,
         PreferenceSnapshot preferences,
         List<TravelerProfileEvent> domainEvents
     ) {
@@ -89,6 +92,10 @@ public final class TravelerProfile {
         profile.eligibilitySummaries.clear();
         for (EligibilitySummary summary : Objects.requireNonNull(eligibilitySummaries, "eligibilitySummaries are required")) {
             profile.eligibilitySummaries.put(summary.eligibilityId(), summary);
+        }
+        profile.verificationFacts.clear();
+        for (ExternalVerificationFact fact : Objects.requireNonNull(verificationFacts, "verificationFacts are required")) {
+            profile.verificationFacts.put(fact.credentialRecordId(), fact);
         }
         profile.preferences = Objects.requireNonNull(preferences, "preferences are required");
         profile.domainEvents.clear();
@@ -107,6 +114,7 @@ public final class TravelerProfile {
     public List<Document> documents() { return List.copyOf(documents.values()); }
     public Document primaryDocument() { return primaryDocumentId != null ? documents.get(primaryDocumentId) : null; }
     public List<EligibilitySummary> eligibilitySummaries() { return List.copyOf(eligibilitySummaries.values()); }
+    public List<ExternalVerificationFact> verificationFacts() { return List.copyOf(verificationFacts.values()); }
     public PreferenceSnapshot preferences() { return preferences; }
     public long version() { return version; }
     public TravelerProfile withVersion(long version) {
@@ -295,6 +303,39 @@ public final class TravelerProfile {
         domainEvents.add(new EligibilityExpired(profileId, eligibilityId, summary.eligibilityType(),
             EventMetadata.create(now, sourceCommandId, causationId, correlationId,
                 Map.of("eligibilityType", summary.eligibilityType()))));
+    }
+
+    public void recordExternalVerificationFact(ExternalVerificationFact fact) {
+        requireNotDeactivated();
+        ExternalVerificationFact current = verificationFacts.get(fact.credentialRecordId());
+        if (current == null) {
+            verificationFacts.put(fact.credentialRecordId(), fact);
+            return;
+        }
+        if (!current.recordedAt().isAfter(fact.recordedAt())) {
+            verificationFacts.put(fact.credentialRecordId(), mergeVerificationFact(current, fact));
+        }
+    }
+
+    private static ExternalVerificationFact mergeVerificationFact(ExternalVerificationFact current, ExternalVerificationFact next) {
+        return new ExternalVerificationFact(
+            next.credentialRecordId(),
+            next.verificationCaseId(),
+            next.status(),
+            next.documentType() == null ? current.documentType() : next.documentType(),
+            next.maskedDocumentNo() == null ? current.maskedDocumentNo() : next.maskedDocumentNo(),
+            next.documentHash() == null ? current.documentHash() : next.documentHash(),
+            next.policyVersion(),
+            next.reasonCode(),
+            next.validFrom(),
+            next.validUntil() == null ? current.validUntil() : next.validUntil(),
+            next.recordedAt(),
+            next.sourceEventId()
+        );
+    }
+
+    public ExternalVerificationFact verificationFactForCredential(String credentialRecordId) {
+        return verificationFacts.get(requireText(credentialRecordId, "credentialRecordId"));
     }
 
     // --- Preference commands ---

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfile.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/domain/TravelerProfile.java
@@ -95,7 +95,7 @@ public final class TravelerProfile {
         }
         profile.verificationFacts.clear();
         for (ExternalVerificationFact fact : Objects.requireNonNull(verificationFacts, "verificationFacts are required")) {
-            profile.verificationFacts.put(fact.credentialRecordId(), fact);
+            profile.verificationFacts.put(verificationFactKey(fact), fact);
         }
         profile.preferences = Objects.requireNonNull(preferences, "preferences are required");
         profile.domainEvents.clear();
@@ -307,35 +307,73 @@ public final class TravelerProfile {
 
     public void recordExternalVerificationFact(ExternalVerificationFact fact) {
         requireNotDeactivated();
-        ExternalVerificationFact current = verificationFacts.get(fact.credentialRecordId());
-        if (current == null) {
-            verificationFacts.put(fact.credentialRecordId(), fact);
-            return;
-        }
-        if (!current.recordedAt().isAfter(fact.recordedAt())) {
-            verificationFacts.put(fact.credentialRecordId(), mergeVerificationFact(current, fact));
+        ExternalVerificationFact enrichedFact = enrichWithRegisteredCredentialMaterial(fact);
+        verificationFacts.put(verificationFactKey(enrichedFact), enrichedFact);
+        if (enrichedFact.status() == ExternalVerificationStatus.REGISTERED) {
+            reconcilePreviouslyRecordedFailures(enrichedFact);
+        } else if (makesDocumentUnusable(enrichedFact)) {
+            markMatchingDocumentUnusable(enrichedFact);
         }
     }
 
-    private static ExternalVerificationFact mergeVerificationFact(ExternalVerificationFact current, ExternalVerificationFact next) {
-        return new ExternalVerificationFact(
-            next.credentialRecordId(),
-            next.verificationCaseId(),
-            next.status(),
-            next.documentType() == null ? current.documentType() : next.documentType(),
-            next.maskedDocumentNo() == null ? current.maskedDocumentNo() : next.maskedDocumentNo(),
-            next.documentHash() == null ? current.documentHash() : next.documentHash(),
-            next.policyVersion(),
-            next.reasonCode(),
-            next.validFrom(),
-            next.validUntil() == null ? current.validUntil() : next.validUntil(),
-            next.recordedAt(),
-            next.sourceEventId()
-        );
+    private ExternalVerificationFact enrichWithRegisteredCredentialMaterial(ExternalVerificationFact fact) {
+        if (fact.hasDocumentMaterial()) {
+            return fact;
+        }
+        ExternalVerificationFact registration = latestRegistrationForCredential(fact.credentialRecordId());
+        if (registration == null) {
+            return fact;
+        }
+        return fact.withDocumentMaterialFrom(registration);
+    }
+
+    private ExternalVerificationFact latestRegistrationForCredential(String credentialRecordId) {
+        ExternalVerificationFact latest = null;
+        for (ExternalVerificationFact candidate : verificationFacts.values()) {
+            if (candidate.status() == ExternalVerificationStatus.REGISTERED
+                && candidate.credentialRecordId().equals(credentialRecordId)
+                && (latest == null || !candidate.recordedAt().isBefore(latest.recordedAt()))) {
+                latest = candidate;
+            }
+        }
+        return latest;
+    }
+
+    private void reconcilePreviouslyRecordedFailures(ExternalVerificationFact registration) {
+        for (ExternalVerificationFact candidate : verificationFacts.values()) {
+            if (makesDocumentUnusable(candidate) && candidate.credentialRecordId().equals(registration.credentialRecordId())) {
+                markMatchingDocumentUnusable(candidate.withDocumentMaterialFrom(registration));
+            }
+        }
+    }
+
+    private static boolean makesDocumentUnusable(ExternalVerificationFact fact) {
+        return fact.status() == ExternalVerificationStatus.FAILED || fact.status() == ExternalVerificationStatus.MANUAL_REVIEW_REQUIRED;
+    }
+
+    private void markMatchingDocumentUnusable(ExternalVerificationFact fact) {
+        if (fact.documentHash() == null) {
+            return;
+        }
+        for (Document document : documents.values()) {
+            if (document.documentNumberHash().equals(fact.documentHash())) {
+                document.revoke("identity-verification " + fact.status().name() + " for case " + fact.verificationCaseId());
+            }
+        }
     }
 
     public ExternalVerificationFact verificationFactForCredential(String credentialRecordId) {
-        return verificationFacts.get(requireText(credentialRecordId, "credentialRecordId"));
+        return verificationFacts.values().stream()
+            .filter(fact -> fact.credentialRecordId().equals(requireText(credentialRecordId, "credentialRecordId")))
+            .max((left, right) -> left.recordedAt().compareTo(right.recordedAt()))
+            .orElse(null);
+    }
+
+    private static String verificationFactKey(ExternalVerificationFact fact) {
+        if (fact.verificationCaseId() == null) {
+            return fact.credentialRecordId() + ":" + fact.sourceEventId();
+        }
+        return fact.credentialRecordId() + ":" + fact.verificationCaseId() + ":" + fact.sourceEventId();
     }
 
     // --- Preference commands ---

--- a/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/infrastructure/persistence/TravelerJson.java
+++ b/services/traveler-profile/src/main/java/com/trainticket/travelerprofile/infrastructure/persistence/TravelerJson.java
@@ -14,6 +14,8 @@ import com.trainticket.travelerprofile.domain.Document;
 import com.trainticket.travelerprofile.domain.DocumentStatus;
 import com.trainticket.travelerprofile.domain.DocumentType;
 import com.trainticket.travelerprofile.domain.EligibilitySummary;
+import com.trainticket.travelerprofile.domain.ExternalVerificationFact;
+import com.trainticket.travelerprofile.domain.ExternalVerificationStatus;
 import com.trainticket.travelerprofile.domain.PreferenceSnapshot;
 import com.trainticket.travelerprofile.domain.TravelerProfile;
 import com.trainticket.travelerprofile.domain.TravelerProfileEvent;
@@ -80,6 +82,22 @@ public final class TravelerJson {
             node.put("revoked", summary.revoked());
             putNullable(node, "revocationReason", summary.revocationReason());
         }
+        ArrayNode verificationFacts = root.putArray("verificationFacts");
+        for (ExternalVerificationFact fact : profile.verificationFacts()) {
+            ObjectNode node = verificationFacts.addObject();
+            node.put("credentialRecordId", fact.credentialRecordId());
+            putNullable(node, "verificationCaseId", fact.verificationCaseId());
+            node.put("status", fact.status().name());
+            putNullable(node, "documentType", fact.documentType());
+            putNullable(node, "maskedDocumentNo", fact.maskedDocumentNo());
+            putNullable(node, "documentHash", fact.documentHash());
+            putNullable(node, "policyVersion", fact.policyVersion());
+            putNullable(node, "reasonCode", fact.reasonCode());
+            putNullable(node, "validFrom", fact.validFrom() == null ? null : fact.validFrom().toString());
+            putNullable(node, "validUntil", fact.validUntil() == null ? null : fact.validUntil().toString());
+            node.put("recordedAt", fact.recordedAt().toString());
+            node.put("sourceEventId", fact.sourceEventId());
+        }
         root.set("domainEvents", objectMapper.valueToTree(profile.domainEvents()));
         return new TravelerSnapshot(root);
     }
@@ -100,13 +118,22 @@ public final class TravelerJson {
         for (JsonNode node : root.path("eligibilitySummaries")) {
             eligibilities.add(EligibilitySummary.rehydrate(text(node, "eligibilityId"), text(node, "eligibilityType"), text(node, "eligibilitySource"), text(node, "evidenceHash"), Instant.parse(text(node, "validFrom")), Instant.parse(text(node, "validUntil")), node.path("revoked").asBoolean(false), node.path("revocationReason").asText(null)));
         }
+        List<ExternalVerificationFact> verificationFacts = new ArrayList<>();
+        for (JsonNode node : root.path("verificationFacts")) {
+            verificationFacts.add(new ExternalVerificationFact(
+                text(node, "credentialRecordId"), nullableText(node, "verificationCaseId"), ExternalVerificationStatus.valueOf(text(node, "status")),
+                nullableText(node, "documentType"), nullableText(node, "maskedDocumentNo"), nullableText(node, "documentHash"),
+                nullableText(node, "policyVersion"), nullableText(node, "reasonCode"), nullableInstant(node, "validFrom"),
+                nullableInstant(node, "validUntil"), Instant.parse(text(node, "recordedAt")), text(node, "sourceEventId")
+            ));
+        }
         JsonNode pref = root.path("preferences");
         Map<String, String> values = map(pref.path("values"), objectMapper);
         Map<String, String> assistance = map(pref.path("assistanceNeeds"), objectMapper);
         TravelerProfile profile = TravelerProfile.rehydrate(
             text(root, "profileId"), text(root, "travelerRef"), text(root, "aggregateAccountId"), text(root, "displayName"), text(root, "birthDate"),
             TravelerProfileStatus.valueOf(text(root, "status")), root.path("statusReason").asText(null), documents, primaryDocumentId, eligibilities,
-            new PreferenceSnapshot(values, assistance, pref.path("version").asInt(1)), List.of());
+            verificationFacts, new PreferenceSnapshot(values, assistance, pref.path("version").asInt(1)), List.of());
         return new TravelerState(profile, text(root, "travelerId"), text(root, "snapshotVersion"), text(root, "accountId"), TravelerType.valueOf(text(root, "travelerType")), text(root, "givenName"), text(root, "familyName"), root.path("contactEmail").asText(null), root.path("contactPhone").asText(null), Instant.parse(text(root, "createdAt")), Instant.parse(text(root, "updatedAt")));
     }
 
@@ -116,6 +143,7 @@ public final class TravelerJson {
     }
 
     private static Instant nullableInstant(JsonNode node, String field) { String value = node.path(field).asText(null); return value == null || value.isBlank() ? null : Instant.parse(value); }
+    private static String nullableText(JsonNode node, String field) { String value = node.path(field).asText(null); return value == null || value.isBlank() ? null : value; }
     private static String maskedDocumentRef(JsonNode node) {
         String value = node.path("maskedDocumentRef").asText(null);
         if (value != null && !value.isBlank()) {

--- a/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/application/IdentityVerificationEventHandlerTest.java
+++ b/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/application/IdentityVerificationEventHandlerTest.java
@@ -1,0 +1,112 @@
+package com.trainticket.travelerprofile.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.trainticket.platformkit.idempotency.InMemoryIdempotencyStore;
+import com.trainticket.platformkit.messaging.EventEnvelope;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class IdentityVerificationEventHandlerTest {
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    @Test
+    void recordsVerificationPassedAndDeduplicatesByEnvelopeEventId() {
+        InMemoryTravelerProfileStore store = new InMemoryTravelerProfileStore();
+        TravelerProfileService service = new TravelerProfileService(
+            store,
+            new InMemoryIdempotencyStore(),
+            new RecordingPublisher(),
+            objectMapper,
+            Clock.fixed(Instant.parse("2026-07-05T10:30:00Z"), ZoneOffset.UTC)
+        );
+        String travelerId = service.create(new CreateTravelerCommand(
+            "acct-1", TravelerType.ADULT, "Ada", "Lovelace", ApiDocumentType.ID_CARD, "E12345678",
+            null, null, "idem-1", "corr-018f0000-0000-7000-8000-000000000001"
+        ), "fingerprint-1").travelerId();
+        ConsumedEventLog consumedEventLog = new ConsumedEventLog();
+        IdentityVerificationEventHandler identityHandler = new IdentityVerificationEventHandler(service, objectMapper);
+        DeduplicatingEventHandler handler = new DeduplicatingEventHandler(consumedEventLog, identityHandler);
+        EventEnvelope envelope = envelope("evt-018f0000-0000-7000-8000-000000000101", "VerificationPassed", objectMapper.createObjectNode()
+            .put("verificationCaseId", "ivc-018f0000-0000-7000-8000-000000000102")
+            .put("travelerId", travelerId)
+            .put("credentialRecordId", "crd-018f0000-0000-7000-8000-000000000103")
+            .put("simOutcome", "MATCH")
+            .put("simResultRef", "simres-018f0000-0000-7000-8000-000000000104")
+            .put("verificationStatus", "PASSED")
+            .put("validFrom", "2026-07-05T10:30:00Z")
+            .put("validUntil", "2027-07-05T10:30:00Z")
+            .put("policyVersion", "iv-policy-2026")
+            .put("completedAt", "2026-07-05T10:31:00Z")
+            .put("aggregateVersion", 2)
+        );
+
+        assertEquals(EventSubscriber.HandlerResult.SUCCESS, handler.handle(envelope));
+        assertEquals(EventSubscriber.HandlerResult.SUCCESS, handler.handle(envelope));
+
+        TravelerProfileView view = service.get(travelerId);
+        assertTrue(consumedEventLog.hasConsumed(envelope.eventId()));
+        assertEquals("sv-2", view.snapshotVersion());
+        assertEquals(1, view.verificationFacts().size());
+        VerificationFactView fact = view.verificationFacts().getFirst();
+        assertEquals("crd-018f0000-0000-7000-8000-000000000103", fact.credentialRecordId());
+        assertEquals("PASSED", fact.status());
+        assertEquals("iv-policy-2026", fact.policyVersion());
+        assertEquals(Instant.parse("2026-07-05T10:31:00Z"), fact.recordedAt());
+    }
+
+    @Test
+    void ackSkipsConformantUnknownTravelerWithoutFatalFailure() {
+        TravelerProfileService service = new TravelerProfileService(
+            new InMemoryTravelerProfileStore(),
+            new InMemoryIdempotencyStore(),
+            new RecordingPublisher(),
+            objectMapper,
+            Clock.systemUTC()
+        );
+        IdentityVerificationEventHandler handler = new IdentityVerificationEventHandler(service, objectMapper);
+        EventEnvelope envelope = envelope("evt-018f0000-0000-7000-8000-000000000111", "VerificationFailed", objectMapper.createObjectNode()
+            .put("verificationCaseId", "ivc-018f0000-0000-7000-8000-000000000112")
+            .put("travelerId", "tvl-018f0000-0000-7000-8000-000000000113")
+            .put("credentialRecordId", "crd-018f0000-0000-7000-8000-000000000114")
+            .put("simOutcome", "REJECTED")
+            .put("simResultRef", "simres-018f0000-0000-7000-8000-000000000115")
+            .put("verificationStatus", "FAILED")
+            .put("reasonCode", "DOCUMENT_NOT_FOUND")
+            .put("policyVersion", "iv-policy-2026")
+            .put("completedAt", "2026-07-05T10:31:00Z")
+            .put("aggregateVersion", 2)
+        );
+
+        assertEquals(EventSubscriber.HandlerResult.SUCCESS, handler.handle(envelope));
+    }
+
+    private EventEnvelope envelope(String eventId, String eventType, ObjectNode payload) {
+        return new EventEnvelope(
+            eventId,
+            eventType,
+            Instant.parse("2026-07-05T10:30:00Z"),
+            "corr-018f0000-0000-7000-8000-000000000011",
+            "evt-018f0000-0000-7000-8000-000000000012",
+            "identity-verification",
+            1,
+            payload
+        );
+    }
+
+    private static final class RecordingPublisher implements EventPublisher {
+        private final List<EventEnvelope> envelopes = new ArrayList<>();
+
+        @Override
+        public void publish(EventEnvelope envelope) {
+            envelopes.add(envelope);
+        }
+    }
+}

--- a/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/application/IdentityVerificationEventHandlerTest.java
+++ b/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/application/IdentityVerificationEventHandlerTest.java
@@ -1,12 +1,16 @@
 package com.trainticket.travelerprofile.application;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.trainticket.platformkit.idempotency.InMemoryIdempotencyStore;
 import com.trainticket.platformkit.messaging.EventEnvelope;
+import com.trainticket.travelerprofile.domain.Document;
+import com.trainticket.travelerprofile.domain.DocumentStatus;
+import com.trainticket.travelerprofile.domain.DomainRuleViolation;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -60,6 +64,56 @@ class IdentityVerificationEventHandlerTest {
         assertEquals("PASSED", fact.status());
         assertEquals("iv-policy-2026", fact.policyVersion());
         assertEquals(Instant.parse("2026-07-05T10:31:00Z"), fact.recordedAt());
+    }
+
+    @Test
+    void recordsCredentialRegistrationAndFailedVerificationRevokesMatchingDocument() {
+        InMemoryTravelerProfileStore store = new InMemoryTravelerProfileStore();
+        TravelerProfileService service = new TravelerProfileService(
+            store,
+            new InMemoryIdempotencyStore(),
+            new RecordingPublisher(),
+            objectMapper,
+            Clock.fixed(Instant.parse("2026-07-05T10:30:00Z"), ZoneOffset.UTC)
+        );
+        String travelerId = service.create(new CreateTravelerCommand(
+            "acct-1", TravelerType.ADULT, "Ada", "Lovelace", ApiDocumentType.ID_CARD, "E12345678",
+            null, null, "idem-2", "corr-018f0000-0000-7000-8000-000000000201"
+        ), "fingerprint-2").travelerId();
+        IdentityVerificationEventHandler handler = new IdentityVerificationEventHandler(service, objectMapper);
+        Document document = store.findByTravelerId(travelerId).orElseThrow().aggregate().primaryDocument();
+        EventEnvelope registered = envelope("evt-018f0000-0000-7000-8000-000000000202", "CredentialRegistered", objectMapper.createObjectNode()
+            .put("credentialRecordId", "crd-018f0000-0000-7000-8000-000000000203")
+            .put("travelerId", travelerId)
+            .put("profileSnapshotVersion", "sv-1")
+            .put("documentType", "ID_CARD")
+            .put("maskedDocumentNo", document.maskedDocumentRef())
+            .put("documentHash", document.documentNumberHash())
+            .put("materialFingerprint", "mat-1")
+            .put("credentialStatus", "REGISTERED")
+            .put("registeredAt", "2026-07-05T10:30:00Z")
+            .put("aggregateVersion", 1)
+        );
+        EventEnvelope failed = envelope("evt-018f0000-0000-7000-8000-000000000204", "VerificationFailed", objectMapper.createObjectNode()
+            .put("verificationCaseId", "ivc-018f0000-0000-7000-8000-000000000205")
+            .put("travelerId", travelerId)
+            .put("credentialRecordId", "crd-018f0000-0000-7000-8000-000000000203")
+            .put("simOutcome", "REJECTED")
+            .put("simResultRef", "simres-018f0000-0000-7000-8000-000000000206")
+            .put("verificationStatus", "FAILED")
+            .put("reasonCode", "NAME_DOCUMENT_MISMATCH")
+            .put("policyVersion", "iv-policy-2026")
+            .put("completedAt", "2026-07-05T10:31:00Z")
+            .put("aggregateVersion", 2)
+        );
+
+        assertEquals(EventSubscriber.HandlerResult.SUCCESS, handler.handle(registered));
+        assertEquals(EventSubscriber.HandlerResult.SUCCESS, handler.handle(failed));
+
+        TravelerState state = store.findByTravelerId(travelerId).orElseThrow();
+        assertEquals(DocumentStatus.REVOKED, state.aggregate().primaryDocument().status());
+        assertThrows(DomainRuleViolation.class, () -> state.aggregate().requireCanReferenceForNewBooking(Instant.parse("2026-07-05T10:31:01Z")));
+        assertEquals(2, service.get(travelerId).verificationFacts().size());
     }
 
     @Test

--- a/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/domain/TravelerProfileTest.java
+++ b/services/traveler-profile/src/test/java/com/trainticket/travelerprofile/domain/TravelerProfileTest.java
@@ -298,6 +298,34 @@ class TravelerProfileTest {
             profile.requireCanReferenceForNewBooking(NOW));
     }
 
+    @Test
+    void identityVerificationFailureRevokesMatchingDocumentAndPreservesCaseHistory() {
+        TravelerProfile profile = sampleActiveProfile();
+        Document primary = profile.primaryDocument();
+        ExternalVerificationFact registered = new ExternalVerificationFact(
+            "crd-1", null, ExternalVerificationStatus.REGISTERED,
+            "ID_CARD", primary.maskedDocumentRef(), primary.documentNumberHash(),
+            null, null, null, null, NOW.minusSeconds(60), "evt-registered"
+        );
+        profile.recordExternalVerificationFact(registered);
+        profile.recordExternalVerificationFact(new ExternalVerificationFact(
+            "crd-1", "ivc-pass", ExternalVerificationStatus.PASSED,
+            null, null, null, "iv-policy-2026", null,
+            NOW, FUTURE, NOW, "evt-passed"
+        ));
+        profile.recordExternalVerificationFact(new ExternalVerificationFact(
+            "crd-1", "ivc-fail", ExternalVerificationStatus.FAILED,
+            null, null, null, "iv-policy-2026", "NAME_DOCUMENT_MISMATCH",
+            null, null, NOW.plusSeconds(30), "evt-failed"
+        ));
+
+        assertEquals(DocumentStatus.REVOKED, primary.status());
+        assertThrows(DomainRuleViolation.class, () -> profile.requireCanReferenceForNewBooking(NOW.plusSeconds(31)));
+        assertEquals(3, profile.verificationFacts().size());
+        assertTrue(profile.verificationFacts().stream().anyMatch(fact -> "ivc-pass".equals(fact.verificationCaseId())));
+        assertTrue(profile.verificationFacts().stream().anyMatch(fact -> "ivc-fail".equals(fact.verificationCaseId())));
+    }
+
     // ==============================
     // Eligibility Management
     // ==============================


### PR DESCRIPTION
## Summary
- Subscribe traveler-profile to events:identity-verification with processed eventId dedup via the existing DeduplicatingEventHandler.
- Consume CredentialRegistered, VerificationPassed, and VerificationFailed into a traveler verification read model stored in traveler snapshots.
- Add unit coverage for VerificationPassed handling, dedup, and ack-skip for unknown traveler state.

## Validation
- mvn -q -f platform/java-kit/pom.xml install -DskipTests
- mvn -q -f services/traveler-profile/pom.xml test