### PR TITLE
Fix ticket issued email notification

### DIFF
--- a/services/notification/src/adapters/storage/runtime.ts
+++ b/services/notification/src/adapters/storage/runtime.ts
@@ -191,7 +191,7 @@ function templateCodeFor(envelope: EventEnvelope): string | undefined {
     case "RefundSettled":
       return "REFUND_COMPLETED";
     case "EntitlementIssued":
-      return "TICKET_ISSUED";
+      return "ticket_issued";
     case "WaitlistFulfilled":
       return "WAITLIST_PROMOTED";
     case "ServiceAlertPublished":

--- a/services/notification/src/application/notification-service.ts
+++ b/services/notification/src/application/notification-service.ts
@@ -159,14 +159,14 @@ export class NotificationApplicationService {
       : new ChannelFallbackChain(command.channel, availableChannels(await this.contacts.getContactProfile(command.recipientRef))).toArray();
 
     if (!command.transactionRequired && !await this.preferences.isEnabled(command.recipientRef, command.intent, channels[0])) {
-      return this.publishCancellation({ ...command, notificationTaskId: newNotificationTaskId(), channel: channels[0], templateCode: templateType ?? command.templateCode }, "SUPPRESSED_BY_PREFERENCES");
+      return this.publishCancellation({ ...command, notificationTaskId: newNotificationTaskId(), channel: channels[0], templateCode: command.templateCode }, "SUPPRESSED_BY_PREFERENCES");
     }
 
     const scheduledCommand: ScheduleNotification = {
       ...command,
       notificationTaskId: newNotificationTaskId(),
       channel: channels[0],
-      templateCode: templateType ?? command.templateCode,
+      templateCode: command.templateCode,
       variables: renderedVariables(command.variables, templateType, channels[0], this.renderer),
     };
     const { task, event: scheduled } = NotificationTaskAggregate.schedule(scheduledCommand);
@@ -247,6 +247,10 @@ function resolveTemplateType(mapping: TriggerMapping, payload: Record<string, un
   return typeof mapping.templateType === "function" ? mapping.templateType(payload) : mapping.templateType;
 }
 
+function resolveTemplateCode(mapping: TriggerMapping, templateType: NotificationTemplateType | undefined): string {
+  return mapping.templateCode === "ticket_issued" ? mapping.templateCode : templateType ?? mapping.templateCode;
+}
+
 function resolveIntent(mapping: TriggerMapping, payload: Record<string, unknown>): string {
   return typeof mapping.intent === "function" ? mapping.intent(payload) : mapping.intent;
 }
@@ -269,6 +273,7 @@ function scheduleCommandsFromEnvelope(envelope: EventEnvelope, aggregator?: Noti
   const businessRef = triggerBusinessRef(envelope);
   const aggregationRef = aggregationBusinessRef(envelope);
   const templateType = resolveTemplateType(mapping, payload);
+  const templateCode = resolveTemplateCode(mapping, templateType);
   const commands: ScheduleNotification[] = [];
   for (const recipientRef of recipientRefs) {
     if (aggregator && templateType && aggregationRef && aggregator.shouldSuppress({
@@ -287,7 +292,7 @@ function scheduleCommandsFromEnvelope(envelope: EventEnvelope, aggregator?: Noti
       correlationId: envelope.correlationId,
       causationId: envelope.eventId,
       recipientRef,
-      templateCode: templateType ?? mapping.templateCode,
+      templateCode,
       channel: mapping.channel,
       intent: resolveIntent(mapping, payload),
       transactionRequired: booleanValue(payload.transactionRequired) ?? true,
@@ -1041,13 +1046,13 @@ function refundMapping(): TriggerMapping {
 
 function ticketIssuedMapping(): TriggerMapping {
   return {
-    templateCode: "TICKET_ISSUED",
+    templateCode: "ticket_issued",
     templateType: "TICKET_ISSUED",
     intent: "TICKET_ISSUED",
-    channel: "PUSH",
-    recipient: (payload) => recipientFromDirectFields(payload) ?? stringValue(payload.travelerRef),
+    channel: "EMAIL",
+    recipient: (payload) => stringValue(payload.travelerRef) ?? recipientFromDirectFields(payload),
     variables: (payload) => ({
-      ...pickStringVariables(payload, ["entitlementId", "journeyOrderId", "orderId", "orderItemId", "segmentBookingId", "segmentRef", "credentialNo", "credentialType", "trainNumber", "seatInfo"]),
+      ...pickStringVariables(payload, ["entitlementId", "journeyOrderId", "orderId", "orderItemId", "segmentBookingId", "segmentRef", "issuePurpose", "credentialNo", "credentialType", "trainNumber", "seatInfo", "issuedAt"]),
       trainNumber: stringValue(payload.trainNumber) ?? stringValue(payload.segmentRef) ?? "--",
       seatInfo: stringValue(payload.seatInfo) ?? stringValue(payload.credentialType) ?? "--",
     }),

--- a/services/notification/src/messaging.test.ts
+++ b/services/notification/src/messaging.test.ts
@@ -6,6 +6,7 @@ import {
   InMemoryEventPublisher,
   NonConformantNotificationTrigger,
   NotificationApplicationService,
+  NOTIFICATION_SUBSCRIBED_STREAMS,
   NotificationTask,
   successfulHandling,
   toEventEnvelope,
@@ -372,6 +373,68 @@ describe("notification messaging integration surface", () => {
       },
     }), "delivered");
     assert.deepEqual(sentChannels, ["SMS"]);
+  });
+
+  it("subscribes to the entitlement-ticketing stream", () => {
+    assert.ok(NOTIFICATION_SUBSCRIBED_STREAMS.includes("events:entitlement-ticketing"));
+  });
+
+  it("maps EntitlementIssued to a ticket_issued EMAIL sent to the traveler", async () => {
+    const publisher = new InMemoryEventPublisher();
+    const sent: Array<{ channel: string; recipientRef: string; templateCode: string; subject?: string; body?: string }> = [];
+    const service = new NotificationApplicationService(
+      publisher,
+      undefined,
+      { send: (task) => {
+        sent.push({
+          channel: task.channel,
+          recipientRef: task.recipientRef,
+          templateCode: task.templateCode,
+          subject: task.variables.subject,
+          body: task.variables.body,
+        });
+        return { ok: true, providerMessageId: "smtp-ticket-issued" };
+      } },
+      undefined,
+      { getContactProfile: () => ({ emailAddress: "traveler@example.test" }) },
+    );
+
+    assert.equal(await service.handleExternalTrigger({
+      eventId: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c240",
+      eventType: "EntitlementIssued",
+      schemaVersion: 1,
+      producer: "entitlement-ticketing",
+      correlationId: "corr-0194f2e0-7b3e-7610-8284-5c26e8b0c240",
+      causationId: "cmd-0194f2e0-7b3e-7610-8284-5c26e8b0c240",
+      occurredAt: "2026-07-05T10:00:00.000Z",
+      payload: {
+        entitlementId: "ent-240",
+        segmentBookingId: "sb-240",
+        journeyOrderId: "ord-240",
+        travelerRef: "tvl-240",
+        segmentRef: "G240-2026-07-05",
+        issuePurpose: "INITIAL_PURCHASE",
+        credentialNo: "********1234",
+        credentialType: "ID_CARD",
+        trainNumber: "G240",
+        seatInfo: "05A",
+        issuedAt: "2026-07-05T10:00:00.000Z",
+      },
+    }), "delivered");
+
+    assert.deepEqual(sent, [{
+      channel: "EMAIL",
+      recipientRef: "tvl-240",
+      templateCode: "ticket_issued",
+      subject: "电子客票已出票",
+      body: "电子客票已出票：G240 05A，请凭身份证进站",
+    }]);
+    assert.deepEqual(
+      publisher.envelopes
+        .filter((envelope) => envelope.eventType === "NotificationScheduled")
+        .map((envelope) => [envelope.payload.templateCode, envelope.payload.templateType, envelope.payload.intent, envelope.payload.recipientRef, envelope.payload.channel]),
+      [["ticket_issued", undefined, "TICKET_ISSUED", "tvl-240", "EMAIL"]],
+    );
   });
 
   it("falls back from failed SMS to EMAIL", async () => {


### PR DESCRIPTION
## Summary
- map EntitlementIssued notifications to the ticket_issued EMAIL template code for traveler delivery
- keep the rendered TICKET_ISSUED domain template while preserving the lower-case provider/search template code
- add coverage for entitlement stream subscription and event-to-email send mapping

## Validation
- npm ci (services/notification)
- npm test (services/notification)