### PR TITLE
REQ-401 Fix post-sales same-fare change fee

### DIFF
--- a/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/application/PostSalesApplicationService.java
@@ -196,11 +196,11 @@ public class PostSalesApplicationService {
 
         PostSalesPolicyContext policyContext = policyContextFor(postSalesCase, now, refundable);
         if (kind == DecisionKind.CHANGE) {
-            Money originalFare = policyContext.originalFareOr(refundable.isZero() ? amountDue : refundable);
-            Money newFare = amountDue.isZero() ? originalFare : originalFare.add(amountDue);
-            ChangeAssessment assessment = changePolicyEngine.evaluateChange(
+            Money originalFare = policyContext.originalFareOr(amountDue.isZero() ? refundable : amountDue);
+            ChangeAssessment assessment = changePolicyEngine.evaluateQuotedChange(
                 originalFare,
-                newFare,
+                amountDue,
+                refundable,
                 now,
                 policyContext.departureTime(),
                 policyContext.appliedChangeCount()

--- a/services/post-sales/src/main/java/com/trainticket/postsales/domain/ChangePolicyEngine.java
+++ b/services/post-sales/src/main/java/com/trainticket/postsales/domain/ChangePolicyEngine.java
@@ -1,12 +1,10 @@
 package com.trainticket.postsales.domain;
 
-import java.math.BigDecimal;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
 
 public final class ChangePolicyEngine {
-    private static final BigDecimal TWENTY_PCT = new BigDecimal("0.20");
+    private static final Money DEFAULT_CHANGE_FEE = Money.of("15.00", "CNY");
 
     public ChangeAssessment evaluateChange(
         Money originalFare,
@@ -15,25 +13,62 @@ public final class ChangePolicyEngine {
         Instant departureTime,
         int changeCount
     ) {
-        Objects.requireNonNull(originalFare, "originalFare is required");
+        requirePolicyInputs(originalFare, requestTime, departureTime, changeCount);
         Objects.requireNonNull(newFare, "newFare is required").compareTo(originalFare);
-        Objects.requireNonNull(requestTime, "requestTime is required");
-        Objects.requireNonNull(departureTime, "departureTime is required");
-        if (changeCount < 0) {
-            throw new DomainRuleViolation("changeCount must not be negative");
-        }
 
-        boolean freeFirstChange = changeCount == 0 && Duration.between(requestTime, departureTime).compareTo(Duration.ofHours(48)) > 0;
-        Money changeFee = freeFirstChange ? Money.zero(originalFare.currency()) : RefundWaterfall.percent(originalFare, TWENTY_PCT);
+        Money changeFee = defaultChangeFee(originalFare);
         Money fareIncrease = newFare.compareTo(originalFare) > 0 ? RefundWaterfall.subtract(newFare, originalFare) : Money.zero(originalFare.currency());
         Money fareDecrease = originalFare.compareTo(newFare) > 0 ? RefundWaterfall.subtract(originalFare, newFare) : Money.zero(originalFare.currency());
         Money grossPayable = changeFee.add(fareIncrease);
         Money netPayable = grossPayable.compareTo(fareDecrease) > 0 ? RefundWaterfall.subtract(grossPayable, fareDecrease) : Money.zero(originalFare.currency());
         Money netRefundable = fareDecrease.compareTo(grossPayable) > 0 ? RefundWaterfall.subtract(fareDecrease, grossPayable) : Money.zero(originalFare.currency());
         Money fareDifference = fareIncrease.isZero() ? fareDecrease : fareIncrease;
-        String explanation = freeFirstChange
-            ? "first change more than 48 hours before departure has no change fee; fare difference netted"
-            : "20% change fee applied; fare difference netted";
-        return new ChangeAssessment(changeFee, fareDifference, netPayable, netRefundable, explanation);
+        return new ChangeAssessment(changeFee, fareDifference, netPayable, netRefundable, "flat default change fee applied; fare difference netted");
+    }
+
+    public ChangeAssessment evaluateQuotedChange(
+        Money originalFare,
+        Money quotedAmountDue,
+        Money quotedRefundable,
+        Instant requestTime,
+        Instant departureTime,
+        int changeCount
+    ) {
+        requirePolicyInputs(originalFare, requestTime, departureTime, changeCount);
+        Objects.requireNonNull(quotedAmountDue, "quotedAmountDue is required").compareTo(originalFare);
+        Objects.requireNonNull(quotedRefundable, "quotedRefundable is required").compareTo(originalFare);
+        if (!quotedAmountDue.isZero() && !quotedRefundable.isZero()) {
+            throw new DomainRuleViolation("a change quote cannot be both payable and refundable");
+        }
+
+        Money changeFee = defaultChangeFee(originalFare);
+        Money fareDifference = quotedFareDifference(changeFee, quotedAmountDue, quotedRefundable);
+        return new ChangeAssessment(changeFee, fareDifference, quotedAmountDue, quotedRefundable, "fare-pricing change quote applied with flat default change fee");
+    }
+
+    private static void requirePolicyInputs(Money originalFare, Instant requestTime, Instant departureTime, int changeCount) {
+        Objects.requireNonNull(originalFare, "originalFare is required");
+        Objects.requireNonNull(requestTime, "requestTime is required");
+        Objects.requireNonNull(departureTime, "departureTime is required");
+        if (changeCount < 0) {
+            throw new DomainRuleViolation("changeCount must not be negative");
+        }
+    }
+
+    private static Money defaultChangeFee(Money fare) {
+        return DEFAULT_CHANGE_FEE.currency().equals(fare.currency()) ? DEFAULT_CHANGE_FEE : Money.zero(fare.currency());
+    }
+
+    private static Money quotedFareDifference(Money changeFee, Money quotedAmountDue, Money quotedRefundable) {
+        if (!quotedRefundable.isZero()) {
+            return changeFee.add(quotedRefundable);
+        }
+        if (quotedAmountDue.compareTo(changeFee) > 0) {
+            return RefundWaterfall.subtract(quotedAmountDue, changeFee);
+        }
+        if (changeFee.compareTo(quotedAmountDue) > 0) {
+            return RefundWaterfall.subtract(changeFee, quotedAmountDue);
+        }
+        return Money.zero(changeFee.currency());
     }
 }

--- a/services/post-sales/src/test/java/com/trainticket/postsales/application/PostSalesApplicationServicePolicyIntegrationTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/application/PostSalesApplicationServicePolicyIntegrationTest.java
@@ -53,7 +53,7 @@ class PostSalesApplicationServicePolicyIntegrationTest {
     }
 
     @Test
-    void secondChangeUsesPersistedChangeCountAndActualDepartureContext() {
+    void changeUsesFarePricingAmountDueWithoutReapplyingChangeFee() {
         InMemoryPostSalesPolicyContextStore contextStore = new InMemoryPostSalesPolicyContextStore();
         contextStore.save(new PostSalesPolicyContext(
             "ord-change-policy",
@@ -69,8 +69,30 @@ class PostSalesApplicationServicePolicyIntegrationTest {
 
         PostSalesCase evaluated = service.evaluate("psc-" + postSalesCase.caseId(), "cmd-evaluate", "corr-policy");
 
-        assertEquals(2_000, evaluated.decision().changeAssessment().changeFee().toMinorUnits());
-        assertEquals(7_000, evaluated.decision().changeAssessment().netPayable().toMinorUnits());
+        assertEquals(1_500, evaluated.decision().changeAssessment().changeFee().toMinorUnits());
+        assertEquals(5_000, evaluated.decision().changeAssessment().netPayable().toMinorUnits());
+    }
+
+    @Test
+    void sameFareChangeQuoteReturnsContractedDefaultChangeFeeAsAmountDue() {
+        InMemoryPostSalesPolicyContextStore contextStore = new InMemoryPostSalesPolicyContextStore();
+        contextStore.save(new PostSalesPolicyContext(
+            "ord-change-same-fare",
+            NOW.plusSeconds(3 * 86_400),
+            Map.of("tvl-1", "ADULT"),
+            1,
+            0,
+            Money.of("75.00", "CNY"),
+            PostSalesPolicyContext.RefundWaterfallComponents.empty(java.util.Currency.getInstance("CNY"))
+        ));
+        PostSalesApplicationService service = service(contextStore, quote("adjq-change-same-fare", 0, "CNY", 1_500, "CNY"));
+        PostSalesCase postSalesCase = service.open(command("ord-change-same-fare", PostSalesCaseType.CHANGE, "idem-change-same-fare"));
+
+        PostSalesCase evaluated = service.evaluate("psc-" + postSalesCase.caseId(), "cmd-evaluate", "corr-policy");
+
+        assertEquals(1_500, evaluated.decision().amountSnapshot().extraChargeAmount().toMinorUnits());
+        assertEquals(1_500, evaluated.decision().changeAssessment().changeFee().toMinorUnits());
+        assertEquals(0, evaluated.decision().changeAssessment().fareDifference().toMinorUnits());
     }
 
     private static PostSalesApplicationService service(

--- a/services/post-sales/src/test/java/com/trainticket/postsales/domain/ChangePolicyEngineTest.java
+++ b/services/post-sales/src/test/java/com/trainticket/postsales/domain/ChangePolicyEngineTest.java
@@ -10,39 +10,47 @@ class ChangePolicyEngineTest {
     private final ChangePolicyEngine engine = new ChangePolicyEngine();
 
     @Test
-    void firstChangeMoreThanFortyEightHoursBeforeDepartureOnlyPaysFareIncrease() {
-        ChangeAssessment assessment = engine.evaluateChange(Money.of("200.00", "CNY"), Money.of("260.00", "CNY"), REQUEST, REQUEST.plusSeconds(3 * 86_400), 0);
+    void sameFareChangePaysFlatDefaultChangeFee() {
+        ChangeAssessment assessment = engine.evaluateChange(Money.of("100.00", "CNY"), Money.of("100.00", "CNY"), REQUEST, REQUEST.plusSeconds(3 * 86_400), 0);
 
-        assertEquals(Money.of("0.00", "CNY"), assessment.changeFee());
-        assertEquals(Money.of("60.00", "CNY"), assessment.fareDifference());
-        assertEquals(Money.of("60.00", "CNY"), assessment.netPayable());
+        assertEquals(Money.of("15.00", "CNY"), assessment.changeFee());
+        assertEquals(Money.of("0.00", "CNY"), assessment.fareDifference());
+        assertEquals(Money.of("15.00", "CNY"), assessment.netPayable());
         assertEquals(Money.of("0.00", "CNY"), assessment.netRefundable());
     }
 
     @Test
-    void changeWithinFortyEightHoursPaysFareIncreasePlusChangeFee() {
+    void fareIncreaseAddsToFlatDefaultChangeFee() {
         ChangeAssessment assessment = engine.evaluateChange(Money.of("200.00", "CNY"), Money.of("260.00", "CNY"), REQUEST, REQUEST.plusSeconds(24 * 3_600), 0);
 
-        assertEquals(Money.of("40.00", "CNY"), assessment.changeFee());
+        assertEquals(Money.of("15.00", "CNY"), assessment.changeFee());
         assertEquals(Money.of("60.00", "CNY"), assessment.fareDifference());
-        assertEquals(Money.of("100.00", "CNY"), assessment.netPayable());
+        assertEquals(Money.of("75.00", "CNY"), assessment.netPayable());
     }
 
     @Test
-    void fareDecreaseIsRefundedNetOfChangeFee() {
+    void fareDecreaseIsRefundedNetOfFlatDefaultChangeFee() {
         ChangeAssessment assessment = engine.evaluateChange(Money.of("200.00", "CNY"), Money.of("140.00", "CNY"), REQUEST, REQUEST.plusSeconds(24 * 3_600), 0);
 
-        assertEquals(Money.of("40.00", "CNY"), assessment.changeFee());
+        assertEquals(Money.of("15.00", "CNY"), assessment.changeFee());
         assertEquals(Money.of("60.00", "CNY"), assessment.fareDifference());
-        assertEquals(Money.of("20.00", "CNY"), assessment.netRefundable());
+        assertEquals(Money.of("45.00", "CNY"), assessment.netRefundable());
         assertEquals(Money.of("0.00", "CNY"), assessment.netPayable());
     }
 
     @Test
-    void secondChangeAlwaysChargesTwentyPercentEvenWhenMoreThanFortyEightHoursBeforeDeparture() {
-        ChangeAssessment assessment = engine.evaluateChange(Money.of("200.00", "CNY"), Money.of("200.00", "CNY"), REQUEST, REQUEST.plusSeconds(5 * 86_400), 1);
+    void quotedSameFareChangeUsesAmountDueWithoutReapplyingChangeFee() {
+        ChangeAssessment assessment = engine.evaluateQuotedChange(
+            Money.of("100.00", "CNY"),
+            Money.of("15.00", "CNY"),
+            Money.zero("CNY"),
+            REQUEST,
+            REQUEST.plusSeconds(24 * 3_600),
+            0
+        );
 
-        assertEquals(Money.of("40.00", "CNY"), assessment.changeFee());
-        assertEquals(Money.of("40.00", "CNY"), assessment.netPayable());
+        assertEquals(Money.of("15.00", "CNY"), assessment.changeFee());
+        assertEquals(Money.of("0.00", "CNY"), assessment.fareDifference());
+        assertEquals(Money.of("15.00", "CNY"), assessment.netPayable());
     }
 }


### PR DESCRIPTION
## Summary
- Use the contracted default flat CNY 15.00 change fee in post-sales change policy calculations.
- Apply fare-pricing change quote amountDue/refundable directly instead of reconstructing a new fare and charging a second fee.
- Add unit/integration coverage for same-fare change amountDue = 1500 minor units.

## Validation
- cd platform/java-kit && mvn install -DskipTests
- cd services/post-sales && mvn test -Dtest=ChangePolicyEngineTest,PostSalesApplicationServicePolicyIntegrationTest