### PR TITLE
REQ-390 Fix wallet promotion snapshot version binding

### DIFF
--- a/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/infrastructure/persistence/PostgresPromotionRepository.java
+++ b/services/wallet-promotion/src/main/java/com/trainticket/walletpromotion/infrastructure/persistence/PostgresPromotionRepository.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import javax.sql.DataSource;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementSetter;
 
 public class PostgresPromotionRepository implements PromotionRepository {
     private final JdbcOperations jdbc;
@@ -226,20 +227,39 @@ public class PostgresPromotionRepository implements PromotionRepository {
     private int insertSnapshot(String table, String id, long newVersion, Object data) {
         return jdbc.update(
             "INSERT INTO " + table + "(id, version, data) VALUES (?, ?, ?::jsonb) ON CONFLICT DO NOTHING",
-            id,
-            newVersion,
-            json(data)
+            snapshotInsertParameters(id, newVersion, data)
         );
+    }
+
+    private PreparedStatementSetter snapshotInsertParameters(String id, long newVersion, Object data) {
+        String snapshotJson = json(data);
+        return statement -> {
+            statement.setString(1, id);
+            statement.setLong(2, newVersion);
+            statement.setString(3, snapshotJson);
+        };
     }
 
     private int updateSnapshot(String table, String id, long expectedVersion, long newVersion, Object data) {
         return jdbc.update(
             "UPDATE " + table + " SET version = ?, data = ?::jsonb, updated_at = now() WHERE id = ? AND version = ?",
-            newVersion,
-            json(data),
-            id,
-            expectedVersion
+            snapshotUpdateParameters(id, expectedVersion, newVersion, data)
         );
+    }
+
+    private PreparedStatementSetter snapshotUpdateParameters(
+        String id,
+        long expectedVersion,
+        long newVersion,
+        Object data
+    ) {
+        String snapshotJson = json(data);
+        return statement -> {
+            statement.setLong(1, newVersion);
+            statement.setString(2, snapshotJson);
+            statement.setString(3, id);
+            statement.setLong(4, expectedVersion);
+        };
     }
 
     private EventEnvelope envelope(WalletPromotionEvent event, PromotionInstrument benefit) {

--- a/services/wallet-promotion/src/test/java/com/trainticket/walletpromotion/infrastructure/persistence/PostgresPromotionRepositoryOptimisticConcurrencyTest.java
+++ b/services/wallet-promotion/src/test/java/com/trainticket/walletpromotion/infrastructure/persistence/PostgresPromotionRepositoryOptimisticConcurrencyTest.java
@@ -2,7 +2,14 @@ package com.trainticket.walletpromotion.infrastructure.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trainticket.platformkit.persistence.OptimisticConcurrencyException;
 import com.trainticket.platformkit.persistence.OutboxAppender;
@@ -12,13 +19,17 @@ import com.trainticket.walletpromotion.domain.PromotionInstrument;
 import com.trainticket.walletpromotion.domain.ReasonType;
 import com.trainticket.walletpromotion.domain.WalletAccount;
 import com.trainticket.walletpromotion.domain.WalletPromotionEvent;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.jdbc.core.PreparedStatementSetter;
 
 class PostgresPromotionRepositoryOptimisticConcurrencyTest {
     private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
@@ -26,8 +37,7 @@ class PostgresPromotionRepositoryOptimisticConcurrencyTest {
     @Test
     void newSnapshotUsesInsertConflictGuard() {
         JdbcOperations jdbc = org.mockito.Mockito.mock(JdbcOperations.class);
-        org.mockito.Mockito.when(jdbc.update(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.any(Object[].class)))
-            .thenReturn(1);
+        when(jdbc.update(anyString(), any(PreparedStatementSetter.class))).thenReturn(1);
         CapturingRepository repository = new CapturingRepository(jdbc, objectMapper);
         PromotionInstrument benefit = baseBenefit();
 
@@ -40,9 +50,66 @@ class PostgresPromotionRepositoryOptimisticConcurrencyTest {
     }
 
     @Test
+    void insertSnapshotBindsIdVersionThenJsonSnapshot() throws Exception {
+        JdbcOperations jdbc = org.mockito.Mockito.mock(JdbcOperations.class);
+        when(jdbc.update(anyString(), any(PreparedStatementSetter.class))).thenReturn(1);
+        PostgresPromotionRepository repository = new PostgresPromotionRepository(
+            jdbc,
+            objectMapper,
+            new OutboxAppender(jdbc, objectMapper)
+        );
+        PromotionInstrument benefit = baseBenefit();
+        WalletAccount wallet = wallet(benefit);
+
+        repository.saveMutation(benefit, wallet, event(benefit), null, null);
+
+        ArgumentCaptor<PreparedStatementSetter> setters = ArgumentCaptor.forClass(PreparedStatementSetter.class);
+        verify(jdbc, atLeastOnce()).update(startsWith("INSERT INTO promotion_instrument_snapshots"), setters.capture());
+        BoundStatement statement = BoundStatement.capture(setters.getAllValues().getFirst());
+
+        assertThat(statement.values()).hasSize(3);
+        assertThat(statement.values()).containsExactly(benefit.benefitId(), benefit.version(), objectMapper.writeValueAsString(benefit));
+        assertThat(statement.boundTypes()).containsExactly(String.class, Long.class, String.class);
+        JsonNode roundTripped = objectMapper.readTree((String) statement.values().get(2));
+        assertThat(roundTripped.get("benefitId").asText()).isEqualTo(benefit.benefitId());
+        assertThat(roundTripped.get("version").asLong()).isEqualTo(benefit.version());
+    }
+
+    @Test
+    void updateSnapshotBindsNewVersionJsonIdThenExpectedVersion() throws Exception {
+        JdbcOperations jdbc = org.mockito.Mockito.mock(JdbcOperations.class);
+        when(jdbc.update(anyString(), any(PreparedStatementSetter.class))).thenReturn(1);
+        PostgresPromotionRepository repository = new PostgresPromotionRepository(
+            jdbc,
+            objectMapper,
+            new OutboxAppender(jdbc, objectMapper)
+        );
+        PromotionInstrument updated = baseBenefit().reserve(
+            new Money("USD", 10),
+            WalletPromotionServiceTest.reason(ReasonType.ORDER_PURCHASE, "RESERVE", "ORDER", "ord-1"),
+            Instant.parse("2026-02-01T00:00:00Z")
+        );
+        WalletAccount wallet = wallet(updated);
+
+        repository.saveMutation(updated, wallet, event(updated), null, null);
+
+        ArgumentCaptor<PreparedStatementSetter> setters = ArgumentCaptor.forClass(PreparedStatementSetter.class);
+        verify(jdbc, atLeastOnce()).update(startsWith("UPDATE promotion_instrument_snapshots"), setters.capture());
+        BoundStatement statement = BoundStatement.capture(setters.getAllValues().getFirst());
+
+        assertThat(statement.values()).hasSize(4);
+        assertThat(statement.values()).containsExactly(updated.version(), objectMapper.writeValueAsString(updated), updated.benefitId(), updated.version() - 1);
+        assertThat(statement.boundTypes()).containsExactly(Long.class, String.class, String.class, Long.class);
+        JsonNode roundTripped = objectMapper.readTree((String) statement.values().get(1));
+        assertThat(roundTripped.get("benefitId").asText()).isEqualTo(updated.benefitId());
+        assertThat(roundTripped.get("updatedAt")).isNotNull();
+        assertThat(roundTripped.get("version").asLong()).isEqualTo(updated.version());
+    }
+
+    @Test
     void staleSnapshotUpdateRaisesOptimisticConcurrencyException() {
         JdbcOperations jdbc = org.mockito.Mockito.mock(JdbcOperations.class);
-        org.mockito.Mockito.when(jdbc.update(org.mockito.ArgumentMatchers.startsWith("UPDATE promotion_instrument_snapshots"), org.mockito.ArgumentMatchers.any(Object[].class)))
+        when(jdbc.update(startsWith("UPDATE promotion_instrument_snapshots"), any(PreparedStatementSetter.class)))
             .thenReturn(0);
         CapturingRepository repository = new CapturingRepository(jdbc, objectMapper);
         PromotionInstrument stale = baseBenefit().reserve(
@@ -107,8 +174,32 @@ class PostgresPromotionRepositoryOptimisticConcurrencyTest {
 
         private List<String> updateSql() {
             ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-            org.mockito.Mockito.verify(jdbc, org.mockito.Mockito.atLeast(0)).update(captor.capture(), org.mockito.ArgumentMatchers.any(Object[].class));
+            org.mockito.Mockito.verify(jdbc, org.mockito.Mockito.atLeast(0)).update(captor.capture(), any(PreparedStatementSetter.class));
             return new ArrayList<>(captor.getAllValues());
+        }
+    }
+
+    private record BoundStatement(List<Object> values, List<Class<?>> boundTypes) {
+        private static BoundStatement capture(PreparedStatementSetter setter) throws SQLException {
+            PreparedStatement statement = org.mockito.Mockito.mock(PreparedStatement.class);
+            Map<Integer, Object> values = new TreeMap<>();
+            Map<Integer, Class<?>> types = new TreeMap<>();
+            org.mockito.Mockito.doAnswer(invocation -> {
+                int index = invocation.getArgument(0);
+                values.put(index, invocation.getArgument(1));
+                types.put(index, String.class);
+                return null;
+            }).when(statement).setString(org.mockito.Mockito.anyInt(), org.mockito.Mockito.anyString());
+            org.mockito.Mockito.doAnswer(invocation -> {
+                int index = invocation.getArgument(0);
+                values.put(index, invocation.getArgument(1));
+                types.put(index, Long.class);
+                return null;
+            }).when(statement).setLong(org.mockito.Mockito.anyInt(), org.mockito.Mockito.anyLong());
+
+            setter.setValues(statement);
+
+            return new BoundStatement(List.copyOf(values.values()), List.copyOf(types.values()));
         }
     }
 }


### PR DESCRIPTION
## Summary
- bind snapshot inserts/updates through explicit PreparedStatementSetter parameter positions
- ensure numeric version columns receive aggregate long versions and JSONB columns receive serialized snapshots
- add repository tests covering insert and update binding order/round-trip JSON

## Validation
- mvn -q -f services/wallet-promotion/pom.xml test

Task: REQ-390