### PR TITLE
REQ-403: Fix waitlist capacity fulfillment convergence

### DIFF
--- a/services/waitlist/src/app.ts
+++ b/services/waitlist/src/app.ts
@@ -1,8 +1,8 @@
 import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from "fastify";
 import { InMemoryEventPublisher, InMemoryIdempotencyStore, errorMessage, handleIdempotency, headerValue, requestContext as kitRequestContext, requestFingerprint, sendError, type EventPublisher, type IdempotencyStore, type RequestContext } from "@trainticket/ts-kit";
 import { DomainError } from "./domain.js";
-import { InMemoryWaitlistRepository, WaitlistApplicationService, type JoinWaitlistRequest, type JourneyOrderClient } from "./application.js";
-import type { CapacityAvailabilityClient, FarePricingClient, OfferManagementClient, WaitlistRepository } from "./promotion.js";
+import { InMemoryWaitlistRepository, WaitlistApplicationService, type JoinWaitlistRequest } from "./application.js";
+import type { CapacityAvailabilityClient, FarePricingClient, JourneyOrderClient, OfferManagementClient, WaitlistRepository } from "./promotion.js";
 import { serviceProfile } from "./profile.js";
 
 type AppStorage = Readonly<{

--- a/services/waitlist/src/application.ts
+++ b/services/waitlist/src/application.ts
@@ -1,6 +1,6 @@
 import { type EventPublisher } from "@trainticket/ts-kit";
 import { DomainError, WaitlistEntry, WaitlistQueue, type CreateWaitlistEntry, type FareClass, type PriorityInput, type WaitlistEntrySnapshot } from "./domain.js";
-import { HttpCapacityAvailabilityClient, HttpFarePricingClient, HttpOfferManagementClient, PromotionOrchestrator, type CapacityAvailabilityClient, type FarePricingClient, type OfferManagementClient, type WaitlistCapacityFreed, type WaitlistRepository } from "./promotion.js";
+import { HttpCapacityAvailabilityClient, HttpFarePricingClient, HttpOfferManagementClient, PromotionOrchestrator, type CapacityAvailabilityClient, type FarePricingClient, type JourneyOrderClient, type OfferManagementClient, type WaitlistCapacityFreed, type WaitlistRepository } from "./promotion.js";
 import { publishAll, waitlistCancelled, waitlistFulfilled, waitlistPaymentAuthorizationRequested, waitlistQueued, waitlistRequestCreated } from "./publisher.js";
 
 export type JoinWaitlistRequest = Readonly<{
@@ -21,7 +21,7 @@ export type JoinWaitlistRequest = Readonly<{
   intentFingerprint?: string;
 }>;
 
-export type AcceptPromotionRequest = Readonly<{ paymentMethodRef?: string }>;
+export type AcceptPromotionRequest = Readonly<Record<string, unknown>>;
 export type CancelWaitlistRequest = Readonly<{ reason?: string }>;
 export type AcceptPromotionResponse = Readonly<{ orderId: string; seatAssignment: unknown }>;
 export type QueueInfo = Readonly<{ totalQueued: number; myPosition: number | null; estimatedPromotionRate: number }>;
@@ -46,14 +46,10 @@ export type WaitlistRequestResource = Readonly<{
   journeyOrderRef?: string;
 }>;
 
-export interface JourneyOrderClient {
-  createOrder(entry: WaitlistEntry, paymentMethodRef?: string): Promise<AcceptPromotionResponse>;
-}
-
 export class HttpJourneyOrderClient implements JourneyOrderClient {
   constructor(private readonly baseUrl = process.env.JOURNEY_ORDER_URL ?? process.env.JOURNEY_ORDER_BASE_URL ?? "http://journey-order") {}
 
-  async createOrder(entry: WaitlistEntry, _paymentMethodRef?: string): Promise<AcceptPromotionResponse> {
+  async createOrder(entry: WaitlistEntry): Promise<AcceptPromotionResponse> {
     if (!entry.offerId || !entry.offerVersion) {
       throw new DomainError("PRECONDITION_FAILED", "Waitlist entry does not have an orderable offer");
     }
@@ -102,7 +98,10 @@ export class InMemoryWaitlistRepository implements WaitlistRepository {
   }
 
   async findExpiredOffers(now: Date): Promise<readonly WaitlistEntry[]> {
-    return [...this.entries.values()].filter((entry) => entry.status === "MATCHING" && entry.offerExpiresAt !== null && entry.offerExpiresAt <= now);
+    return [...this.entries.values()].filter((entry) => {
+      if (entry.status === "QUEUED") return hasDeadlinePassed(entry, now);
+      return entry.status === "MATCHING" && ((entry.offerExpiresAt !== null && entry.offerExpiresAt <= now) || hasDeadlinePassed(entry, now));
+    });
   }
 
   async findArchivable(): Promise<readonly WaitlistEntry[]> {
@@ -197,14 +196,11 @@ export class WaitlistApplicationService {
     return { waitlistRequestId: snapshot.entryId, status: "CANCELLED", cancelledAt };
   }
 
-  async accept(entryId: string, request: AcceptPromotionRequest = {}, correlationId?: string): Promise<AcceptPromotionResponse> {
+  async accept(entryId: string, _request: AcceptPromotionRequest = {}, _correlationId?: string): Promise<AcceptPromotionResponse> {
     const entry = await this.requireEntry(entryId);
-    const now = this.now();
-    entry.ensureOfferAcceptable(now);
-    const order = await this.journeyOrder.createOrder(entry, request.paymentMethodRef);
-    entry.attachJourneyOrder(order.orderId);
-    await this.repository.save(entry);
-    return order;
+    entry.ensureOfferAcceptable(this.now());
+    const order = await this.journeyOrder.createOrder(entry);
+    return { orderId: order.orderId, seatAssignment: order.seatAssignment ?? null };
   }
 
   async queueInfo(segmentRef: string, departureDate: string, seatClass?: string, entryId?: string): Promise<QueueInfo> {
@@ -214,7 +210,7 @@ export class WaitlistApplicationService {
   }
 
   async handleCapacityFreed(event: WaitlistCapacityFreed, correlationId?: string) {
-    return this.promotion.onCapacityFreed(event, correlationId);
+    return this.promotion.onCapacityFreed(event, this.journeyOrder, correlationId);
   }
 
   async handleJourneyOrderConfirmed(orderId: string, correlationId?: string): Promise<WaitlistRequestResource | undefined> {
@@ -295,6 +291,11 @@ function isActiveStatus(status: WaitlistEntrySnapshot["status"]): boolean {
 
 function isArchivableStatus(status: WaitlistEntrySnapshot["status"]): boolean {
   return status === "FULFILLED" || status === "EXPIRED" || status === "CANCELLED";
+}
+
+function hasDeadlinePassed(entry: WaitlistEntry, now: Date): boolean {
+  const deadline = new Date(entry.deadline).getTime();
+  return Number.isFinite(deadline) && deadline <= now.getTime();
 }
 
 function toWaitlistRequestResource(snapshot: WaitlistEntrySnapshot): WaitlistRequestResource {

--- a/services/waitlist/src/domain.ts
+++ b/services/waitlist/src/domain.ts
@@ -180,7 +180,7 @@ export class WaitlistEntry {
     this._loadedVersion = version;
   }
 
-  offer(offerId: string, offerVersion: number, fareQuoteId: string, capacityHoldId: string, now: Date, expiresAt: Date): void {
+  offer(offerId: string, offerVersion: number, fareQuoteId: string, capacityHoldId: string | undefined, now: Date, expiresAt: Date): void {
     this.assertStatus("QUEUED", "Only queued waitlist entries can begin matching");
     if (expiresAt <= now) throw new DomainError("VALIDATION_FAILED", "Offer expiry must be in the future");
     this._status = "MATCHING";
@@ -270,11 +270,6 @@ export class WaitlistEntry {
 
   private assertStatus(expected: WaitlistStatus, message: string): void {
     if (this._status !== expected) throw new DomainError("INVALID_TRANSITION", message);
-  }
-
-  attachJourneyOrder(journeyOrderRef: string): void {
-    this.assertStatus("MATCHING", "Only matching waitlist entries can be attached to a journey order");
-    this.recordJourneyOrderRef(journeyOrderRef);
   }
 
   private recordJourneyOrderRef(journeyOrderRef: string): void {

--- a/services/waitlist/src/promotion.ts
+++ b/services/waitlist/src/promotion.ts
@@ -1,6 +1,6 @@
 import { isPrefixedUuidV7, type EventPublisher } from "@trainticket/ts-kit";
 import { DomainError, type WaitlistEntry, type WaitlistEntrySnapshot } from "./domain.js";
-import { publishAll, waitlistExpired, waitlistHoldAuthorized, waitlistMatchStarted } from "./publisher.js";
+import { publishAll, waitlistExpired, waitlistFulfilled, waitlistMatchStarted } from "./publisher.js";
 
 export type WaitlistCapacityFreed = Readonly<{
   segmentRef: string;
@@ -15,7 +15,7 @@ export type WaitlistOffer = Readonly<{
   offerVersion: number;
   entryId: string;
   fareQuoteId: string;
-  capacityHoldId: string;
+  capacityHoldId?: string;
   expiresAt: string;
 }>;
 
@@ -49,6 +49,12 @@ export interface OfferManagementClient {
 export interface CapacityAvailabilityClient {
   hold(entry: WaitlistEntry, fareQuoteId: string): Promise<{ capacityHoldId: string }>;
   releaseHold(entry: WaitlistEntry, capacityHoldId: string): Promise<void>;
+}
+
+export type JourneyOrderCreation = Readonly<{ orderId: string; seatAssignment?: unknown }>;
+
+export interface JourneyOrderClient {
+  createOrder(entry: WaitlistEntry): Promise<JourneyOrderCreation>;
 }
 
 export class HttpFarePricingClient implements FarePricingClient {
@@ -144,28 +150,29 @@ export class PromotionOrchestrator {
     private readonly now: () => Date = () => new Date(),
   ) {}
 
-  async onCapacityFreed(event: WaitlistCapacityFreed, correlationId?: string): Promise<PromotionResult> {
+  async onCapacityFreed(event: WaitlistCapacityFreed, journeyOrder: JourneyOrderClient, correlationId?: string): Promise<PromotionResult> {
+    assertCapacityReleaseRef(event.capacityReleaseRef);
     const promoted: PromotedWaitlistRequest[] = [];
     const offers: WaitlistOffer[] = [];
     const slots = Math.max(0, Math.floor(event.freedSlots));
     for (let index = 0; index < slots; index++) {
       const entry = await this.repository.findTopQueued(event.segmentRef, event.departureDate, event.seatClass);
       if (!entry) break;
-      assertCapacityReleaseRef(event.capacityReleaseRef);
       const quote = await this.farePricing.quote(entry);
       const commercialOffer = await this.offerManagement.createOffer(entry, quote.fareQuoteId);
-      const hold = await this.capacityAvailability.hold(entry, quote.fareQuoteId);
       const now = this.now();
       const expiresAt = new Date(now.getTime() + 15 * 60 * 1000);
-      const offer = { offerId: commercialOffer.offerId, offerVersion: commercialOffer.offerVersion, entryId: entry.entryId, fareQuoteId: quote.fareQuoteId, capacityHoldId: hold.capacityHoldId, expiresAt: expiresAt.toISOString() };
-      entry.offer(offer.offerId, offer.offerVersion, quote.fareQuoteId, hold.capacityHoldId, now, expiresAt);
-      const snapshot = await this.repository.save(entry);
+      const offer = { offerId: commercialOffer.offerId, offerVersion: commercialOffer.offerVersion, entryId: entry.entryId, fareQuoteId: quote.fareQuoteId, expiresAt: expiresAt.toISOString() };
+      entry.offer(offer.offerId, offer.offerVersion, quote.fareQuoteId, undefined, now, expiresAt);
+      let snapshot = await this.repository.save(entry);
+      await publishAll(this.publisher, [waitlistMatchStarted(snapshot, entry.loadedVersion, event.capacityReleaseRef, correlationId, now.toISOString())]);
+
+      const order = await journeyOrder.createOrder(entry);
+      entry.accept(this.now(), order.orderId);
+      snapshot = await this.repository.save(entry);
       promoted.push({ ...snapshot, waitlistRequestId: snapshot.entryId });
       offers.push(offer);
-      await publishAll(this.publisher, [
-        waitlistHoldAuthorized(snapshot, entry.loadedVersion, correlationId, now.toISOString()),
-        waitlistMatchStarted(snapshot, entry.loadedVersion, event.capacityReleaseRef, correlationId, now.toISOString()),
-      ]);
+      await publishAll(this.publisher, [waitlistFulfilled(snapshot, entry.loadedVersion, order.orderId, correlationId, this.now().toISOString())]);
     }
     return { promoted, offers };
   }
@@ -186,7 +193,7 @@ export class PromotionOrchestrator {
 }
 
 export function offerFromEntry(entry: WaitlistEntry): WaitlistOffer {
-  if (!entry.offerId || !entry.offerVersion || !entry.fareQuoteId || !entry.capacityHoldId || !entry.offerExpiresAt) {
+  if (!entry.offerId || !entry.offerVersion || !entry.fareQuoteId || !entry.offerExpiresAt) {
     throw new DomainError("PRECONDITION_FAILED", "Waitlist entry does not have an active offer");
   }
   return { offerId: entry.offerId, offerVersion: entry.offerVersion, entryId: entry.entryId, fareQuoteId: entry.fareQuoteId, capacityHoldId: entry.capacityHoldId, expiresAt: entry.offerExpiresAt.toISOString() };

--- a/services/waitlist/src/storage.ts
+++ b/services/waitlist/src/storage.ts
@@ -58,7 +58,13 @@ export class PostgresWaitlistRepository implements WaitlistRepository {
   }
 
   async findExpiredOffers(now: Date): Promise<readonly WaitlistEntry[]> {
-    const result = await this.db.query(`SELECT * FROM waitlist_entries WHERE status = 'MATCHING' AND offer_expires_at <= $1 ORDER BY offer_expires_at ASC`, [now.toISOString()]) as QueryResult<WaitlistRow>;
+    const result = await this.db.query(
+      `SELECT * FROM waitlist_entries
+       WHERE (status = 'MATCHING' AND offer_expires_at <= $1)
+          OR (status IN ('QUEUED', 'MATCHING') AND (data->>'deadline')::timestamptz <= $1)
+       ORDER BY COALESCE(offer_expires_at, (data->>'deadline')::timestamptz) ASC, entry_id ASC`,
+      [now.toISOString()],
+    ) as QueryResult<WaitlistRow>;
     return result.rows.map(entryFromRow);
   }
 

--- a/services/waitlist/src/subscriber.ts
+++ b/services/waitlist/src/subscriber.ts
@@ -68,7 +68,8 @@ export function parseCapacityFreed(envelope: EventEnvelope): WaitlistCapacityFre
 }
 
 export function parseJourneyOrderId(envelope: EventEnvelope): string {
-  return string((envelope.payload as Record<string, unknown>).orderId);
+  const payload = envelope.payload as Record<string, unknown>;
+  return string(payload.orderId ?? payload.journeyOrderRef);
 }
 
 function string(value: unknown): string {

--- a/services/waitlist/tests/http-clients.test.ts
+++ b/services/waitlist/tests/http-clients.test.ts
@@ -10,7 +10,7 @@ function promotedEntry() {
   return entry;
 }
 
-test("HTTP downstream clients use documented endpoint shapes and idempotency keys", async () => {
+test("HTTP downstream clients use documented endpoint shapes and idempotency keys without payment calls", async () => {
   const calls: Array<{ url: string; method: string; headers: Headers; body: unknown }> = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
@@ -35,13 +35,15 @@ test("HTTP downstream clients use documented endpoint shapes and idempotency key
     globalThis.fetch = originalFetch;
   }
 
-  assert.deepEqual(calls.map((call) => [call.method, new URL(call.url).pathname]), [
+  const calledPaths = calls.map((call) => [call.method, new URL(call.url).pathname]);
+  assert.deepEqual(calledPaths, [
     ["POST", "/api/v1/fare-quotes"],
     ["POST", "/api/v1/offers"],
     ["POST", "/api/v1/capacity-holds"],
     ["POST", "/api/v1/capacity-holds/hold-1/release"],
     ["POST", "/api/v1/journey-orders"],
   ]);
+  assert.equal(calledPaths.some(([, path]) => String(path).includes("payment") || String(path).includes("capture")), false);
   assert.ok(calls.every((call) => call.headers.has("Idempotency-Key")));
   assert.deepEqual(calls[0]?.body, { travelerRefs: ["tvl-1", "tvl-2"], channel: "WEB", segmentRefs: ["seg-1"], productCode: "rail-standard" });
   assert.deepEqual({ ...(calls[2]?.body as Record<string, unknown>), segmentBookingId: undefined }, { segmentRef: "seg-1", travelerRef: "tvl-1", classRef: "SECOND", quantity: 2, segmentBookingId: undefined });

--- a/services/waitlist/tests/promotion.test.ts
+++ b/services/waitlist/tests/promotion.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { InMemoryEventPublisher } from "@trainticket/ts-kit";
-import { InMemoryWaitlistRepository, WaitlistApplicationService, type JourneyOrderClient } from "../src/application.js";
-import type { CapacityAvailabilityClient, FarePricingClient, OfferManagementClient } from "../src/promotion.js";
+import { HttpJourneyOrderClient, InMemoryWaitlistRepository, WaitlistApplicationService } from "../src/application.js";
+import { HttpFarePricingClient, HttpOfferManagementClient, type CapacityAvailabilityClient, type FarePricingClient, type JourneyOrderClient, type OfferManagementClient } from "../src/promotion.js";
 import type { WaitlistEntry } from "../src/domain.js";
 
 const CAPACITY_RELEASE_REF = "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c123";
@@ -24,46 +24,86 @@ class StubCapacity implements CapacityAvailabilityClient {
 }
 
 class StubJourneyOrder implements JourneyOrderClient {
-  async createOrder(entry: WaitlistEntry) { return { orderId: `ord-${entry.entryId}`, seatAssignment: { segmentRef: entry.segmentRef } }; }
+  public orders: string[] = [];
+  async createOrder(entry: WaitlistEntry) {
+    this.orders.push(entry.entryId);
+    return { orderId: `ord-${entry.entryId}`, seatAssignment: { segmentRef: entry.segmentRef } };
+  }
 }
 
-test("WaitlistCapacityFreed promotes highest-priority queued entry", async () => {
+test("WaitlistCapacityFreed fulfills highest-priority queued entry through journey order", async () => {
   const repository = new InMemoryWaitlistRepository();
   const publisher = new InMemoryEventPublisher();
   const fare = new StubFarePricing();
   const capacity = new StubCapacity();
-  const service = new WaitlistApplicationService(repository, publisher, fare, capacity, new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
+  const journeyOrder = new StubJourneyOrder();
+  const service = new WaitlistApplicationService(repository, publisher, fare, capacity, journeyOrder, () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
   const regular = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "NONE", tripCount: 0, daysBefore: 20 });
   const platinum = await service.join({ accountId: "acc", travelerRefs: ["t2"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
 
   const result = await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: CAPACITY_RELEASE_REF });
 
   assert.equal(result.promoted[0]?.waitlistRequestId, platinum.waitlistRequestId);
-  assert.equal((await service.get(platinum.waitlistRequestId)).status, "MATCHING");
+  assert.equal(result.promoted[0]?.status, "FULFILLED");
+  assert.equal(result.promoted[0]?.journeyOrderRef, `ord-${platinum.waitlistRequestId}`);
+  assert.equal((await service.get(platinum.waitlistRequestId)).status, "FULFILLED");
+  assert.equal((await service.get(platinum.waitlistRequestId)).journeyOrderRef, `ord-${platinum.waitlistRequestId}`);
   assert.equal((await service.get(regular.waitlistRequestId)).status, "QUEUED");
+  assert.deepEqual(journeyOrder.orders, [platinum.waitlistRequestId]);
+  assert.deepEqual(capacity.holds, []);
+  assert.equal(publisher.findByEventType("WaitlistHoldAuthorized").length, 0);
   const matchStarted = publisher.findByEventType("WaitlistMatchStarted")[0];
   assert.equal(matchStarted?.payload.matchedCapacityReleaseRef, CAPACITY_RELEASE_REF);
   assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 1);
-  assert.equal(publisher.findByEventType("WaitlistHoldAuthorized").length, 1);
+  const fulfilled = publisher.findByEventType("WaitlistFulfilled")[0];
+  assert.equal(fulfilled?.payload.journeyOrderRef, `ord-${platinum.waitlistRequestId}`);
+  assert.equal(fulfilled?.payload.status, "FULFILLED");
 });
 
-test("expired matching attempt expires and waits for CapacityReleased before promoting another entry", async () => {
-  let current = new Date("2026-01-01T00:00:00.000Z");
+test("no payment-service calls are made while fulfilling a matched waitlist entry", async () => {
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    calls.push(url);
+    if (url.endsWith("/api/v1/fare-quotes")) return Response.json({ quoteId: "fq-http" }, { status: 201 });
+    if (url.endsWith("/api/v1/offers")) return Response.json({ offerId: "off-http", offerVersion: 1 }, { status: 201 });
+    if (url.endsWith("/api/v1/journey-orders")) return Response.json({ orderId: "ord-http" }, { status: 201 });
+    return Response.json({ error: "unexpected" }, { status: 500 });
+  }) as typeof fetch;
+  try {
+    const service = new WaitlistApplicationService(
+      new InMemoryWaitlistRepository(),
+      new InMemoryEventPublisher(),
+      new HttpFarePricingClient("http://fare-pricing", "WEB"),
+      new StubCapacity(),
+      new HttpJourneyOrderClient("http://journey-order"),
+      () => new Date("2026-01-01T00:00:00.000Z"),
+      new HttpOfferManagementClient("http://offer-management", "WEB"),
+    );
+    const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20, paymentGuaranteeRef: "pay-auth-existing" });
+
+    await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: CAPACITY_RELEASE_REF });
+
+    assert.equal((await service.get(entry.waitlistRequestId)).journeyOrderRef, "ord-http");
+    assert.deepEqual(calls.map((url) => new URL(url).pathname), ["/api/v1/fare-quotes", "/api/v1/offers", "/api/v1/journey-orders"]);
+    assert.deepEqual(calls.filter((url) => url.includes("payment") || url.includes("payment-intents") || url.includes("/capture")), []);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("deadline-passed queued request expires during expiry sweep", async () => {
   const repository = new InMemoryWaitlistRepository();
   const publisher = new InMemoryEventPublisher();
-  const capacity = new StubCapacity();
-  const service = new WaitlistApplicationService(repository, publisher, new StubFarePricing(), capacity, new StubJourneyOrder(), () => current, new StubOfferManagement());
-  const first = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
-  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: CAPACITY_RELEASE_REF });
+  const service = new WaitlistApplicationService(repository, publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
+  const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20, deadline: "2025-12-31T23:59:59.000Z" });
 
-  current = new Date("2026-01-01T00:16:00.000Z");
-  await service.expireDueOffers();
+  const expired = await service.expireDueOffers();
 
-  assert.equal((await service.get(first.waitlistRequestId)).status, "EXPIRED");
-  assert.deepEqual(capacity.released, [`hold-${first.waitlistRequestId}`]);
+  assert.equal(expired[0]?.entryId, entry.waitlistRequestId);
+  assert.equal((await service.get(entry.waitlistRequestId)).status, "EXPIRED");
   assert.equal(publisher.findByEventType("WaitlistExpired").length, 1);
-  assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 1);
-  assert.equal(publisher.findByEventType("WaitlistMatchStarted").at(-1)?.payload.matchedCapacityReleaseRef, CAPACITY_RELEASE_REF);
 });
 
 test("capacity freed without a CapacityReleased eventId is rejected before publishing a match fact", async () => {
@@ -79,26 +119,28 @@ test("capacity freed without a CapacityReleased eventId is rejected before publi
   assert.equal(publisher.findByEventType("WaitlistMatchStarted").length, 0);
 });
 
-test("accept promotion creates journey order and records order ref", async () => {
+test("accept promotion creates journey order without recording order ref before confirmation", async () => {
   const publisher = new InMemoryEventPublisher();
   const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
   const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
-  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: CAPACITY_RELEASE_REF });
-  const order = await service.accept(entry.waitlistRequestId, { paymentMethodRef: "pm-1" });
-  assert.equal(order.orderId, `ord-${entry.waitlistRequestId}`);
-  assert.equal((await service.get(entry.waitlistRequestId)).journeyOrderRef, `ord-${entry.waitlistRequestId}`);
-  assert.equal(publisher.findByEventType("WaitlistFulfilled").length, 0);
+  const stored = await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: CAPACITY_RELEASE_REF });
+  const fulfilled = await service.get(entry.waitlistRequestId);
+
+  assert.equal(stored.promoted[0]?.journeyOrderRef, `ord-${entry.waitlistRequestId}`);
+  assert.equal(fulfilled.status, "FULFILLED");
+  assert.equal(fulfilled.journeyOrderRef, `ord-${entry.waitlistRequestId}`);
+  assert.equal(publisher.findByEventType("WaitlistFulfilled").length, 1);
 });
 
-test("accept does not mutate entry when journey order creation fails", async () => {
+test("journey order creation failure leaves matched entry in MATCHING for retry or cancellation", async () => {
   class FailingJourneyOrder implements JourneyOrderClient {
     async createOrder(): Promise<never> { throw new Error("downstream unavailable"); }
   }
   const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), new InMemoryEventPublisher(), new StubFarePricing(), new StubCapacity(), new FailingJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
   const entry = await service.join({ accountId: "acc", travelerRefs: ["t1"], segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", loyaltyTier: "PLATINUM", tripCount: 0, daysBefore: 20 });
-  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: CAPACITY_RELEASE_REF });
 
-  await assert.rejects(() => service.accept(entry.waitlistRequestId), /downstream unavailable/);
+  await assert.rejects(() => service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: CAPACITY_RELEASE_REF }), /downstream unavailable/);
 
   assert.equal((await service.get(entry.waitlistRequestId)).status, "MATCHING");
+  assert.equal((await service.get(entry.waitlistRequestId)).journeyOrderRef, undefined);
 });

--- a/services/waitlist/tests/publisher.test.ts
+++ b/services/waitlist/tests/publisher.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { InMemoryEventPublisher, isUuidV7 } from "@trainticket/ts-kit";
-import { InMemoryWaitlistRepository, WaitlistApplicationService, type JourneyOrderClient } from "../src/application.js";
-import type { CapacityAvailabilityClient, FarePricingClient, OfferManagementClient } from "../src/promotion.js";
+import { InMemoryWaitlistRepository, WaitlistApplicationService } from "../src/application.js";
+import type { CapacityAvailabilityClient, FarePricingClient, JourneyOrderClient, OfferManagementClient } from "../src/promotion.js";
 import type { WaitlistEntry } from "../src/domain.js";
 import { deterministicEventId } from "../src/publisher.js";
 
@@ -94,19 +94,17 @@ test("cancel publishes WaitlistCancelled with supplied reason without defaulting
   assert.equal(event?.payload.status, "CANCELLED");
 });
 
-test("journey order cancellation requeue publishes WaitlistQueued with journeyOrderRef", async () => {
+test("capacity-freed fulfillment publishes WaitlistFulfilled with journeyOrderRef", async () => {
   const publisher = new InMemoryEventPublisher();
   const service = new WaitlistApplicationService(new InMemoryWaitlistRepository(), publisher, new StubFarePricing(), new StubCapacity(), new StubJourneyOrder(), () => new Date("2026-01-01T00:00:00.000Z"), new StubOfferManagement());
   const entry = await service.join({ accountId: "acc", travelerRef: "tvl", segmentRef: "seg", departureDate: "2026-07-20", travelClass: "SECOND", paymentGuaranteeRef: "pay-auth-1", itineraryRef: "itn", intentFingerprint: "intent" });
-  await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c123" });
-  await service.accept(entry.waitlistRequestId);
-  const matching = await service.get(entry.waitlistRequestId);
 
-  const requeued = await service.handleJourneyOrderCancelled(`ord-${entry.waitlistRequestId}`);
+  const result = await service.handleCapacityFreed({ segmentRef: "seg", departureDate: "2026-07-20", seatClass: "SECOND", freedSlots: 1, capacityReleaseRef: "evt-0194f2e0-7b3e-7610-8284-5c26e8b0c123" });
 
-  assert.equal(matching.status, "MATCHING");
-  assert.equal(requeued?.status, "QUEUED");
-  const queued = publisher.findByEventType("WaitlistQueued").at(-1);
-  assert.equal(queued?.eventId, deterministicEventId(`waitlist:WaitlistQueued:${entry.waitlistRequestId}:4`));
-  assert.equal(queued?.payload.journeyOrderRef, `ord-${entry.waitlistRequestId}`);
+  assert.equal(result.promoted[0]?.status, "FULFILLED");
+  assert.equal(result.promoted[0]?.journeyOrderRef, `ord-${entry.waitlistRequestId}`);
+  const fulfilled = publisher.findByEventType("WaitlistFulfilled")[0];
+  assert.equal(fulfilled?.eventId, deterministicEventId(`waitlist:WaitlistFulfilled:${entry.waitlistRequestId}:3`));
+  assert.equal(fulfilled?.payload.journeyOrderRef, `ord-${entry.waitlistRequestId}`);
+  assert.equal(fulfilled?.payload.status, "FULFILLED");
 });


### PR DESCRIPTION
## Summary
- Drive matching WaitlistCapacityFreed events through quote -> offer -> journey-order, then transition to FULFILLED and publish WaitlistFulfilled with journeyOrderRef.
- Keep payment ownership in Journey Order: waitlist records paymentGuaranteeRef only and does not call payment-service/payment-intents/capture.
- Expand expiry sweep to deadline-passed QUEUED requests and matching attempts; preserve deterministic event IDs and OCC repository paths.

## Validation
- npm run build --prefix services/waitlist
- npm test --prefix services/waitlist