### PR TITLE
REQ-392 Fix corporate travel migrations

### DIFF
--- a/services/corporate-travel/migrations/001_corporate_travel.sql
+++ b/services/corporate-travel/migrations/001_corporate_travel.sql
@@ -54,12 +54,6 @@ CREATE TABLE IF NOT EXISTS corporate_billing_periods (
     CONSTRAINT corporate_billing_unique_period UNIQUE (corporate_id, agreement_id, billing_period)
 );
 
-CREATE TABLE IF NOT EXISTS corporate_travel_inbox (
-    event_id TEXT PRIMARY KEY,
-    event_type TEXT NOT NULL,
-    processed_at TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-
 CREATE TABLE IF NOT EXISTS outbox_events (
     event_id TEXT PRIMARY KEY,
     producer TEXT NOT NULL,

--- a/services/corporate-travel/src/corporate_travel/api.py
+++ b/services/corporate-travel/src/corporate_travel/api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, Request
@@ -322,7 +323,7 @@ def create_app(service: CorporateTravelService | None = None) -> FastAPI:
     app_service = service or CorporateTravelService(publisher=InMemoryEventPublisher(), repository=InMemoryCorporateTravelRepository())
     if database_config is not None and service is None:
         pool = DatabasePool(database_config)
-        migrations_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "migrations")
+        migrations_dir = Path(os.environ.get("MIGRATIONS_DIR", Path(__file__).resolve().parents[2] / "migrations"))
         run_migrations(pool, migrations_dir)
         repository = PostgresCorporateTravelRepository(pool)
         app_service = CorporateTravelService(repository=repository, unit_of_work=repository.transaction)

--- a/services/corporate-travel/tests/test_api.py
+++ b/services/corporate-travel/tests/test_api.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from fastapi.testclient import TestClient
 
 from corporate_travel.api import create_app
+
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
 
 
 def create_payload() -> dict[str, object]:
@@ -16,6 +21,44 @@ def create_payload() -> dict[str, object]:
         "billingCalendar": {"billingPeriod": "2026-01", "cutoffAt": "2026-02-01T00:00:00Z", "dueAt": "2026-02-15T00:00:00Z"},
         "contact": {"displayName": "A*** Finance"},
     }
+
+
+def test_default_migrations_path_points_to_service_migrations(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+
+    class StubPool:
+        def __init__(self, config: object) -> None:
+            calls["config"] = config
+
+        def close(self) -> None:
+            calls["closed"] = True
+
+    class StubConfig:
+        @classmethod
+        def from_env(cls) -> object:
+            return object()
+
+    def fake_run_migrations(pool: object, migrations_dir: object) -> None:
+        calls["pool"] = pool
+        calls["migrations_dir"] = migrations_dir
+
+    monkeypatch.delenv("MIGRATIONS_DIR", raising=False)
+    monkeypatch.setattr("corporate_travel.api.DatabaseConfig", StubConfig)
+    monkeypatch.setattr("corporate_travel.api.DatabasePool", StubPool)
+    monkeypatch.setattr("corporate_travel.api.run_migrations", fake_run_migrations)
+
+    app = create_app()
+
+    assert app.state.corporate_travel_service is not None
+    assert calls["migrations_dir"] == SERVICE_ROOT / "migrations"
+
+
+def test_migration_creates_processed_events_table_not_legacy_inbox() -> None:
+    migration_sql = (SERVICE_ROOT / "migrations" / "001_corporate_travel.sql").read_text(encoding="utf-8")
+
+    assert "CREATE TABLE IF NOT EXISTS processed_events" in migration_sql
+    assert "event_id TEXT PRIMARY KEY" in migration_sql
+    assert "corporate_travel_inbox" not in migration_sql
 
 
 def test_health_and_agreement_endpoints() -> None:


### PR DESCRIPTION
## Summary
- Fix corporate-travel default migrations path so startup applies services/corporate-travel/migrations/001_corporate_travel.sql when MIGRATIONS_DIR is not set
- Remove stale corporate_travel_inbox table from migration 001; processed_events remains the durable dedup table with event_id primary key
- Add regression tests for migration path resolution and processed_events table naming

## Validation
- cd services/corporate-travel && uv run pytest tests/test_api.py
- cd services/corporate-travel && uv run pytest