### PR TITLE
Fix transfer risk for pre-cutoff delayed arrivals

### DIFF
--- a/services/transfer-management/src/transfer_management/application/service.py
+++ b/services/transfer-management/src/transfer_management/application/service.py
@@ -852,10 +852,6 @@ class TransferManagementService:
                 place_graph_version = topology.placeGraphVersion
         except (PlaceNetworkUnavailable, PlaceNetworkValidationError):
             degraded_reasons = ("PLACE_NETWORK_UNAVAILABLE",)
-        actual_arrival = window.actualArrivalAt or window.plannedArrivalAt
-        effective_mct = MinimumConnectionTime(connection.toNodeRef, connection.fromMode, connection.toMode, window.mctMinutes)
-        if MissedConnectionDetector().is_missed(actual_arrival, window.nextDepartureAt, effective_mct):
-            reasons.append("MISSED_CONNECTION_MCT_VIOLATION")
         evaluation = self._evaluate_window(window, rule, at, new_prefixed_uuid7("tre"), reasons, place_graph_version, degraded_reasons)
         updated = connection.apply_evaluation(evaluation, window, at)
         events = [self._risk_event(updated, previous_status if previous_status != updated.status else None, correlation_id, causation_id, at, report.segmentStatusReportId if report else None)]

--- a/services/transfer-management/src/transfer_management/domain.py
+++ b/services/transfer-management/src/transfer_management/domain.py
@@ -783,7 +783,7 @@ class TransferRiskPolicy:
 
     def classify(self, available_minutes: int, buffer_minutes: int, reasons: Iterable[str]) -> tuple[RiskLevel, tuple[str, ...]]:
         explanation = list(reasons)
-        if "NEXT_SEGMENT_CANCELLED" in explanation or "PREVIOUS_SEGMENT_CANCELLED" in explanation or "MISSED_CONNECTION_MCT_VIOLATION" in explanation:
+        if "NEXT_SEGMENT_CANCELLED" in explanation or "PREVIOUS_SEGMENT_CANCELLED" in explanation:
             return RiskLevel.MISSED, tuple(dict.fromkeys(explanation))
         if available_minutes < 0:
             explanation.append("CUTOFF_EXPIRED")

--- a/services/transfer-management/tests/test_api.py
+++ b/services/transfer-management/tests/test_api.py
@@ -281,7 +281,7 @@ def test_reaccommodate_precondition_and_self_completion_skip() -> None:
     assert [e for e in store.take_outbox() if e.eventType == "ConnectionRecovered"] == []
 
 
-def test_fulfillment_segment_delayed_event_marks_connection_missed_when_mct_is_violated() -> None:
+def test_fulfillment_segment_delayed_event_marks_connection_at_risk_when_mct_is_violated_before_cutoff() -> None:
     from datetime import UTC, datetime
     from train_ticket_platform.events import EventEnvelope
     from transfer_management.application.service import TransferManagementService
@@ -299,7 +299,8 @@ def test_fulfillment_segment_delayed_event_marks_connection_missed_when_mct_is_v
 
     assert service.handle_fulfillment_event(envelope, "events:fulfillment") is True
     updated = service.get_connection(connection["connectionId"])
-    assert updated["status"] == "MISSED"
+    assert updated["status"] == "AT_RISK"
+    assert updated["latestEvaluation"]["riskLevel"] == "AT_RISK"
     assert store.mark_processed(envelope.eventId, "events:fulfillment") is False
 
 

--- a/services/transfer-management/tests/test_domain.py
+++ b/services/transfer-management/tests/test_domain.py
@@ -16,7 +16,7 @@ def test_folded_uuid7_shape_is_stable() -> None:
     assert UUID(key).version == 7
 
 
-def test_connection_missed_never_returns_feasible() -> None:
+def test_connection_delay_before_cutoff_becomes_at_risk_then_missed_never_returns_feasible() -> None:
     service = TransferManagementService(InMemoryStore())
     now = datetime(2026, 1, 1, tzinfo=UTC)
     rule = service.create_mct_rule({"fromNodeType": "STATION", "toNodeType": "STATION", "transferCategory": "SAME_STATION", "minimumMinutes": 20, "conditions": {}, "validFrom": "2025-01-01T00:00:00Z"}, "corr-test", "cmd-test")
@@ -24,10 +24,14 @@ def test_connection_missed_never_returns_feasible() -> None:
     plan = service.create_plan({"itineraryRef": "iti-1", "planningSnapshotVersion": 1, "travelerRefs": ["trav-1"], "journeyOrderId": "jo-1"}, "corr-test", "cmd-test")
     con = service.register_connection({"transferPlanId": plan["transferPlanId"], "itineraryRef": "iti-1", "journeyOrderId": "jo-1", "previousSegmentRef": "seg-a", "nextSegmentRef": "seg-b", "travelerRefs": ["trav-1"], "fromNodeRef": "sta-a", "toNodeRef": "sta-a", "fromNodeType": "STATION", "toNodeType": "STATION", "transferCategory": "SAME_STATION", "contractId": "cct-x", "contractType": "SELF_TRANSFER", "window": {"plannedArrivalAt": now.isoformat().replace("+00:00", "Z"), "nextDepartureAt": (now + timedelta(minutes=60)).isoformat().replace("+00:00", "Z"), "nextCutoffAt": (now + timedelta(minutes=50)).isoformat().replace("+00:00", "Z")}}, "corr-test", "cmd-test")
     assert con["status"] == "FEASIBLE"
-    service.report_segment_status({"segmentRef": "seg-a", "reportType": "DELAY", "reportedBy": {"actorType": "SYSTEM", "actorId": "sys"}, "sourceSystem": "OPERATIONS", "sourceRecordId": "r1", "observedAt": (now + timedelta(minutes=1)).isoformat().replace("+00:00", "Z"), "estimatedArrivalAt": (now + timedelta(minutes=70)).isoformat().replace("+00:00", "Z")}, "corr-test", "cmd-test")
+    service.report_segment_status({"segmentRef": "seg-a", "reportType": "DELAY", "reportedBy": {"actorType": "SYSTEM", "actorId": "sys"}, "sourceSystem": "OPERATIONS", "sourceRecordId": "r1-risk", "observedAt": (now + timedelta(minutes=1)).isoformat().replace("+00:00", "Z"), "estimatedArrivalAt": (now + timedelta(minutes=40)).isoformat().replace("+00:00", "Z")}, "corr-test", "cmd-test")
+    at_risk = service.get_connection(con["connectionId"])
+    assert at_risk["status"] == "AT_RISK"
+    assert at_risk["latestEvaluation"]["riskLevel"] == "AT_RISK"
+    service.report_segment_status({"segmentRef": "seg-a", "reportType": "DELAY", "reportedBy": {"actorType": "SYSTEM", "actorId": "sys"}, "sourceSystem": "OPERATIONS", "sourceRecordId": "r1-missed", "observedAt": (now + timedelta(minutes=2)).isoformat().replace("+00:00", "Z"), "estimatedArrivalAt": (now + timedelta(minutes=70)).isoformat().replace("+00:00", "Z")}, "corr-test", "cmd-test")
     missed = service.get_connection(con["connectionId"])
     assert missed["status"] == "MISSED"
-    service.report_segment_status({"segmentRef": "seg-a", "reportType": "ARRIVAL", "reportedBy": {"actorType": "SYSTEM", "actorId": "sys"}, "sourceSystem": "OPERATIONS", "sourceRecordId": "r2", "observedAt": (now + timedelta(minutes=2)).isoformat().replace("+00:00", "Z"), "actualArrivalAt": now.isoformat().replace("+00:00", "Z")}, "corr-test", "cmd-test")
+    service.report_segment_status({"segmentRef": "seg-a", "reportType": "ARRIVAL", "reportedBy": {"actorType": "SYSTEM", "actorId": "sys"}, "sourceSystem": "OPERATIONS", "sourceRecordId": "r2", "observedAt": (now + timedelta(minutes=3)).isoformat().replace("+00:00", "Z"), "actualArrivalAt": now.isoformat().replace("+00:00", "Z")}, "corr-test", "cmd-test")
     assert service.get_connection(con["connectionId"])["status"] == "MISSED"
 
 


### PR DESCRIPTION
## Summary
- Treat delayed arrivals that violate MCT but remain before the cutoff as AT_RISK instead of MISSED
- Keep cancellations and cutoff-expired windows driving MISSED and recovery flow
- Add/update transfer-management tests for the pre-cutoff at-risk transition

## Validation
- cd services/transfer-management && uv run pytest -q tests/test_domain.py tests/test_api.py